### PR TITLE
Add .desktop file and placeholder icon.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ configure_file(py/openage/config.py.in "${CMAKE_SOURCE_DIR}/py/openage/config.py
 doxygen_configure(cpp/ py/)
 
 add_subdirectory(cpp/)
+add_subdirectory(dist/)
 add_subdirectory(py/)
 
 # process the included python sources, generate setup.py

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -1,0 +1,13 @@
+message("Cropping gaben.png to create placeholder desktop icon...")
+
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/dist")
+execute_process(COMMAND python3 -c "
+import PIL.Image;
+cropped=PIL.Image.open('${GLOBAL_ASSET_DIR}/gaben.png').crop((92,137,604,649));
+cropped.save('${CMAKE_BINARY_DIR}/dist/openage.png')")
+
+install(FILES "${GLOBAL_ASSET_DIR}/dist/openage.desktop"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/share/applications")
+
+install(FILES "${CMAKE_BINARY_DIR}/dist/openage.png"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/share/pixmaps")

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,15 @@
+# Distribution
+
+Contains files useful for package distribution.
+
+## Desktop file
+
+The [openage.desktop](openage.desktop) file can be found in this directory and will be installed at
+`/usr/share/applications/openage.desktop`.
+
+## Desktop icon
+
+In lieu of a logo/icon for openage a cropped version of [assets/gaben.png](/assets/gaben.png) is
+created instead. See [assets/CMakeLists.txt](/assets/CMakeLists.txt) for details on how the icon
+is generated. The final icon will be installed at `/usr/share/pixmaps/openage.png` via
+`make install`.

--- a/dist/openage.desktop
+++ b/dist/openage.desktop
@@ -1,0 +1,10 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=openage
+Comment=Free engine clone of Age of Empires II
+Exec=openage --data=assets %u
+Path=.openage
+Terminal=true
+Type=Application
+Icon=openage
+Categories=Game;StrategyGame;


### PR DESCRIPTION
When packaging openage it would be nice to have a common .desktop and icon file to use.
