### PR TITLE
codecompliance: fixed error messages for legal header copyright years

### DIFF
--- a/py/openage/codecompliance/legal.py
+++ b/py/openage/codecompliance/legal.py
@@ -161,16 +161,16 @@ def test_git_copyright_timespan(filename, hdr_start_year, hdr_stop_year):
 
     if hdr_start_year != years[0]:
         raise LegalIssue((
-            "\tBad copyright start year in legal header:\n"
-            "\texpected {} (from git history start {})\n"
+            "Bad copyright start year in legal header:\n"
+            "\texpected {}\n"
             "\tfound    {}").format(
-                output[-1][:4], output[-1],
+                years[0],
                 hdr_start_year))
 
     if hdr_stop_year != years[-1]:
         raise LegalIssue((
-            "\tBad copyright stop year in legal header:\n"
-            "\texpected {} (from git history end {})\n"
+            "Bad copyright stop year in legal header:\n"
+            "\texpected {}\n"
             "\tfound    {}").format(
-                output[0][:4], output[0],
+                years[-1],
                 hdr_stop_year))


### PR DESCRIPTION
The compliance checker printed only the first digit of the expected year when one of the copyright years in the legal header was wrong. This should now work correctly.
Also the "from git history" part still assumed that the topmost git log entry is the most recent one (this is no longer true when someone swaps commits during a rebase, see Jonas' previous commit on that file). I deleted that part since I didn't come up with an easy fix immediately (and I don't think it is useful, just use git log if there are problems).