### PR TITLE
[apparently unused yet] convert: typo on ressource -> resource

### DIFF
--- a/doc/media/gamedata-struct.md
+++ b/doc/media/gamedata-struct.md
@@ -128,7 +128,7 @@ struct {
 		int16_t enabled;
 		char name0[13];
 		char name1[13];
-		int32_t ressource_id;
+		int32_t resource_id;
 		int32_t unknown;
 		int32_t unknown;
 		uint8_t color[3];
@@ -176,9 +176,9 @@ struct {
 			int16_t class_id;
 			int16_t unit_id;
 			int16_t unknown;
-			int16_t ressource_in;
+			int16_t resource_in;
 			int16_t sub_type_id;
-			int16_t ressource_out;
+			int16_t resource_out;
 			int16_t unknown;
 			float work_rate_multiplier;
 			float execution_radius;
@@ -200,10 +200,10 @@ struct {
 	struct {
 		int8_t one;
 		char name[20];
-		uint16_t ressources_count;
+		uint16_t resources_count;
 		int16_t tech_tree_id;
 		int16_t team_bonus_id;
-		float[ressources_count] ressources;
+		float[resources_count] resources;
 		int8_t graphic_set;
 		uint16_t unit_count;
 		int32_t unit_offsets[unit_count];
@@ -259,8 +259,8 @@ struct {
 				int8_t visible_in_fog;
 				int16_t terrain_restriction;
 				int8_t fly_mode;
-				int16_t ressource_capacity;
-				float ressource_decay;
+				int16_t resource_capacity;
+				float resource_decay;
 				int8_t blast_type_id;
 				int8_t unknown;
 				int8_t interaction_mode;
@@ -385,7 +385,7 @@ struct {
 					int16_t type_id;
 					int16_t amount;
 					int16_t enabled;
-				} ressource_cost[3];
+				} resource_cost[3];
 				int16_t train_time;
 				int16_t train_location_id;
 				int8_t button_id;

--- a/py/openage/convert/gamedata/civ.py
+++ b/py/openage/convert/gamedata/civ.py
@@ -16,10 +16,10 @@ class Civ(dataformat.Exportable):
     data_format = (
         (dataformat.READ, "enabled", "int8_t"),
         (dataformat.READ_EXPORT, "name", "char[20]"),
-        (dataformat.READ, "ressources_count", "uint16_t"),
+        (dataformat.READ, "resources_count", "uint16_t"),
         (dataformat.READ_EXPORT, "tech_tree_id",  "int16_t"),             #links to tech id (to apply its effects)
         (dataformat.READ_EXPORT, "team_bonus_id", "int16_t"),             #links to tech id as well
-        (dataformat.READ, "ressources", "float[ressources_count]"),
+        (dataformat.READ, "resources", "float[resources_count]"),
         (dataformat.READ, "icon_set", "int8_t"),                          #building icon set, trade cart graphics, changes no other graphics
         (dataformat.READ_EXPORT, "unit_count", "uint16_t"),
         (dataformat.READ, "unit_offsets", "int32_t[unit_count]"),

--- a/py/openage/convert/gamedata/research.py
+++ b/py/openage/convert/gamedata/research.py
@@ -7,13 +7,13 @@ from ..util import dbg, zstr
 from .empiresdat import endianness
 
 
-class ResearchRessourceCost(dataformat.Exportable):
-    name_struct        = "research_ressource_cost"
+class ResearchResourceCost(dataformat.Exportable):
+    name_struct        = "research_resource_cost"
     name_struct_file   = "research"
-    struct_description = "amount definition for a single type ressource for researches."
+    struct_description = "amount definition for a single type resource for researches."
 
     data_format = (
-        (dataformat.READ, "ressource_id", "int16_t"),  #see unit/ressource_cost, TODO: type xref
+        (dataformat.READ, "resource_id", "int16_t"),  #see unit/resource_cost, TODO: type xref
         (dataformat.READ, "amount", "int16_t"),
         (dataformat.READ, "enabled", "int8_t"),
     )
@@ -26,8 +26,8 @@ class Research(dataformat.Exportable):
 
     data_format = (
         (dataformat.READ, "required_techs", "int16_t[6]"),         #research ids of techs that are required for activating the possible research
-        (dataformat.READ, "research_ressource_costs", dataformat.SubdataMember(
-            ref_type=ResearchRessourceCost,
+        (dataformat.READ, "research_resource_costs", dataformat.SubdataMember(
+            ref_type=ResearchResourceCost,
             length=3,
         )),
         (dataformat.READ, "required_tech_count", "int16_t"),       #a subset of the above required techs may be sufficient

--- a/py/openage/convert/gamedata/tech.py
+++ b/py/openage/convert/gamedata/tech.py
@@ -20,15 +20,15 @@ class Effect(dataformat.Exportable):
                 #unused assignage: a = -1, b = -1, c = -1, d = 0
                 -1: "DISABLED",
                 0: "ATTRIBUTE_ABSSET",   #if a != -1: a == unit_id, else b == unit_class_id; c = attribute_id, d = new_value
-                1: "RESSOURCE_MODIFY",   #a == ressource_id, if b == 0: then d = absval, else d = relval (for inc/dec)
+                1: "RESOURCE_MODIFY",   #a == resource_id, if b == 0: then d = absval, else d = relval (for inc/dec)
                 2: "UNIT_ENABLED",       #a == unit_id, if b == 0: disable unit, else b == 1: enable unit
                 3: "UNIT_UPGRADE",       #a == old_unit_id, b == new_unit_id
                 4: "ATTRIBUTE_RELSET",   #if a != -1: unit_id, else b == unit_class_id; c=attribute_id, d=relval
                 5: "ATTRIBUTE_MUL",      #if a != -1: unit_id, else b == unit_class_id; c=attribute_id, d=factor
-                6: "RESSOURCE_MUL",      #a == ressource_id, d == factor
+                6: "RESOURCE_MUL",      #a == resource_id, d == factor
 
                 #these are only used in technology trees, 103 even requires one
-                101: "TECHCOST_MODIFY",  #a == research_id, b == ressource_id, if c == 0: d==absval else: d == relval
+                101: "TECHCOST_MODIFY",  #a == research_id, b == resource_id, if c == 0: d==absval else: d == relval
                 102: "TECH_DISABLE",     #d == research_id
                 103: "TECH_TIME_MODIFY", #a == research_id, if c == 0: d==absval else d==relval
 

--- a/py/openage/convert/gamedata/terrain.py
+++ b/py/openage/convert/gamedata/terrain.py
@@ -107,7 +107,7 @@ class TerrainBorder(dataformat.Exportable):
         (dataformat.READ, "enabled", "int16_t"),
         (dataformat.READ, "name0", "char[13]"),
         (dataformat.READ, "name1", "char[13]"),
-        (dataformat.READ, "ressource_id", "int32_t"),
+        (dataformat.READ, "resource_id", "int32_t"),
         (dataformat.READ_UNKNOWN, None, "int32_t"),
         (dataformat.READ_UNKNOWN, None, "int32_t"),
         (dataformat.READ, "color", "uint8_t[3]"),

--- a/py/openage/convert/gamedata/unit.py
+++ b/py/openage/convert/gamedata/unit.py
@@ -60,10 +60,10 @@ class UnitCommand(dataformat.Exportable):
         (dataformat.READ_EXPORT, "class_id", "int16_t"),
         (dataformat.READ_EXPORT, "unit_id", "int16_t"),
         (dataformat.READ_UNKNOWN, None, "int16_t"),
-        (dataformat.READ_EXPORT, "ressource_in", "int16_t"),
-        (dataformat.READ_EXPORT, "ressource_productivity", "int16_t"), #resource that multiplies the amount you can gather
-        (dataformat.READ_EXPORT, "ressource_out", "int16_t"),
-        (dataformat.READ_EXPORT, "ressource", "int16_t"),
+        (dataformat.READ_EXPORT, "resource_in", "int16_t"),
+        (dataformat.READ_EXPORT, "resource_productivity", "int16_t"), #resource that multiplies the amount you can gather
+        (dataformat.READ_EXPORT, "resource_out", "int16_t"),
+        (dataformat.READ_EXPORT, "resource", "int16_t"),
         (dataformat.READ_EXPORT, "work_rate_multiplier", "float"),
         (dataformat.READ_EXPORT, "execution_radius", "float"),
         (dataformat.READ_EXPORT, "extra_range", "float"),
@@ -89,12 +89,12 @@ class UnitCommand(dataformat.Exportable):
         )),
         (dataformat.READ_UNKNOWN, None, "int8_t"),
         (dataformat.READ_UNKNOWN, None, "int8_t"),
-        (dataformat.READ, "tool_graphic_id", "int16_t"),               #walking with tool but no ressource
-        (dataformat.READ, "proceed_graphic_id", "int16_t"),            #proceeding ressource gathering or attack
+        (dataformat.READ, "tool_graphic_id", "int16_t"),               #walking with tool but no resource
+        (dataformat.READ, "proceed_graphic_id", "int16_t"),            #proceeding resource gathering or attack
         (dataformat.READ, "action_graphic_id", "int16_t"),             #actual execution or transformation graphic
-        (dataformat.READ, "carrying_graphic_id", "int16_t"),           #display ressources in hands
+        (dataformat.READ, "carrying_graphic_id", "int16_t"),           #display resources in hands
         (dataformat.READ, "execution_sound_id", "int16_t"),            #sound to play when execution starts
-        (dataformat.READ, "ressource_deposit_sound_id", "int16_t"),    #sound to play on ressource drop
+        (dataformat.READ, "resource_deposit_sound_id", "int16_t"),    #sound to play on resource drop
     )
 
 
@@ -113,8 +113,8 @@ class UnitHeader(dataformat.Exportable):
     )
 
 
-class RessourceStorage(dataformat.Exportable):
-    name_struct        = "ressource_storage"
+class ResourceStorage(dataformat.Exportable):
+    name_struct        = "resource_storage"
     name_struct_file   = "unit"
     struct_description = "determines the resource storage capacity for one unit mode."
 
@@ -123,7 +123,7 @@ class RessourceStorage(dataformat.Exportable):
         (dataformat.READ, "amount", "float"),
         (dataformat.READ, "used_mode", dataformat.EnumLookupMember(
             raw_type    = "int8_t",
-            type_name   = "ressource_handling",
+            type_name   = "resource_handling",
             lookup_dict = {
                 0: "DECAYABLE",
                 1: "KEEP_AFTER_DEATH",
@@ -194,15 +194,15 @@ class HitType(dataformat.Exportable):
     )
 
 
-class RessourceCost(dataformat.Exportable):
-    name_struct        = "ressource_cost"
+class ResourceCost(dataformat.Exportable):
+    name_struct        = "resource_cost"
     name_struct_file   = "unit"
-    struct_description = "stores cost for one ressource for creating the unit."
+    struct_description = "stores cost for one resource for creating the unit."
 
     data_format = (
         (dataformat.READ, "type_id", dataformat.EnumLookupMember(
             raw_type = "int16_t",
-            type_name = "ressource_types",
+            type_name = "resource_types",
             lookup_dict = {
                 -1: "NONE",
                 0: "FOOD_STORAGE",
@@ -567,8 +567,8 @@ class UnitObject(dataformat.Exportable):
             },
         )),
         (dataformat.READ_EXPORT, "fly_mode", "int8_t"),
-        (dataformat.READ_EXPORT, "ressource_capacity", "int16_t"),
-        (dataformat.READ_EXPORT, "ressource_decay", "float"),                 #when animals rot, their ressources decay
+        (dataformat.READ_EXPORT, "resource_capacity", "int16_t"),
+        (dataformat.READ_EXPORT, "resource_decay", "float"),                 #when animals rot, their resources decay
         (dataformat.READ_EXPORT, "blast_type", dataformat.EnumLookupMember(
             raw_type    = "int8_t",
             type_name   = "blast_types",
@@ -678,8 +678,8 @@ class UnitObject(dataformat.Exportable):
         (dataformat.READ, "selection_radius0", "float"),
         (dataformat.READ, "selection_radius1", "float"),
         (dataformat.READ, "hp_bar_height1", "float"),           #vertical hp bar distance from ground
-        (dataformat.READ_EXPORT, "ressource_storage", dataformat.SubdataMember(
-            ref_type=RessourceStorage,
+        (dataformat.READ_EXPORT, "resource_storage", dataformat.SubdataMember(
+            ref_type=ResourceStorage,
             length=3,
         )),
         (dataformat.READ, "damage_graphic_count", "int8_t"),
@@ -774,7 +774,7 @@ class UnitBird(UnitDeadOrFish):
         (dataformat.READ, "sheep_conversion", "int16_t"), #0=can be converted by unit command 107 (you found sheep!!1)
         (dataformat.READ, "search_radius", "float"),
         (dataformat.READ, "work_rate", "float"),
-        (dataformat.READ, "drop_site0", "int16_t"),       #unit id where gathered ressources shall be delivered to
+        (dataformat.READ, "drop_site0", "int16_t"),       #unit id where gathered resources shall be delivered to
         (dataformat.READ, "drop_site1", "int16_t"),       #alternative unit id
         (dataformat.READ_EXPORT, "villager_mode", "int8_t"),     #unit can switch villager type (holza? gathara!) 1=male, 2=female
         (dataformat.READ_EXPORT, "move_sound", "int16_t"),
@@ -826,7 +826,7 @@ class UnitMovable(UnitBird):
             raw_type    = "int8_t",
             type_name   = "range_damage_type",
             lookup_dict = {
-                0: "RESSOURCES",
+                0: "RESOURCES",
                 1: "TREES",
                 2: "NEARBY_UNITS",
                 3: "TARGET_ONLY",
@@ -879,7 +879,7 @@ class UnitLiving(UnitMovable):
 
     data_format = (
         (dataformat.READ_EXPORT, None, dataformat.IncludeMembers(cls=UnitMovable)),
-        (dataformat.READ, "ressource_cost", dataformat.SubdataMember(ref_type=RessourceCost, length=3)),
+        (dataformat.READ, "resource_cost", dataformat.SubdataMember(ref_type=ResourceCost, length=3)),
         (dataformat.READ, "creation_time", "int16_t"),         #in seconds
         (dataformat.READ, "creation_location_id", "int16_t"),  #e.g. 118 = villager
 

--- a/py/openage/convert/hardcoded/langcodes.py
+++ b/py/openage/convert/hardcoded/langcodes.py
@@ -1,6 +1,6 @@
 # Copyright 2013-2014 the openage authors. See copying.md for legal info.
 
-# language codes, as used in PE file ressources
+# language codes, as used in PE file resources
 # this file is used by pefile.py
 
 langcodes = {

--- a/py/openage/convert/pefile.py
+++ b/py/openage/convert/pefile.py
@@ -115,11 +115,11 @@ struct image_section_header {
 """
 image_section_header = Struct(endianness + "8s 6I HH I")
 
-# ressource section
+# resource section
 SECTION_NAME_RESOURCE = ".rsrc"
 
-# ressource tree
-# types for id in ressource directory root node
+# resource tree
+# types for id in resource directory root node
 restypes = {
     0: 'unknown',
     1: 'cursor',
@@ -148,7 +148,7 @@ restypes = {
 # reverse-lookup directory
 restypesinv = {v: k for k, v in restypes.items()}
 
-# string ressources
+# string resources
 STRINGTABLE_SIZE = 16
 STRINGTABLE_ENCODING = 'utf-16-le'
 STRINGTABLE_LENGTH_MULTIPLIER = 2
@@ -292,7 +292,7 @@ class PEFile:
     def parse_rsrc_strings(self):
         """
         returns a dict of dicts:
-        {languageid: {stringid: ressource_string}}
+        {languageid: {stringid: resource_string}}
         """
 
         result = defaultdict(lambda: {})


### PR DESCRIPTION
Apparently we aren't using this on cpp code, but anyway **they are breaking changes**: if at some point we use the fixed version of the assets but we have the old converted ones on disk, it will fail.
