### PR TITLE
codegen: improve unknown enum value error message

### DIFF
--- a/py/openage/convert/dataformat.py
+++ b/py/openage/convert/dataformat.py
@@ -1430,7 +1430,7 @@ class EnumMember(RefMember):
 
         enum_parser.extend([
             "else {",
-            "\tthrow openage::util::Error(\"unknown enum value '%%s' encountered. valid are: %s\", buf[%d]);" % (",".join(self.values), idx),
+            "\tthrow openage::util::Error(\"unknown enum value '%%s' encountered. valid are: %s\\n---\\nIf this is an inconsistency due to updates in the media converter, `make media` should fix it\\n---\", buf[%d]);" % (",".join(self.values), idx),
             "}",
         ])
 


### PR DESCRIPTION
In order to prevent further issues due to changes like #119 (see #144, [a comment on #69](https://github.com/SFTtech/openage/pull/69#issuecomment-61998049)) this improves the error message when an unknown enum value has been encountered. 

It simply suggests to `make media` :)

new error message:

```
    FATAL Exception: unknown enum value 'OLD_IDENTIFIER' encountered. valid are: TERRAIN,SHADOW,RUBBLE,UNIT_LOW,FISH,CRATER,UNIT,BLACKSMITH,BIRD,PROJECTILE
    ---
    If this is an inconsistency due to updates in the media converter, `make media` should fix it
    ---
```
