### PR TITLE
Fix warnings on 32 bit systems

### DIFF
--- a/buildsystem/cpp.cmake
+++ b/buildsystem/cpp.cmake
@@ -5,7 +5,7 @@
 #TODO: integrate PGO (profile-guided optimization) build
 
 function(cpp_init)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -std=c++11 -D__STDC_FORMAT_MACROS")
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		# suppress useless warnings about using struct hash as friend class hash
 		# which occur with older stdlib versions, like the one used by travis

--- a/copying.md
+++ b/copying.md
@@ -35,6 +35,7 @@ _the openage authors_ are:
 | Michael Sebastiyan          | BugExplorer                 | sebastiyan.michael@outlook.com   |
 | Adam Miartus                | miartad                     | adam.miartus@gmail.com           |
 | Benoît Legat                | blegat                      | benoit.legat@gmail.com           |
+| James Hagborg               | blucoat                     | jameshagborg@gmail.com           |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/cpp/audio/hash_functions.h
+++ b/cpp/audio/hash_functions.h
@@ -19,7 +19,7 @@ struct hash<::openage::audio::category_t> {
 template<>
 struct hash<std::tuple<::openage::audio::category_t,int>> {
 	size_t operator()(const std::tuple<::openage::audio::category_t,int> &t) const {
-		return static_cast<size_t>(std::get<0>(t))<<32 | std::get<1>(t);
+		return static_cast<size_t>(std::get<0>(t)) << (sizeof(size_t) * 8 - 2) | std::get<1>(t);
 	}
 };
 

--- a/cpp/audio/in_memory_loader.cpp
+++ b/cpp/audio/in_memory_loader.cpp
@@ -2,6 +2,8 @@
 
 #include "in_memory_loader.h"
 
+#include <cinttypes>
+
 #include <opusfile.h>
 
 #include "../log.h"
@@ -53,7 +55,7 @@ pcm_data_t OpusInMemoryLoader::get_resource() {
 	// determine number of channels and number of pcm samples
 	auto op_channels = op_channel_count(op_file.get(), -1);
 	auto pcm_length = op_pcm_total(op_file.get(), -1);
-	log::dbg("Opus channels=%d, pcm_length=%lu", op_channels, pcm_length);
+	log::dbg("Opus channels=%d, pcm_length=%" PRIuPTR, op_channels, static_cast<uintptr_t>(pcm_length));
 
 	// calculate pcm buffer size depending on the number of channels
 	// if the opus file only had one channel, the pcm buffer size must be

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cinttypes>
 
 #include "args.h"
 #include "audio/sound.h"
@@ -169,7 +170,7 @@ GameMain::GameMain(Engine *engine)
 			(int)(building.radius_size1 * 2),
 		};
 
-		log::msg("   building has foundation size %.2f x %.2f = %ldx%ld",
+		log::msg("   building has foundation size %.2f x %.2f = %" PRIi64 "x%" PRIi64,
 		         building.radius_size0,
 		         building.radius_size1,
 		         foundation_size.ne,
@@ -388,7 +389,7 @@ bool GameMain::on_input(SDL_Event *e) {
 			         ((float) mousepos_phys3.ne) / phys_per_tile,
 			         ((float) mousepos_phys3.se) / phys_per_tile,
 			         ((float) mousepos_phys3.up) / phys_per_tile);
-			log::dbg("LMB [tile]:      NE %8ld SE %8ld",
+			log::dbg("LMB [tile]:      NE %8" PRIi64 " SE %8" PRIi64,
 			         mousepos_tile.ne,
 			         mousepos_tile.se);
 

--- a/cpp/terrain/terrain.cpp
+++ b/cpp/terrain/terrain.cpp
@@ -4,6 +4,7 @@
 
 #include <unordered_map>
 #include <set>
+#include <cinttypes>
 
 #include "terrain_chunk.h"
 #include "../engine.h"
@@ -53,7 +54,9 @@ Terrain::Terrain(AssetManager &assetmanager,
 	this->influences_buf           = new struct influence[this->terrain_id_count];
 
 
-	log::dbg("terrain prefs: %lu tiletypes, %lu blendmodes", this->terrain_id_count, this->blendmode_count);
+	log::dbg("terrain prefs: %" PRIuPTR " tiletypes, %" PRIuPTR " blendmodes",
+	         static_cast<uintptr_t>(this->terrain_id_count),
+		 static_cast<uintptr_t>(this->blendmode_count));
 
 	// create tile textures (snow, ice, grass, whatever)
 	for (size_t i = 0; i < this->terrain_id_count; i++) {
@@ -197,7 +200,7 @@ bool Terrain::validate_terrain(terrain_t terrain_id) {
 
 bool Terrain::validate_mask(ssize_t mask_id) {
 	if (mask_id >= (ssize_t)this->blendmode_count) {
-		throw util::Error("requested mask_id is out of range: %lu", mask_id);
+		throw util::Error("requested mask_id is out of range: %" PRIiPTR, static_cast<intptr_t>(mask_id));
 	}
 	else {
 		return true;

--- a/cpp/terrain/terrain_chunk.cpp
+++ b/cpp/terrain/terrain_chunk.cpp
@@ -3,7 +3,7 @@
 #include "terrain_chunk.h"
 
 #include <cmath>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "terrain_object.h"
 #include "../engine.h"
@@ -33,9 +33,9 @@ TerrainChunk::TerrainChunk()
 		this->neighbors.neighbor[i] = nullptr;
 	}
 
-	log::dbg("created terrain chunk: %lu size, %lu tiles",
-	         chunk_size,
-	         this->tile_count);
+	log::dbg("created terrain chunk: %" PRIuPTR " size, %" PRIuPTR " tiles",
+	         static_cast<uintptr_t>(chunk_size),
+	         static_cast<uintptr_t>(this->tile_count));
 }
 
 TerrainChunk::~TerrainChunk() {

--- a/cpp/util/file.h
+++ b/cpp/util/file.h
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <cinttypes>
 
 #include "error.h"
 #include "dir.h"
@@ -57,8 +58,9 @@ std::vector<lineformat> read_csv_file(std::string fname) {
 			//use the line copy to fill the current line struct.
 			int error_column = current_line_data.fill(line_rw);
 			if (error_column != -1) {
-				throw Error("failed reading csv file %s in line %lu column %d: error parsing '%s'",
-				            fname.c_str(), line_count, error_column, line.c_str());
+				throw Error("failed reading csv file %s in line %" PRIuPTR " column %d: error parsing '%s'",
+				            fname.c_str(), static_cast<uintptr_t>(line_count), error_column,
+				            line.c_str());
 			}
 
 			delete[] line_rw;
@@ -90,8 +92,8 @@ std::vector<lineformat> recurse_data_files(Dir basedir, std::string fname) {
 		for (auto &entry : result) {
 			line_count += 1;
 			if (not entry.recurse(new_basedir)) {
-				throw Error("failed reading follow up files for %s in line %lu",
-				            merged_filename.c_str(), line_count);
+				throw Error("failed reading follow up files for %s in line %" PRIuPTR,
+				            merged_filename.c_str(), static_cast<uintptr_t>(line_count));
 			}
 		}
 	}

--- a/py/openage/convert/cabextract/lzxd/lzxd.cpp
+++ b/py/openage/convert/cabextract/lzxd/lzxd.cpp
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cinttypes>
 
 #include "util.h"
 
@@ -956,7 +957,7 @@ void LZXDStream::decompress(off_t out_bytes) {
 
 		// check that we've used all of the previous frame first
 		if (this->o_ptr != this->o_end) {
-			throwerr("%ld avail bytes, new %d frame", this->o_end - this->o_ptr, frame_size);
+			throwerr("%" PRIiPTR " avail bytes, new %d frame", this->o_end - this->o_ptr, frame_size);
 		}
 
 		// does this intel block _really_ need decoding?


### PR DESCRIPTION
- Change format specifiers to not make assumptions about integer and
  size_t sizes
- Change audio hash function to shift a different amount based on
  sizeof(size_t)
