### PR TITLE
convert script updates and memory fixes

### DIFF
--- a/assets/shaders/alphamask.frag.glsl
+++ b/assets/shaders/alphamask.frag.glsl
@@ -1,25 +1,24 @@
 #version 120
 
-//alpha masking shader
+// alpha masking shader
 //
-//applies an alpha mask texture to a base texture,
-//then draws the masked texture.
+// applies an alpha mask texture to a base texture,
+// then draws the masked texture.
 
-//the base and mask texture, base is the plain terrain tile
+// the base and mask texture, base is the plain terrain tile
 uniform sampler2D base_texture;
 uniform sampler2D mask_texture;
 
-//disable blending and show the mask instead
+// disable blending and show the mask instead
 uniform bool show_mask;
 
-//get those interpolated texture position from vertexshader
+// get those interpolated texture position from vertexshader
 varying vec2 base_tex_position;
 varying vec2 mask_tex_position;
 
 
-void main()
-{
-	//get the texel from the uniform texture.
+void main() {
+	// get the texel from the uniform texture.
 	vec4 base_pixel = texture2D(base_texture, base_tex_position);
 	vec4 mask_pixel = texture2D(mask_texture, mask_tex_position);
 
@@ -27,8 +26,6 @@ void main()
 
 	vec4 blended_pixel = vec4(base_pixel.r, base_pixel.g, base_pixel.b, base_pixel.a - factor);
 
-	//force to pink
-	//blended_pixel = vec4(255.0/255.0, 20.0/255.0, 147.0/255.0, 1.0);
 	if (show_mask) {
 		gl_FragColor = mask_pixel;
 	} else {

--- a/assets/shaders/alphamask.vert.glsl
+++ b/assets/shaders/alphamask.vert.glsl
@@ -1,25 +1,25 @@
-//vertex shader for applying an alpha mask to a texture
+// vertex shader for applying an alpha mask to a texture
 #version 120
 
-//modelview*projection matrix
+// modelview*projection matrix
 uniform mat4 mvp_matrix;
 
-//the position of this vertex
+// the position of this vertex
 attribute vec4 vertex_position;
 
-//send the texture coordinates to the fragmentshader
+// send the texture coordinates to the fragmentshader
 attribute vec2 base_tex_coordinates;
 attribute vec2 mask_tex_coordinates;
 
-//send the texture coordinates to the fragmentshader
+// send the texture coordinates to the fragmentshader
 varying vec2 base_tex_position;
 varying vec2 mask_tex_position;
 
 void main(void) {
-	//transform the position with the mvp matrix
+	// transform the position with the mvp matrix
 	gl_Position = gl_ModelViewProjectionMatrix * vertex_position;
 
-	//set the fixpoints for the tex coordinates at this vertex
+	// set the fixpoints for the tex coordinates at this vertex
 	mask_tex_position = mask_tex_coordinates;
 	base_tex_position = base_tex_coordinates;
 }

--- a/copying.md
+++ b/copying.md
@@ -40,6 +40,7 @@ _the openage authors_ are:
 | Jonathan Remnant            | Jon0                        | jono4728@gmail.com               |
 | Sam Schetterer              | schets                      | samschet@gmail.com               |
 | Georg Kilzer                | leper                       | leper@wildfiregames.com          |
+| Florian Erler               | ethon                       | ethon@ethon.cc                   |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/cpp/assetmanager.h
+++ b/cpp/assetmanager.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_ASSETMANAGER_H_
 #define OPENAGE_ASSETMANAGER_H_
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <memory>
 
 #include "texture.h"
 
@@ -16,10 +17,9 @@ namespace openage {
  * Container class for all available assets.
  * Responsible for loading, providing and updating requested files.
  */
-class AssetManager {
+class AssetManager final {
 public:
 	AssetManager(util::Dir *root);
-	virtual ~AssetManager();
 
 	/**
 	 * Test whether a requested asset filename can be loaded.
@@ -46,7 +46,12 @@ protected:
 	/**
 	 * Create an internal texture handle.
 	 */
-	Texture *load_texture(const std::string &name);
+	std::shared_ptr<Texture> load_texture(const std::string &name);
+
+	/**
+	 * Retrieves the texture for missing textures.
+	 */
+	std::shared_ptr<Texture> get_missing_tex();
 
 private:
 	/**
@@ -57,12 +62,12 @@ private:
 	/**
 	 * The replacement texture for missing textures.
 	 */
-	Texture *missing_tex;
+	std::shared_ptr<Texture> missing_tex;
 
 	/**
 	 * Map from texture filename to texture instance ptr.
 	 */
-	std::unordered_map<std::string, Texture *> textures;
+	std::unordered_map<std::string, std::shared_ptr<Texture>> textures;
 
 #if WITH_INOTIFY
 	/**
@@ -74,7 +79,7 @@ private:
 	 * Map from inotify watch handle fd to texture instance ptr.
 	 * The kernel returns the handle fd when events are triggered.
 	 */
-	std::unordered_map<int, Texture *> watch_fds;
+	std::unordered_map<int, std::shared_ptr<Texture>> watch_fds;
 #endif
 };
 

--- a/cpp/engine.h
+++ b/cpp/engine.h
@@ -4,6 +4,7 @@
 #define OPENAGE_ENGINE_H_
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <SDL2/SDL.h>
@@ -36,7 +37,6 @@ class GameMain;
  * central foundation for everything the openage engine is capable of.
  */
 class Engine : public ResizeHandler {
-	friend class GameMain;
 private:
 	/**
 	 * global engine singleton instance.
@@ -184,6 +184,11 @@ public:
 	unsigned int lastframe_msec();
 
 	/**
+	 * render text with the at a position with specified font size
+	 */
+	void render_text(coord::window position, size_t size, const char *format, ...);
+
+	/**
 	 * current engine state variable.
 	 * to be set to false to stop the engine loop.
 	 */
@@ -293,13 +298,10 @@ private:
 	job::JobManager *job_manager;
 
 	/**
-	 * the text font to be used for (can you believe it?) texts.
-	 * dejavu serif, book, 20pts
+	 * the text fonts to be used for (can you believe it?) texts.
+	 * maps fontsize -> font
 	 */
-	std::unique_ptr<Font> dejavuserif20;
-
-	/** smaller font, used for... you guessed it. smaller texts. */
-	std::unique_ptr<Font> dejavuserif12;
+	std::unordered_map<int, std::unique_ptr<Font>> fonts;
 
 	/**
 	 * SDL window where everything is displayed within.
@@ -313,6 +315,6 @@ private:
 	SDL_GLContext glcontext;
 };
 
-} //namespace openage
+} // namespace openage
 
 #endif

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -1,19 +1,19 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "game_main.h"
 
 #include <SDL2/SDL.h>
-#include "crossplatform/opengl.h"
+#include <cinttypes>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <cinttypes>
 
 #include "args.h"
 #include "audio/sound.h"
 #include "callbacks.h"
 #include "console/console.h"
 #include "coord/vec2f.h"
+#include "crossplatform/opengl.h"
 #include "engine.h"
 #include "gamedata/string_resource.gen.h"
 #include "log.h"
@@ -605,26 +605,25 @@ bool GameMain::on_drawhud() {
 	return true;
 }
 
-Texture *GameMain::find_graphic(int16_t graphic_id) {
-	if (graphic_id <= 0 || this->graphics.count(graphic_id) == 0) {
-		log::msg("  -> ignoring graphics_id: %d", graphic_id);
+Texture *GameMain::find_graphic(int graphic_id) {
+	auto tex_it = this->graphics.find(graphic_id);
+	if (tex_it == this->graphics.end()) {
+		log::msg("  -> ignoring graphics_id: %zd", graphic_id);
 		return nullptr;
 	}
 
-	int slp_id = this->graphics[graphic_id]->slp_id;
+	int slp_id = tex_it->second->slp_id;
 	if (slp_id <= 0) {
 		log::msg("  -> ignoring slp_id: %d", slp_id);
 		return nullptr;
 	}
 
 	log::msg("   slp id/name: %d %s", slp_id, this->graphics[graphic_id]->name0.c_str());
-	char *tex_fname = util::format("converted/Data/graphics.drs/%d.slp.png", slp_id);
-	Texture *tex = this->assetmanager.get_texture(tex_fname);
-	delete[] tex_fname;
-	return tex;
+	std::string tex_fname = util::sformat("converted/Data/graphics.drs/%d.slp.png", slp_id);
+	return this->assetmanager.get_texture(tex_fname);
 }
 
-TestSound *GameMain::find_sound(int16_t sound_id) {
+TestSound *GameMain::find_sound(int sound_id) {
 	return &this->available_sounds[sound_id];
 }
 

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -571,7 +571,7 @@ bool GameMain::on_draw() {
 	Engine &engine = Engine::get();
 
 	// draw gaben, our great and holy protector, bringer of the half-life 3.
-	gaben->draw(coord::camgame {0, 0});
+	gaben->draw(coord::camgame{0, 0});
 
 	// draw terrain
 	terrain->draw(&engine);
@@ -582,7 +582,7 @@ bool GameMain::on_draw() {
 
 	if (not gamedata_loaded) {
 		// Show that gamedata is still loading
-		engine.dejavuserif20->render(0, 0, "Loading gamedata...");
+		engine.render_text({0, 0}, 20, "Loading gamedata...");
 	}
 
 	return true;

--- a/cpp/game_main.h
+++ b/cpp/game_main.h
@@ -1,9 +1,8 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_GAME_MAIN_H_
 #define OPENAGE_GAME_MAIN_H_
 
-#include <memory>
 #include <SDL2/SDL.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -73,8 +72,15 @@ public:
 	virtual bool on_drawhud();
 	virtual bool on_input(SDL_Event *e);
 
-	Texture *find_graphic(int16_t graphic_id);
-	TestSound *find_sound(int16_t sound_id);
+	/**
+	 * return a texture handle associated with the given graphic id.
+	 */
+	Texture *find_graphic(int graphic_id);
+
+	/**
+	 * return a testsound ptr for a given sound id.
+	 */
+	TestSound *find_sound(int sound_id);
 
 	/**
 	 * all available game objects.
@@ -90,7 +96,6 @@ public:
 	 * map graphic id to gamedata graphic.
 	 */
 	std::unordered_map<int, gamedata::graphic *> graphics;
-
 
 	/**
 	 * all the buildings that have been placed.

--- a/cpp/input.cpp
+++ b/cpp/input.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #include "input.h"
 
@@ -45,13 +45,13 @@ bool CoreInputHandler::on_input(SDL_Event *event) {
 		break;
 
 	case SDL_KEYUP: {
-		SDL_Keycode sym = ((SDL_KeyboardEvent *) event)->keysym.sym;
+		SDL_Keycode sym = reinterpret_cast<SDL_KeyboardEvent *>(event)->keysym.sym;
 		this->key_states[sym] = false;
 	}
 		break;
 
 	case SDL_KEYDOWN: {
-		SDL_Keycode sym = ((SDL_KeyboardEvent *) event)->keysym.sym;
+		SDL_Keycode sym = reinterpret_cast<SDL_KeyboardEvent *>(event)->keysym.sym;
 		this->key_states[sym] = true;
 	}
 		break;

--- a/cpp/terrain/terrain.h
+++ b/cpp/terrain/terrain.h
@@ -1,9 +1,10 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_TERRAIN_TERRAIN_H_
 #define OPENAGE_TERRAIN_TERRAIN_H_
 
 #include <functional>
+#include <memory>
 #include <stddef.h>
 #include <set>
 #include <unordered_map>
@@ -318,7 +319,8 @@ public:
 	 *
 	 * @returns a drawing instruction struct that contains all information for rendering
 	 */
-	struct terrain_render_data create_draw_advice(coord::tile ab, coord::tile cd, coord::tile ef, coord::tile gh);
+	struct terrain_render_data create_draw_advice(coord::tile ab, coord::tile cd,
+	                                              coord::tile ef, coord::tile gh);
 
 	/**
 	 * create rendering and blending information for a single tile on the terrain.
@@ -332,7 +334,9 @@ public:
 	 * @param neigh_tiles: the destination buffer where the neighbors will be stored
 	 * @param influences_by_terrain_id: influence buffer that is reset in the same step
 	 */
-	void get_neighbors(coord::tile basepos, struct neighbor_tile *neigh_tiles, struct influence *influences_by_terrain_id);
+	void get_neighbors(coord::tile basepos,
+	                   struct neighbor_tile *neigh_tiles,
+	                   struct influence *influences_by_terrain_id);
 
 	/**
 	 * look at neighbor tiles around the base_tile, and store the influence bits.
@@ -342,7 +346,9 @@ public:
 	 * @param influences_by_terrain_id: influences will be stored to this buffer, as bitmasks
 	 * @returns an influence group that describes the maximum 8 possible influences on the base_tile
 	 */
-	struct influence_group calculate_influences(struct tile_data *base_tile, struct neighbor_tile *neigh_tiles, struct influence *influences_by_terrain_id);
+	struct influence_group calculate_influences(struct tile_data *base_tile,
+	                                            struct neighbor_tile *neigh_tiles,
+	                                            struct influence *influences_by_terrain_id);
 
 	/**
 	 * calculate blending masks for a given tile position.
@@ -353,7 +359,9 @@ public:
 	 *
 	 * @see calculate_influences
 	 */
-	void calculate_masks(coord::tile position, struct tile_draw_data *tile_data, struct influence_group *influences);
+	void calculate_masks(coord::tile position,
+	                     struct tile_draw_data *tile_data,
+	                     struct influence_group *influences);
 
 	size_t terrain_id_count;
 	size_t blendmode_count;
@@ -364,13 +372,13 @@ private:
 	 */
 	std::unordered_map<coord::chunk, TerrainChunk *, coord_chunk_hash> chunks;
 
-	Texture **textures;
-	Texture **blending_masks;
+	std::vector<Texture *> textures;
+	std::vector<Texture *> blending_masks;
 
-	int *terrain_id_priority_map;
-	int *terrain_id_blendmode_map;
+	std::unique_ptr<int[]> terrain_id_priority_map;
+	std::unique_ptr<int[]> terrain_id_blendmode_map;
 
-	struct influence *influences_buf;
+	std::unique_ptr<influence[]> influences_buf;
 };
 
 } // namespace openage

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_TERRAIN_TERRAIN_OBJECT_H_
 #define OPENAGE_TERRAIN_TERRAIN_OBJECT_H_
@@ -45,8 +45,10 @@ std::vector<coord::tile> tile_list(const tile_range &rng);
  * half a tile
  */
 constexpr coord::phys3_delta phys_half_tile = coord::phys3_delta{
-		coord::settings::phys_per_tile / 2, 
-		coord::settings::phys_per_tile / 2, 0};
+	coord::settings::phys_per_tile / 2,
+	coord::settings::phys_per_tile / 2,
+	0
+};
 
 /**
  * Base class for map location types which include square tile aligned
@@ -62,7 +64,9 @@ constexpr coord::phys3_delta phys_half_tile = coord::phys3_delta{
  */
 class TerrainObject {
 public:
-	TerrainObject(Unit *, std::function<bool(const coord::phys3 &)> pass);
+	TerrainObject(Unit *,
+	              std::function<bool(const coord::phys3 &)> pass,
+	              std::shared_ptr<Texture> outline_tex);
 	virtual ~TerrainObject();
 
 	/**
@@ -165,7 +169,7 @@ protected:
 	/**
 	 * texture for drawing outline
 	 */
-	Texture *outline_texture;
+	std::shared_ptr<Texture> outline_texture;
 
 	/**
 	 * placement function which does not check passibility
@@ -180,8 +184,10 @@ protected:
  */
 class SquareObject: public TerrainObject {
 public:
-	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size);
-	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass, coord::tile_delta foundation_size, Texture *out_tex);
+	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass,
+	             coord::tile_delta foundation_size);
+	SquareObject(Unit *, std::function<bool(const coord::phys3 &)> pass,
+	             coord::tile_delta foundation_size, std::shared_ptr<Texture> out_tex);
 	virtual ~SquareObject();
 
 
@@ -220,8 +226,10 @@ public:
  */
 class RadialObject: public TerrainObject {
 public:
-	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass, float rad);
-	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass, float rad, Texture *out_tex);
+	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass,
+	             float rad);
+	RadialObject(Unit *, std::function<bool(const coord::phys3 &)> pass,
+	             float rad, std::shared_ptr<Texture> out_tex);
 	virtual ~RadialObject();
 
 	/**

--- a/cpp/terrain/terrain_outline.cpp
+++ b/cpp/terrain/terrain_outline.cpp
@@ -14,7 +14,7 @@ std::shared_ptr<Texture> square_outline(coord::tile_delta foundation_size) {
 	int width = (foundation_size.ne + foundation_size.se) * 48;
 	int height = (foundation_size.ne + foundation_size.se) * 24;
 
-	auto image_data = util::make_unique<int[]>(width * height);
+	auto image_data = util::make_unique<uint32_t[]>(width * height);
 	for (int i = 0; i < width; ++i) {
 		for (int j = 0; j < height; ++j) {
 			float w_percent = (float) abs(i - (width / 2)) / (float) (width / 2);
@@ -28,7 +28,7 @@ std::shared_ptr<Texture> square_outline(coord::tile_delta foundation_size) {
 		}
 	}
 
-	return std::make_shared<Texture>(width, height, image_data.get());
+	return std::make_shared<Texture>(width, height, std::move(image_data));
 }
 
 std::shared_ptr<Texture> radial_outline(float radius) {
@@ -41,7 +41,7 @@ std::shared_ptr<Texture> radial_outline(float radius) {
 	int half_width = width / 2;
 	int half_height = height / 2;
 
-	auto image_data = util::make_unique<int[]>(width * height);
+	auto image_data = util::make_unique<uint32_t[]>(width * height);
 
 	for (int i = 0; i < width; ++i) {
 		for (int j = 0; j < height; ++j) {
@@ -56,7 +56,7 @@ std::shared_ptr<Texture> radial_outline(float radius) {
 		}
 	}
 
-	return std::make_shared<Texture>(width, height, image_data.get());
+	return std::make_shared<Texture>(width, height, std::move(image_data));
 }
 
 } // namespace openage

--- a/cpp/terrain/terrain_outline.cpp
+++ b/cpp/terrain/terrain_outline.cpp
@@ -1,17 +1,20 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include <cmath>
 #include <math.h>
+#include <memory>
 
 #include "../texture.h"
+#include "../util/unique.h"
 #include "terrain_outline.h"
 
 namespace openage {
 
-Texture *square_outline(coord::tile_delta foundation_size) {
+std::shared_ptr<Texture> square_outline(coord::tile_delta foundation_size) {
 	int width = (foundation_size.ne + foundation_size.se) * 48;
 	int height = (foundation_size.ne + foundation_size.se) * 24;
-	int *image_data = new int[width * height];
+
+	auto image_data = util::make_unique<int[]>(width * height);
 	for (int i = 0; i < width; ++i) {
 		for (int j = 0; j < height; ++j) {
 			float w_percent = (float) abs(i - (width / 2)) / (float) (width / 2);
@@ -25,12 +28,10 @@ Texture *square_outline(coord::tile_delta foundation_size) {
 		}
 	}
 
-	Texture *ret = new Texture(width, height, image_data);
-	delete[] image_data;
-	return ret;
+	return std::make_shared<Texture>(width, height, image_data.get());
 }
 
-Texture *radial_outline(float radius) {
+std::shared_ptr<Texture> radial_outline(float radius) {
 	// additional pixels around the edge
 	int border = 4;
 
@@ -39,7 +40,8 @@ Texture *radial_outline(float radius) {
 	int height = border + radius * 48 * 2;
 	int half_width = width / 2;
 	int half_height = height / 2;
-	int *image_data = new int[width*height];
+
+	auto image_data = util::make_unique<int[]>(width * height);
 
 	for (int i = 0; i < width; ++i) {
 		for (int j = 0; j < height; ++j) {
@@ -54,9 +56,7 @@ Texture *radial_outline(float radius) {
 		}
 	}
 
-	Texture *ret = new Texture(width, height, image_data);
-	delete[] image_data;
-	return ret;
+	return std::make_shared<Texture>(width, height, image_data.get());
 }
 
 } // namespace openage

--- a/cpp/terrain/terrain_outline.h
+++ b/cpp/terrain/terrain_outline.h
@@ -1,7 +1,9 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_TERRAIN_TERRAIN_OUTLINE_H_
 #define OPENAGE_TERRAIN_TERRAIN_OUTLINE_H_
+
+#include <memory>
 
 #include "../coord/tile.h"
 
@@ -12,12 +14,12 @@ class Texture;
 /**
  * Generate a isometric square outline texture
  */
-Texture *square_outline(coord::tile_delta foundation_size);
+std::shared_ptr<Texture> square_outline(coord::tile_delta foundation_size);
 
 /**
  * Generate a isometric circle outline texture
  */
-Texture *radial_outline(float radius);
+std::shared_ptr<Texture> radial_outline(float radius);
 
 } // namespace openage
 

--- a/cpp/texture.cpp
+++ b/cpp/texture.cpp
@@ -34,7 +34,7 @@ shader::Program *program;
 GLint base_texture, mask_texture, base_coord, mask_coord, show_mask;
 }
 
-Texture::Texture(int width, int height, void *data)
+Texture::Texture(int width, int height, std::unique_ptr<uint32_t[]> data)
 	:
 	use_metafile{false} {
 
@@ -42,12 +42,12 @@ Texture::Texture(int width, int height, void *data)
 
 	this->w = width;
 	this->h = height;
-	this->id = make_gl_texture(
+	this->id = this->make_gl_texture(
 		GL_RGBA8,
 		GL_RGBA,
 		width,
 		height,
-		data
+		data.get()
 	);
 
 	gamedata::subtexture s{0, 0, this->w, this->h, this->w/2, this->h/2};
@@ -96,7 +96,7 @@ void Texture::load() {
 
 	this->w = surface->w;
 	this->h = surface->h;
-	this->id = make_gl_texture(
+	this->id = this->make_gl_texture(
 		texture_format_in,
 		texture_format_out,
 		surface->w,

--- a/cpp/texture.cpp
+++ b/cpp/texture.cpp
@@ -1,12 +1,13 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #include "texture.h"
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 
-#include <math.h>
-#include <stdio.h>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
 
 #include "log.h"
 #include "util/error.h"
@@ -36,6 +37,9 @@ GLint base_texture, mask_texture, base_coord, mask_coord, show_mask;
 Texture::Texture(int width, int height, void *data)
 	:
 	use_metafile{false} {
+
+	assert(glGenBuffers != nullptr && "gl not initialized properly");
+
 	this->w = width;
 	this->h = height;
 	this->id = make_gl_texture(

--- a/cpp/texture.h
+++ b/cpp/texture.h
@@ -1,10 +1,11 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_TEXTURE_H_
 #define OPENAGE_TEXTURE_H_
 
 #include "crossplatform/opengl.h"
 #include <vector>
+#include <memory>
 
 #include "gamedata/texture.gen.h"
 #include "coord/camgame.h"
@@ -20,18 +21,18 @@ namespace openage {
 namespace texture_shader {
 extern shader::Program *program;
 extern GLint texture, tex_coord;
-} //namespace texture_shader
+} // namespace texture_shader
 
 namespace teamcolor_shader {
 extern shader::Program *program;
 extern GLint texture, tex_coord;
 extern GLint player_id_var, alpha_marker_var, player_color_var;
-} //namespace teamcolor_shader
+} // namespace teamcolor_shader
 
 namespace alphamask_shader {
 extern shader::Program *program;
 extern GLint base_texture, mask_texture, base_coord, mask_coord, show_mask;
-} //namespace alphamask_shader
+} // namespace alphamask_shader
 
 // bitmasks for shader modes
 constexpr int PLAYERCOLORED = 1 << 0;
@@ -39,7 +40,7 @@ constexpr int ALPHAMASKED   = 1 << 1;
 
 
 /**
- * a texture for rendering graphically.
+ * A texture for rendering graphically.
  *
  * You may believe it or not, but this class represents a single texture,
  * which can be drawn on the screen.
@@ -58,8 +59,8 @@ public:
 	 */
 	size_t atlas_dimensions;
 
-	Texture(int width, int height, void *data); // single frame rgba8 texture
 	Texture(const std::string &filename, bool use_metafile = false);
+	Texture(int width, int height, std::unique_ptr<uint32_t[]> data);
 	~Texture();
 
 	void draw(coord::camhud pos, unsigned int mode = 0, bool mirrored = false, int subid = 0, unsigned player = 0) const;

--- a/cpp/texture.h
+++ b/cpp/texture.h
@@ -59,19 +59,45 @@ public:
 	 */
 	size_t atlas_dimensions;
 
-	Texture(const std::string &filename, bool use_metafile = false);
+	/**
+	 * Create a texture from a rgba8 array.
+	 * It will have w * h * 32bit storage.
+	 */
 	Texture(int width, int height, std::unique_ptr<uint32_t[]> data);
+
+	/**
+	 * Create a texture from a existing image file.
+	 * For supported image file types, see the SDL_Image initialization in the engine.
+	 */
+	Texture(const std::string &filename, bool use_metafile=false);
 	~Texture();
 
-	void draw(coord::camhud pos, unsigned int mode = 0, bool mirrored = false, int subid = 0, unsigned player = 0) const;
-	void draw(coord::camgame pos, unsigned int mode = 0, bool mirrored = false, int subid = 0, unsigned player = 0) const;
-	void draw(coord::tile pos, unsigned int mode, int subid, Texture *alpha_texture = nullptr, int alpha_subid = -1) const;
+	void draw(coord::camhud pos, unsigned int mode=0, bool mirrored=false, int subid=0, unsigned player=0) const;
+	void draw(coord::camgame pos, unsigned int mode=0, bool mirrored=false, int subid=0, unsigned player=0) const;
+	void draw(coord::tile pos, unsigned int mode, int subid, Texture *alpha_texture=nullptr, int alpha_subid=-1) const;
 	void draw(coord::pixel_t x, coord::pixel_t y, unsigned int mode, bool mirrored, int subid, unsigned player, Texture *alpha_texture, int alpha_subid) const;
 
+	/**
+	 * Reload the image file. Used for inotify refreshing.
+	 */
 	void reload();
 
-	const struct gamedata::subtexture *get_subtexture(int subid) const;
+	/**
+	 * Get the subtexture coordinates by its idea.
+	 */
+	const gamedata::subtexture *get_subtexture(int subid) const;
+
+	/**
+	 * @return the number of available subtextures
+	 */
 	int get_subtexture_count() const;
+
+	/**
+	 * Fetch the size of the given subtexture.
+	 * @param subid: index of the requested subtexture
+	 * @param w: the subtexture width
+	 * @param h: the subtexture height
+	 */
 	void get_subtexture_size(int subid, int *w, int *h) const;
 
 	/**
@@ -85,25 +111,25 @@ public:
 	void get_subtexture_coordinates(const gamedata::subtexture *subtex, float *txl, float *txr, float *txt, float *txb) const;
 
 	/**
-	fixes the hotspots of all subtextures to (x,y).
-	this is a temporary workaround; such fixes should actually be done in the
-	convert script.
-	*/
+	 * fixes the hotspots of all subtextures to (x,y).
+	 * this is a temporary workaround; such fixes should actually be done in the
+	 * convert script.
+	 */
 	void fix_hotspots(unsigned x, unsigned y);
 
 	/**
-	activates the influence of a given alpha mask to this texture.
-	*/
+	 * activates the influence of a given alpha mask to this texture.
+	 */
 	void activate_alphamask(Texture *mask, int subid);
 
 	/**
-	disable a previously activated alpha mask.
-	*/
+	 * disable a previously activated alpha mask.
+	 */
 	void disable_alphamask();
 
 	/**
-	returns the opengl texture id of this texture.
-	*/
+	 * returns the opengl texture id of this texture.
+	 */
 	GLuint get_texture_id() const;
 
 private:
@@ -119,6 +145,6 @@ private:
 	void unload();
 };
 
-} //namespace openage
+} // namespace openage
 
 #endif

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_UNIT_PRODUCER_H_
 #define OPENAGE_UNIT_PRODUCER_H_
@@ -55,14 +55,14 @@ public:
 class UnitTypeTest: public UnitProducer {
 public:
 	UnitTypeTest(const gamedata::unit_living *,
-	             Texture *,
-	             Texture *,
-	             Texture *,
-	             Texture *,
-	             TestSound *,
-	             TestSound *,
-	             TestSound *,
-	             TestSound *);
+	             Texture *deadt,
+	             Texture *idlet,
+	             Texture *movet,
+	             Texture *attackt,
+	             TestSound *on_create,
+	             TestSound *on_destroy,
+	             TestSound *on_move,
+	             TestSound *on_attack);
 
 	virtual ~UnitTypeTest();
 
@@ -72,7 +72,7 @@ public:
 
 private:
 	const gamedata::unit_living unit_data;
-	Texture *terrain_outline;
+	std::shared_ptr<Texture> terrain_outline;
 	Texture *dead;
 	Texture *idle;
 	Texture *moving;
@@ -104,7 +104,7 @@ public:
 	Texture *default_texture();
 
 private:
-	Texture *terrain_outline;
+	std::shared_ptr<Texture> terrain_outline;
 	Texture *texture;
 	coord::tile_delta size;
 	int foundation_terrain;

--- a/cpp/util/strings.cpp
+++ b/cpp/util/strings.cpp
@@ -1,10 +1,12 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #include "strings.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace openage {
@@ -33,6 +35,21 @@ char *vformat(const char *fmt, va_list ap) {
 	vsnprintf(result, sz, fmt, ap);
 
 	return result;
+}
+
+std::string sformat(const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	std::string ret = vsformat(fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+std::string vsformat(const char *fmt, va_list ap) {
+	std::unique_ptr<char> str{vformat(fmt, ap)};
+	std::string ret{str.get()};
+	return ret;
 }
 
 char *copy(const char *s) {

--- a/cpp/util/strings.h
+++ b/cpp/util/strings.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_UTIL_STRINGS_H_
 #define OPENAGE_UTIL_STRINGS_H_
@@ -6,6 +6,7 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <functional>
+#include <string>
 
 namespace openage {
 namespace util {
@@ -21,6 +22,16 @@ char *format(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
  * same as format, but takes a va_list instead of ...
  */
 char *vformat(const char *fmt, va_list ap);
+
+/**
+ * formats fmt to a std::string
+ */
+std::string sformat(const char *fmt, ...);
+
+/**
+ * same as sformat, but takes va_list instead of ...
+ */
+std::string vsformat(const char *fmt, va_list ap);
 
 /**
  * makes a copy of the string (up to and including the first null byte).

--- a/cpp/util/unique.h
+++ b/cpp/util/unique.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_UTIL_UNIQUE_H_
 #define OPENAGE_UTIL_UNIQUE_H_
@@ -39,7 +39,7 @@ struct unique_rval<T[N]> {
 /**
  * Creates a unique_ptr pointing towards new T(Args...)
  * Implementation of http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
- * 
+ *
  * @param Args The arguments forwarded to the constructor of T
  */
 template<class T, class... Args>
@@ -51,7 +51,7 @@ make_unique(Args&&... args) {
 /**
  * Creates a unique_ptr pointing towards a new T[n]
  * Implementation of http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
- * 
+ *
  * @param n The size of the array being allocated
  */
 template<class T>

--- a/doc/ai/interface.md
+++ b/doc/ai/interface.md
@@ -1,7 +1,8 @@
 AI Interface
 ============
 
-This is a very early draft with some ideas taken from http://bwmirror.jurenka.sk/javadoc/bwapi/package-summary.html
+This is a very early draft with some ideas taken
+from http://bwmirror.jurenka.sk/javadoc/bwapi/package-summary.html
 
 This file shall provide information about the AI interface design.
 
@@ -12,6 +13,7 @@ General ideas
  * An AI registers hooks for desired events
  * The C++ engine triggers python AI functions when desired events occur
  * The AI then can trigger actions on the controllable units
+ * Periodically (1 Hz?), the AI gets ticked to allow event independent decisions
 
 
 Event types
@@ -24,63 +26,68 @@ Python interface basic events:
  * on_end(Player winner)
 
 Some AIs may prefer an event driven approach (rule based AI):
+
  * on_unit_discover(Unit unit)
  * on_unit_complete(Unit unit)
  * on_unit_lost(Unit unit)
  * many more...
 
 
-Some AIs will need to simulate ticks into the future to help make decisions for the current tick. (min-max, MCTS, etc.)
+Some AIs will need to simulate ticks into the future to help
+make decisions for the current tick. (min-max, MCTS, etc.)
 
 
 Relevant structures for the AI
 ------------------------------
 
+Remember: These are just some ideas for possible interfaces,
+they are not existant in the game yet.
+
 ```cpp
-    struct game_info {
-        int num_players;
-        int map_size;
-        int pop_limit;
-        resources_type;
-        map_view;
-        starting_age;
-        victory_mode;
-    }
+struct game_info {
+	int num_players;
+	int map_size;
+	int pop_limit;
+	resources_type;
+	map_view;
+	starting_age;
+	victory_mode;
+}
 ```
 
 ```cpp
-    class Game {
-        Player[] allies();      // all the ally players that have not left or been defeated.
-        bool     canBuildHere(Unit builder, TilePosition position, UnitType type);
-        bool     canMake(Unit builder, UnitType type);
-        bool     canResearch(Unit unit, TechType type);
-        bool     canUpgrade(Unit unit, UpgradeType type);
-        Player[] enemies();     // all the enemy players that have not left or been defeated.
-        Unit[]   getAllUnits(); // returns all the visible units.
+class Game {
+	Player[] allies();      // all the ally players that have not left or been defeated.
+	bool     canBuildHere(Unit builder, TilePosition position, UnitType type);
+	bool     canMake(Unit builder, UnitType type);
+	bool     canResearch(Unit unit, TechType type);
+	bool     canUpgrade(Unit unit, UpgradeType type);
+	Player[] enemies();     // all the enemy players that have not left or been defeated.
+	Unit[]   getAllUnits(); // returns all the visible units.
 
-        // many more examples at: http://bwmirror.jurenka.sk/javadoc/bwapi/Game.html
-    }
+	// many more examples at: http://bwmirror.jurenka.sk/javadoc/bwapi/Game.html
+}
 ```
 
 ```cpp
-    class Player {
-        string getName();   // returns the name of the player.
-        Race   getRace();   // returns the race of the player.
-        Unit[] getUnits();  // returns the set of units the player own.
-        bool   hasResearched(TechType tech);
-        int    getWood()    // Returns the ammount of wood the player owns.
-        // many more...
-    }
+class Player {
+	string getName();   // returns the name of the player.
+	Race   getRace();   // returns the race of the player.
+	Unit[] getUnits();  // returns the set of units the player own.
+	bool   hasResearched(TechType tech);
+	int    getWood()    // Returns the ammount of wood the player owns.
+	// many more...
+}
 ```
 
 ```cpp
-    class Unit {
-        // used to get information about individual units as well as issue orders to units
-    }
+class Unit {
+	// used to get information about individual units as well as issue orders to units
+}
 ```
 
 ```cpp
-    class Calculation {
-        // used to get computation heavy calculations from the C++ engine
-    }
+class Calculation {
+	// used to get computation heavy calculations from the C++ engine
+}
 ```

--- a/doc/code_style/mom.cpp
+++ b/doc/code_style/mom.cpp
@@ -1,68 +1,57 @@
 #include "mom.h"
 
+#include <cmath>
 #include <cstdio>
 #include <SDL/SDL.h>
 
-#include "lolinclude.h"
 #include "../whatever.h"
+#include "lolinclude.h"
+#include "roflinclude.h"
+#include "wtfinclude.h"
 
 // [SFT]tech coding guidelines
 // ---------------------------
 //
-// to make the code look nice and be readable:
-//  * sort things alphabetically.
-//  * align things beautifully
-//  * if you write documentation correctly, then:
-//    * it's parsable by Doxygen
-//    * cool generated docs!
-//  * look at the following example code
-//  * look at the "mom.h" header file for a header example.
+// please also have a look at `mom.h` for a header example.
 
 
-// indentation:
+// Indentation:
 //    ========> see doc/code_style/tabs_n_spaces.md <=========
-// use tabs to indent code, if you display that as 4 or 8 or 13.37 doesn't matter.
-// use spaces for drawing ascii-art or adapting code positions after indentation.
+// Use tabs to indent code: you can display that as 4 or 8 or 13.37,
+// it doesn't matter and always looks correct.
+// Use spaces for drawing ascii-art or adapting code positions
+// after tab indentation.
 //
 // => this ensures custom tab-widths AND correct indentation levels.
 
 
 
-/**
- * Write a short introductory sentence here first.
- * Then you can explain what the class/struct is doing,
- * explain why it is the way it is.
- * If you got time afterwards, explain how to achieve world peace,
- * solve P=NP or just browse cat pictures on the internet.
- *
- * Write class name in CamelCase!
- */
-class UselessDemonstration {
-// the access modifier is at the same indent level
+class HalfLife3 {
+// The access modifier is at the same indent level
 // as the class definition:
 public:
-	// i hope you read the tabs_n_spaces.md file,
+	// I hope you read the tabs_n_spaces.md file,
 	// now follows a practical application for it:
 
-	// example for using tabs for indentation and spaces for adjustment
+	// Example for using tabs for indentation and spaces for adjustment
 	// the argument list is too long, therefore wrap it
-	// => tabs are used to reach level of `void`,
+	// => Tabs are used to reach level of `void`,
 	//    spaces indent the alignment of each argument.
-	void lol_useless_function(char *rofl_a_text,
-	                          int   asdf,
-	                          bool  another_argument,
-	                          char  yeah_really_thats_many_arguments,
-	                          int   you_wont_believe_me,
-	                          bool  fak_u) {
+	void calculate_release_date(std::string &,
+	                          ValveTeam team,
+	                          bool      randomize_delay,
+	                          char      yeah_really_thats_many_arguments,
+	                          int       you_wont_believe_me,
+	                          bool      fak_u) {
 		if (fak_u) {
-			// try to align things nicely:
-			asdf                *= 20;
+			// try to align things nicely by = and friends
+			qwertyuiop          *= 20;
 			you_wont_believe_me  = 5;
 
 			printf("%s: %d \n", rofl_a_text, asdf);
 		}
 		else if (another_argument) {
-			// the argument list is too long again, so wrap the args
+			// The argument list is too long again, so wrap the args
 			// and indent them with spaces.
 			printf("%05d pls... %c %s\n",
 			       you_wont_believe_me,
@@ -76,8 +65,7 @@ public:
 };
 
 
-/**
- * Just a short struct demonstration.
+/*
  * Structs should be used to pack variables etc.
  * Use as few member functions as possible, mainly use them as a container.
  *
@@ -90,15 +78,14 @@ struct another_stupid_type {
 	ub0rtype røfëlkøptør;  //!< proper documentation is Doxygen parsable.
 };
 
-// variables in lowercase with _ as word separator,
-// classes are written in camel case.
+// variables in lowercase with _ as word separator
 elts::YourMom *my_special_mom;
 
 
-// a namespace does not increase the indentation level.
 namespace elts {
+// A namespace does not increase the indentation level!
 
-// classes are written in camel case (structs are lowercase like variables)
+// Classes are written in camel case (structs are lowercase like variables)
 YourMom::YourMom(int her_mass)
 	:
 	mass{her_mass},

--- a/doc/code_style/mom.h
+++ b/doc/code_style/mom.h
@@ -1,35 +1,66 @@
 #ifndef OPENAGE_DOC_CODESTYLE_MOM_H_
 #define OPENAGE_DOC_CODESTYLE_MOM_H_
 
+// [SFT]tech coding guidelines
+// ---------------------------
+//
+// please also have a look at `mom.cpp`
+// to make the code look nice and be readable:
+//  * sort things alphabetically.
+//  * align things beautifully
+//  * if you write documentation correctly, then:
+//    * it's parsable by Doxygen
+//    * cool generated docs!
+//  * look at the following example code
+//  * look at the "mom.cpp" file for a implementation example.
+
+
 // .h files that don't need header guards shouldn't exist.
 // if they are necessary, they must be explicitly marked with a comment
 // of the following format:
 
 // has no header guard: including your mom _twice_ would be impossible anyway.
 
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
-// see `mom.cpp` for the code style entry point.
+// Try to keep the code < 120 chars in width (no hard limit...)
+// All documentation is in the header
+// No swearing in comments!
 
-// try to keep the code < 120 chars in width (no hard limit...)
-// all documentation is in the header
-// no swearing in comments!
-
-// no preprocessor shit crap!
+// No preprocessor shit crap!
 constexpr int DEFAULT_MOM_MASS = 9001;
 
+
+// Doxygen will then generate nice shiny documentation files.
+// Exported (API) documentation of all source code is in the header file:
+
 /**
- * you may document a namespace if it's something special.
- * this documentation will also show up in generated docs then.
+ * You may document a namespace if it's something special.
+ * This documentation will also show up in generated docs then.
  */
 namespace elts {
 
-// global variables are declared extern in the header.
+// the namespace does not increase the indentation level!
+
+/**
+ * Write a short introductory sentence here first.
+ * Then you can explain what the class/struct/variable/method is doing,
+ * explain why it is the way it is.
+ * If you got time afterwards, explain how to achieve world peace,
+ * solve P=NP or just browse cat pictures on the internet.
+ *
+ * Global variables are declared extern in the header.
+ * Keep in mind that we will probably murder you if you actually
+ * use global variables.
+ */
 extern int64_t sum_mom_masses;
 
 /**
- * class about your mother.
- * manages all kinds of useful information about your mother.
+ * Class about your mother.
+ * Manages all kinds of useful information about your mother.
+ *
+ * Classes are written in CamelCase!
  */
 class YourMom {
 public:
@@ -43,13 +74,13 @@ public:
 	// because that would be entirely unnecessary.
 
 	/**
-	 * prints your mom's current mass to stdout.
+	 * Prints your mom's current mass to stdout.
 	 */
 	void print_mass();
 
 	/**
-	 * ticks your mom.
-	 * simulates her for one physics frame.
+	 * Ticks your mom.
+	 * Simulates her for one physics frame.
 	 *
 	 * @see mass
 	 * @returns true if the simulation was successful.
@@ -57,11 +88,12 @@ public:
 	bool tick();
 
 protected:
+	// To have doxygen parse one-liners, write the following:
 	int mass; //!< your mom's mass (solar masses).
 
 	/**
-	 * your mom's number of non-artificial satellites.
-	 * scales well with your mom's mass.
+	 * Your mom's number of non-artificial satellites.
+	 * Scales well with your mom's mass.
 	 */
 	int number_of_moons;
 };
@@ -69,8 +101,9 @@ protected:
 } // namespace elts
 
 
-// try to avoid forward declarations,
+// Try to avoid forward declarations,
 // use the newly defined types after their definition.
+// avoid global variables whenever possible though!
 extern elts::YourMom *my_special_mom;
 
 

--- a/doc/ideas/gameplay.md
+++ b/doc/ideas/gameplay.md
@@ -101,6 +101,51 @@ Bridges
  - Destructible, repairable, ...
  - Long build time
 
+
+Team interaction
+----------------
+
+ - Better team interaction
+ - Work/ressource sharing
+ - Unit sharing (transport boats)
+
+
+Unit grouping
+-------------
+
+ - Manually coloring units (e.g. for teammates)
+ - "Mobile ping": designated unit pings its position periodically
+ - Implicite group definitions/reselections
+
+
+Color marking / signs on map
+----------------------------
+
+- For better team coordination:
+  - Create signs
+  - Paint on map
+  - Create arrows
+
+
+More intelligent units
+----------------------
+
+ - Restrictions for action areas (don't do anything here)
+   - Wood chopping
+   - Castle rampages
+ - Emergency evacuation points
+ - Formations and movement when attacking
+ - Dynamic hardlocking on target units when attacking
+   - Don't lock on unreachable current target
+   - Attack the blocking units first
+
+
+Infinite Ressources
+-------------------
+
+ - Forest regeneration
+
+
 For the lulz
 ------------
 

--- a/py/openage/codecompliance/legal.py
+++ b/py/openage/codecompliance/legal.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2014 the openage authors. See copying.md for legal info.
+# Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 import os
 import itertools
@@ -104,7 +104,8 @@ def find_issues(paths, git_copyright_timespan=False):
                     # them (probably it's an empty file)
                     pass
                 else:
-                    test_git_copyright_timespan(filename, start_year, end_year)
+                    test_git_copyright_timespan(filename,
+                                                int(start_year), int(end_year))
 
             if headertype is thirdpartylegalheader:
                 third_party_files.add(filename)
@@ -156,9 +157,9 @@ def test_git_copyright_timespan(filename, hdr_start_year, hdr_stop_year):
     if proc.returncode != 0 or not output:
         return
 
-    output = output.split('\n')
+    years = sorted(int(y[:4]) for y in output.split('\n'))
 
-    if hdr_start_year != output[-1][:4]:
+    if hdr_start_year != years[0]:
         raise LegalIssue((
             "\tBad copyright start year in legal header:\n"
             "\texpected {} (from git history start {})\n"
@@ -166,7 +167,7 @@ def test_git_copyright_timespan(filename, hdr_start_year, hdr_stop_year):
                 output[-1][:4], output[-1],
                 hdr_start_year))
 
-    if hdr_stop_year != output[0][:4]:
+    if hdr_stop_year != years[-1]:
         raise LegalIssue((
             "\tBad copyright stop year in legal header:\n"
             "\texpected {} (from git history end {})\n"

--- a/py/openage/convert/gamedata/graphic.py
+++ b/py/openage/convert/gamedata/graphic.py
@@ -87,11 +87,12 @@ class Graphic(Exportable):
         (READ_EXPORT, "replay_delay", "float"),         # seconds to wait before current_frame=0 again
         (READ_EXPORT, "sequence_type", "int8_t"),
         (READ_EXPORT, "id", "int16_t"),
-        (READ_EXPORT, "mirroring_mode", "int16_t"),
+        (READ_EXPORT, "mirroring_mode", "int8_t"),
         (READ, "graphic_deltas", SubdataMember(
             ref_type=GraphicDelta,
             length="delta_count",
         )),
+        (READ_UNKNOWN, None, "int8_t"),                 # maybe something for the sprite editor of aoe:hd?
 
         # if attack_sound_used:
         (READ, "graphic_attack_sounds", SubdataMember(

--- a/py/openage/convert/gamedata/sound.py
+++ b/py/openage/convert/gamedata/sound.py
@@ -28,9 +28,10 @@ class Sound(Exportable):
     struct_description = "describes a sound, consisting of several sound items."
 
     data_format = (
-        (READ_EXPORT, "id", "int32_t"),
+        (READ_EXPORT, "id", "int16_t"),
+        (READ_UNKNOWN, None, "int16_t"),
         (READ_EXPORT, "item_count", "uint16_t"),
-        (READ_UNKNOWN, None, "int32_t"),
+        (READ_UNKNOWN, None, "int32_t"),  # always 300000
         (READ_EXPORT, "sound_items", SubdataMember(
             ref_type=SoundItem,
             ref_to="id",

--- a/py/openage/convert/gamedata/tech.py
+++ b/py/openage/convert/gamedata/tech.py
@@ -46,10 +46,10 @@ class Effect(Exportable):
                 # 12: range
                 # 13: working rate
                 # 14: resource carriage
-                # 15: unknown
+                # 15: default armor
                 # 16: new projectile unit
-                # 17: upgrade graphic
-                # 18: unknown?
+                # 17: upgrade graphic (icon), graphics angle
+                # 18: terrain restriction damage TODO
                 # 19: intelligent projectile aim 1=on, 0=off
                 # 20: minimum range
                 # 21: population support
@@ -87,6 +87,9 @@ class Tech(Exportable):  # also called techage in some other tools
             length="effect_count",
         )),
     )
+
+
+# TODO: add common tech class
 
 
 class AgeTechTree(Exportable):
@@ -141,7 +144,7 @@ class BuildingConnection(Exportable):
         (READ, "mode1", "int32_t"),  # TODO, xref possible values to the enum above (reuse them)
         (READ_UNKNOWN, None, "int32_t[8]"),
         (READ_UNKNOWN, None, "int8_t[11]"),
-        (READ_EXPORT, "connections", "int32_t"),          # 5: >=1 connections, 6: no connections
+        (READ_EXPORT, "line_mode", "int32_t"),          # 5: >=1 connections, 6: no connections
         (READ, "enabled_by_research_id", "int32_t"),      # current building is unlocked by this research id, -1=no unlock needed
     )
 
@@ -195,6 +198,6 @@ class ResearchConnection(Exportable):
         (READ, "line_mode", "int32_t"),
         (READ_UNKNOWN, None, "int32_t[8]"),
         (READ, "vertical_line", "int32_t"),
-        (READ, "location_in_age", "int32_t"), # 0=hidden, 1=first, 2=second
-        (READ, "first_age_mode", "int32_t"),  # 0=first age, else other ages.
+        (READ, "location_in_age", "int32_t"),  # 0=hidden, 1=first, 2=second
+        (READ, "line_mode", "int32_t"),        # 0=first age, else other ages.
     )

--- a/py/openage/convert/gamedata/tech.py
+++ b/py/openage/convert/gamedata/tech.py
@@ -104,8 +104,8 @@ class AgeTechTree(Exportable):
         (READ, "units", "int32_t[unit_count]"),
         (READ, "research_count", "int8_t"),
         (READ, "researches", "int32_t[research_count]"),
-        (READ_UNKNOWN, None, "int32_t"),
-        (READ_UNKNOWN, None, "int32_t"),
+        (READ_UNKNOWN, None, "int32_t"),                  # always 1
+        (READ, "second_age_id", "int32_t"),
         (READ, "zeroes", ZeroMember("int16_t", length=49)),
     )
 
@@ -195,6 +195,6 @@ class ResearchConnection(Exportable):
         (READ, "line_mode", "int32_t"),
         (READ_UNKNOWN, None, "int32_t[8]"),
         (READ, "vertical_line", "int32_t"),
-        (READ, "location_in_age", "int32_t"),
-        (READ_UNKNOWN, None, "int32_t"),
+        (READ, "location_in_age", "int32_t"), # 0=hidden, 1=first, 2=second
+        (READ, "first_age_mode", "int32_t"),  # 0=first age, else other ages.
     )

--- a/py/openage/convert/gamedata/terrain.py
+++ b/py/openage/convert/gamedata/terrain.py
@@ -35,8 +35,8 @@ class TerrainRestriction(Exportable):
     data_format = (
         # index of each array == terrain id
         # when this restriction was selected, can the terrain be accessed?
-        (READ, "terrain_accessible", "float[terrain_count]"),
-        (READ, "terrain_pass_graphics", SubdataMember(
+        (READ, "accessible_dmgmultiplier", "float[terrain_count]"),  # unit interaction_type activates this as damage multiplier
+        (READ, "pass_graphics", SubdataMember(
             ref_type=TerrainPassGraphic,
             length="terrain_count",
         )),

--- a/py/openage/convert/gamedata/unit.py
+++ b/py/openage/convert/gamedata/unit.py
@@ -609,7 +609,7 @@ class UnitObject(Exportable):
             },
         )),
         (READ_EXPORT, "command_attribute", EnumLookupMember(
-            raw_type    = "int16_t",             # selects the available ui command buttons for the unit
+            raw_type    = "int8_t",         # selects the available ui command buttons for the unit
             type_name   = "command_attributes",
             lookup_dict = {
                 0: "LIVING",                # commands: delete, garrison, stop, attributes: hit points
@@ -626,8 +626,8 @@ class UnitObject(Exportable):
                 11: "SHIELDED_BUILDING",    # shield building (build page 3)
             },
         )),
-        (READ_UNKNOWN, None, "int16_t"),
-        (READ_UNKNOWN, None, "int16_t"),
+        (READ_UNKNOWN, None, "float"),
+        (READ_UNKNOWN, None, "int8_t"),
         (READ_EXPORT, "language_dll_help", "uint16_t"),
         (READ, "hot_keys", "int16_t[4]"),
         (READ_UNKNOWN, None, "int8_t"),
@@ -688,7 +688,8 @@ class UnitObject(Exportable):
         )),
         (READ_EXPORT, "sound_selection", "int16_t"),
         (READ_EXPORT, "sound_dying", "int16_t"),
-        (READ_EXPORT, "attack_mode", "int16_t"),      # 0: no attack, 1: attack by following, 2: run when attacked, 3:?, 4: attack
+        (READ_EXPORT, "attack_mode", "int8_t"),     # 0: no attack, 1: attack by following, 2: run when attacked, 3:?, 4: attack
+        (READ, "is_edible_meat", "int8_t"),         # 1: yup, you may eat it
         (READ_EXPORT, "name", "char[name_length]"),
         (READ_EXPORT, "id1", "int16_t"),
         (READ_EXPORT, "id2", "int16_t"),
@@ -934,18 +935,18 @@ class UnitBuilding(UnitLiving):
         (READ_EXPORT, None, IncludeMembers(cls=UnitLiving)),
         (READ_EXPORT, "construction_graphic_id", "int16_t"),
         (READ, "snow_graphic_id", "int16_t"),
-        (READ, "adjacent_mode", "int16_t"),           # 1=adjacent units may change the graphics
-        (READ_UNKNOWN, None, "int8_t"),
-        (READ_UNKNOWN, None, "int8_t"),
+        (READ, "adjacent_mode", "int8_t"),            # 1=adjacent units may change the graphics
+        (READ, "icon_disabler", "int16_t"),
+        (READ, "disappears_when_built", "int8_t"),
         (READ, "stack_unit_id", "int16_t"),           # second building to place directly on top
         (READ_EXPORT, "terrain_id", "int16_t"),       # change underlying terrain to this id when building completed
-        (READ_UNKNOWN, None, "int16_t"),
+        (READ, "resource_id", "int16_t"),
         (READ, "research_id", "int16_t"),             # research_id to be enabled when building creation
         (READ_UNKNOWN, None, "int8_t"),
         (READ_EXPORT, "building_annex", SubdataMember(ref_type=BuildingAnnex, length=4)),
         (READ, "head_unit_id", "int16_t"),            # building at which an annex building is attached to
         (READ, "transform_unit_id", "int16_t"),       # destination unit id when unit shall transform (e.g. unpack)
-        (READ_UNKNOWN, None, "int16_t"),
+        (READ_UNKNOWN, None, "int16_t"),              # unit_id for something unknown
         (READ, "construction_sound_id", "int16_t"),
         (READ_EXPORT, "garrison_type", EnumLookupMember(
             raw_type    = "int8_t",
@@ -963,7 +964,7 @@ class UnitBuilding(UnitLiving):
         (READ, "garrison_heal_rate", "float"),
         (READ_UNKNOWN, None, "int32_t"),
         (READ_UNKNOWN, None, "int16_t"),
-        (READ_UNKNOWN, None, "int8_t[6]"),
+        (READ_UNKNOWN, None, "int8_t[6]"),  # might be related to building annexes?
     )
 
     def __init__(self):

--- a/py/openage/convert/gamedata/unit.py
+++ b/py/openage/convert/gamedata/unit.py
@@ -24,7 +24,7 @@ class UnitCommand(Exportable):
                 3: "GARRISON",
                 4: "EXPLORE",
                 5: "GATHER",   # gather, rebuild
-                6: "UNKNOWN_ANIMAL",
+                6: "NATURAL_WONDERS_CHEAT",
                 7: "ATTACK",
                 8: "SHOOT",
                 10: "FLY",
@@ -32,15 +32,16 @@ class UnitCommand(Exportable):
                 12: "UNLOAD",    # transport, garrison
                 13: "GUARD",
                 20: "ESCAPE",    # sure?
-                21: "UNKNOWN_FARM",
+                21: "MAKE_FARM",
                 101: "BUILD",
                 102: "MAKE_OBJECT",
                 103: "MAKE_TECH",
                 104: "CONVERT",
                 105: "HEAL",
                 106: "REPAIR",
-                107: "CONVERT_AUTO",
-                109: "UNKNOWN_109",
+                107: "CONVERT_AUTO",  # can get auto-converted
+                108: "DISCOVERY",
+                109: "SHOOTING_RANGE_RETREAT",
                 110: "HUNT",
                 111: "TRADE",
                 120: "WONDER_VICTORY_GENERATE",
@@ -48,10 +49,12 @@ class UnitCommand(Exportable):
                 122: "LOOT",
                 123: "HOUSING",
                 125: "UNPACK_ATTACK",
-                131: "UNKNOWN_131",
+                130: "OFF_MAP_TRADE_0",
+                131: "OFF_MAP_TRADE_1",
                 132: "PICKUP_UNIT",
                 135: "KIDNAP_UNIT",
                 136: "DEPOSIT_UNIT",
+                149: "SHEAR",
                 768: "UNKNOWN_768",
                 1024: "UNKNOWN_1024",
             },
@@ -218,45 +221,50 @@ class ResourceCost(Exportable):
                 11: "POPULATION",           # both current population and population headroom
                 12: "CORPSE_DECAY_TIME",
                 13: "DISCOVERY",
-                14: "RUIN_MONUMENTS_CAPTURED",  # unused
-                15: "PREDATOR_ANIMAL_FOOD",
-                16: "CROPS",
+                14: "RUIN_MONUMENTS_CAPTURED",
+                15: "MEAT_STORAGE",
+                16: "BERRY_STORAGE",
                 17: "FISH_STORAGE",
-                18: "UNKNOWN_18",
+                18: "UNKNOWN_18",           # in starwars: power core range
                 19: "TOTAL_UNITS_OWNED",    # or just military ones? used for counting losses
                 20: "UNITS_KILLED",
                 21: "RESEARCHED_TECHNOLOGIES_COUNT",
-                23: "TECHNOLOGY_ID_0",      # default: 102
-                24: "TECHNOLOGY_ID_1",      # default: 103
-                25: "TECHNOLOGY_ID_2",      # default: 101
-                27: "ATONEMENT",            # bool
-                28: "REDEMPTION",           # bool
-                30: "VAL_500",              # default: 500
+                22: "MAP_EXPLORED_PERCENTAGE",
+                23: "CASTLE_AGE_TECH_INDEX",      # default: 102
+                24: "IMPERIAL_AGE_TECH_INDEX",    # default: 103
+                25: "FEUDAL_AGE_TECH_INDEX",      # default: 101
+                26: "ATTACK_WARNING_SOUND",
+                27: "ENABLE_MONK_CONVERSION",
+                28: "ENABLE_BUILDING_CONVERSION",
+                30: "BUILDING_COUNT",              # default: 500
+                31: "FOOD_COUNT",
                 32: "BONUS_POPULATION",
+                33: "MAINTENANCE",
+                34: "FAITH",
                 35: "FAITH_RECHARGE_RATE",  # default: 1.6
                 36: "FARM_FOOD_AMOUNT",     # default: 175
                 37: "CIVILIAN_POPULATION",
-                38: "UNKNOWN_38",
+                38: "UNKNOWN_38",           # starwars: shields for bombers/fighters
                 39: "ALL_TECHS_ACHIEVED",   # default: 178
                 40: "MILITARY_POPULATION",  # -> largest army
-                41: "UNITS_CONVERTED",
+                41: "UNITS_CONVERTED",      # monk success count
                 42: "WONDERS_STANDING",
                 43: "BUILDINGS_RAZED",
                 44: "KILL_RATIO",
                 45: "SURVIVAL_TO_FINISH",   # bool
                 46: "TRIBUTE_FEE",          # default: 0.3
                 47: "GOLD_MINING_PRODUCTIVITY",  # default: 1
-                48: "TOWN_CENTER_AVAILABLE",
+                48: "TOWN_CENTER_UNAVAILABLE",  # -> you may build a new one
                 49: "GOLD_COUNTER",
                 50: "REVEAL_ALLY",          # bool, ==cartography discovered
-                51: "HOUSES_UNUSED",
+                51: "HOUSES_COUNT",
                 52: "MONASTERY_COUNT",
                 53: "TRIBUTE_SENT",
                 54: "RUINES_CAPTURED_ALL",  # bool
                 55: "RELICS_CAPTURED_ALL",  # bool
-                56: "LOAD_STORAGE",         # or unit unload room?
+                56: "ORE_STORAGE",
                 57: "CAPTURED_UNITS",
-                58: "DARK_AGE",             # default: 104
+                58: "DARK_AGE_TECH_INDEX",  # default: 104
                 59: "TRADE_GOOD_QUALITY",   # default: 1
                 60: "TRADE_MARKET_LEVEL",
                 61: "FORMATIONS",
@@ -265,7 +273,7 @@ class ResourceCost(Exportable):
                 64: "GATHER_ACCUMULATOR",
                 65: "SALVAGE_DECAY_RATE",     # default: 5
                 66: "ALLOW_FORMATION",        # bool, something with age?
-                67: "CONVERSIONS",            # bool?
+                67: "ALLOW_CONVERSIONS",      # bool
                 68: "HIT_POINTS_KILLED",      # unused
                 69: "KILLED_PLAYER_1",        # bool
                 70: "KILLED_PLAYER_2",        # bool
@@ -276,7 +284,7 @@ class ResourceCost(Exportable):
                 75: "KILLED_PLAYER_7",        # bool
                 76: "KILLED_PLAYER_8",        # bool
                 77: "CONVERSION_RESISTANCE",
-                78: "TRADE_FEE",              # default: 0.3
+                78: "TRADE_VIG_RATE",             # default: 0.3
                 79: "STONE_MINING_PRODUCTIVITY",  # default: 1
                 80: "QUEUED_UNITS",
                 81: "TRAINING_COUNT",
@@ -285,19 +293,19 @@ class ResourceCost(Exportable):
                 84: "STARTING_VILLAGERS",        # default: 3
                 85: "RESEARCH_COST_MULTIPLIER",
                 86: "RESEARCH_TIME_MULTIPLIER",
-                87: "CONVERT_SHIPS_ABILITY",     # bool
+                87: "CONVERT_SHIPS_ALLOWED",     # bool
                 88: "FISH_TRAP_FOOD_AMOUNT",     # default: 700
-                89: "BONUS_HEALING_RATE",
+                89: "HEALING_RATE_MULTIPLIER",
                 90: "HEALING_RANGE",
-                91: "BONUS_STARTING_FOOD",
-                92: "BONUS_STARTING_WOOD",
-                93: "BONUS_STARTING_STONE",
-                94: "BONUS_STARTING_GOLD",
-                95: "TOWN_CENTER_PACKING",       # or raider, default: 3
-                96: "SELF_HEALING_SECONDS_BERSERKER",
-                97: "ANIMAL_DISCOVERY_DOMINANT_LOS",  # bool, sheep/turkey
-                98: "SCORE_ECONOMY",                  # object cost summary
-                99: "SCORE_TECHNOLOGY",
+                91: "STARTING_FOOD",
+                92: "STARTING_WOOD",
+                93: "STARTING_STONE",
+                94: "STARTING_GOLD",
+                95: "TOWN_CENTER_PACKING",        # or raider, default: 3
+                96: "BERSERKER_HEAL_TIME",        # in seconds
+                97: "DOMINANT_ANIMAL_DISCOVERY",  # bool, sheep/turkey
+                98: "SCORE_OBJECT_COST",          # object cost summary, economy?
+                99: "SCORE_RESEARCH",
                 100: "RELIC_GOLD_COLLECTED",
                 101: "TRADE_PROFIT",
                 102: "TRIBUTE_P1",
@@ -382,7 +390,7 @@ class ResourceCost(Exportable):
                 181: "CONVERT_BUILDIN_MAX",             # default: 25
                 182: "CONVERT_BUILDIN_CHANCE",          # default: 25
                 183: "REVEAL_ENEMY",
-                184: "SCORE_SOCIETY",
+                184: "SCORE_SOCIETY",                   # wonders, castles
                 185: "SCORE_FOOD",
                 186: "SCORE_WOOD",
                 187: "SCORE_STONE",
@@ -390,11 +398,11 @@ class ResourceCost(Exportable):
                 189: "CHOPPING_PRODUCTIVITY",           # default: 1
                 190: "FOOD_GATHERING_PRODUCTIVITY",     # default: 1
                 191: "RELIC_GOLD_PRODUCTION_RATE",      # default: 30
-                192: "HERESY_ACTIVE",                   # bool
+                192: "CONVERTED_UNITS_DIE",             # bool
                 193: "THEOCRACY_ACTIVE",                # bool
                 194: "CRENELLATIONS_ACTIVE",            # bool
-                195: "CONSTRUCTION_RATE",               # except for wonders
-                196: "WONDER_BONUS",
+                195: "CONSTRUCTION_RATE_MULTIPLIER",    # except for wonders
+                196: "HUN_WONDER_BONUS",
                 197: "SPIES_DISCOUNT",                  # or atheism_active?
             }
         )),
@@ -802,11 +810,11 @@ class UnitMovable(UnitBird):
         (READ, "attacks", SubdataMember(ref_type=HitType, length="attack_count")),
         (READ, "armor_count", "uint16_t"),
         (READ, "armors", SubdataMember(ref_type=HitType, length="armor_count")),
-        (READ_EXPORT, "interaction_type", EnumLookupMember(
-            raw_type    = "int16_t",
+        (READ_EXPORT, "interaction_type", EnumLookupMember(  # the damage received by this unit is multiplied by
+            raw_type    = "int16_t",                         # the accessible values on the specified terrain restriction
             type_name   = "interaction_types",
             lookup_dict = {
-                -1: "UNIT",
+                -1: "NONE",
                 4: "BUILDING",
                 6: "DOCK",
                 10: "WALL",


### PR DESCRIPTION
Includes the #186 changes for loading the "missing" texure lazily.
Additionally, fixed pointer owners by smart pointers (`unique_ptr`, `shared_ptr`).

More convert script updates: Variables for tech, units, terrain, graphics and sounds uncovered.

Fixes to the codecompliance script to be compatible with `git rebase` and `cherry-pick`.

Also we got some new ideas from 31c3 people :grinning: