### PR TITLE
coord: divide negatives as supposed, make rendering pixel perfect

### DIFF
--- a/cpp/coord/phys3.cpp
+++ b/cpp/coord/phys3.cpp
@@ -44,8 +44,8 @@ camgame_delta phys3_delta::to_camgame() {
 	//scaling factor: w/2 for x, h/2 for y
 	//and the (1 << 16) fixed-point scaling factor for both.
 	camgame_delta result;
-	result.x = (pixel_t) (scaled.x * e.tile_halfsize.x / settings::phys_per_tile);
-	result.y = (pixel_t) (scaled.y * e.tile_halfsize.y / settings::phys_per_tile);
+	result.x = (pixel_t) util::div(scaled.x * e.tile_halfsize.x, settings::phys_per_tile);
+	result.y = (pixel_t) util::div(scaled.y * e.tile_halfsize.y, settings::phys_per_tile);
 
 	return result;
 }


### PR DESCRIPTION
I SPENT TWO HOURS ON FIGURING HOW TO FIX THIS!
I'm really tired so here is an explanation: 
http://www.microhowto.info/howto/round_towards_minus_infinity_when_dividing_integers_in_c_or_c++.html

This caused that the 4 "quadrants" of the rendering were misaligned. Not good for perfectionists (?)

This bug went unnoticed until put some solid lines on the tile borders. Also when the game starts it's fine, it breaks when you move the camera. 

---

demo pictures look at them in 1:1 because pixels and look in the center, vertical horizontal lines

before:
![openage_2014-11-07_04-19-02_00](https://cloud.githubusercontent.com/assets/726447/4949673/90f9024c-664e-11e4-85e0-25cbbf7fa8c2.png)

after:
![openage_2014-11-07_04-18-27_00](https://cloud.githubusercontent.com/assets/726447/4949675/961656b2-664e-11e4-952b-b08e4afedf47.png)
