### PR TITLE
convert: fixes strings with garbage data past their \0 terminators

### DIFF
--- a/py/openage/convert/util.py
+++ b/py/openage/convert/util.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 the openage authors. See copying.md for legal info.
+# Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 import os
 import os.path
@@ -119,4 +119,8 @@ def zstr(data):
     terminates on end of string, or when \0 is reached.
     """
 
-    return data.decode("utf-8").rstrip("\x00")
+    end = data.find(0)
+    if end != -1:
+        data = data[0:end]
+
+    return data.decode("utf-8")


### PR DESCRIPTION
Real world case: empires2_x1.dat has a string `b'M\x00\xf8\x004"\xf8\x00\x00\x00\x00\x00\x00'` for one of the graphic `name1`s, which has a bunch of garbage after its terminator. `data.decode('utf-8')` trips up on this because `\xf8` is not a valid unicode char.

This patches `zstr` to truncate data to right before the first \0, or to keep it entirely if there is no \0, before utf8-decoding it.

Thanks to rkreis on #sfttech IRC for the report & patch hint :)