### PR TITLE
Fix SDL2_image include directory hints for OS X systems

### DIFF
--- a/buildsystem/modules/FindSDL2Image.cmake
+++ b/buildsystem/modules/FindSDL2Image.cmake
@@ -2,7 +2,21 @@ find_package(PackageHandleStandardArgs)
 
 if(APPLE)
 	find_library(SDL2IMAGE_LIBRARIES SDL2_image DOC "SDL2 library framework for MacOS X")
-	find_path(SDL2IMAGE_INCLUDE_DIRS SDL2_image/SDL_image.h DOC "Include directory for SDL2_image under MacOS X")
+	find_path(SDL2IMAGE_INCLUDE_DIRS SDL_image.h
+		HINTS
+		$ENV{SDL2DIR}
+		PATH_SUFFIXES include/SDL2 include
+		PATHS
+		~/Library/Frameworks
+		/Library/Frameworks
+		/usr/local/include/SDL2
+		/usr/include/SDL2
+		/sw # Fink
+		/opt/local # DarwinPorts
+		/opt/csw # Blastwave
+		/opt
+		DOC "Include directory for SDL2_image under MacOS X"
+	)
 else()
 	find_library(SDL2IMAGE_LIBRARIES SDL2_image DOC "SDL2 library")
 	find_path(SDL2IMAGE_INCLUDE_DIRS SDL2/SDL_image.h DOC "Include directory for SDL2_image")


### PR DESCRIPTION
Added some hints where to find SDL2_image include headers on OS X.
