### PR TITLE
Fix decaying units

### DIFF
--- a/cpp/unit/ability.cpp
+++ b/cpp/unit/ability.cpp
@@ -133,13 +133,14 @@ BuildAbility::BuildAbility(Sound *s)
 	sound{s} {
 }
 
-bool BuildAbility::can_invoke(Unit &, const Command &cmd) {
+bool BuildAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	if (cmd.has_producer() && cmd.has_position()) {
-		return true;
+		return to_modify.location;
 	}
 	if (cmd.has_unit()) {
 		Unit *target = cmd.unit();
-		return target->has_attribute(attr_type::building) &&
+		return to_modify.location &&
+		       target->has_attribute(attr_type::building) &&
 		       target->get_attribute<attr_type::building>().completed < 1.0f;
 	}
 	return false;
@@ -168,6 +169,7 @@ bool GatherAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	if (cmd.has_unit()) {
 		Unit &target = *cmd.unit();
 		return &to_modify != &target &&
+		       to_modify.location &&
 		       to_modify.has_attribute(attr_type::gatherer) &&
 		       has_resource(target);
 	}
@@ -193,6 +195,7 @@ bool AttackAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	if (cmd.has_unit()) {
 		Unit &target = *cmd.unit();
 		return &to_modify != &target &&
+		       to_modify.location &&
 		       to_modify.has_attribute(attr_type::attack) &&
 		       has_hitpoints(target) &&
 		       (is_enemy(to_modify, target) || has_resource(target));

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -75,6 +75,26 @@ void UnitAction::move_to(Unit &target) {
 	this->entity->invoke(cmd);
 }
 
+DecayAction::DecayAction(Unit *e)
+	:
+	UnitAction(e, graphic_type::standing),
+	end_frame{.0f} {
+
+	if (this->entity->graphics->count(graphic) > 0) {
+		this->end_frame = this->entity->graphics->at(graphic)->frame_count - 1;
+	}
+}
+
+void DecayAction::update(unsigned int time) {
+	this->frame += time * this->frame_rate / 10000.0f;
+}
+
+void DecayAction::on_completion() {}
+
+bool DecayAction::completed() const {
+	return this->frame > this->end_frame;
+}
+
 DeadAction::DeadAction(Unit *e, std::function<void()> on_complete)
 	:
 	UnitAction(e, graphic_type::dying),
@@ -93,21 +113,18 @@ void DeadAction::update(unsigned int time) {
 	}
 
 	// inc frame but do not pass the end frame
+	// the end frame will remain if the object carries resources
 	if (this->frame < this->end_frame) {
-		this->frame += 0.01 + time * this->frame_rate / 3.0f;
+		this->frame += 0.001 + time * this->frame_rate / 3.0f;
 	}
 	else {
 		this->frame = this->end_frame;
 	}
-	
-
-	// TODO: move to on_completion
-	if (this->completed()) {
-		this->on_complete_func();
-	}
 }
 
-void DeadAction::on_completion() {}
+void DeadAction::on_completion() {
+	this->on_complete_func();
+}
 
 bool DeadAction::completed() const {
 	// check resource, trees/huntables with resource are not removed

--- a/cpp/unit/action.h
+++ b/cpp/unit/action.h
@@ -128,6 +128,26 @@ protected:
 /**
  * plays a fixed number of frames for the units dying animation
  */
+class DecayAction: public UnitAction {
+public:
+	DecayAction(Unit *e);
+	virtual ~DecayAction() {}
+
+	void update(unsigned int) override;
+	void on_completion() override;
+	bool completed() const override;
+	bool allow_interupt() const override { return false; }
+	bool allow_destruction() const override { return false; }
+	std::string name() const override { return "decay"; }
+
+private:
+	float end_frame;
+
+};
+
+/**
+ * plays a fixed number of frames for the units dying animation
+ */
 class DeadAction: public UnitAction {
 public:
 	DeadAction(Unit *e, std::function<void()> on_complete=[]() {});

--- a/cpp/unit/action.h
+++ b/cpp/unit/action.h
@@ -82,6 +82,11 @@ public:
 	 */
 	virtual bool allow_destruction() const = 0;
 
+	/**
+	 * debug string to identify action types
+	 */
+	virtual std::string name() const = 0;
+
 	void draw_debug();
 
 	/**
@@ -133,6 +138,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
 	bool allow_destruction() const override { return false; }
+	std::string name() const override { return "dead"; }
 
 private:
 	float end_frame;
@@ -154,6 +160,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "idle"; }
 };
 
 /**
@@ -177,6 +184,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "move"; }
 
 	coord::phys3 next_waypoint() const;
 
@@ -206,6 +214,7 @@ public:
 	bool completed() const override { return complete; }
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "garrison"; }
 
 private:
 	UnitReference building;
@@ -226,6 +235,7 @@ public:
 	bool completed() const override { return complete; }
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "ungarrison"; }
 
 private:
 	coord::phys3 position;
@@ -245,6 +255,7 @@ public:
 	bool completed() const override { return complete; }
 	bool allow_interupt() const override { return false; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "train"; }
 
 private:
 	UnitProducer *trained;
@@ -265,6 +276,7 @@ public:
 	bool completed() const override { return complete >= 1.0f; }
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "build"; }
 
 private:
 	UnitReference building;
@@ -286,6 +298,7 @@ public:
 	bool completed() const override { return complete; }
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "repair"; }
 
 private:
 	UnitReference target;
@@ -305,6 +318,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "gather"; }
 
 private:
 	bool complete;
@@ -325,6 +339,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "attack"; }
 
 private:
 	UnitReference target;
@@ -354,6 +369,7 @@ public:
 	bool completed() const override { return complete >= 1.0; }
 	bool allow_interupt() const override { return true; }
 	bool allow_destruction() const override { return true; }
+	std::string name() const override { return "convert"; }
 
 private:
 	UnitReference target;
@@ -373,6 +389,7 @@ public:
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
 	bool allow_destruction() const override { return false; }
+	std::string name() const override { return "projectile"; }
 
 private:
 	coord::phys_t grav;

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -49,6 +49,9 @@ ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 	default_tex{dm.get_unit_texture(ud->graphic_standing0)},
 	dead_unit_producer{dm.get_producer(ud->dead_unit_id)} {
 
+	// for now just look for type names ending with "_D"
+	this->decay = unit_data.name.substr(unit_data.name.length() - 2) == "_D";
+
 	// find suitable sounds
 	int creation_sound = this->unit_data.sound_creation0;
 	int dying_sound = this->unit_data.sound_dying;
@@ -163,26 +166,32 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 		unit->add_attribute(new Attribute<attr_type::resource>(game_resource::stone, 350));
 	}
 	
-	// if destruction graphic is available
-	if (this->dead_unit_producer) {
-		unit->push_action(
-			std::make_unique<DeadAction>(
-				unit, 
-				[this, unit, &player]() {
-
-					// modify unit to have  dead type
-					this->dead_unit_producer->initialise(unit, player);
-				}
-			), 
-			true);
+	// decaying units have a timed lifespan
+	if (decay) {
+		unit->push_action(std::make_unique<DecayAction>(unit), true);
 	}
 	else {
-		unit->push_action(std::make_unique<DeadAction>(unit), true);
+		// if destruction graphic is available
+		if (this->dead_unit_producer) {
+			unit->push_action(
+				std::make_unique<DeadAction>(
+					unit, 
+					[this, unit, &player]() {
+
+						// modify unit to have  dead type
+						this->dead_unit_producer->initialise(unit, player);
+					}
+				), 
+				true);
+		}
+		else {
+			unit->push_action(std::make_unique<DeadAction>(unit), true);
+		}
+
+		// the default action
+		unit->push_action(std::make_unique<IdleAction>(unit), true);
 	}
-
-	// the default standing graphic
-	unit->push_action(std::make_unique<IdleAction>(unit), true);
-
+	
 	// give required abilitys
 	for (auto &a : this->type_abilities) {
 		unit->give_ability(a);
@@ -194,10 +203,10 @@ TerrainObject *ObjectProducer::place(Unit *u, Terrain &terrain, coord::phys3 ini
 	// create new object with correct base shape
 	TerrainObject *obj = nullptr;
 	if (this->unit_data.selection_shape > 1) {
-		obj = new RadialObject(*u, this->unit_data.radius_size0, this->terrain_outline.get());
+		obj = new RadialObject(*u, this->unit_data.radius_size0, this->terrain_outline, !decay);
 	}
 	else {
-		obj = new SquareObject(*u, this->foundation_size, this->terrain_outline.get());
+		obj = new SquareObject(*u, this->foundation_size, this->terrain_outline, !decay);
 	}
 
 	// find set of allowed terrains
@@ -287,7 +296,9 @@ void MovableProducer::initialise(Unit *unit, Player &player) {
 	/*
 	 * basic attributes
 	 */
-	unit->add_attribute(new Attribute<attr_type::direction>(coord::phys3_delta{ 1, 0, 0 }));
+	if (!unit->has_attribute(attr_type::direction)) {
+		unit->add_attribute(new Attribute<attr_type::direction>(coord::phys3_delta{ 1, 0, 0 }));
+	}
 
 	/*
 	 * distance per millisecond -- consider original game speed

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -120,10 +120,8 @@ std::string ObjectProducer::producer_name() const {
 void ObjectProducer::initialise(Unit *unit, Player &player) {
 
 	// log attributes
-	unit->log(MSG(dbg) << "creating " <<
-		this->unit_data.id0 << " (" <<
-		this->unit_data.id1 << " " <<
-		this->unit_data.id2 << ") " <<
+	unit->log(MSG(dbg) << "setting unit type " <<
+		this->unit_data.id0 <<
 		this->unit_data.name);
 
 	// reset existing attributes

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -203,10 +203,10 @@ TerrainObject *ObjectProducer::place(Unit *u, Terrain &terrain, coord::phys3 ini
 	// create new object with correct base shape
 	TerrainObject *obj = nullptr;
 	if (this->unit_data.selection_shape > 1) {
-		obj = new RadialObject(*u, this->unit_data.radius_size0, this->terrain_outline, !decay);
+		obj = new RadialObject(*u, this->unit_data.radius_size0, this->terrain_outline, !this->decay);
 	}
 	else {
-		obj = new SquareObject(*u, this->foundation_size, this->terrain_outline, !decay);
+		obj = new SquareObject(*u, this->foundation_size, this->terrain_outline, !this->decay);
 	}
 
 	// find set of allowed terrains

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -124,7 +124,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 
 	// log attributes
 	unit->log(MSG(dbg) << "setting unit type " <<
-		this->unit_data.id0 <<
+		this->unit_data.id0 << " " <<
 		this->unit_data.name);
 
 	// reset existing attributes

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -109,6 +109,11 @@ protected:
 	const gamedata::unit_object unit_data;
 
 	/**
+	 * decaying objects have a timed lifespan
+	 */
+	bool decay;
+
+	/**
 	 * Sound id played when object is created or destroyed.
 	 */
 	Sound *on_create;

--- a/cpp/unit/selection.cpp
+++ b/cpp/unit/selection.cpp
@@ -5,6 +5,7 @@
 #include "../coord/tile.h"
 #include "../coord/tile3.h"
 #include "../terrain/terrain.h"
+#include "action.h"
 #include "producer.h"
 #include "selection.h"
 #include "unit.h"
@@ -178,6 +179,7 @@ void UnitSelection::all_invoke(Command &cmd) {
 
 void UnitSelection::show_attributes(Unit *u) {
 	std::vector<std::string> lines;
+	lines.push_back(u->top()->name());
 
 	if (u->has_attribute(attr_type::owner)) {
 		auto &own_attr = u->get_attribute<attr_type::owner>();

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -219,7 +219,7 @@ void Unit::erase_after(std::function<bool(std::unique_ptr<UnitAction> &)> func) 
 		std::end(this->action_stack),
 		func);
 
-	if (position_it < std::end(this->action_stack)) {
+	if (position_it != std::end(this->action_stack)) {
 		auto completed_action = std::move(*position_it);
 
 		// erase from the stack

--- a/cpp/unit/unit.h
+++ b/cpp/unit/unit.h
@@ -72,6 +72,7 @@ public:
 
 	/** 
 	 * removes all actions and abilities
+	 * current attributes are kept
 	 */
 	void reset();
 
@@ -205,6 +206,8 @@ private:
 	 * the container that updates this unit
 	 */
 	UnitContainer &container;
+
+	void erase_after(std::function<bool(std::unique_ptr<UnitAction> &)> func);
 
 };
 


### PR DESCRIPTION
Decaying units face correct direction and disappear after a short time.

Im not sure how the original engine knows which units decay based on gamedata, so it will just check for unit names ending in "_D" for now.