### PR TITLE
Make FindOpusfile.cmake compatible with MinGW build

### DIFF
--- a/buildsystem/modules/FindOpusfile.cmake
+++ b/buildsystem/modules/FindOpusfile.cmake
@@ -1,30 +1,24 @@
-# Copyright 2014-2014 the openage authors. See copying.md for legal info.
+# Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
-# Try to find Opusfile
+# - Try to find opusfile
+# Once done this will define
 #
-# Once done this will define:
-#  OPUSFILE_FOUND        - System has Opusfile
-#  OPUSFILE_INCLUDE_DIRS - The Opusfile include directories
-#  OPUSFILE_LIBRARIES    - The libraries needed to use Opusfile
+# OPUSFILE_FOUND - system has libopusfile
+# OPUSFILE_INCLUDE_DIRS - the libopusfile include directory
+# OPUSFILE_LIBRARIES - The libopusfile libraries
 
 find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules (OPUSFILE opusfile)
+  list(APPEND OPUSFILE_INCLUDE_DIRS ${OPUSFILE_INCLUDEDIR})
+endif()
 
-find_path(OPUSFILE_INCLUDE_DIR opusfile.h
-	HINTS
-	/usr/include/opus
-	/usr/local/include/opus
-)
-
-find_library(OPUSFILE_LIBRARY NAMES opusfile)
-
-set(OPUSFILE_LIBRARIES "${OPUSFILE_LIBRARY}")
-set(OPUSFILE_INCLUDE_DIRS "${OPUSFILE_INCLUDE_DIR}")
+if(NOT OPUSFILE_FOUND)
+  find_path(OPUSFILE_INCLUDE_DIRS opus/opusfile.h)
+  find_library(OPUSFILE_LIBRARIES opusfile)
+endif()
 
 include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OPUSFILE DEFAULT_MSG OPUSFILE_INCLUDE_DIRS OPUSFILE_LIBRARIES)
 
-# handle the QUIETLY and REQUIRED arguments and set OPUSFILE_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(Opusfile DEFAULT_MSG
-                                  OPUSFILE_LIBRARY OPUSFILE_INCLUDE_DIR)
-
-mark_as_advanced(OPUSFILE_INCLUDE_DIR OPUSFILE_LIBRARY)
+mark_as_advanced(OPUSFILE_INCLUDE_DIRS OPUSFILE_LIBRARIES)

--- a/cpp/audio/dynamic_loader.h
+++ b/cpp/audio/dynamic_loader.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 #include "format.h"
 #include "types.h"

--- a/cpp/audio/in_memory_loader.cpp
+++ b/cpp/audio/in_memory_loader.cpp
@@ -4,7 +4,7 @@
 
 #include <cinttypes>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 #include "../log.h"
 #include "../util/error.h"

--- a/cpp/audio/types.h
+++ b/cpp/audio/types.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 namespace openage {
 namespace audio {


### PR DESCRIPTION
Hopefully this is optimal and doesn't break any platform.

pulled from:
https://raw.githubusercontent.com/notspiff/audiodecoder.opus/master/FindOpusFile.cmake

thanks!