### PR TITLE
crossplattform: enable math constants on all plattforms

### DIFF
--- a/cpp/crossplatform/math_constants.h
+++ b/cpp/crossplatform/math_constants.h
@@ -1,0 +1,30 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#ifndef OPENAGE_CROSSPLATFORM_MATH_CONSTANTS_H_
+#define OPENAGE_CROSSPLATFORM_MATH_CONSTANTS_H_
+
+// instruct the windows math header to define the constants.
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+namespace openage {
+namespace math {
+
+constexpr double E            = M_E;        //!< e
+constexpr double LOG2E        = M_LOG2E;    //!< log_2 e
+constexpr double LOG10E       = M_LOG10E;   //!< log_10 e
+constexpr double LN2          = M_LN2;      //!< log_e 2
+constexpr double LN10         = M_LN10;     //!< log_e 10
+constexpr double PI           = M_PI;       //!< pi
+constexpr double PI_2         = M_PI_2;     //!< pi/2
+constexpr double PI_4         = M_PI_4;     //!< pi/4
+constexpr double INV_PI       = M_1_PI;     //!< 1/pi
+constexpr double INV2_PI      = M_2_PI;     //!< 2/pi
+constexpr double INV2_SQRT_PI = M_2_SQRTPI; //!< 2/sqrt(pi)
+constexpr double SQRT_2       = M_SQRT2;    //!< sqrt(2)
+constexpr double INV_SQRT_2   = M_SQRT1_2;  //!< 1/sqrt(2)
+
+} // namespace math
+} // namespace openage
+
+#endif

--- a/cpp/crossplatform/math_constants.h
+++ b/cpp/crossplatform/math_constants.h
@@ -3,26 +3,22 @@
 #ifndef OPENAGE_CROSSPLATFORM_MATH_CONSTANTS_H_
 #define OPENAGE_CROSSPLATFORM_MATH_CONSTANTS_H_
 
-// instruct the windows math header to define the constants.
-#define _USE_MATH_DEFINES
-#include <cmath>
-
 namespace openage {
 namespace math {
 
-constexpr double E            = M_E;        //!< e
-constexpr double LOG2E        = M_LOG2E;    //!< log_2 e
-constexpr double LOG10E       = M_LOG10E;   //!< log_10 e
-constexpr double LN2          = M_LN2;      //!< log_e 2
-constexpr double LN10         = M_LN10;     //!< log_e 10
-constexpr double PI           = M_PI;       //!< pi
-constexpr double PI_2         = M_PI_2;     //!< pi/2
-constexpr double PI_4         = M_PI_4;     //!< pi/4
-constexpr double INV_PI       = M_1_PI;     //!< 1/pi
-constexpr double INV2_PI      = M_2_PI;     //!< 2/pi
-constexpr double INV2_SQRT_PI = M_2_SQRTPI; //!< 2/sqrt(pi)
-constexpr double SQRT_2       = M_SQRT2;    //!< sqrt(2)
-constexpr double INV_SQRT_2   = M_SQRT1_2;  //!< 1/sqrt(2)
+constexpr double E            = 2.71828182845904523536;  //!< e
+constexpr double LOG2E        = 1.44269504088896340736;  //!< log_2 e
+constexpr double LOG10E       = 0.434294481903251827651; //!< log_10 e
+constexpr double LN2          = 0.693147180559945309417; //!< log_e 2
+constexpr double LN10         = 2.30258509299404568402;  //!< log_e 10
+constexpr double PI           = 3.14159265358979323846;  //!< pi
+constexpr double PI_2         = 1.57079632679489661923;  //!< pi/2
+constexpr double PI_4         = 0.785398163397448309616; //!< pi/4
+constexpr double INV_PI       = 0.318309886183790671538; //!< 1/pi
+constexpr double INV2_PI      = 0.636619772367581343076; //!< 2/pi
+constexpr double INV2_SQRT_PI = 1.12837916709551257390;  //!< 2/sqrt(pi)
+constexpr double SQRT_2       = 1.41421356237309504880;  //!< sqrt(2)
+constexpr double INV_SQRT_2   = 0.707106781186547524401; //!< 1/sqrt(2)
 
 } // namespace math
 } // namespace openage

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -5,6 +5,7 @@
 
 #include "../terrain/terrain.h"
 #include "../engine.h"
+#include "../crossplatform/math_constants.h"
 #include "ability.h"
 #include "action.h"
 #include "producer.h"
@@ -151,10 +152,11 @@ unsigned int dir_group(coord::phys3_delta dir, unsigned int angles, unsigned int
 	double dir_ne = static_cast<double>(dir.ne) / len;
 	double dir_se = static_cast<double>(dir.se) / len;
 
-	/*
-	 * formula to find the correct angle...
-	 */
-	return static_cast<unsigned int>(round(angles * atan2(dir_se, dir_ne) * M_1_PI / 2 ) + first_angle) % angles;
+	// formula to find the correct angle...
+	return static_cast<unsigned int>(
+		round(angles * atan2(dir_se, dir_ne) * (math::INV_PI / 2))
+		+ first_angle
+	) % angles;
 }
 
 } /* namespace openage */


### PR DESCRIPTION
This introduces namespaced math constants available on all plattforms.

closes #208.