### PR TITLE
convert: HD support (re: #10) (the real thing)

### DIFF
--- a/py/openage/convert/hardcoded/langcodes_hd.py
+++ b/py/openage/convert/hardcoded/langcodes_hd.py
@@ -1,0 +1,16 @@
+# HD Edition uses short language codes.
+# For consistency with AoK:TC's PE-file-extracted codes, they are mapped to these longer codes
+
+short_to_long_codes_map = {
+    'br': 'pt_BR',
+    'cn': 'zh_CN',
+    'de': 'de_DE',
+    'en': 'en_US',
+    'es': 'es_ES',
+    'fr': 'fr_FR',
+    'it': 'it_IT',
+    'ja': 'ja_JP',
+    'ko': 'ko_KR',
+    'nl': 'nl_NL',
+    'ru': 'ru_RU'
+}

--- a/py/openage/convert/hdlanguagefile.py
+++ b/py/openage/convert/hdlanguagefile.py
@@ -1,0 +1,30 @@
+from collections import defaultdict
+from . import util
+from .hardcoded.langcodes_hd import short_to_long_codes_map
+from .util import dbg
+
+class HDLanguageFile:
+
+    def __init__(self, fname, langcode):
+        self.fname = fname
+        self.lang = short_to_long_codes_map[langcode] if langcode in short_to_long_codes_map else langcode
+        fname = util.file_get_path(fname)
+
+        dbg("HD Language file [%s]" % (fname), 1)
+        self.data = open(fname, mode='r', encoding='iso-8859-1').read()
+        self.strings = self.extract_strings()
+
+    def extract_strings(self):
+        result = defaultdict(lambda: {})
+        for i in self.data.split('\n'):
+            i = i.strip()
+            #comments & empty lines
+            if i.startswith('//') or len(i) == 0:
+                continue
+            num, string = i.split(None, 1)
+            #strings that were added in the HD edition release have UPPERCASE_STRINGS
+            #as names, instead of the numeric ID stuff in AoK:TC
+            #we only need the AoK:TC strings, and skip the rest
+            if num.isdigit():
+                result[self.lang][num] = string
+        return result

--- a/py/openage/convert/mediafile.py
+++ b/py/openage/convert/mediafile.py
@@ -73,11 +73,15 @@ def media_convert(args):
         "interface": DRS("Data/interfac.drs"),
         "sounds0":   DRS("Data/sounds.drs"),
         "sounds1":   DRS("Data/sounds_x1.drs"),
-        "gamedata0": DRS("Data/gamedata.drs"),
         "gamedata1": DRS("Data/gamedata_x1.drs"),
         "gamedata2": DRS("Data/gamedata_x1_p1.drs"),
         "terrain":   DRS("Data/terrain.drs")
     }
+
+    #gamedata.drs does not exist in HD edition, but its contents are
+    #in gamedata_x1.drs instead, so we can ignore this file if it doesn't exist
+    if os.path.isfile(file_get_path("Data/gamedata.drs")):
+        drsfiles["gamedata0"] = DRS("Data/gamedata.drs")
 
     #this is the ingame color palette file id, 256 color lookup for all graphics pixels
     palette_id = 50500
@@ -107,15 +111,32 @@ def media_convert(args):
             player_palette.save_visualization('info/playercolortable.pal.png')
 
         from . import blendomatic
-        blend_data = blendomatic.Blendomatic("Data/blendomatic.dat")
+        #HD Edition has a blendomatic_x1.dat in addition to its new blendomatic.dat
+        #blendomatic_x1.dat is the same file as AoK:TC's blendomatic.dat, and TC does not have
+        #blendomatic.dat, so we try _x1 first and fall back to the AoK:TC way if it does not exist
+        blend_file = "Data/blendomatic_x1.dat"
+        if not os.path.isfile(file_get_path(blend_file)):
+            blend_file = "Data/blendomatic.dat"
+        blend_data = blendomatic.Blendomatic(blend_file)
         blend_data.save(os.path.join(asset_folder, "blendomatic.dat/"), output_formats)
 
-        from .pefile import PEFile
         from .stringresource import StringResource
         stringres = StringResource()
-        stringres.fill_from(PEFile("language.dll"))
-        stringres.fill_from(PEFile("language_x1.dll"))
-        stringres.fill_from(PEFile("language_x1_p1.dll"))
+        #AoK:TC uses .DLL files for its string resources,
+        #HD uses plaintext files
+        if os.path.isfile(file_get_path("language.dll")):
+            from .pefile import PEFile
+            stringres.fill_from(PEFile("language.dll"))
+            stringres.fill_from(PEFile("language_x1.dll"))
+            stringres.fill_from(PEFile("language_x1_p1.dll"))
+        else:
+            from .hdlanguagefile import HDLanguageFile
+            for lang in os.listdir(file_get_path("Bin")):
+                langfile = "Bin/%s/%s-language.txt" % (lang, lang)
+                #there is some "base language" files in HD that we don't need
+                #and only the dir for the language that's currently in use contains a language file
+                if os.path.isdir(file_get_path("Bin/%s" % (lang))) and os.path.isfile(file_get_path(langfile)):
+                    stringres.fill_from(HDLanguageFile(langfile, lang))
         #stringres.fill_from(PEFile("Games/Forgotten Empires/Data/language_x1_p1.dll"))
         #TODO: transform and cleanup the read strings... (strip html, insert formatchars, ...)
 


### PR DESCRIPTION
/me learns

This PR makes the convert script work with HD Edition's resources, so people don't necessarily have to have the CD version, but can also get HD Edition from Steam and use that.

It relies on some obsolete files that still ship with HD Edition, so it may break in the future, if they clean up their builds.

Tested with a new HD Edition installation as of october 27, 2014.
