### PR TITLE
Include termios.h instead of the termio.h

### DIFF
--- a/cpp/util/fds.h
+++ b/cpp/util/fds.h
@@ -3,7 +3,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <termio.h>
+#include <termios.h>
 
 namespace openage {
 namespace util {


### PR DESCRIPTION
Termio is specific for System III and System V machines and not part of
the POSIX standard ([see this Wikipedia article](http://en.wikipedia.org/wiki/POSIX_terminal_interface#The_termios_data_structure)).
