### PR TITLE
Fix format specifiers for long longs

### DIFF
--- a/cpp/terrain_chunk.cpp
+++ b/cpp/terrain_chunk.cpp
@@ -1,5 +1,7 @@
 #include "terrain_chunk.h"
 
+#include <inttypes.h>
+
 #include "engine.h"
 #include "texture.h"
 #include "log.h"
@@ -148,7 +150,7 @@ the returned index would be 6 (count for each ne row, starting at se=0)
 */
 size_t TerrainChunk::tile_position(coord::tile pos) {
 	if (this->neighbor_id_by_pos(pos) != -1) {
-		throw util::Error("requested tile (%ld, %ld) that's not on this terrain chunk.", pos.ne, pos.se);
+		throw util::Error("requested tile (%" PRId64 ", %" PRId64 ") that's not on this terrain chunk.", pos.ne, pos.se);
 	}
 
 	return pos.se * chunk_size + pos.ne;

--- a/py/openage/convert/cabextract/lzxd/lzxd.cpp
+++ b/py/openage/convert/cabextract/lzxd/lzxd.cpp
@@ -1020,7 +1020,7 @@ void LZXDStream::decompress(off_t out_bytes) {
 	} // while (this->frame < end_frame)
 
 	if (out_bytes) {
-		throwerr("decrunch: %ld bytes left to output", out_bytes);
+		throwerr("decrunch: %jd bytes left to output", (intmax_t)out_bytes);
 	}
 }
 


### PR DESCRIPTION
This removes some warnings when compiling with `clang` on OS X 10.10.
