### PR TITLE
add -Wno-mismatched-tags flag for llvm builds

### DIFF
--- a/buildsystem/cpp.cmake
+++ b/buildsystem/cpp.cmake
@@ -5,7 +5,11 @@
 #TODO: integrate PGO (profile-guided optimization) build
 
 function(cpp_init)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11" PARENT_SCOPE)
+	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11 -Wno-mismatched-tags" PARENT_SCOPE)
+	else()
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11" PARENT_SCOPE)
+	endif()
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g" PARENT_SCOPE)
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
 


### PR DESCRIPTION
Fixes #89. Will supress useless warnings in the travis build. Flag is added for llvm only since gcc doesn't recognise it.
