### PR TITLE
Windows support on MSYS2, stubs unimplemented unused stuff when on WIN32

### DIFF
--- a/cpp/console/tests.cpp
+++ b/cpp/console/tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include <unistd.h>
 #include "../crossplatform/pty.h"
@@ -35,6 +35,7 @@ void render() {
 }
 
 void demo(int /* unused */, char ** /* unused */) {
+	#ifndef _WIN32
 	console::Buf buf{{80, 25}, 1337, 80};
 	struct winsize ws;
 
@@ -158,6 +159,7 @@ void demo(int /* unused */, char ** /* unused */) {
 
 	// show cursor
 	termout.puts("\x1b[?25h");
+	#endif
 }
 
 } // namespace tests

--- a/cpp/crossplatform/os.cpp
+++ b/cpp/crossplatform/os.cpp
@@ -22,7 +22,7 @@ namespace os {
 
 std::string read_symlink(const char *path) {
 	#ifdef _WIN32
-	static_assert(false, "os::read_symlink is not yet implemented for WIN32");
+	//static_assert(false, "os::read_symlink is not yet implemented for WIN32");
 	#else
 	size_t bufsize = 1024;
 
@@ -67,7 +67,7 @@ std::string self_exec_filename() {
 		return std::string{buf.get()};
 	}
 	#elif _WIN32
-	static_assert(false, "subprocess::self_filename is not yet implemented for WIN32");
+	//static_assert(false, "subprocess::self_filename is not yet implemented for WIN32");
 	#else
 	static_assert(false, "subprocess::self_filename is not yet implemented for... whatever platform you're using right now.");
 	#endif
@@ -76,7 +76,7 @@ std::string self_exec_filename() {
 int execute_file(const char *path, bool background) {
 	#ifdef _WIN32
 	// some sort of shell-open
-	static_assert(false, "subprocess::execute_file is not yet implemented for WIN32");
+	//static_assert(false, "subprocess::execute_file is not yet implemented for WIN32");
 	#else
 		std::string runner = "";
 		#ifdef __APPLE__

--- a/cpp/crossplatform/pty.h
+++ b/cpp/crossplatform/pty.h
@@ -1,10 +1,12 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_CROSSPLATFORM_PTY_H_
 #define OPENAGE_CROSSPLATFORM_PTY_H_
 
 #ifdef __APPLE__
 #  include <util.h>
+#elif _WIN32
+// TODO not yet implemented
 #else
 #  include <pty.h>
 #endif

--- a/cpp/crossplatform/subprocess.cpp
+++ b/cpp/crossplatform/subprocess.cpp
@@ -25,7 +25,7 @@ namespace subprocess {
 bool is_executable(const char *filename) {
 	#ifdef _WIN32
 	// TODO not yet implemented
-	static_assert(false, "subprocess::is_executable is not yet implemented for WIN32");
+	//static_assert(false, "subprocess::is_executable is not yet implemented for WIN32");
 	#else
 	struct stat sb;
 	return (stat(filename, &sb) == 0
@@ -37,7 +37,7 @@ bool is_executable(const char *filename) {
 std::string which(const char *name) {
 	#ifdef _WIN32
 	// TODO not yet implemented
-	static_assert(false, "subprocess::which is not yet implemented for WIN32");
+	//static_assert(false, "subprocess::which is not yet implemented for WIN32");
 	#else
 	char *path = util::copy(getenv("PATH"));
 
@@ -62,7 +62,7 @@ std::string which(const char *name) {
 
 int call(const std::vector<const char *> &argv, bool wait, const char *redirect_stdout_to) {
 	#ifdef _WIN32
-	static_assert(false, "subprocess::call is not yet implemented for WIN32");
+	//static_assert(false, "subprocess::call is not yet implemented for WIN32");
 	#else
 
 	// used by child to communicate execve() to its parent.

--- a/cpp/util/fds.cpp
+++ b/cpp/util/fds.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "fds.h"
 
@@ -8,8 +8,9 @@
 #include <string.h>
 
 #include <fcntl.h>
-#include "../crossplatform/pty.h"
 #include <unistd.h>
+
+#include "../crossplatform/pty.h"
 
 #include "unicode.h"
 
@@ -25,8 +26,10 @@ FD::FD(int fd, bool set_nonblocking) {
 	this->close_on_destroy = true;
 
 	if (set_nonblocking) {
+		#ifndef _WIN32
 		int flags = ::fcntl(this->fd, F_GETFL, 0);
 		::fcntl(this->fd, F_SETFL, flags | O_NONBLOCK);
+		#endif
 	}
 }
 
@@ -105,6 +108,7 @@ int FD::printf(const char *format, ...) {
 
 void FD::setinputmodecanon() {
 	if (isatty(this->fd)) {
+		#ifndef _WIN32
 		//get the terminal settings for stdin
 		::tcgetattr(this->fd, &this->old_tio);
 		//backup old settings
@@ -114,14 +118,17 @@ void FD::setinputmodecanon() {
 		//set the settings
 		::tcsetattr(this->fd, TCSANOW, &new_tio);
 		this->restore_input_mode_on_destroy = true;
+		#endif
 	}
 }
 
 void FD::restoreinputmode() {
+	#ifndef _WIN32
 	if (::isatty(this->fd)) {
 		::tcsetattr(this->fd, TCSANOW, &this->old_tio);
 		this->restore_input_mode_on_destroy = false;
 	}
+	#endif
 }
 
 } //namespace util

--- a/cpp/util/fds.h
+++ b/cpp/util/fds.h
@@ -1,11 +1,14 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_UTIL_FDS_H_
 #define OPENAGE_UTIL_FDS_H_
 
 #include <stdlib.h>
 #include <unistd.h>
+
+#ifndef _WIN32
 #include <termios.h>
+#endif
 
 namespace openage {
 namespace util {
@@ -83,7 +86,9 @@ public:
 	 */
 	void restoreinputmode();
 
+	#ifndef _WIN32
 	struct termios old_tio;
+	#endif
 };
 
 } //namespace util


### PR DESCRIPTION
**heavily** based on @mappu guide on #9. This aims to close that issue, and enables openage to be built on MSYS2 with traditional `cmake` by stubbing not yet implemented (and coincidentally, unused) features under WIN32. 

A better solution is to implement the features (I think this is desirable on os.cpp functions), or strip the entire feature from all platforms if it's not useful (I never used the console tests, they seem dated).

Needs #218 so it should be merged first, and this branch should be rebased. If you want to test, just pull TheJJ/math-constants into master, and then this branch into the result, it should build.

In contrast with mappu's guide, this doesn't modify`./configure` nor `buildsystem/simple`. Also, the majority of the patches that mappu required are no longer necessary due to better code quality :) Oh, and we now have opusfile on the MSYS2 repos, so no manual compiling of that dep.

TL;DR: 
```
# convert assets or copy them already converted
mkdir build && cd build
cmake -G "MSYS Makefiles" .. #configures flawlessly
make #compiles flawlessly
cd .. #changes directory flawlessly
./build/cpp/openage #runs flawlessly
```

---


This was on a Windows7 32bit VM. This guide should work without issues, please try it out and comment about your experience!

- Install [msys2](https://msys2.github.io/) on C:\msys2. When the wizard asks, don't open the shell. 

`/` means C:\msys2 and `~` is `/home/<username>`.

- Move AoE2 directory to ~, assuming "~/age2/Data" is the right directory (contains a lot of dat an drs).

From now on, you need to use mingw32_shell.bat from C:\msys2. Open up a shell and go:
- `pacman -Syu`
- copypasta this package installing havoc:
```
pacman -S git mingw-w64-i686-{gcc,pkg-config,make,openssl,libogg,opus{,file,-tools},SDL2{,_image},glew,freetype,ftgl,python3{,-{,numpy,Pillow}}}
```
- copy mingw32-make to make, so standard tools don't whine:
```
cp /mingw32/bin/{mingw32-,}make.exe
```
- get the windows branch from my repo:
```
cd ~
git clone https://github.com/franciscod/openage
cd openage
git checkout windows
```
- cmake magic!:
```
mkdir build && cd build
cmake -G "MSYS Makefiles" ..
make
cd ..
```
- you might need to install dejavu serif from http://sourceforge.net/projects/dejavu/files/dejavu/2.34/dejavu-fonts-ttf-2.34.zip
- convert *dat ass*ets:
```
PYTHONPATH=py python3 -m openage.convert -v media -o "assets/converted" "/c/Program Files (x86)/Age of Empires/" graphics:*.* terrain:*.* sounds0:*.* sounds1:*.* gamedata0:*.* gamedata1:*.* gamedata2:*.* interface:*.*
```
- Convert all *.docx files from CRLF to LF: 
```
find ./assets/converted/ | grep 'docx$' | xargs -n1 sed -rie 's/\r\n/\n/'
```
- enjoy openage on MSYS2! :dancer: 

```
./build/cpp/openage
```
