### PR TITLE
Fixing memory leaks and unsafe attribute casting

### DIFF
--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -20,17 +20,23 @@
 
 namespace openage {
 
-TerrainObject::TerrainObject(Unit *u, std::function<bool(const coord::phys3 &)> pass)
+TerrainObject::TerrainObject(Unit *u, std::function<bool(const coord::phys3 &)> pass, std::shared_ptr<Texture> out_tex)
 	:
 	unit{u},
 	passable{pass},
 	placed{false},
 	terrain{nullptr},
-	occupied_chunk_count{0} {
-	unit->location = this; // ensure the unit points back
+	occupied_chunk_count{0},
+	outline_texture(out_tex) {
 }
 
-TerrainObject::~TerrainObject() {}
+TerrainObject::TerrainObject(Unit *u, std::function<bool(const coord::phys3 &)> pass)
+	:
+	TerrainObject(u, pass, nullptr) {
+}
+
+TerrainObject::~TerrainObject() {
+}
 
 bool TerrainObject::place(Terrain *terrain, coord::phys3 &position) {
 	if (this->placed) {
@@ -187,14 +193,11 @@ SquareObject::SquareObject(Unit *u, std::function<bool(const coord::phys3 &)> pa
 
 }
 
-SquareObject::SquareObject(Unit *u, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size, Texture *out_tex)
+SquareObject::SquareObject(Unit *u, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size, std::shared_ptr<Texture> out_tex)
 	:
-	TerrainObject(u, pass),
+	TerrainObject(u, pass, out_tex),
 	size(foundation_size) {
-	this->outline_texture = out_tex;
 }
-
-SquareObject::~SquareObject() {}
 
 tile_range SquareObject::get_range(const coord::phys3 &pos) const {
 	tile_range result;
@@ -270,14 +273,11 @@ RadialObject::RadialObject(Unit *u, std::function<bool(const coord::phys3 &)> pa
 
 }
 
-RadialObject::RadialObject(Unit *u, std::function<bool(const coord::phys3 &)> pass, float rad, Texture *out_tex)
+RadialObject::RadialObject(Unit *u, std::function<bool(const coord::phys3 &)> pass, float rad, std::shared_ptr<Texture> out_tex)
 	:
-	TerrainObject(u, pass),
+	TerrainObject(u, pass, out_tex),
 	phys_radius(coord::settings::phys_per_tile * rad) {
-	this->outline_texture = out_tex;
 }
-
-RadialObject::~RadialObject() {}
 
 tile_range RadialObject::get_range(const coord::phys3 &pos) const {
 	tile_range result;

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -63,6 +63,7 @@ constexpr coord::phys3_delta phys_half_tile = coord::phys3_delta{
 class TerrainObject {
 public:
 	TerrainObject(Unit *, std::function<bool(const coord::phys3 &)> pass);
+	TerrainObject(Unit *, std::function<bool(const coord::phys3 &)> pass, std::shared_ptr<Texture>(out_tex));
 	virtual ~TerrainObject();
 
 	/**
@@ -165,7 +166,7 @@ protected:
 	/**
 	 * texture for drawing outline
 	 */
-	Texture *outline_texture;
+	std::shared_ptr<Texture> outline_texture;
 
 	/**
 	 * placement function which does not check passibility
@@ -181,9 +182,7 @@ protected:
 class SquareObject: public TerrainObject {
 public:
 	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size);
-	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size, Texture *out_tex);
-	virtual ~SquareObject();
-
+	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size, std::shared_ptr<Texture> out_tex);
 
 	/**
 	 * tile size of this objects base
@@ -221,8 +220,7 @@ public:
 class RadialObject: public TerrainObject {
 public:
 	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass, float rad);
-	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass, float rad, Texture *out_tex);
-	virtual ~RadialObject();
+	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass, float rad, std::shared_ptr<Texture> out_tex);
 
 	/**
 	 * radius of this cirular space

--- a/cpp/terrain/terrain_outline.cpp
+++ b/cpp/terrain/terrain_outline.cpp
@@ -1,19 +1,19 @@
 // Copyright 2014-2014 the openage authors. See copying.md for legal info.
 
 #include <cmath>
-#include <math.h>
 
 #include "../texture.h"
+#include "../util/unique.h"
 #include "terrain_outline.h"
 
 namespace openage {
 
-Texture *square_outline(coord::tile_delta foundation_size) {
+std::unique_ptr<Texture> square_outline(coord::tile_delta foundation_size) {
 	int width = (foundation_size.ne + foundation_size.se) * 48;
 	int height = (foundation_size.ne + foundation_size.se) * 24;
-	int *image_data = new int[width * height];
-	for (int i = 0; i < width; ++i) {
-		for (int j = 0; j < height; ++j) {
+	std::vector<int> image_data(width*height);
+	for (int j = 0; j < height; ++j) {
+		for (int i = 0; i < width; ++i) {
 			float w_percent = (float) abs(i - (width / 2)) / (float) (width / 2);
 			float h_percent = (float) abs(j - (height / 2)) / (float) (height / 2);
 
@@ -25,12 +25,10 @@ Texture *square_outline(coord::tile_delta foundation_size) {
 		}
 	}
 
-	Texture *ret = new Texture(width, height, image_data);
-	delete[] image_data;
-	return ret;
+	return util::make_unique<Texture>(width, height, image_data.data());
 }
 
-Texture *radial_outline(float radius) {
+std::unique_ptr<Texture> radial_outline(float radius) {
 	// additional pixels around the edge
 	int border = 4;
 
@@ -39,10 +37,10 @@ Texture *radial_outline(float radius) {
 	int height = border + radius * 48 * 2;
 	int half_width = width / 2;
 	int half_height = height / 2;
-	int *image_data = new int[width*height];
+	std::vector<int> image_data(width*height);
 
-	for (int i = 0; i < width; ++i) {
-		for (int j = 0; j < height; ++j) {
+	for (int j = 0; j < height; ++j) {
+		for (int i = 0; i < width; ++i) {
 			float w_percent = (float) (border+i-half_width) / (float) (half_width-border);
 			float h_percent = (float) (border/2+j-half_height) / (float) (half_height-border/2);
 
@@ -54,9 +52,7 @@ Texture *radial_outline(float radius) {
 		}
 	}
 
-	Texture *ret = new Texture(width, height, image_data);
-	delete[] image_data;
-	return ret;
+	return util::make_unique<Texture>(width, height, image_data.data());
 }
 
 } // namespace openage

--- a/cpp/terrain/terrain_outline.h
+++ b/cpp/terrain/terrain_outline.h
@@ -3,6 +3,8 @@
 #ifndef OPENAGE_TERRAIN_TERRAIN_OUTLINE_H_
 #define OPENAGE_TERRAIN_TERRAIN_OUTLINE_H_
 
+#include <memory>
+
 #include "../coord/tile.h"
 
 namespace openage {
@@ -12,12 +14,12 @@ class Texture;
 /**
  * Generate a isometric square outline texture
  */
-Texture *square_outline(coord::tile_delta foundation_size);
+std::unique_ptr<Texture> square_outline(coord::tile_delta foundation_size);
 
 /**
  * Generate a isometric circle outline texture
  */
-Texture *radial_outline(float radius);
+std::unique_ptr<Texture> radial_outline(float radius);
 
 } // namespace openage
 

--- a/cpp/texture.h
+++ b/cpp/texture.h
@@ -107,7 +107,7 @@ public:
 
 private:
 	GLuint id, vertbuf;
-	std::vector<gamedata::subtexture>subtextures;
+	std::vector<gamedata::subtexture> subtextures;
 	size_t subtexture_count;
 	bool use_metafile;
 

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -222,7 +222,7 @@ coord::phys3 MoveAction::next_waypoint() const {
 
 void MoveAction::set_path() {
 	if (this->unit_target.is_valid()) {
-		this->path = path::to_object(this->entity->location, this->unit_target.get()->location);
+		this->path = path::to_object(this->entity->location.get(), this->unit_target.get()->location.get());
 	}
 	else {
 		coord::phys3 start = this->entity->location->pos.draw;
@@ -250,7 +250,7 @@ void GatherAction::update(unsigned int time) {
 	}
 
 	// set direction unit should face
-	TerrainObject *target_location = this->target.get()->location;
+	TerrainObject *target_location = this->target.get()->location.get();
 	if (this->entity->has_attribute(attr_type::direction)) {
 		auto &d_attr = this->entity->get_attribute<attr_type::direction>();
 		d_attr.unit_dir = target_location->pos.draw - this->entity->location->pos.draw;

--- a/cpp/unit/attribute.h
+++ b/cpp/unit/attribute.h
@@ -20,37 +20,29 @@ enum class attr_type {
 	dropsite
 };
 
-template<attr_type T> class Attribute;
 
 /**
  * wraps a templated attribute
  */
 class AttributeContainer {
 public:
-	AttributeContainer() {}
-
-	AttributeContainer(attr_type t)
-		:
-		type{t} {}
-
-	attr_type type;
+	virtual ~AttributeContainer() = 0;
 };
 
-using attr_map_t = std::map<attr_type, AttributeContainer *>;
-
-template<attr_type T> Attribute<T> get_attr(attr_map_t &map) {
-	return *reinterpret_cast<Attribute<T> *>(map[T]);
+inline AttributeContainer::~AttributeContainer(){
 }
 
 // -----------------------------
 // attribute definitions go here
 // -----------------------------
 
+template<attr_type T>
+class Attribute;
+
 template<> class Attribute<attr_type::color>: public AttributeContainer {
 public:
 	Attribute(uint c)
 		:
-		AttributeContainer{attr_type::color},
 		color{c} {}
 
 	uint color;
@@ -60,7 +52,6 @@ template<> class Attribute<attr_type::hitpoints>: public AttributeContainer {
 public:
 	Attribute(uint i, uint m)
 		:
-		AttributeContainer{attr_type::hitpoints},
 		current{i},
 		max{m} {}
 
@@ -72,7 +63,6 @@ template<> class Attribute<attr_type::speed>: public AttributeContainer {
 public:
 	Attribute(coord::phys_t sp)
 		:
-		AttributeContainer{attr_type::speed},
 		unit_speed{sp} {}
 
 	coord::phys_t unit_speed; // possibly use a pointer to account for tech upgrades
@@ -82,7 +72,6 @@ template<> class Attribute<attr_type::direction>: public AttributeContainer {
 public:
 	Attribute(coord::phys3_delta dir)
 		:
-		AttributeContainer{attr_type::direction},
 		unit_dir(dir) {}
 
 	coord::phys3_delta unit_dir;
@@ -90,10 +79,6 @@ public:
 
 template<> class Attribute<attr_type::dropsite>: public AttributeContainer {
 public:
-	Attribute()
-		:
-		AttributeContainer{attr_type::dropsite} {}
-
 	uint resource_type; // todo resource type enum
 };
 

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -24,13 +24,15 @@ class UnitAbility;
 class UnitAction;
 
 /**
- * Initializes a unit with the required attributes, each unit type should implement these funcrtions
+ * Initializes a unit with the required attributes, each unit type should implement these functions
  * initialise should be called on construction of units 'new Unit(some_unit_producer)'
  * place is called to customise how the unit gets added to the world -- used to setup the TerrainObject position
  */
 class UnitProducer {
 public:
-	virtual ~UnitProducer() {}
+	virtual ~UnitProducer();
+
+	UnitProducer(std::shared_ptr<Texture> outline);
 
 	/**
 	 * Initialize units attributes
@@ -46,6 +48,9 @@ public:
 	 * Get a default text for HUD drawing
 	 */
 	virtual Texture *default_texture() = 0;
+
+protected:
+	std::shared_ptr<Texture> terrain_outline;
 };
 
 /**
@@ -64,15 +69,12 @@ public:
 	             TestSound *,
 	             TestSound *);
 
-	virtual ~UnitTypeTest();
-
 	void initialise(Unit *);
 	bool place(Unit *, Terrain *, coord::tile);
 	Texture *default_texture();
 
 private:
 	const gamedata::unit_living unit_data;
-	Texture *terrain_outline;
 	Texture *dead;
 	Texture *idle;
 	Texture *moving;
@@ -87,11 +89,10 @@ private:
  * Stores graphics and attributes for a building type
  * Will be replaced with nyan system in future
  */
-class BuldingProducer: public UnitProducer {
+class BuildingProducer: public UnitProducer {
 public:
-	BuldingProducer(Texture *tex, coord::tile_delta foundation_size,
-	                int foundation, TestSound *create,  TestSound *destroy);
-	virtual ~BuldingProducer();
+	BuildingProducer(Texture *tex, coord::tile_delta foundation_size,
+	                 int foundation, TestSound *create,  TestSound *destroy);
 
 	/**
 	 * Sound id played when object is created or destroyed.
@@ -104,7 +105,6 @@ public:
 	Texture *default_texture();
 
 private:
-	Texture *terrain_outline;
 	Texture *texture;
 	coord::tile_delta size;
 	int foundation_terrain;

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -92,12 +92,8 @@ void Unit::push_action(std::unique_ptr<UnitAction> action) {
 	this->action_stack.push_back(std::move(action));
 }
 
-void Unit::add_attribute(AttributeContainer *attr) {
-	this->attribute_map.insert(attr_map_t::value_type(attr->type, attr));
-}
-
-bool Unit::has_attribute(attr_type type) {
-	return (this->attribute_map.count(type) > 0);
+bool Unit::has_attribute(attr_type type) const {
+	return this->attribute_map.count(type);
 }
 
 bool Unit::target(coord::phys3 target, ability_set type) {
@@ -132,7 +128,7 @@ void Unit::erase_interuptables() {
 	/*
 	 * discard all interruptible tasks
 	 */
-	auto position_it = std::find_if(
+	auto position_it = std::remove_if(
 		std::begin(this->action_stack),
 		std::end(this->action_stack),
 		[](std::unique_ptr<UnitAction> &e) {

--- a/cpp/util/unique.h
+++ b/cpp/util/unique.h
@@ -62,9 +62,39 @@ make_unique(size_t n) {
 }
 
 template<class T, class... Args>
-typename _unique_help::unique_rval<T>::known_bound
+inline typename _unique_help::unique_rval<T>::known_bound
 make_unique(Args&&...) {
 	return std::unique_ptr<T>(nullptr);
+}
+
+
+/**
+ * Changes the value of the passed unique_ptr<OldT>
+ * to be make_unique<NewT>(Args...), and destroys the old value
+ * OldT and Args are inferred, so one will generally call like
+ * set_unique<derived>(unique_ptr<base>, stuff)
+ *
+ * @param oldptr The unique_ptr<OldT> which will be made to point to
+ * new NewT(Args...)
+ * @param Args The arguments being passed to the constructer of NewT
+ */
+template<class NewT, class OldT, class... Args>
+inline void
+set_unique(std::unique_ptr<OldT>& oldptr, Args&&... args) {
+	std::unique_ptr<OldT> temp(make_unique<NewT>(std::forward<Args>(args)...));
+	oldptr.swap(temp);
+}
+
+/**
+ * Changes the value of the passed unique_ptr<T>
+ * to be equal make_unique<T>(Args...);
+ * @param oldptr The unique_ptr<T> being set to new T(Args)
+ * @param Args the arguments passed to the constructor of T
+ */
+template<class T, class... Args>
+inline void
+set_unique(std::unique_ptr<T>& oldptr, Args&&... args) {
+	set_unique<T, T, Args...>(oldptr, std::forward<Args>(args)...);
 }
 
 } //namespace util


### PR DESCRIPTION
There are some memory leaks in the unit texture outlines and locations, and unsafe operations with the attributes. This fixes the leaks and puts compile time restrictions on attribute typing