### PR TITLE
[WIP] Media versioning

### DIFF
--- a/py/openage/CMakeLists.txt
+++ b/py/openage/CMakeLists.txt
@@ -3,4 +3,5 @@ add_py_package(openage)
 add_test_py(openage.assets.test "tests python asset locator")
 
 add_subdirectory("convert")
+add_subdirectory("pack")
 add_subdirectory("testing")

--- a/py/openage/convert/dataformat/exportable.py
+++ b/py/openage/convert/dataformat/exportable.py
@@ -1,5 +1,6 @@
-# Copyright 2014-2014 the openage authors. See copying.md for legal info.
+# Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
+import hashlib
 import struct
 
 from ..util import zstr
@@ -381,7 +382,7 @@ class Exportable:
             dbg(lazymsg=lambda: "%s: exporting member %s<%s>" % (repr(cls), member_name, member_type), lvl=3)
 
             if isinstance(member_type, MultisubtypeMember):
-                for subtype_name, subtype_class in member_type.class_lookup.items():
+                for subtype_name, subtype_class in sorted(member_type.class_lookup.items()):
                     if not issubclass(subtype_class, Exportable):
                         raise Exception("tried to export structs from non-exportable %s" % subtype_class)
                     ret += subtype_class.structs()
@@ -404,11 +405,61 @@ class Exportable:
         return ret
 
     @classmethod
+    def format_hash(cls, hasher=None):
+        """
+        provides a deterministic hash of all exported structure members
+
+        used for determining changes in the exported data, which requires
+        data reconversion.
+        """
+
+        if not hasher:
+            hasher = hashlib.sha512()
+
+        # struct properties
+        hasher.update(cls.name_struct.encode())
+        hasher.update(cls.name_struct_file.encode())
+        hasher.update(cls.struct_description.encode())
+
+        # only hash exported struct members!
+        # non-exported values don't influence anything.
+        members = cls.get_data_format(
+            allowed_modes=(True, READ_EXPORT, NOREAD_EXPORT),
+            flatten_includes=False,
+        )
+        for is_parent, export, member_name, member_type in members:
+
+            # includemembers etc have no name.
+            if member_name:
+                hasher.update(member_name.encode())
+
+            if isinstance(member_type, DataMember):
+                hasher = member_type.format_hash(hasher)
+
+            elif isinstance(member_type, str):
+                hasher.update(member_type.encode())
+
+            else:
+                raise Exception("can't hash unsupported member")
+
+            hasher.update(export.name.encode())
+
+        return hasher
+
+    @classmethod
     def get_effective_type(cls):
         return cls.name_struct
 
     @classmethod
     def get_data_format(cls, allowed_modes=False, flatten_includes=False, is_parent=False):
+        """
+        return all members of this exportable (a struct.)
+
+        can filter by export modes and can also return included members:
+        inherited members can either be returned as to-be-included,
+        or can be fetched and displayed as if they weren't inherited.
+        """
+
         for member in cls.data_format:
             export, member_name, member_type = member
 

--- a/py/openage/convert/gamedata/empiresdat.py
+++ b/py/openage/convert/gamedata/empiresdat.py
@@ -78,7 +78,7 @@ class EmpiresDat(Exportable):
     data_format = (
         (READ, "versionstr", "char[8]"),
 
-        # terain header data
+        # terrain header data
         (READ, "terrain_restriction_count", "uint16_t"),
         (READ, "terrain_count", "uint16_t"),
         (READ, "terrain_restriction_offset0", "int32_t[terrain_restriction_count]"),

--- a/py/openage/convert/gamedata/sound.py
+++ b/py/openage/convert/gamedata/sound.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 the openage authors. See copying.md for legal info.
+# Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 from ..dataformat.exportable import Exportable
 from ..dataformat.members import SubdataMember
@@ -11,7 +11,7 @@ class SoundItem(Exportable):
     struct_description = "one possible file for a sound."
 
     data_format = (
-        (READ_EXPORT, "filename",    "char[13]"),
+        (READ_EXPORT, "filename",     "char[13]"),
         (READ_EXPORT, "resource_id",  "int32_t"),
         (READ_EXPORT, "probablilty",  "int16_t"),
         (READ_EXPORT, "civilisation", "int16_t"),

--- a/py/openage/convert/versioning.py
+++ b/py/openage/convert/versioning.py
@@ -1,0 +1,8 @@
+# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+# Provides versioning information for converted files.
+
+
+from .gamedata import empiresdat
+
+print(empiresdat.EmpiresDat.format_hash().hexdigest())

--- a/py/openage/pack/CMakeLists.txt
+++ b/py/openage/pack/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_py_package(openage.pack)
+
+add_test_py(openage.pack.tests.packcfg_read "tests reading mod pack root config files")
+add_test_py(openage.pack.tests.packcfg_write "tests reading mod pack root config files")

--- a/py/openage/pack/pack_config.py
+++ b/py/openage/pack/pack_config.py
@@ -1,0 +1,113 @@
+# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+import configparser
+import re
+
+
+class PackConfig:
+    """
+    main config file for a mod pack.
+
+    stores the package metainformation for the mod list.
+
+    file contents:
+
+    [openage-pack]
+    name = <package name>
+    version = <package version>
+    author = <pack author>
+    pack_type = (game|mod|...)
+    config_type = (cfg|nyan|...)
+    config = <filename.cfg>
+    """
+
+    # everything has to be in this section:
+    root_cfg = "openage-pack"
+
+    # required attributes
+    pack_attrs = ("name", "version", "author",
+                  "pack_type", "config_type", "config")
+
+    def __init__(self):
+        """
+        init all required attributes to None.
+        """
+
+        self.cfg = dict()
+
+        for attr in self.pack_attrs:
+            self.cfg[attr] = None
+
+    def check_sanity(self):
+        """
+        checks whether the current config is valid.
+        """
+
+        if None in self.cfg.values():
+            nones = [v for k, v in self.cfg.items() if v is None]
+            raise Exception("unset attribute(s): %s" % nones)
+
+        if self.cfg["pack_type"] not in ("game", "mod"):
+            raise Exception("unsupported data pack type")
+
+        if self.cfg["config_type"] not in ("cfg",):
+            raise Exception("config_type not supported: %s" %
+                            self.cfg["config_type"])
+
+        if not re.match(r"[a-zA-Z][a-zA-Z0-9_]*", self.cfg["name"]):
+            raise Exception("disallowed chars in pack name found")
+
+        if not re.match(r"v[0-9]+(\.[0-9]+)*(-r[0-9]+)", self.cfg["version"]):
+            raise Exception("invalid pack version")
+
+    def read(self, handle):
+        """
+        fill this pack config by the contents provided by the file handle.
+        """
+
+        cfp = configparser.ConfigParser()
+
+        # read the config from the (pseudo-?)handle
+        cfp.read_file(handle, source=handle.name)
+
+        if self.root_cfg not in cfp:
+            raise Exception("pack root config doesn't contain '%s' section."
+                            % self.root_cfg)
+        else:
+            self.cfg = cfp[self.root_cfg]
+
+        self.check_sanity()
+
+    def write(self, handle):
+        """
+        store the settings of this configfile to the given file handle.
+        """
+
+        self.check_sanity()
+
+        cfp = configparser.ConfigParser()
+        cfp[self.root_cfg] = self.cfg
+
+        cfp.write(handle)
+
+    def set_attrs(self, **dct):
+        """
+        set all attributes from the dict to this pack config.
+        """
+
+        # just take the known attributes
+        to_set = {k: v for k, v in dct.items() if k in self.pack_attrs}
+
+        # check if all keys were used
+        unknown_keys = dct.keys() - to_set.keys()
+        if unknown_keys:
+            raise Exception("unknown attr name(s) to set: %s" % unknown_keys)
+
+        self.cfg.update(to_set)
+
+    def get_attrs(self):
+        """
+        return this config's settings.
+        """
+
+        return self.cfg

--- a/py/openage/pack/tests.py
+++ b/py/openage/pack/tests.py
@@ -1,0 +1,74 @@
+# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+from .pack_config import PackConfig
+
+from openage.util import VirtualFile
+
+
+def packcfg_read():
+    """
+    test reading a virtual root config file
+    """
+
+    pcfg = PackConfig()
+
+    f = VirtualFile(name="virtual_input_test.cfg", binary=False)
+    content = (
+        "[" + PackConfig.root_cfg + "]\n"
+        "name = {name}\n"
+        "version = {version}\n"
+        "author = {author}\n"
+        "pack_type = {pack_type}\n"
+        "config_type = {config_type}\n"
+        "config = {config}\n"
+    )
+
+    test = {
+        "name": "Valid_Name_1337",
+        "version": "v42-r8",
+        "pack_type": "mod",
+        "author": "test bot 9001",
+        "config_type": "cfg",
+        "config": "nonexistant.cfg",
+    }
+
+    f.set_data(content.format(**test))
+    pcfg.read(f)
+
+    if not pcfg.get_attrs() == test:
+        raise Exception("parsed config does not equal the input")
+
+
+def packcfg_write():
+    """
+    test writing the root config to a virtual file
+    """
+
+    pcfg = PackConfig()
+    test = {
+        "name": "roflPack2000",
+        "version": "v1337-r42",
+        "pack_type": "game",
+        "author": "i did nothing wrong",
+        "config_type": "cfg",
+        "config": "roflfile.cfg",
+    }
+    pcfg.set_attrs(**test)
+
+    o = VirtualFile(name="virtual_output_test.cfg", binary=False)
+    pcfg.write(o)
+
+    lines = o.data().split("\n")
+
+    result = dict()
+    # ignore first and last line
+    for line in lines[1:-2]:
+        k, v = tuple(line.split(" = "))
+        result[k] = v
+
+    if test.keys() != result.keys():
+        raise Exception("unexpected key set found.")
+
+    for k, v in result.items():
+        if test[k] != v:
+            raise Exception("%s didn't have expected value" % k)

--- a/py/openage/util.py
+++ b/py/openage/util.py
@@ -26,23 +26,45 @@ class VirtualFile:
     operates in binary mode.
     """
 
-    def __init__(self):
-        self.buf = b""
+    def __init__(self, name=None, binary=True):
+        self.buf = b"" if binary else ""
+        self.name = name
+        self.pos = 0
 
-    def seek(self, destination, whence=0):
-        raise NotImplementedError("seek not implemented")
+    def seek(self, offset, whence=0):
+        raise NotImplementedError("seeking not implemented")
 
     def tell(self):
-        raise NotImplementedError("tell not implemented")
+        return self.pos
 
     def read(self):
-        raise NotImplementedError("read not implemented")
+        return self.buf[self.pos:]
 
     def write(self, data):
-        self.buf += data
+        # we're at the end:
+        if self.pos == len(self.buf) - 1:
+            self.buf += data
+        # we're somewhere in the middle:
+        else:
+            self.buf = (self.buf[0:self.pos] + data +
+                        self.buf[(self.pos + len(data)):])
+
+        self.pos += len(data)
 
     def data(self):
         return self.buf
+
+    def set_data(self, data):
+        self.buf = data
+        self.pos = 0
+
+    def __iter__(self):
+        lines = self.data().split("\n")
+
+        def get_lines():
+            for l in lines:
+                yield l
+        return get_lines()
 
 
 def gen_dict_key2lists(keys):


### PR DESCRIPTION
My attempt on versioning the media files. Introduces a data pack format (#86).

Basically, all converted and generated files will store some version (e.g. the gamedata specification hash). The engine can detect required/present discrepancies and trigger reconversion.

When this is merged, users won't have to reconvert everything for changes in one area only, but this will require #79 to be finished.

This implements and thus closes #204.

New features:

* [X] Hashing the exported struct member configuration
* [X] Simple mod data pack format
* [ ] Check if the compiled-in struct format hash == exported-gamedata-files-format-hash