### PR TITLE
move screenshot and blending toggle from keydown to keyup

### DIFF
--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -494,16 +494,28 @@ bool GameMain::on_input(SDL_Event *e) {
 
 	case SDL_KEYUP:
 		switch (((SDL_KeyboardEvent *) e)->keysym.sym) {
+
 		case SDLK_ESCAPE:
 			//stop the game
 			engine.stop();
 			break;
+
 		case SDLK_F1:
 			engine.drawing_huds = !engine.drawing_huds;
 			break;
+
+		case SDLK_F2:
+			engine.get_screenshot_manager().save_screenshot();
+			break;
+
 		case SDLK_F3:
 			engine.drawing_debug_overlay = !engine.drawing_debug_overlay;
 			break;
+
+		case SDLK_SPACE:
+			this->terrain->blending_enabled = !terrain->blending_enabled;
+			break;
+
 		case SDLK_LCTRL:
 			this->ctrl_active = false;
 			break;
@@ -512,12 +524,6 @@ bool GameMain::on_input(SDL_Event *e) {
 		break;
 	case SDL_KEYDOWN:
 		switch (((SDL_KeyboardEvent *) e)->keysym.sym) {
-		case SDLK_SPACE:
-			this->terrain->blending_enabled = !terrain->blending_enabled;
-			break;
-		case SDLK_F2:
-			engine.get_screenshot_manager().save_screenshot();
-			break;
 		case SDLK_LCTRL:
 			this->ctrl_active = true;
 			break;


### PR DESCRIPTION
Both F1 and F3 are handled on KEYUP.
Toggling blending and screenshots are handled to KEYDOWN: this makes them susceptible to "the holding thing", in which holding a key makes the KEYDOWN event fire repeatedly.

This fixes that "holding thing" moving those keybindings to KEYUP, which also makes the code tidier :dancer: 

Supersedes #139 
