### PR TITLE
Fix include of OpenGL headers on OS X systems

### DIFF
--- a/cpp/console/draw.cpp
+++ b/cpp/console/draw.cpp
@@ -5,7 +5,11 @@
 #include <stdlib.h>
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <FTGL/ftgl.h>
 
 #include <unistd.h>

--- a/cpp/engine.cpp
+++ b/cpp/engine.cpp
@@ -4,7 +4,11 @@
 #include <stdlib.h>
 #include <time.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <FTGL/ftgl.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -2,7 +2,11 @@
 
 #include <SDL2/SDL.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/cpp/shader/program.h
+++ b/cpp/shader/program.h
@@ -2,7 +2,11 @@
 #define _SHADER_PROGRAM_H_
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 #include "shader.h"
 

--- a/cpp/shader/shader.h
+++ b/cpp/shader/shader.h
@@ -2,7 +2,11 @@
 #define _SHADER_SHADER_H_
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 namespace openage {
 namespace shader {

--- a/cpp/texture.h
+++ b/cpp/texture.h
@@ -2,7 +2,11 @@
 #define _TEXTURE_H_
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include <vector>
 
 #include "gamedata/texture.gen.h"

--- a/cpp/util/color.cpp
+++ b/cpp/util/color.cpp
@@ -1,7 +1,11 @@
 #include "color.h"
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 namespace openage {
 namespace util {

--- a/cpp/util/opengl.cpp
+++ b/cpp/util/opengl.cpp
@@ -1,7 +1,11 @@
 #include "opengl.h"
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 #include "error.h"
 


### PR DESCRIPTION
On OS X systems, the OpenGL headers are located in an `OpenGl` folder instead of the `GL` folder they're located in in most other systems. See [the official OpenGL intro](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_drawing/opengl_drawing.html#//apple_ref/doc/uid/TP40001987-CH404-SW7).

This patch fixes the includes using a preprocessor if-else construct:

``` c
#ifdef __APPLE__
#include <OpenGL/gl.h>
#else
#include <GL/gl.h>
#endif
```

I would be glad to discuss this patch, because there are some decisions to be made:
- Should the two `#include` lines be indented?
- Should a different approach be made instead of preprocessor checks (e.g. using cmake)?
