### PR TITLE
Moving uneeded shared_ptrs to unique_ptr

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -38,6 +38,7 @@ _the openage authors_ are:
 | James Hagborg               | blucoat                     | jameshagborg@gmail.com           |
 | Prashanth Jonnala           | jprashanth                  | prashanth.neo@gmail.com          |
 | Jonathan Remnant            | Jon0                        | jono4728@gmail.com               |
+| Sam Schetterer              | schets                      | samschet@gmail.com               |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -393,7 +393,7 @@ bool GameMain::on_input(SDL_Event *e) {
 				obj->unit->delete_unit();
 			} else if ( this->available_objects.size() > 0 ) {
 				// try creating a unit
-				std::shared_ptr<UnitProducer> producer = this->available_objects[this->editor_current_building];
+				UnitProducer &producer = *this->available_objects[this->editor_current_building];
 				this->placed_units.new_unit(producer, terrain, mousepos_tile);
 			}
 			break;
@@ -599,9 +599,9 @@ bool GameMain::on_drawhud() {
 		coord::window bpreview_pos;
 		bpreview_pos.x = e.window_size.x - 200;
 		bpreview_pos.y = 200;
-		this->available_objects[this->editor_current_building]->default_texture()->draw(bpreview_pos.to_camhud());
+		auto txt = this->available_objects[this->editor_current_building].get()->default_texture();
+		txt->draw(bpreview_pos.to_camhud());
 	}
-
 	return true;
 }
 

--- a/cpp/game_main.h
+++ b/cpp/game_main.h
@@ -79,7 +79,7 @@ public:
 	/**
 	 * all available game objects.
 	 */
-	std::vector<std::shared_ptr<UnitProducer>> available_objects;
+	std::vector<std::unique_ptr<UnitProducer>> available_objects;
 
 	/**
 	 * all available sounds.

--- a/cpp/unit/ability.cpp
+++ b/cpp/unit/ability.cpp
@@ -1,6 +1,7 @@
 // Copyright 2014-2014 the openage authors. See copying.md for legal info.
 
 #include "../terrain/terrain_object.h"
+#include "../util/unique.h"
 #include "ability.h"
 #include "action.h"
 #include "unit.h"
@@ -21,13 +22,16 @@ bool MoveAbility::can_target(Unit *, Unit *) {
 	return false;
 }
 
-std::shared_ptr<UnitAction> MoveAbility::target(Unit *to_modify, coord::phys3 target) {
-	return std::make_shared<MoveAction>(to_modify, this->tex, this->sound, target);
+std::unique_ptr<UnitAction> MoveAbility::target(Unit *to_modify, coord::phys3 target) {
+	return util::make_unique<MoveAction>(to_modify, this->tex,
+	                                     this->sound, target);
 }
 
-std::shared_ptr<UnitAction> MoveAbility::target(Unit *to_modify, Unit *target) {
+std::unique_ptr<UnitAction> MoveAbility::target(Unit *to_modify, Unit *target) {
 	coord::phys_t radius = (path::path_grid_size * 2) + to_modify->location->min_axis() / 2;
-	return std::make_shared<MoveAction>(to_modify, this->tex, nullptr, target->get_ref(), radius);
+	return util::make_unique<MoveAction>(to_modify, this->tex,
+	                                     nullptr, target->get_ref(),
+	                                     radius);
 }
 
 GatherAbility::GatherAbility(Texture *t, TestSound *s)
@@ -44,12 +48,13 @@ bool GatherAbility::can_target(Unit *u1, Unit *target) {
 	return u1 != target;
 }
 
-std::shared_ptr<UnitAction> GatherAbility::target(Unit *, coord::phys3) {
+std::unique_ptr<UnitAction> GatherAbility::target(Unit *, coord::phys3) {
 	return nullptr;
 }
 
-std::shared_ptr<UnitAction> GatherAbility::target(Unit *to_modify, Unit *target) {
-	return std::make_shared<GatherAction>(to_modify, target->get_ref(), this->tex, this->sound);
+std::unique_ptr<UnitAction> GatherAbility::target(Unit *to_modify, Unit *target) {
+	return util::make_unique<GatherAction>(to_modify, target->get_ref(),
+	                                                this->tex, this->sound);
 }
 
 AttackAbility::AttackAbility(Texture *t, TestSound *s)
@@ -69,12 +74,13 @@ bool AttackAbility::can_target(Unit *u1, Unit *target) {
 	       target->get_attribute<attr_type::hitpoints>().current > 0;
 }
 
-std::shared_ptr<UnitAction> AttackAbility::target(Unit *, coord::phys3) {
+std::unique_ptr<UnitAction> AttackAbility::target(Unit *, coord::phys3) {
 	return nullptr;
 }
 
-std::shared_ptr<UnitAction> AttackAbility::target(Unit *to_modify, Unit *target) {
-	return std::make_shared<AttackAction>(to_modify, target->get_ref(), this->tex, this->sound);
+std::unique_ptr<UnitAction> AttackAbility::target(Unit *to_modify, Unit *target) {
+	return util::make_unique<AttackAction>(to_modify, target->get_ref(),
+	                                                 this->tex, this->sound);
 }
 
 } /* namespace openage */

--- a/cpp/unit/ability.h
+++ b/cpp/unit/ability.h
@@ -44,8 +44,8 @@ public:
 	virtual bool can_target(Unit *u1, coord::phys3 target) = 0;
 	virtual bool can_target(Unit *u1, Unit *target) = 0;
 
-	virtual std::shared_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target) = 0;
-	virtual std::shared_ptr<UnitAction> target(Unit *to_modify, Unit *target) = 0;
+	virtual std::unique_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target) = 0;
+	virtual std::unique_ptr<UnitAction> target(Unit *to_modify, Unit *target) = 0;
 };
 
 /*
@@ -62,8 +62,8 @@ public:
 	bool can_target(Unit *u1, coord::phys3 target);
 	bool can_target(Unit *u1, Unit *target);
 
-	std::shared_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target);
-	std::shared_ptr<UnitAction> target(Unit *to_modify, Unit *target);
+	std::unique_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target) override;
+	std::unique_ptr<UnitAction> target(Unit *to_modify, Unit *target) override;
 
 private:
 	Texture *tex;
@@ -84,8 +84,8 @@ public:
 	bool can_target(Unit *u1, coord::phys3 target);
 	bool can_target(Unit *u1, Unit *target);
 
-	std::shared_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target);
-	std::shared_ptr<UnitAction> target(Unit *to_modify, Unit *target);
+	std::unique_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target) override;
+	std::unique_ptr<UnitAction> target(Unit *to_modify, Unit *target) override;
 
 private:
 	Texture *tex;
@@ -106,8 +106,8 @@ public:
 	bool can_target(Unit *u1, coord::phys3 target);
 	bool can_target(Unit *u1, Unit *target);
 
-	std::shared_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target);
-	std::shared_ptr<UnitAction> target(Unit *to_modify, Unit *target);
+	std::unique_ptr<UnitAction> target(Unit *to_modify, coord::phys3 target) override;
+	std::unique_ptr<UnitAction> target(Unit *to_modify, Unit *target) override;
 
 private:
 	Texture *tex;

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+
 #include "../coord/tile.h"
 #include "../gamedata/gamedata.gen.h"
 #include "../gamedata/graphic.gen.h"
@@ -88,7 +89,8 @@ private:
  */
 class BuldingProducer: public UnitProducer {
 public:
-	BuldingProducer(Texture *tex, coord::tile_delta foundation_size, int foundation, TestSound *create,  TestSound *destroy);
+	BuldingProducer(Texture *tex, coord::tile_delta foundation_size,
+	                int foundation, TestSound *create,  TestSound *destroy);
 	virtual ~BuldingProducer();
 
 	/**
@@ -120,15 +122,15 @@ public:
 	/**
 	 * makes producers for all types in the game data
 	 */
-	std::vector<std::shared_ptr<UnitProducer>> create_producers(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id);
+	std::vector<std::unique_ptr<UnitProducer>> create_producers(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id);
 
 	/**
 	 * loads required assets to produce an entity type
 	 * returns null if type cannot be created
 	 */
-	std::shared_ptr<UnitProducer> load_building(const gamedata::unit_building &);
-	std::shared_ptr<UnitProducer> load_living(const gamedata::unit_living &);
-	std::shared_ptr<UnitProducer> load_object(const gamedata::unit_object &);
+	std::unique_ptr<UnitProducer> load_building(const gamedata::unit_building &);
+	std::unique_ptr<UnitProducer> load_living(const gamedata::unit_living &);
+	std::unique_ptr<UnitProducer> load_object(const gamedata::unit_object &);
 
 
 private:

--- a/cpp/unit/unit.h
+++ b/cpp/unit/unit.h
@@ -61,18 +61,18 @@ public:
 	 * this turns targeted objects into actions which are pushed
 	 * onto the stack, eg. targeting a relic may push a collect relic action
 	 */
-	void give_ability(std::shared_ptr<UnitAbility>);
+	void give_ability(std::unique_ptr<UnitAbility>);
 
 	/**
 	 * get ability with specified type, null if not available
 	 */
-	std::shared_ptr<UnitAbility> get_ability(ability_type type);
+	UnitAbility *get_ability(ability_type type);
 
 	/**
 	 * adds a new action on top of the action stack
 	 * will be performed immediately
 	 */
-	void push_action(std::shared_ptr<UnitAction>);
+	void push_action(std::unique_ptr<UnitAction>);
 
 	/**
 	 * give a new attribute this this unit
@@ -120,12 +120,12 @@ private:
 	 * ability available -- actions that this entity
 	 * can perform when controlled
 	 */
-	std::vector<std::shared_ptr<UnitAbility>> ability_available;
+	std::vector<std::unique_ptr<UnitAbility>> ability_available;
 
 	/**
 	 * action stack -- top action determines graphic to be drawn
 	 */
-	std::vector<std::shared_ptr<UnitAction>> action_stack;
+	std::vector<std::unique_ptr<UnitAction>> action_stack;
 
 	/**
 	 * Unit attributes include color, hitpoints, speed, objects garrisoned etc

--- a/cpp/unit/unit_container.h
+++ b/cpp/unit/unit_container.h
@@ -54,7 +54,7 @@ public:
 	/**
 	 * adds a new unit to the container
 	 */
-	bool new_unit(std::shared_ptr<UnitProducer> producer, Terrain *terrain, coord::tile tile);
+	bool new_unit(UnitProducer &producer, Terrain *terrain, coord::tile tile);
 
 	/**
 	 * give a command to a unit -- unit creation and deletion should be done as commands
@@ -73,7 +73,7 @@ private:
 	/**
 	 * mapping unit ids to unit objects
 	 */
-	std::unordered_map<id_t, Unit *> live_units;
+	std::unordered_map<id_t, std::unique_ptr<Unit>> live_units;
 
 };
 

--- a/cpp/util/unique.h
+++ b/cpp/util/unique.h
@@ -1,0 +1,73 @@
+// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+
+#ifndef OPENAGE_UTIL_UNIQUE_H_
+#define OPENAGE_UTIL_UNIQUE_H_
+
+#include <type_traits>
+#include <utility>
+#include <memory>
+
+namespace openage {
+namespace util {
+
+//essentially the implementation from libc++, clang
+
+namespace _unique_help {
+//make_unique is different for T, T[], and T[N] (ill formed for T[N])
+//These helper structs allow proper specializations
+
+template<class T>
+struct unique_rval {
+	using single_return = std::unique_ptr<T>;
+};
+
+template<class T>
+struct unique_rval<T[]> {
+	using multi_return = std::unique_ptr<T[]>;
+};
+
+//causes compile fail for fixed_type arrays
+//since result is unspecified by standard.
+template<class T, size_t N>
+struct unique_rval<T[N]> {
+	using known_bound = std::unique_ptr<T[N]>;
+	static_assert(N < 0, "make_unique does not work for fixed_size arrays");
+};
+
+} //namespace _unique_help
+
+/**
+ * Creates a unique_ptr pointing towards new T(Args...)
+ * Implementation of http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
+ * 
+ * @param Args The arguments forwarded to the constructor of T
+ */
+template<class T, class... Args>
+inline typename _unique_help::unique_rval<T>::single_return
+make_unique(Args&&... args) {
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+/**
+ * Creates a unique_ptr pointing towards a new T[n]
+ * Implementation of http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
+ * 
+ * @param n The size of the array being allocated
+ */
+template<class T>
+inline typename _unique_help::unique_rval<T>::multi_return
+make_unique(size_t n) {
+	using create_type = typename std::remove_extent<T>::type;
+	return std::unique_ptr<T>(new create_type[n]);
+}
+
+template<class T, class... Args>
+typename _unique_help::unique_rval<T>::known_bound
+make_unique(Args&&...) {
+	return std::unique_ptr<T>(nullptr);
+}
+
+} //namespace util
+} //namespace openage
+
+#endif


### PR DESCRIPTION
A lot of the objects that were using shared_ptrs actually had a sole owner and a well-defined lifetime, so I refactored them to be held in unique_ptrs.

This makes it easier to reason about the value's lifetime, as well as ensures that destruction is deterministic and has performance benefits.

The shared pointers being used in pathfinding are removed in #150
