### PR TITLE
add debug overlay grid, togglable with F4

### DIFF
--- a/cpp/game_main.h
+++ b/cpp/game_main.h
@@ -88,10 +88,16 @@ public:
 	 */
 	std::unordered_set<openage::TerrainObject *> placed_buildings;
 
+	/**
+	 * debug function that draws a simple overlay grid
+	 */
+	void draw_debug_grid();
+
 	// currently selected terrain id
 	openage::terrain_t editor_current_terrain;
 	int editor_current_building;
 
+	bool debug_grid_active;
 	bool clicking_active;
 	bool ctrl_active;
 	bool scrolling_active;


### PR DESCRIPTION
Inspired on  #135.

This simply draws 2d lines over the screen: it has no fancy shaders or anything. It won't work once we have terrain altitude. But it has helped me to spot what I think it's a bug on the coordinate conversion code :D also, it's useful for fixing #57.
