### PR TITLE
crossplatform: use _WIN32 instead of WIN32

### DIFF
--- a/cpp/crossplatform/os.cpp
+++ b/cpp/crossplatform/os.cpp
@@ -1,10 +1,10 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "os.h"
 
 #include <memory>
 
-#ifdef WIN32
+#ifdef _WIN32
 // TODO not yet implemented
 #else
 #include <unistd.h>
@@ -21,7 +21,7 @@ namespace openage {
 namespace os {
 
 std::string read_symlink(const char *path) {
-	#ifdef WIN32
+	#ifdef _WIN32
 	static_assert(false, "os::read_symlink is not yet implemented for WIN32");
 	#else
 	size_t bufsize = 1024;
@@ -66,7 +66,7 @@ std::string self_exec_filename() {
 
 		return std::string{buf.get()};
 	}
-	#elif WIN32
+	#elif _WIN32
 	static_assert(false, "subprocess::self_filename is not yet implemented for WIN32");
 	#else
 	static_assert(false, "subprocess::self_filename is not yet implemented for... whatever platform you're using right now.");
@@ -74,7 +74,7 @@ std::string self_exec_filename() {
 }
 
 int execute_file(const char *path, bool background) {
-	#ifdef WIN32
+	#ifdef _WIN32
 	// some sort of shell-open
 	static_assert(false, "subprocess::execute_file is not yet implemented for WIN32");
 	#else

--- a/cpp/crossplatform/subprocess.cpp
+++ b/cpp/crossplatform/subprocess.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "subprocess.h"
 
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <cerrno>
 
-#ifdef WIN32
+#ifdef _WIN32
 // TODO not yet implemented
 #else
 #include <sys/types.h>
@@ -23,7 +23,7 @@ namespace openage {
 namespace subprocess {
 
 bool is_executable(const char *filename) {
-	#ifdef WIN32
+	#ifdef _WIN32
 	// TODO not yet implemented
 	static_assert(false, "subprocess::is_executable is not yet implemented for WIN32");
 	#else
@@ -35,7 +35,7 @@ bool is_executable(const char *filename) {
 }
 
 std::string which(const char *name) {
-	#ifdef WIN32
+	#ifdef _WIN32
 	// TODO not yet implemented
 	static_assert(false, "subprocess::which is not yet implemented for WIN32");
 	#else
@@ -61,7 +61,7 @@ std::string which(const char *name) {
 }
 
 int call(const std::vector<const char *> &argv, bool wait, const char *redirect_stdout_to) {
-	#ifdef WIN32
+	#ifdef _WIN32
 	static_assert(false, "subprocess::call is not yet implemented for WIN32");
 	#else
 


### PR DESCRIPTION
While Clang/LLVM, GCC, and Portland Group compilers define a lot of WIN32 and WIN64 macros with various numbers of underscores, the only macros that matter are those that are compatible with Microsoft's Visual Studio: _WIN32 and _WIN64.

http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system#WindowsCygwinnonPOSIXandMinGW