### PR TITLE
Adds a move physics camera in Engine class.

### DIFF
--- a/cpp/engine.cpp
+++ b/cpp/engine.cpp
@@ -377,4 +377,20 @@ void Engine::render_text(coord::window position, size_t size, const char *format
 	font->render_static(position.x, position.y, buf.c_str());
 }
 
+void Engine::move_phys_camera(float x, float y, float amount) {
+	// move the cam
+	coord::vec2f cam_movement {x, y};
+
+	// this factor controls the scroll speed
+	cam_movement *= amount;
+
+	// calculate camera position delta from velocity and frame duration
+	coord::camgame_delta cam_delta;
+	cam_delta.x = cam_movement.x;
+	cam_delta.y = - cam_movement.y;
+
+	//update camera phys position
+	this->camgame_phys += cam_delta.to_phys3();
+}
+
 } //namespace openage

--- a/cpp/engine.h
+++ b/cpp/engine.h
@@ -11,6 +11,7 @@
 
 #include "audio/audio_manager.h"
 #include "coord/camgame.h"
+#include "coord/vec2f.h"
 #include "coord/phys3.h"
 #include "coord/window.h"
 #include "font.h"
@@ -187,6 +188,11 @@ public:
 	 * render text with the at a position with specified font size
 	 */
 	void render_text(coord::window position, size_t size, const char *format, ...);
+
+	/**
+	 * move the phys3 camera incorporated in the engine
+	 */
+	void move_phys_camera(float x, float y, float amount = 1.0);
 
 	/**
 	 * current engine state variable.

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -426,22 +426,7 @@ bool GameMain::on_input(SDL_Event *e) {
 		// scroll, if middle mouse is being pressed
 		//  SDL_GetRelativeMouseMode() queries sdl for that.
 		if (scrolling_active) {
-
-			// move the cam
-			coord::vec2f cam_movement {0.0, 0.0};
-			cam_movement.x = e->motion.xrel;
-			cam_movement.y = e->motion.yrel;
-
-			// this factor controls the scroll speed
-			// cam_movement *= 1;
-
-			// calculate camera position delta from velocity and frame duration
-			coord::camgame_delta cam_delta;
-			cam_delta.x = cam_movement.x;
-			cam_delta.y = - cam_movement.y;
-
-			//update camera phys position
-			engine.camgame_phys += cam_delta.to_phys3();
+			engine.move_phys_camera(e->motion.xrel, e->motion.yrel);
 		}
 		break;
 
@@ -524,34 +509,24 @@ void GameMain::move_camera() {
 
 	// camera movement speed, in pixels per millisecond
 	// one pixel per millisecond equals 14.3 tiles/second
-	float cam_movement_speed_keyboard = 0.5;
-
-	coord::vec2f cam_movement {0.0, 0.0};
+	float mov_x = 0.0, mov_y = 0.0, cam_movement_speed_keyboard = 0.5;
 
 	CoreInputHandler &input_handler = engine.get_input_handler();
 
 	if (input_handler.is_key_down(SDLK_LEFT)) {
-		cam_movement.x -= cam_movement_speed_keyboard;
+		mov_x = -cam_movement_speed_keyboard;
 	}
 	if (input_handler.is_key_down(SDLK_RIGHT)) {
-		cam_movement.x += cam_movement_speed_keyboard;
+		mov_x = cam_movement_speed_keyboard;
 	}
 	if (input_handler.is_key_down(SDLK_DOWN)) {
-		cam_movement.y -= cam_movement_speed_keyboard;
+		mov_y = cam_movement_speed_keyboard;
 	}
 	if (input_handler.is_key_down(SDLK_UP)) {
-		cam_movement.y += cam_movement_speed_keyboard;
+		mov_y = -cam_movement_speed_keyboard;
 	}
 
-	cam_movement *= (float) engine.lastframe_msec();
-
-	// calculate camera position delta from velocity and frame duration
-	coord::camgame_delta cam_delta;
-	cam_delta.x = cam_movement.x;
-	cam_delta.y = cam_movement.y;
-
-	// update camera phys position
-	engine.camgame_phys += cam_delta.to_phys3();
+	engine.move_phys_camera(mov_x, mov_y, (float) engine.lastframe_msec());
 }
 
 


### PR DESCRIPTION
This is a simple refactor which points to standarize the way
to access to engine camera. For instance, scrolling with keyboard
arrows and mouse middle button was modificated to call this single
method instead of have duplicated code.