### PR TITLE
take screens on F2 release, not on press or hold

### DIFF
--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -501,6 +501,9 @@ bool GameMain::on_input(SDL_Event *e) {
 		case SDLK_F1:
 			engine.drawing_huds = !engine.drawing_huds;
 			break;
+		case SDLK_F2:
+			engine.get_screenshot_manager().save_screenshot();
+			break;
 		case SDLK_F3:
 			engine.drawing_debug_overlay = !engine.drawing_debug_overlay;
 			break;
@@ -514,9 +517,6 @@ bool GameMain::on_input(SDL_Event *e) {
 		switch (((SDL_KeyboardEvent *) e)->keysym.sym) {
 		case SDLK_SPACE:
 			this->terrain->blending_enabled = !terrain->blending_enabled;
-			break;
-		case SDLK_F2:
-			engine.get_screenshot_manager().save_screenshot();
 			break;
 		case SDLK_LCTRL:
 			this->ctrl_active = true;


### PR DESCRIPTION
Both F1 and F3 are handled on KEYUP.

Screenshot should be handled on KEYUP too: not only it makes the code tidier,  this also prevents taking repeated screenshots if SDL decides the key has hit the "hold" delay and reraises the KEYDOWN event.
