### PR TITLE
define _USE_MATH_CONSTANTS for cmath

### DIFF
--- a/cpp/pathfinding/a_star.cpp
+++ b/cpp/pathfinding/a_star.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 /** @file
  *
@@ -10,9 +10,10 @@
  * Cybernetics, IEEE Transactions on 4, no. 2 (1968): 100-107.
  */
 
-#include "a_star.h"
-
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include "a_star.h"
 
 #include "../datastructure/pairing_heap.h"
 #include "../log.h"

--- a/cpp/pathfinding/heuristics.cpp
+++ b/cpp/pathfinding/heuristics.cpp
@@ -1,9 +1,9 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
-#include "heuristics.h"
-
+#define _USE_MATH_DEFINES
 #include <cmath>
 
+#include "heuristics.h"
 
 namespace openage {
 namespace path {

--- a/cpp/pathfinding/path.cpp
+++ b/cpp/pathfinding/path.cpp
@@ -1,5 +1,6 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "path.h"

--- a/cpp/terrain/terrain_chunk.cpp
+++ b/cpp/terrain/terrain_chunk.cpp
@@ -1,8 +1,10 @@
-// Copyright 2013-2014 the openage authors. See copying.md for legal info.
+// Copyright 2013-2015 the openage authors. See copying.md for legal info.
+
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 #include "terrain_chunk.h"
 
-#include <cmath>
 #include <cinttypes>
 
 #include "terrain_object.h"

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -1,7 +1,9 @@
 // Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 
 #include "terrain_object.h"
 

--- a/cpp/terrain/terrain_outline.cpp
+++ b/cpp/terrain/terrain_outline.cpp
@@ -1,6 +1,8 @@
 // Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <math.h>
 #include <memory>
 

--- a/cpp/texture.cpp
+++ b/cpp/texture.cpp
@@ -1,12 +1,14 @@
 // Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "texture.h"
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 
 #include <cassert>
-#include <cmath>
 #include <cstdio>
 
 #include "log.h"

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -1,5 +1,6 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "../game_main.h"

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -1,7 +1,8 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+#include <algorithm>
 
 #include "../terrain/terrain.h"
 #include "../engine.h"


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/4hwaceh6.aspx

Math Constants are not defined in Standard C/C++. To use them, you must
first define _USE_MATH_DEFINES and then include cmath or math.h.