### PR TITLE
Refactored the Opusfile cmake rules into own module

### DIFF
--- a/buildsystem/modules/FindOpusfile.cmake
+++ b/buildsystem/modules/FindOpusfile.cmake
@@ -1,0 +1,26 @@
+# - Try to find Opusfile
+# Once done this will define
+#  OPUSFILE_FOUND - System has Opusfile
+#  OPUSFILE_INCLUDE_DIRS - The Opusfile include directories
+#  OPUSFILE_LIBRARIES - The libraries needed to use Opusfile
+
+find_package(PkgConfig)
+
+find_path(OPUSFILE_INCLUDE_DIR opusfile.h
+  HINTS
+  /usr/include/opus
+  /usr/local/include/opus
+)
+
+find_library(OPUSFILE_LIBRARY NAMES opusfile)
+
+set(OPUSFILE_LIBRARIES ${OPUSFILE_LIBRARY} )
+set(OPUSFILE_INCLUDE_DIRS ${OPUSFILE_INCLUDE_DIR} )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set OPUSFILE_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Opusfile DEFAULT_MSG
+                                  OPUSFILE_LIBRARY OPUSFILE_INCLUDE_DIR)
+
+mark_as_advanced(OPUSFILE_INCLUDE_DIR OPUSFILE_LIBRARY)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -52,7 +52,7 @@ finalize_executable(${PROJECT_NAME})
 
 # freetype includedir hint for ubuntu...
 find_path(FREETYPE_INCLUDE_DIRS freetype/freetype.h HINTS /usr/include/freetype2)
-find_path(OPUSFILE_INCLUDE_DIR opusfile.h HINTS /usr/include/opus)
+find_package(Opusfile REQUIRED)
 
 include(FindPkgConfig)
 include(FindPackageHandleStandardArgs)
@@ -63,7 +63,6 @@ if(NOT WIN32)
 endif()
 
 find_library(FONTCONFIG_LIB fontconfig)
-find_library(OPUSFILE_LIB opusfile)
 if(NOT WIN32)
 	find_library(UTIL_LIB util)
 endif()
@@ -102,7 +101,7 @@ target_link_libraries(${PROJECT_NAME}
 	${GLEW_LIBRARIES}
 	${MATH_LIB}
 	${OPENGL_LIBRARY}
-	${OPUSFILE_LIB}
+	${OPUSFILE_LIBRARIES}
 	${PYTHON_LIBRARY}
 	${SDL2IMAGE_LIBRARIES}
 	${SDL2_LIBRARY}


### PR DESCRIPTION
To properly find Opusfile on OS X (and possibly other systems too) a hint had to be added to find the include directory of Opusfile. To keep the CMakeLists.txt file clean, a new cmake module was created for finding the Opusfile include directories and libraries.
