### PR TITLE
Make media conversion work on file sensitive system

### DIFF
--- a/py/openage/convert/util.py
+++ b/py/openage/convert/util.py
@@ -144,7 +144,7 @@ def file_get_path(fname, write=False, mkdir=False):
         basedir = readpath
 
     path = path_insensitive(os.path.join(basedir, fname))
-	
+
     if mkdir:
         dirname = os.path.dirname(path)
         mkdirs(dirname)


### PR DESCRIPTION
My AoE installation has directories like DATA where openage expects Data. This pull request should solve the general case.
