### PR TITLE
find opusfile via cmake, improved edition™

### DIFF
--- a/buildsystem/modules/FindOpusfile.cmake
+++ b/buildsystem/modules/FindOpusfile.cmake
@@ -1,30 +1,43 @@
-# Copyright 2014-2014 the openage authors. See copying.md for legal info.
+# This file was taken from Unvanquished,
+# Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+# It's licensed under the terms of the 3-clause OpenBSD license.
+# Modifications Copyright 2014-2015 the openage authors.
+# See copying.md for further legal info.
 
-# Try to find Opusfile
-#
-# Once done this will define:
-#  OPUSFILE_FOUND        - System has Opusfile
-#  OPUSFILE_INCLUDE_DIRS - The Opusfile include directories
-#  OPUSFILE_LIBRARIES    - The libraries needed to use Opusfile
+# - Find opus library
+# Find the native Opus headers and libraries.
+# This module defines
+#  OPUS_INCLUDE_DIRS   - where to find opus/opus.h, opus/opusfile.h, etc
+#  OPUS_LIBRARIES      - List of libraries when using libopus
+#  OPUS_FOUND          - True if opus is found.
 
-find_package(PkgConfig)
-
-find_path(OPUSFILE_INCLUDE_DIR opusfile.h
-	HINTS
-	/usr/include/opus
-	/usr/local/include/opus
+# find the opusfile header, defines our api.
+find_path(OPUS_INCLUDE_DIR
+	NAMES opus/opusfile.h
+	DOC "Opus include directory"
 )
+mark_as_advanced(OPUS_INCLUDE_DIR)
 
-find_library(OPUSFILE_LIBRARY NAMES opusfile)
+# look for libopusfile, the highlevel container-aware api.
+find_library(OPUSFILE_LIBRARY
+	NAMES opusfile
+	DOC "Path to OpusFile library"
+)
+mark_as_advanced(OPUSFILE_LIBRARY)
 
-set(OPUSFILE_LIBRARIES "${OPUSFILE_LIBRARY}")
-set(OPUSFILE_INCLUDE_DIRS "${OPUSFILE_INCLUDE_DIR}")
+# find libopus, the core codec component.
+find_library(OPUS_LIBRARY
+	NAMES opus
+	DOC "Path to Opus library"
+)
+mark_as_advanced(OPUS_LIBRARY)
 
+
+# handle the QUIETLY and REQUIRED arguments and set OPUSFILE_FOUND to TRUE if
+# all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Opus DEFAULT_MSG OPUSFILE_LIBRARY OPUS_LIBRARY OPUS_INCLUDE_DIR)
 
-# handle the QUIETLY and REQUIRED arguments and set OPUSFILE_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(Opusfile DEFAULT_MSG
-                                  OPUSFILE_LIBRARY OPUSFILE_INCLUDE_DIR)
-
-mark_as_advanced(OPUSFILE_INCLUDE_DIR OPUSFILE_LIBRARY)
+# export the variables
+set(OPUS_LIBRARIES "${OPUSFILE_LIBRARY}" "${OPUS_LIBRARY}")
+set(OPUS_INCLUDE_DIRS "${OPUS_INCLUDE_DIR}" "${OPUS_INCLUDE_DIR}/opus")

--- a/copying.md
+++ b/copying.md
@@ -124,6 +124,7 @@ cmake modules ([3-clause BSD license](legal/BSD-3-clause))
  - `buildsystem/modules/FindSDL2.cmake` (taken from [openmw](https://github.com/OpenMW/openmw))
  - `buildsystem/modules/FindFTGL.cmake` (taken from [ulrichard's FTGL fork](https://github.com/ulrichard/ftgl))
  - `buildsystem/modules/FindGPerfTools.cmake` (taken from [VAST](https://github.com/mavam/vast))
+ - `buildsystem/modules/FindOpusfile.cmake` (taken from [Unvanquished](https://github.com/Unvanquished/Unvanquished))
 
 Notes about this file:
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,8 +54,6 @@ finalize_executable(${PROJECT_NAME})
 
 # freetype includedir hint for ubuntu...
 find_path(FREETYPE_INCLUDE_DIRS freetype/freetype.h HINTS /usr/include/freetype2)
-find_package(Opusfile REQUIRED)
-
 include(FindPkgConfig)
 include(FindPackageHandleStandardArgs)
 
@@ -72,10 +70,10 @@ endif()
 find_package(Freetype REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(OpenGL REQUIRED)
-
 find_package(SDL2 REQUIRED)
 find_package(FTGL REQUIRED)
 find_package(SDL2Image REQUIRED)
+find_package(Opusfile REQUIRED)
 
 if(WANT_GPERFTOOLS_PROFILER OR WANT_GPERFTOOLS_TCMALLOC)
 	find_package(GPerfTools)
@@ -97,7 +95,7 @@ else()
 	have_config_option(gperftools-tcmalloc GPERFTOOLS_TCMALLOC false)
 endif()
 
-#inotify support
+# inotify support
 if(WANT_INOTIFY)
 	find_package(Inotify)
 endif()
@@ -119,7 +117,7 @@ include_directories(
 	${OPENGL_INCLUDE_DIR}
 	${FREETYPE_INCLUDE_DIRS}
 	${FTGL_INCLUDE_DIRS}
-	${OPUSFILE_INCLUDE_DIR}
+	${OPUS_INCLUDE_DIRS}
 	${PYTHON_INCLUDE_DIR}
 	${SDL2_INCLUDE_DIR}
 	${SDL2IMAGE_INCLUDE_DIRS}
@@ -133,7 +131,7 @@ target_link_libraries(${PROJECT_NAME}
 	${GLEW_LIBRARIES}
 	${MATH_LIB}
 	${OPENGL_LIBRARY}
-	${OPUSFILE_LIBRARIES}
+	${OPUS_LIBRARIES}
 	${PYTHON_LIBRARY}
 	${SDL2IMAGE_LIBRARIES}
 	${SDL2_LIBRARY}

--- a/cpp/audio/dynamic_loader.h
+++ b/cpp/audio/dynamic_loader.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_AUDIO_DYNAMIC_LOADER_H_
 #define OPENAGE_AUDIO_DYNAMIC_LOADER_H_
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 #include "format.h"
 #include "types.h"

--- a/cpp/audio/in_memory_loader.cpp
+++ b/cpp/audio/in_memory_loader.cpp
@@ -1,10 +1,10 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "in_memory_loader.h"
 
 #include <cinttypes>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 #include "../log.h"
 #include "../util/error.h"

--- a/cpp/audio/types.h
+++ b/cpp/audio/types.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2014 the openage authors. See copying.md for legal info.
+// Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #ifndef OPENAGE_AUDIO_TYPES_H_
 #define OPENAGE_AUDIO_TYPES_H_
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-#include <opusfile.h>
+#include <opus/opusfile.h>
 
 namespace openage {
 namespace audio {
@@ -28,7 +28,7 @@ using pcm_chunk_t = std::vector<int16_t>;
  * opus_file_t is a OggOpusFile pointer that is stored inside a unique_ptr and
  * uses a custom deleter.
  */
-using opus_file_t = std::unique_ptr<OggOpusFile,std::function<void(OggOpusFile*)>>;
+using opus_file_t = std::unique_ptr<OggOpusFile, std::function<void(OggOpusFile*)>>;
 
 }
 }


### PR DESCRIPTION
improves portability of the opus location, resubmit of #212.

Probably still works for fedora (#164), somebody could test it if we're in doubt.