### PR TITLE
add prerequisite steps for installing openage on Fedora 20

### DIFF
--- a/building.md
+++ b/building.md
@@ -61,6 +61,10 @@ Dependency list:
  - `sudo apt-get update`
  - `sudo apt-get install cmake libfreetype6-dev python3-dev libglew-dev libsdl2-dev ftgl-dev  libsdl2-image-dev libopusfile-dev libfontconfig1-dev opus-tools python3-pil python3-numpy`
 
+### Prerequisite steps for Fedora users (Fedora 20)
+
+    sudo yum install cmake gcc-c++ clang SDL2-devel SDL2_image-devel python3-devel python3-numpy python3-pillow ftgl-devel glew-devel opus-tools opusfile
+
 ### Prerequisite steps for openSUSE users (openSUSE 13.1)
 
 If you already have python3 or one of packman/games repositories then no need to run the first two lines. If unsure then just run last line and see if all packages can be installed. Also feel free to drop `--no-recommends` from last line.

--- a/copying.md
+++ b/copying.md
@@ -33,6 +33,7 @@ _the openage authors_ are:
 | Charles Pigott              | LordAro                     | charlespigott@googlemail.com     |
 | Andrew Eikum                | ColdPie1                    | coldpies@gmail.com               |
 | Michael Sebastiyan          | BugExplorer                 | sebastiyan.michael@outlook.com   |
+| Adam Miartus                | miartad                     | adam.miartus@gmail.com           |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
squashed it like a pro
