### PR TITLE
Abort on checkfull fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ notifications:
     channels:
       - "chat.freenode.net#sfttech"
     template:
-      - "%{repository}/%{branch} (%{commit} - %{author}): %{message}"
+      - "%{repository_slug}/%{branch} (%{commit} - %{author}): %{message}"
+      - "took %{duration}, moar info: %{build_url}"
     use_notice: true
     skip_join: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,7 @@ before_script:
   - sudo ln -sf /usr/bin/python${PYVERSION} /usr/bin/python3
 
 script:
-  - ./configure
-  - make checkfull  # test code quality, copyright, etc
-  - make openage    # running 'make'/'make all' would cause 'make check' to run after building
-  - make runtest    # running 'make test' would cause 'make check' to run after testing
+  - ./configure && make runci
 
 after_script:
   - echo test build exited

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,12 @@ checklegalfull:
 check:
 	@$(RUN_PYMODULE) openage.codecompliance --quick
 
-.PHONY: checkallfull
+.PHONY: checkfull
 checkfull:
 	@$(RUN_PYMODULE) openage.codecompliance --all
+
+.PHONY: runci
+runci: checkfull openage runtest
 
 .PHONY: help
 help: $(BUILDDIR)/Makefile
@@ -172,6 +175,7 @@ help: $(BUILDDIR)/Makefile
 	@echo "run                -> run openage"
 	@echo "runval             -> run openage in valgrind, analyzing for memleaks"
 	@echo "rungdb             -> run openage in gdb"
+	@echo "runci              -> run the continuous integration script (checkfull, tests)"
 	@echo "runtest            -> run the tests (py modules + openage)"
 	@echo ""
 	@echo "checkheaderguards  -> check header guards"


### PR DESCRIPTION
Currently, the sanity check is done before compiling, but the build doesn't abort if something is wrong.
That way, the error messages get burried before all the compilation output.

With this, Travis won't compile if checkfull fails.
Also, fancier IRC notification.