### PR TITLE
Auto-task idle units

### DIFF
--- a/cpp/datamanager.cpp
+++ b/cpp/datamanager.cpp
@@ -94,21 +94,21 @@ Sound *DataManager::get_sound(index_t sound_id) {
 	return &this->available_sounds[sound_id];
 }
 
-UnitProducer *DataManager::get_producer(index_t producer_id) {
-	if (this->producers.count(producer_id) == 0) {
-		if (producer_id > 0) {
-			log::log(MSG(info) << "  -> ignoring producer_id: " << producer_id);
+UnitType *DataManager::get_type(index_t type_id) {
+	if (this->producers.count(type_id) == 0) {
+		if (type_id > 0) {
+			log::log(MSG(info) << "  -> ignoring type_id: " << type_id);
 		}
 		return nullptr;
 	}
-	return this->producers[producer_id];
+	return this->producers[type_id];
 }
 
-UnitProducer *DataManager::get_producer_index(size_t producer_index) {
-	if (producer_index < available_objects.size()) {
-		return available_objects[producer_index].get();
+UnitType *DataManager::get_type_index(size_t type_index) {
+	if (type_index < available_objects.size()) {
+		return available_objects[type_index].get();
 	}
-	log::log(MSG(info) << "  -> ignoring producer_index: " << producer_index);
+	log::log(MSG(info) << "  -> ignoring type_index: " << type_index);
 	return nullptr;
 }
 
@@ -208,7 +208,7 @@ void DataManager::on_gamedata_loaded(std::vector<gamedata::empiresdat> &gamedata
 
 	log::log(MSG(info) << "Using the " << gamedata[0].civs.data[your_civ_id].name << " civilisation.");
 	this->create_abilities(gamedata);
-	this->create_producers(gamedata, your_civ_id);
+	this->create_unit_types(gamedata, your_civ_id);
 }
 
 bool DataManager::valid_graphic_id(index_t graphic_id) {
@@ -221,19 +221,19 @@ bool DataManager::valid_graphic_id(index_t graphic_id) {
 	return true;
 }
 
-void DataManager::load_building(const gamedata::unit_building &building, producer_list &list) {
+void DataManager::load_building(const gamedata::unit_building &building, unit_type_list &list) {
 
 	// check graphics
 	if (this->valid_graphic_id(building.graphic_standing0)) {
 		list.emplace_back(std::make_unique<BuldingProducer>(*this, &building));
 
 		auto producer_ptr = list.back().get();
-		this->producers[producer_ptr->producer_id()] = producer_ptr;
+		this->producers[producer_ptr->id()] = producer_ptr;
 		this->buildings[building.id0] = &building;
 	}
 }
 
-void DataManager::load_living(const gamedata::unit_living &unit, producer_list &list) {
+void DataManager::load_living(const gamedata::unit_living &unit, unit_type_list &list) {
 
 	// check graphics
 	if (this->valid_graphic_id(unit.graphic_dying0) &&
@@ -242,30 +242,30 @@ void DataManager::load_living(const gamedata::unit_living &unit, producer_list &
 		list.emplace_back(std::make_unique<LivingProducer>(*this, &unit));
 
 		auto producer_ptr = list.back().get();
-		this->producers[producer_ptr->producer_id()] = producer_ptr;
+		this->producers[producer_ptr->id()] = producer_ptr;
 		
 	}
 }
 
-void DataManager::load_object(const gamedata::unit_object &object, producer_list &list) {
+void DataManager::load_object(const gamedata::unit_object &object, unit_type_list &list) {
 
 	// check graphics
 	if (this->valid_graphic_id(object.graphic_standing0)) {
 		list.emplace_back(std::make_unique<ObjectProducer>(*this, &object));
 
 		auto producer_ptr = list.back().get();
-		this->producers[producer_ptr->producer_id()] = producer_ptr;
+		this->producers[producer_ptr->id()] = producer_ptr;
 	}
 }
 
-void DataManager::load_projectile(const gamedata::unit_projectile &proj, producer_list &list) {
+void DataManager::load_projectile(const gamedata::unit_projectile &proj, unit_type_list &list) {
 
 	// check graphics
 	if (this->valid_graphic_id(proj.graphic_standing0)) {
 		list.emplace_back(std::make_unique<ProjectileProducer>(*this, &proj));
 
 		auto producer_ptr = list.back().get();
-		this->producers[producer_ptr->producer_id()] = producer_ptr;
+		this->producers[producer_ptr->id()] = producer_ptr;
 	}
 }
 
@@ -295,7 +295,7 @@ void DataManager::create_abilities(const std::vector<gamedata::empiresdat> &game
 	}
 }
 
-void DataManager::create_producers(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id) {
+void DataManager::create_unit_types(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id) {
 
 	// create projectile types first
 	for (auto &obj : gamedata[0].civs.data[0].units.projectile.data) {

--- a/cpp/datamanager.h
+++ b/cpp/datamanager.h
@@ -55,7 +55,7 @@ public:
 	void check_updates();
 
 	/**
-	 * check if loading has been completed 
+	 * check if loading has been completed
 	 */
 	bool load_complete();
 
@@ -69,7 +69,7 @@ public:
 	 */
 	index_t get_slp_graphic(index_t slp);
 
-	/** 
+	/**
 	 * get a texture by id, this specifically avoids returning the missing placeholder texture
 	 */
 	Texture *get_texture(index_t graphic_id);
@@ -95,7 +95,7 @@ public:
 	 */
 	UnitType *get_type_index(size_t type_index);
 
-	/** 
+	/**
 	 * data for a graphic
 	 */
 	const gamedata::graphic *get_graphic_data(index_t grp_id);
@@ -170,8 +170,8 @@ private:
 	void create_unit_types(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id);
 
 	/**
-	 * loads required assets to produce an entity type
-	 * adds to the producer list if the object can be created safely
+	 * loads required assets to construct a unit type
+	 * adds to the type list if the object can be created safely
 	 */
 	void load_building(const gamedata::unit_building &, unit_type_list &);
 	void load_living(const gamedata::unit_living &, unit_type_list &);

--- a/cpp/datamanager.h
+++ b/cpp/datamanager.h
@@ -86,12 +86,12 @@ public:
 	Sound *get_sound(index_t sound_id);
 
 	/**
-	 * producers by aoe unit ids -- the producer which corresponds to an aoe unit id
+	 * unit types by aoe gamedata unit ids -- the unit type which corresponds to an aoe unit id
 	 */
 	UnitType *get_type(index_t type_id);
 
 	/**
-	 * producers by list index -- a continuous array of all producers
+	 * unit types by list index -- a continuous array of all types
 	 */
 	UnitType *get_type_index(size_t type_index);
 
@@ -140,12 +140,12 @@ private:
 	std::unordered_map<index_t, std::vector<const gamedata::unit_command *>> commands;
 
 	/**
-	 * unit ids -> producer for that id
+	 * unit ids -> unit type for that id
 	 */
 	std::unordered_map<index_t, UnitType *> producers;
 
 	/**
-	 * unit ids -> producer for that id
+	 * unit ids -> unit type for that id
 	 */
 	std::unordered_map<index_t, std::shared_ptr<UnitTexture>> unit_textures;
 

--- a/cpp/datamanager.h
+++ b/cpp/datamanager.h
@@ -14,13 +14,13 @@
 namespace openage {
 
 class AssetManager;
-class UnitProducer;
+class UnitType;
 
 /**
  * the key type mapped to data objects
  */
 using index_t = int;
-using producer_list = std::vector<std::unique_ptr<UnitProducer>>;
+using unit_type_list = std::vector<std::unique_ptr<UnitType>>;
 
 /**
  * simple sound object
@@ -88,12 +88,12 @@ public:
 	/**
 	 * producers by aoe unit ids -- the producer which corresponds to an aoe unit id
 	 */
-	UnitProducer *get_producer(index_t producer_id);
+	UnitType *get_type(index_t type_id);
 
 	/**
 	 * producers by list index -- a continuous array of all producers
 	 */
-	UnitProducer *get_producer_index(size_t producer_index);
+	UnitType *get_type_index(size_t type_index);
 
 	/** 
 	 * data for a graphic
@@ -117,7 +117,7 @@ private:
 	/**
 	 * all available game objects.
 	 */
-	producer_list available_objects;
+	unit_type_list available_objects;
 
 	/**
 	 * slp to graphic reverse lookup
@@ -142,7 +142,7 @@ private:
 	/**
 	 * unit ids -> producer for that id
 	 */
-	std::unordered_map<index_t, UnitProducer *> producers;
+	std::unordered_map<index_t, UnitType *> producers;
 
 	/**
 	 * unit ids -> producer for that id
@@ -167,16 +167,16 @@ private:
 	/**
 	 * makes producers for all types in the game data
 	 */
-	void create_producers(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id);
+	void create_unit_types(const std::vector<gamedata::empiresdat> &gamedata, int your_civ_id);
 
 	/**
 	 * loads required assets to produce an entity type
 	 * adds to the producer list if the object can be created safely
 	 */
-	void load_building(const gamedata::unit_building &, producer_list &);
-	void load_living(const gamedata::unit_living &, producer_list &);
-	void load_object(const gamedata::unit_object &, producer_list &);
-	void load_projectile(const gamedata::unit_projectile &, producer_list &);
+	void load_building(const gamedata::unit_building &, unit_type_list &);
+	void load_living(const gamedata::unit_living &, unit_type_list &);
+	void load_object(const gamedata::unit_object &, unit_type_list &);
+	void load_projectile(const gamedata::unit_projectile &, unit_type_list &);
 
 	/**
 	 * has game data been load yet

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -289,8 +289,8 @@ GameMain::GameMain(Engine *engine)
 	this->keybind_context.bind(keybinds::action_t::TRAIN_OBJECT, [this]() {
 		// attempt to train editor selected object
 		if ( this->datamanager.producer_count() > 0 ) {
-			UnitProducer *producer = this->datamanager.get_producer_index(this->editor_current_building);
-			Command cmd(this->players[0], producer);
+			auto type = this->datamanager.get_type_index(this->editor_current_building);
+			Command cmd(this->players[0], type);
 			this->selection.all_invoke(cmd);
 		}
 	});
@@ -346,7 +346,7 @@ bool GameMain::on_input(SDL_Event *e) {
 			if (this->building_placement) {
 
 				// confirm building placement with left click
-				Command cmd(this->players[0], this->datamanager.get_producer_index(this->editor_current_building), mousepos_phys3);
+				Command cmd(this->players[0], this->datamanager.get_type_index(this->editor_current_building), mousepos_phys3);
 				cmd.set_ability(ability_type::build);
 				selection.all_invoke(cmd);
 				this->building_placement = false;
@@ -408,7 +408,7 @@ bool GameMain::on_input(SDL_Event *e) {
 			} else if ( this->datamanager.producer_count() > 0 ) {
 				// try creating a unit
 				log::log(MSG(dbg) << "create unit with producer id " << this->editor_current_building);
-				UnitProducer &producer = *this->datamanager.get_producer_index(this->editor_current_building);
+				auto &producer = *this->datamanager.get_type_index(this->editor_current_building);
 				this->placed_units.new_unit(producer, this->players[rand() % this->players.size()], mousepos_tile.to_phys2().to_phys3());
 			}
 			break;
@@ -560,7 +560,7 @@ bool GameMain::on_draw() {
 	}
 
 	if (this->building_placement) {
-		auto txt = this->datamanager.get_producer_index(this->editor_current_building)->default_texture();
+		auto txt = this->datamanager.get_type_index(this->editor_current_building)->default_texture();
 		txt->draw(mousepos_tile.to_phys2().to_phys3().to_camgame(), 0, 1);
 	}
 
@@ -578,7 +578,7 @@ bool GameMain::on_drawhud() {
 		coord::window bpreview_pos;
 		bpreview_pos.x = e.engine_coord_data->window_size.x - 200;
 		bpreview_pos.y = 200;
-		auto txt = this->datamanager.get_producer_index(this->editor_current_building)->default_texture();
+		auto txt = this->datamanager.get_type_index(this->editor_current_building)->default_texture();
 		txt->sample(bpreview_pos.to_camhud());
 	}
 	return true;

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -347,18 +347,18 @@ bool GameMain::on_input(SDL_Event *e) {
 
 				// confirm building placement with left click
 				// first create foundation using the producer
-				auto player = this->selection.owner();
+				Player *player = this->selection.owner();
 				if (player) {
-					auto container = &this->placed_units;
-					auto building_type = this->datamanager.get_type_index(this->editor_current_building);
-					auto new_building = container->new_unit(*building_type, *player, mousepos_phys3);
+					UnitContainer *container = &this->placed_units;
+					UnitType *building_type = this->datamanager.get_type_index(this->editor_current_building);
+					UnitReference new_building = container->new_unit(*building_type, *player, mousepos_phys3);
 
 					// task all selected villagers to build
 					if (new_building.is_valid()) {
 						Command cmd(*player, new_building.get());
 						cmd.set_ability(ability_type::build);
 						this->selection.all_invoke(cmd);
-					}	
+					}
 				}
 				this->building_placement = false;
 			}
@@ -419,7 +419,7 @@ bool GameMain::on_input(SDL_Event *e) {
 			} else if ( this->datamanager.producer_count() > 0 ) {
 				// try creating a unit
 				log::log(MSG(dbg) << "create unit with producer id " << this->editor_current_building);
-				auto &producer = *this->datamanager.get_type_index(this->editor_current_building);
+				UnitType &producer = *this->datamanager.get_type_index(this->editor_current_building);
 				this->placed_units.new_unit(producer, this->players[rand() % this->players.size()], mousepos_tile.to_phys2().to_phys3());
 			}
 			break;

--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -413,7 +413,7 @@ bool GameMain::on_input(SDL_Event *e) {
 			// delete any unit on the tile
 			if (!chunk->get_data(mousepos_tile)->obj.empty()) {
 				// get first object currently standing at the clicked position
-				auto obj = chunk->get_data(mousepos_tile)->obj[0].lock();
+				TerrainObject *obj = chunk->get_data(mousepos_tile)->obj[0];
 				log::log(MSG(dbg) << "delete unit with unit id " << obj->unit.id);
 				obj->unit.delete_unit();
 			} else if ( this->datamanager.producer_count() > 0 ) {

--- a/cpp/game_main.h
+++ b/cpp/game_main.h
@@ -26,7 +26,6 @@
 namespace openage {
 
 class Unit;
-class UnitProducer;
 
 /**
  * runs the game.

--- a/cpp/game_save.cpp
+++ b/cpp/game_save.cpp
@@ -5,6 +5,7 @@
 
 #include "unit/producer.h"
 #include "unit/unit.h"
+#include "unit/unit_type.h"
 #include "game_main.h"
 #include "game_save.h"
 
@@ -12,7 +13,7 @@ namespace openage {
 namespace gameio {
 
 void save_unit(std::ofstream &file, Unit *unit) {
-	file << unit->producer->producer_id() << std::endl;
+	file << unit->unit_type->id() << std::endl;
 	file << unit->get_attribute<attr_type::owner>().player.player_number << std::endl;
 	coord::tile pos = unit->location->pos.start;
 	file << pos.ne << " " << pos.se << std::endl;
@@ -27,7 +28,7 @@ void load_unit(std::ifstream &file, openage::GameMain *game) {
 	file >> ne;
 	file >> se;
 
-	auto p = game->datamanager.get_producer(pr_id);
+	auto p = game->datamanager.get_type(pr_id);
 	game->placed_units.new_unit(*p, game->players[player_no], coord::tile{ne, se}.to_phys2().to_phys3());
 }
 

--- a/cpp/game_save.cpp
+++ b/cpp/game_save.cpp
@@ -28,8 +28,8 @@ void load_unit(std::ifstream &file, openage::GameMain *game) {
 	file >> ne;
 	file >> se;
 
-	auto p = game->datamanager.get_type(pr_id);
-	game->placed_units.new_unit(*p, game->players[player_no], coord::tile{ne, se}.to_phys2().to_phys3());
+	UnitType &saved_type = *game->datamanager.get_type(pr_id);
+	game->placed_units.new_unit(saved_type, game->players[player_no], coord::tile{ne, se}.to_phys2().to_phys3());
 }
 
 void save_tile_content(std::ofstream &file, openage::TileContent *content) {

--- a/cpp/pathfinding/a_star.cpp
+++ b/cpp/pathfinding/a_star.cpp
@@ -61,35 +61,6 @@ Path find_nearest(coord::phys3 start,
 	return a_star(start, valid_end, zero, passable);
 }
 
-openage::TerrainObject *find_nearest(openage::TerrainObject *to_move,
-            std::function<bool(const openage::TerrainObject *)> valid_end) {
-	coord::phys3 start = to_move->pos.draw;
-
-	// check any objects containing the serach point
-	openage::Terrain *terrain = to_move->get_terrain();
-	auto valid_end_pos = [=](const coord::phys3 &p) -> bool {
-		auto obj = terrain->obj_at_point(p).get();
-		if (obj) {
-			return valid_end(obj);
-		}
-		return false;
-	};
-
-	// Use Dijkstra (hueristic = 0)
-	auto zero = [](const coord::phys3 &) -> cost_t { return .0f; };
-	auto passable = [](const coord::phys3 &) -> bool { return true; };
-
-	// find using a star
-	Path p = a_star(start, valid_end_pos, zero, passable);
-	if (p.waypoints.empty()) {
-		return nullptr;
-	}
-
-	// use endpoint to identify an object
-	coord::phys3 end = p.waypoints.front().position;
-	return terrain->obj_at_point(end).get();
-}
-
 Path a_star(coord::phys3 start,
             std::function<bool(const coord::phys3 &)> valid_end,
             std::function<cost_t(const coord::phys3 &)> heuristic,

--- a/cpp/pathfinding/a_star.h
+++ b/cpp/pathfinding/a_star.h
@@ -34,12 +34,6 @@ Path find_nearest(coord::phys3 start,
                   std::function<bool(const coord::phys3 &)> passable);
 
 /**
- * search outwards to find an object and return object
- */
-openage::TerrainObject *find_nearest(TerrainObject *to_move,
-            std::function<bool(const TerrainObject *)> valid_end);
-
-/**
  * finds a path between two endpoints
  * @param start the starting tile coords
  * @param end the ending tile coords

--- a/cpp/player.cpp
+++ b/cpp/player.cpp
@@ -1,5 +1,6 @@
 // Copyright 2015-2015 the openage authors. See copying.md for legal info.
 
+#include "unit/unit.h"
 #include "player.h"
 
 namespace openage {
@@ -22,6 +23,13 @@ bool Player::is_ally(const Player &other) const {
 
 	// everyone else is enemy
 	return player_number == other.player_number;
+}
+
+bool Player::owns(Unit &unit) const {
+	if (unit.has_attribute(attr_type::owner)) {
+		return this == &unit.get_attribute<attr_type::owner>().player;
+	}
+	return false;
 }
 
 }

--- a/cpp/player.h
+++ b/cpp/player.h
@@ -10,6 +10,8 @@
 
 namespace openage {
 
+class Unit;
+
 class Player {
 public:
 	Player(unsigned int number);
@@ -24,8 +26,20 @@ public:
 
 	const std::string name;
 
+	/**
+	 * the specified player is an enemy of this player
+	 */
 	bool is_enemy(const Player &) const;
+
+	/**
+	 * the specified player is an ally of this player
+	 */
 	bool is_ally(const Player &) const;
+
+	/**
+	 * this player owns the specified unit
+	 */ 
+	bool owns(Unit &) const;
 
 private:
 	std::unordered_map<game_resource, double> resources;

--- a/cpp/player.h
+++ b/cpp/player.h
@@ -16,7 +16,7 @@ class Player {
 public:
 	Player(unsigned int number);
 
-	const unsigned int player_number; 
+	const unsigned int player_number;
 
 	/**
 	 * would be better to have rgb color value
@@ -38,7 +38,7 @@ public:
 
 	/**
 	 * this player owns the specified unit
-	 */ 
+	 */
 	bool owns(Unit &) const;
 
 private:

--- a/cpp/terrain/CMakeLists.txt
+++ b/cpp/terrain/CMakeLists.txt
@@ -3,4 +3,5 @@ add_sources(${PROJECT_NAME}
 	terrain_chunk.cpp
 	terrain_object.cpp
 	terrain_outline.cpp
+	terrain_search.cpp
 )

--- a/cpp/terrain/terrain.cpp
+++ b/cpp/terrain/terrain.cpp
@@ -185,14 +185,13 @@ TileContent *Terrain::get_data(coord::tile position) {
 	}
 }
 
-std::shared_ptr<TerrainObject> Terrain::obj_at_point(const coord::phys3 &point) {
+TerrainObject *Terrain::obj_at_point(const coord::phys3 &point) {
 	coord::tile t = point.to_tile3().to_tile();
 	TileContent *tc = this->get_data(t);
 	if (!tc) {
 		return nullptr;
 	}
-	for (auto o : tc->obj) {
-		auto obj_ptr = o.lock();
+	for (auto obj_ptr : tc->obj) {
 		if (obj_ptr->contains(point)) {
 			return obj_ptr;
 		}
@@ -438,8 +437,8 @@ struct terrain_render_data Terrain::create_draw_advice(coord::tile ab,
 			// TODO: make the terrain independent of objects standing on it.
 			TileContent *tile_content = this->get_data(tilepos);
 			if (tile_content != nullptr) {
-				for (auto obj_item : tile_content->obj ) {
-					objects->insert(obj_item.lock().get());
+				for (auto obj_item : tile_content->obj) {
+					objects->insert(obj_item);
 				}
 			}
 		}

--- a/cpp/terrain/terrain.h
+++ b/cpp/terrain/terrain.h
@@ -56,7 +56,7 @@ public:
 	TileContent();
 	~TileContent();
 	terrain_t terrain_id;
-	std::vector<std::weak_ptr<TerrainObject>> obj;
+	std::vector<TerrainObject *> obj;
 };
 
 
@@ -228,7 +228,7 @@ public:
 	/**
 	 * an object which contains the given point, null otherwise
 	 */
-	std::shared_ptr<TerrainObject> obj_at_point(const coord::phys3 &point);
+	TerrainObject *obj_at_point(const coord::phys3 &point);
 
 	/**
 	 * get the neighbor chunks of a given chunk.

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -250,19 +250,7 @@ SquareObject::SquareObject(Unit &u, coord::tile_delta foundation_size, std::shar
 SquareObject::~SquareObject() {}
 
 tile_range SquareObject::get_range(const coord::phys3 &pos) const {
-	tile_range result;
-	result.start = pos.to_tile3().to_tile();
-	result.end   = result.start + this->size;
-
-	// TODO temporary hacky solution until openage::coord has been properly fixed.
-	coord::phys2 draw_pos = result.start.to_phys2();
-
-	draw_pos.ne += ((this->size.ne - 1) * coord::settings::phys_per_tile) / 2;
-	draw_pos.se += ((this->size.se - 1) * coord::settings::phys_per_tile) / 2;
-
-	result.draw  = draw_pos.to_phys3();
-
-	return result;
+	return building_center(pos, this->size);
 }
 
 coord::phys_t SquareObject::from_edge(const coord::phys3 &point) const {
@@ -404,6 +392,21 @@ std::vector<coord::tile> tile_list(const tile_range &rng) {
 		tiles.push_back(rng.start);
 	}
 	return tiles;
+}
+
+tile_range building_center(coord::phys3 west, coord::tile_delta size) {
+	tile_range result;
+	result.start = west.to_tile3().to_tile();
+	result.end   = result.start + size;
+
+	// TODO temporary hacky solution until openage::coord has been properly fixed.
+	coord::phys2 draw_pos = result.start.to_phys2();
+
+	draw_pos.ne += ((size.ne - 1) * coord::settings::phys_per_tile) / 2;
+	draw_pos.se += ((size.se - 1) * coord::settings::phys_per_tile) / 2;
+
+	result.draw  = draw_pos.to_phys3();
+	return result;
 }
 
 } //namespace openage

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -49,6 +49,11 @@ struct tile_range {
  */
 std::vector<coord::tile> tile_list(const tile_range &rng);
 
+/**
+ * given the west most point of a building foundation and the tile_delta
+ * size of the foundation, this will return the tile range covered by the base,
+ * which includes start and end tiles, and phys3 center point (used for drawing)
+ */
 tile_range building_center(coord::phys3 west, coord::tile_delta size);
 
 /**
@@ -65,6 +70,9 @@ constexpr coord::phys3_delta phys_half_tile = coord::phys3_delta{
  * positions and radial positions This enables two inheriting classes
  * SquareObject and RadialObject to specify different areas of the map
  *
+ * All TerrainObjects are owned by a Unit, to construct TerrainObjects,
+ * use the make_location function on any Unit
+ *
  * This class allows intersection testing between two TerrainObjects to
  * cover all cases of intersection (water, land or flying objects) the units
  * lambda function is used which takes a tile and returns a bool value of
@@ -75,6 +83,8 @@ constexpr coord::phys3_delta phys_half_tile = coord::phys3_delta{
 class TerrainObject : public std::enable_shared_from_this<TerrainObject> {
 public:
 	TerrainObject(Unit &u);
+	TerrainObject(const TerrainObject &) = delete;	// disable copy constructor
+	TerrainObject(TerrainObject &&) = delete;		// disable move constructor
 	virtual ~TerrainObject();
 
 	/**
@@ -159,11 +169,11 @@ public:
 	/**
 	 * add a child terrain object
 	 */
-	void annex(std::shared_ptr<TerrainObject> other);
+	void annex(TerrainObject *other);
 
-	const std::shared_ptr<TerrainObject> get_parent() const;
+	const TerrainObject *get_parent() const;
 
-	std::vector<std::shared_ptr<TerrainObject>> get_children() const;
+	std::vector<TerrainObject *> get_children() const;
 
 	/*
 	 * terrain this object was placed on
@@ -222,8 +232,8 @@ protected:
 	/**
 	 * annexes and grouped units
 	 */
-	std::shared_ptr<TerrainObject> parent;
-	std::vector<std::shared_ptr<TerrainObject>> children;
+	TerrainObject *parent;
+	std::vector<TerrainObject *> children;
 
 	/**
 	 * texture for drawing outline

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -45,6 +45,8 @@ struct tile_range {
  */
 std::vector<coord::tile> tile_list(const tile_range &rng);
 
+tile_range building_center(coord::phys3 west, coord::tile_delta size);
+
 /**
  * half a tile
  */

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -33,15 +33,19 @@ enum class object_state {
 /**
  * A rectangle or square of tiles which is the minimim
  * space to fit the units foundation or radius
+ * the end tile will have ne and se values greater or equal to
+ * the start tile
  */
 struct tile_range {
 	coord::tile start;
-	coord::tile end;
-	coord::phys3 draw; // gets used as center point of radial objects
+	coord::tile end;	// start <= end
+	coord::phys3 draw;	// gets used as center point of radial objects
 };
 
 /**
  * get all tiles in the tile range -- useful for iterating
+ * returns a flat list of tiles between the rectangle enclosed
+ * by the tile_range start and end tiles
  */
 std::vector<coord::tile> tile_list(const tile_range &rng);
 
@@ -87,7 +91,9 @@ public:
 	Unit &unit;
 
 	/**
-	 * is the object a floating outline
+	 * is the object a floating outline -- it is only an indicator
+	 * of where a building will be built, but not yet started building
+	 * and does not affect any collisions
 	 */
 	bool is_floating() const;
 

--- a/cpp/terrain/terrain_search.cpp
+++ b/cpp/terrain/terrain_search.cpp
@@ -8,7 +8,7 @@
 
 namespace openage {
 
-std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
+TerrainObject *find_near(const TerrainObject &start,
                                          std::function<bool(const TerrainObject &)> found,
                                          unsigned int search_limit) {
 
@@ -16,14 +16,12 @@ std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
 	auto tile = start.pos.draw.to_tile3().to_tile();
 	TerrainSearch search(terrain, tile);
 
-	for (int i = 0; i < search_limit; ++i) {
+	for (unsigned int i = 0; i < search_limit; ++i) {
 		for (auto o : terrain->get_data(tile)->obj) {
 
-			// lock should always work as the weak pointers
-			// are removed when the object is deleted
-			auto shared_o = o.lock();
-			if (found(*shared_o)) {
-				return shared_o;
+			// invalid pointers are removed when the object is deleted
+			if (found(*o)) {
+				return o;
 			}
 		}
 		tile = search.next_tile();

--- a/cpp/terrain/terrain_search.cpp
+++ b/cpp/terrain/terrain_search.cpp
@@ -8,15 +8,19 @@
 
 namespace openage {
 
-std::shared_ptr<TerrainObject> find_near(const TerrainObject &start, 
-                                         std::function<bool(const TerrainObject &)> found) {
-	
+std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
+                                         std::function<bool(const TerrainObject &)> found,
+                                         unsigned int search_limit) {
+
 	auto terrain = start.get_terrain();
 	auto tile = start.pos.draw.to_tile3().to_tile();
 	TerrainSearch search(terrain, tile);
 
-	for (int i = 0; i < 500; ++i) {
+	for (int i = 0; i < search_limit; ++i) {
 		for (auto o : terrain->get_data(tile)->obj) {
+
+			// lock should always work as the weak pointers
+			// are removed when the object is deleted
 			auto shared_o = o.lock();
 			if (found(*shared_o)) {
 				return shared_o;
@@ -26,7 +30,7 @@ std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
 	}
 
 	return nullptr;
-}	
+}
 
 TerrainSearch::TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s)
 	:
@@ -40,8 +44,6 @@ TerrainSearch::TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s, float ra
 	previous_radius{.0f},
 	max_radius{radius} {
 }
-
-TerrainSearch::~TerrainSearch() {}
 
 coord::tile TerrainSearch::start_tile() const {
 	return this->start;

--- a/cpp/terrain/terrain_search.cpp
+++ b/cpp/terrain/terrain_search.cpp
@@ -1,0 +1,80 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#include <cmath>
+
+#include "terrain.h"
+#include "terrain_object.h"
+#include "terrain_search.h"
+
+namespace openage {
+
+std::shared_ptr<TerrainObject> find_near(const TerrainObject &start, 
+                                         std::function<bool(const TerrainObject &)> found) {
+	
+	auto terrain = start.get_terrain();
+	auto tile = start.pos.draw.to_tile3().to_tile();
+	TerrainSearch search(terrain, tile);
+
+	for (int i = 0; i < 500; ++i) {
+		for (auto o : terrain->get_data(tile)->obj) {
+			auto shared_o = o.lock();
+			if (found(*shared_o)) {
+				return shared_o;
+			}
+		}
+		tile = search.next_tile();
+	}
+
+	return nullptr;
+}	
+
+TerrainSearch::TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s)
+	:
+	TerrainSearch(t, s, .0f) {
+}
+
+TerrainSearch::TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s, float radius)
+	:
+	terrain{t},
+	start(s),
+	previous_radius{.0f},
+	max_radius{radius} {
+}
+
+TerrainSearch::~TerrainSearch() {}
+
+coord::tile TerrainSearch::start_tile() const {
+	return this->start;
+}
+
+void TerrainSearch::reset() {
+	std::queue<coord::tile> empty;
+	std::swap(this->tiles, empty);
+	this->visited.clear();
+	this->tiles.push(this->start);
+}
+
+coord::tile TerrainSearch::next_tile() {
+	// conditions for returning to the initial tile
+	if (this->tiles.empty() ||
+	    (this->max_radius && this->previous_radius > this->max_radius)) {
+		this->reset();
+	}
+	coord::tile result = this->tiles.front();
+	this->tiles.pop();
+
+	for (auto i = 0; i < 4; ++i) {
+		auto to_add = result + neigh_tile[i];
+
+		// check not visited and tile is within map
+		if (this->visited.count(to_add) == 0 && terrain->get_data(to_add)) {
+			this->visited.insert(to_add);
+			this->tiles.push(to_add);
+		}
+	}
+
+	this->previous_radius = std::hypot(result.ne - start.ne, result.se - start.se);
+	return result;
+}
+
+} // namespace openage

--- a/cpp/terrain/terrain_search.h
+++ b/cpp/terrain/terrain_search.h
@@ -16,7 +16,7 @@ namespace openage {
 class Terrain;
 class TerrainObject;
 
-std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
+TerrainObject *find_near(const TerrainObject &start,
                                          std::function<bool(const TerrainObject &)> found,
                                          unsigned int search_limit=500);
 

--- a/cpp/terrain/terrain_search.h
+++ b/cpp/terrain/terrain_search.h
@@ -1,0 +1,71 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#ifndef OPENAGE_TERRAIN_TERRAIN_SEARCH_H_
+#define OPENAGE_TERRAIN_TERRAIN_SEARCH_H_
+
+#include <functional>
+#include <memory>
+#include <queue>
+#include <unordered_set>
+#include <vector>
+
+#include "../coord/tile.h"
+
+namespace openage {
+
+class Terrain;
+class TerrainObject;
+
+std::shared_ptr<TerrainObject> find_near(const TerrainObject &start, 
+                                         std::function<bool(const TerrainObject &)> found);
+
+constexpr coord::tile_delta const neigh_tile[] = {
+	{0, 1},
+	{0,  -1},
+	{1,  0},
+	{-1,  0}
+};
+
+/**
+ * searches outward from a point and returns nearby objects
+ */
+class TerrainSearch {
+public:
+	/**
+	 * next_tile will cover all tiles on the map
+	 */
+	TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s);
+
+	/**
+	 * next_tile will iterate over a range of tiles within a radius
+	 */
+	TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s, float radius);
+	~TerrainSearch();
+
+	/**
+	 * the tile the search began on
+	 */
+	coord::tile start_tile() const;
+
+	/**
+	 * restarts the search from the start tile
+	 */
+	void reset();
+
+	/**
+	 * returns all objects on the next tile
+	 */
+	coord::tile next_tile();
+
+private:
+	const std::shared_ptr<Terrain> terrain;
+	const coord::tile start;
+	std::queue<coord::tile> tiles;
+	std::unordered_set<coord::tile> visited;
+	float previous_radius, max_radius;
+
+};
+
+} // namespace openage
+
+#endif

--- a/cpp/terrain/terrain_search.h
+++ b/cpp/terrain/terrain_search.h
@@ -16,18 +16,21 @@ namespace openage {
 class Terrain;
 class TerrainObject;
 
-std::shared_ptr<TerrainObject> find_near(const TerrainObject &start, 
-                                         std::function<bool(const TerrainObject &)> found);
+std::shared_ptr<TerrainObject> find_near(const TerrainObject &start,
+                                         std::function<bool(const TerrainObject &)> found,
+                                         unsigned int search_limit=500);
 
 constexpr coord::tile_delta const neigh_tile[] = {
-	{0, 1},
-	{0,  -1},
+	{0,  1},
+	{0, -1},
 	{1,  0},
-	{-1,  0}
+	{-1, 0}
 };
 
 /**
  * searches outward from a point and returns nearby objects
+ * The state of the search is kept within the class, which allows
+ * a user to look at a limited number of tiles per update cycle
  */
 class TerrainSearch {
 public:
@@ -40,7 +43,7 @@ public:
 	 * next_tile will iterate over a range of tiles within a radius
 	 */
 	TerrainSearch(std::shared_ptr<Terrain> t, coord::tile s, float radius);
-	~TerrainSearch();
+	~TerrainSearch() = default;
 
 	/**
 	 * the tile the search began on

--- a/cpp/unit/CMakeLists.txt
+++ b/cpp/unit/CMakeLists.txt
@@ -7,4 +7,5 @@ add_sources(${PROJECT_NAME}
 	unit.cpp
 	unit_container.cpp
 	unit_texture.cpp
+	unit_type.cpp
 )

--- a/cpp/unit/ability.cpp
+++ b/cpp/unit/ability.cpp
@@ -55,7 +55,7 @@ bool MoveAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 		       cmd.unit()->location &&
 		       &to_modify != cmd.unit(); // cannot target self
 	}
-	return false; 
+	return false;
 }
 
 void MoveAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
@@ -241,10 +241,10 @@ void AttackAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound)
 	to_modify.push_action(std::make_unique<AttackAction>(&to_modify, target->get_ref()));
 }
 
-ability_set from_list(const std::vector<ability_type> &items) {
+ability_set UnitAbility::set_from_list(const std::vector<ability_type> &items) {
 	ability_set result;
 	for (auto i : items) {
-		result[i] = 1;
+		result[static_cast<int>(i)] = 1;
 	}
 	return result;
 }
@@ -279,8 +279,9 @@ string to_string(const openage::ability_type &at) {
 		return "repair";
 	case openage::ability_type::heal:
 		return "heal";
+	default:
+		return "unknown";
 	}
-	return "unknown";
-}	
+}
 
 } // namespace std

--- a/cpp/unit/ability.cpp
+++ b/cpp/unit/ability.cpp
@@ -11,17 +11,17 @@
 
 namespace openage {
 
-bool has_hitpoints(Unit &target) {
+bool UnitAbility::has_hitpoints(Unit &target) {
 	return target.has_attribute(attr_type::hitpoints) &&
 	       target.get_attribute<attr_type::hitpoints>().current > 0;
 }
 
-bool has_resource(Unit &target) {
+bool UnitAbility::has_resource(Unit &target) {
 	return target.has_attribute(attr_type::resource) &&
 	       target.get_attribute<attr_type::resource>().amount > 0;
 }
 
-bool is_ally(Unit &to_modify, Unit &target) {
+bool UnitAbility::is_ally(Unit &to_modify, Unit &target) {
 	if (to_modify.has_attribute(attr_type::owner) &&
 	    target.has_attribute(attr_type::owner)) {
 		auto &mod_player = to_modify.get_attribute<attr_type::owner>().player;
@@ -31,7 +31,7 @@ bool is_ally(Unit &to_modify, Unit &target) {
 	return false;
 }
 
-bool is_enemy(Unit &to_modify, Unit &target) {
+bool UnitAbility::is_enemy(Unit &to_modify, Unit &target) {
 	if (to_modify.has_attribute(attr_type::owner) &&
 		target.has_attribute(attr_type::owner)) {
 		auto &mod_player = to_modify.get_attribute<attr_type::owner>().player;
@@ -164,9 +164,6 @@ BuildAbility::BuildAbility(Sound *s)
 }
 
 bool BuildAbility::can_invoke(Unit &to_modify, const Command &cmd) {
-	if (cmd.has_type() && cmd.has_position()) {
-		return bool(to_modify.location);
-	}
 	if (cmd.has_unit()) {
 		Unit *target = cmd.unit();
 		return to_modify.location &&
@@ -184,9 +181,6 @@ void BuildAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) 
 
 	if (cmd.has_unit()) {
 		to_modify.push_action(std::make_unique<BuildAction>(&to_modify, cmd.unit()->get_ref()));
-	}
-	else {
-		to_modify.push_action(std::make_unique<BuildAction>(&to_modify, cmd.type(), cmd.position()));
 	}
 }
 
@@ -227,6 +221,8 @@ bool AttackAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 		bool target_is_resource = has_resource(target);
 		return &to_modify != &target &&
 		       to_modify.location &&
+		       target.location &&
+		       target.location->is_placed() &&
 		       to_modify.has_attribute(attr_type::attack) &&
 		       has_hitpoints(target) &&
 		       (is_enemy(to_modify, target) || target_is_resource) &&

--- a/cpp/unit/ability.h
+++ b/cpp/unit/ability.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <type_traits>
 #include <unordered_map>
+#include <vector>
 
 #include "../coord/phys3.h"
 #include "resource.h"
@@ -17,8 +18,8 @@ class Command;
 class Sound;
 class Unit;
 class UnitAction;
-class UnitProducer;
 class UnitTexture;
+class UnitType;
 
 /**
  * roughly the same as command_ability in game data
@@ -40,6 +41,11 @@ enum ability_type {
 
 using ability_set = std::bitset<16>;
 using ability_id_t = unsigned int;
+
+/**
+ * set bits corresponding to abilities
+ */
+ability_set from_list(const std::vector<ability_type> &items);
 
 /**
  * all bits set to 1

--- a/cpp/unit/ability.h
+++ b/cpp/unit/ability.h
@@ -53,14 +53,6 @@ ability_set from_list(const std::vector<ability_type> &items);
 const ability_set ability_all = ability_set().set();
 
 /**
- * some common functions
- */
-bool has_hitpoints(Unit &target);
-bool has_resource(Unit &target);
-bool is_ally(Unit &to_modify, Unit &target);
-bool is_enemy(Unit &to_modify, Unit &target);
-
-/**
  * Abilities create an action when given a target
  * some abilities target positions such as moving or patroling
  * others target other game objects, such as attacking or
@@ -84,6 +76,15 @@ public:
 	 * applys command to a given unit
 	 */
 	virtual void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
+
+	/**
+ 	 * some common functions
+	 */
+	bool has_hitpoints(Unit &target);
+	bool has_resource(Unit &target);
+	bool is_ally(Unit &to_modify, Unit &target);
+	bool is_enemy(Unit &to_modify, Unit &target);
+
 };
 
 /*

--- a/cpp/unit/ability.h
+++ b/cpp/unit/ability.h
@@ -24,7 +24,7 @@ class UnitType;
 /**
  * roughly the same as command_ability in game data
  */
-enum ability_type {
+enum class ability_type {
 	move,
 	garrison,
 	ungarrison,
@@ -36,16 +36,13 @@ enum ability_type {
 	attack,
 	convert,
 	repair,
-	heal
+	heal,
+	MAX
 };
 
-using ability_set = std::bitset<16>;
+constexpr int ability_type_size = static_cast<int>(ability_type::MAX);
+using ability_set = std::bitset<ability_type_size>;
 using ability_id_t = unsigned int;
-
-/**
- * set bits corresponding to abilities
- */
-ability_set from_list(const std::vector<ability_type> &items);
 
 /**
  * all bits set to 1
@@ -73,7 +70,7 @@ public:
 	virtual bool can_invoke(Unit &to_modify, const Command &cmd) = 0;
 
 	/**
-	 * applys command to a given unit
+	 * applies command to a given unit
 	 */
 	virtual void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
 
@@ -84,6 +81,12 @@ public:
 	bool has_resource(Unit &target);
 	bool is_ally(Unit &to_modify, Unit &target);
 	bool is_enemy(Unit &to_modify, Unit &target);
+
+	/**
+ 	 * set bits corresponding to abilities, useful for initialising an ability_set
+ 	 * using a brace enclosed list
+	 */
+	static ability_set set_from_list(const std::vector<ability_type> &items);
 
 };
 
@@ -231,8 +234,11 @@ std::string to_string(const openage::ability_type &at);
  */
 template<>
 struct hash<openage::ability_type> {
-	size_t operator()(const openage::ability_type &arg) const {
-		return arg;
+	typedef underlying_type<openage::ability_type>::type underlying_type;
+	typedef hash<underlying_type>::result_type result_type;
+	result_type operator()(const openage::ability_type &arg) const {
+		hash<underlying_type> hasher;
+		return hasher(static_cast<underlying_type>(arg));
 	}
 };
 

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -100,7 +100,7 @@ TargetAction::TargetAction(Unit *u, graphic_type gt, UnitReference r, coord::phy
 	:
 	UnitAction(u, gt),
 	target{r},
-	allow_move{true},
+	repath_attempts{10},
 	end_action{false},
 	radius{rad} {
 	this->update_distance();
@@ -162,14 +162,14 @@ void TargetAction::update(unsigned int time) {
 		// the derived class controls what to
 		// do when in range of the target
 		this->update_in_range(time, target_ptr);
-		this->allow_move = true;
+		this->repath_attempts = 10;
 	}
-	else if (this->allow_move) {
+	else if (this->repath_attempts) {
 
 		// out of range so try move towards
 		// if this unit has a move ability
 		this->move_to(*target_ptr);
-		this->allow_move = false;
+		this->repath_attempts -= 1;
 	}
 	else {
 
@@ -669,7 +669,9 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 		auto target_location = target_unit->location;
 		if (target_location->is_floating()) {
 			target_location->place(object_state::placed);
-			target_location->set_ground(build.foundation_terrain, 0);
+			if (build.foundation_terrain) {
+				target_location->set_ground(build.foundation_terrain, 0);
+			}
 		}	
 
 		// increment building completion

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -308,7 +308,9 @@ void IdleAction::update(unsigned int time) {
 
 	// auto task searching
 	if (this->entity->location &&
-		this->entity->has_attribute(attr_type::owner)) {
+	    this->entity->has_attribute(attr_type::owner) &&
+	    this->entity->has_attribute(attr_type::attack) &&
+	    this->entity->get_attribute<attr_type::attack>().stance != attack_stance::do_nothing) {
 
 		// restart search from new tile when moved
 		auto terrain = this->entity->location->get_terrain();

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -39,7 +39,16 @@ UnitAction::UnitAction(Unit *u, graphic_type initial_gt)
 	frame_rate{.0f} {
 
 	if (u->graphics->count(initial_gt) > 0) {
-		this->frame_rate = u->graphics->at(initial_gt)->frame_rate;
+		auto utex = u->graphics->at(initial_gt);
+		if (utex) {
+			this->frame_rate = utex->frame_rate;
+		}
+		else {
+			this->entity->log(MSG(dbg) << "Broken graphic (null)");
+		}
+	}
+	else {
+		this->entity->log(MSG(dbg) << "Broken graphic (not available)");
 	}
 
 	if (frame_rate == 0) {

--- a/cpp/unit/action.h
+++ b/cpp/unit/action.h
@@ -59,9 +59,9 @@ public:
 	virtual bool completed() const = 0;
 
 	/**
-	 * checks if the action can be interrupted, allowing it to be popped if the user 
-	 * specifies a new action, if false the action must reach a completed state 
-	 * before removal 
+	 * checks if the action can be interrupted, allowing it to be popped if the user
+	 * specifies a new action, if false the action must reach a completed state
+	 * before removal
 	 * eg dead action must be completed and cannot be discarded
 	 */
 	virtual bool allow_interupt() const = 0;
@@ -134,7 +134,7 @@ public:
 
 	/**
 	 * action_rad is how close a unit must come to another
-	 * unit to be considered to touch the other, for example in 
+	 * unit to be considered to touch the other, for example in
 	 * gathering resource and melee attack
 	 */
 	TargetAction(Unit *e, graphic_type gt, UnitReference r, coord::phys_t action_rad);
@@ -143,7 +143,7 @@ public:
 	 * this constructor uses the default action radius formula which will
 	 * bring the object as near to the target as the pathing grid will allow.
 	 */
-	TargetAction(Unit *e, graphic_type gt, UnitReference r); 
+	TargetAction(Unit *e, graphic_type gt, UnitReference r);
 	virtual ~TargetAction() {}
 
 	void update(unsigned int) override;
@@ -224,7 +224,7 @@ private:
  */
 class FoundationAction: public UnitAction {
 public:
-	FoundationAction(Unit *e);
+	FoundationAction(Unit *e, bool add_destuction=false);
 	virtual ~FoundationAction() {}
 
 	void update(unsigned int) override;
@@ -233,7 +233,10 @@ public:
 	bool allow_interupt() const override { return true; }
 	bool allow_control() const override { return false; }
 	std::string name() const override { return "foundation"; }
-	
+
+private:
+	bool add_destruct_effect, cancel;
+
 };
 
 /**
@@ -289,7 +292,7 @@ private:
 
 	// how near the units should come to target
 	coord::phys_t distance_to_target, radius;
-	
+
 	path::Path path;
 
 	// should a new path be found if unit gets blocked
@@ -457,7 +460,7 @@ public:
 
 private:
 	float complete;
-	
+
 };
 
 /**

--- a/cpp/unit/action.h
+++ b/cpp/unit/action.h
@@ -168,7 +168,8 @@ public:
 
 private:
 	UnitReference target;
-	bool allow_move, end_action;
+	int repath_attempts;
+	bool end_action;
 
 	/**
 	 * tracks distance to target from last update

--- a/cpp/unit/attribute.h
+++ b/cpp/unit/attribute.h
@@ -67,6 +67,13 @@ enum class attr_type {
 	garrison
 };
 
+enum class attack_stance {
+	aggresive,
+	devensive,
+	stand_ground,
+	do_nothing
+};
+
 /**
  * this type gets specialized for each attribute
  */
@@ -144,6 +151,7 @@ public:
 		range{r},
 		init_height{h},
 		damage{d},
+		stance{attack_stance::do_nothing},
 		attack_graphic_set{&grp} {}
 
 	AttributeContainer *copy() const override {
@@ -157,6 +165,7 @@ public:
 	coord::phys_t range;
 	coord::phys_t init_height;
 	unsigned int damage;
+	attack_stance stance;
 
 	// used to change graphics back to normal for villagers
 	graphic_set *attack_graphic_set;

--- a/cpp/unit/attribute.h
+++ b/cpp/unit/attribute.h
@@ -29,7 +29,7 @@ template<> struct hash<gamedata::unit_classes> {
 
 namespace openage {
 
-/** 
+/**
  * types of action graphics
  */
 enum class graphic_type {
@@ -46,7 +46,7 @@ enum class graphic_type {
 
 class UnitTexture;
 
-/** 
+/**
  * collection of graphics attached to each unit
  */
 using graphic_set = std::map<graphic_type, std::shared_ptr<UnitTexture>>;
@@ -78,7 +78,7 @@ enum class attack_stance {
  * this type gets specialized for each attribute
  */
 template<attr_type T> class Attribute;
- 
+
 /**
  * wraps a templated attribute
  */
@@ -147,7 +147,7 @@ public:
 	Attribute(UnitType *type, coord::phys_t r, coord::phys_t h, uint d, graphic_set &grp)
 		:
 		AttributeContainer{attr_type::attack},
-		pp{type},
+		ptype{type},
 		range{r},
 		init_height{h},
 		damage{d},
@@ -161,7 +161,7 @@ public:
 	// TODO: can a unit have multiple attacks such as villagers hunting
 	// map target classes onto attacks
 
-	UnitType *pp; // projectile type
+	UnitType *ptype; // projectile type
 	coord::phys_t range;
 	coord::phys_t init_height;
 	unsigned int damage;
@@ -234,7 +234,7 @@ public:
 	int foundation_terrain;
 
 	// TODO: use unit class, fish and forage have different dropsites
-	game_resource resource_type; 
+	game_resource resource_type;
 
 	// TODO: list allowed trainable producers
 	UnitType *pp;

--- a/cpp/unit/attribute.h
+++ b/cpp/unit/attribute.h
@@ -84,6 +84,8 @@ public:
 		type{t} {}
 
 	attr_type type;
+
+	virtual AttributeContainer *copy() const = 0;
 };
 
 using attr_map_t = std::map<attr_type, AttributeContainer *>;
@@ -109,6 +111,10 @@ public:
 		AttributeContainer{attr_type::owner},
 		player(p) {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::owner>(*this);
+	}
+
 	Player &player;
 };
 
@@ -120,6 +126,10 @@ public:
 		current{static_cast<int>(i)},
 		max{i} {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::hitpoints>(*this);
+	}
+
 	int current; // can become negative
 	unsigned int max;
 	float hp_bar_height;
@@ -127,19 +137,23 @@ public:
 
 template<> class Attribute<attr_type::attack>: public AttributeContainer {
 public:
-	Attribute(UnitProducer *p, coord::phys_t r, coord::phys_t h, uint d, graphic_set &grp)
+	Attribute(UnitType *type, coord::phys_t r, coord::phys_t h, uint d, graphic_set &grp)
 		:
 		AttributeContainer{attr_type::attack},
-		pp{p},
+		pp{type},
 		range{r},
 		init_height{h},
 		damage{d},
 		attack_graphic_set{&grp} {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::attack>(*this);
+	}
+
 	// TODO: can a unit have multiple attacks such as villagers hunting
 	// map target classes onto attacks
 
-	UnitProducer *pp; // projectile producer
+	UnitType *pp; // projectile type
 	coord::phys_t range;
 	coord::phys_t init_height;
 	unsigned int damage;
@@ -155,6 +169,10 @@ public:
 		AttributeContainer{attr_type::speed},
 		unit_speed{sp} {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::speed>(*this);
+	}
+
 	coord::phys_t unit_speed; // possibly use a pointer to account for tech upgrades
 };
 
@@ -164,6 +182,10 @@ public:
 		:
 		AttributeContainer{attr_type::direction},
 		unit_dir(dir) {}
+
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::direction>(*this);
+	}
 
 	coord::phys3_delta unit_dir;
 };
@@ -176,6 +198,10 @@ public:
 		projectile_arc{arc},
 		launched{false} {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::projectile>(*this);
+	}
+
 	float projectile_arc;
 	UnitReference launcher;
 	bool launched;
@@ -186,16 +212,23 @@ public:
 	Attribute()
 		:
 		AttributeContainer{attr_type::building},
-		completed{.0f} {}
+		completed{.0f},
+		is_dropsite{true},
+		foundation_terrain{0} {}
+
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::building>(*this);
+	}
 
 	float completed;
 	bool is_dropsite;
+	int foundation_terrain;
 
 	// TODO: use unit class, fish and forage have different dropsites
 	game_resource resource_type; 
 
 	// TODO: list allowed trainable producers
-	UnitProducer *pp;
+	UnitType *pp;
 	coord::phys3 gather_point;
 };
 
@@ -209,6 +242,10 @@ public:
 		AttributeContainer{attr_type::resource},
 		resource_type{type},
 		amount{init_amount} {}
+
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::resource>(*this);
+	}
 
 	game_resource resource_type;
 	float amount;
@@ -226,13 +263,17 @@ public:
 		AttributeContainer{attr_type::gatherer},
 		amount{.0f} {}
 
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::gatherer>(*this);
+	}
+
 	game_resource current_type;
 	float amount;
 	float capacity;
 	float gather_rate;
 
 	// texture sets available for each resource
-	std::unordered_map<gamedata::unit_classes, UnitProducer *> graphics;
+	std::unordered_map<gamedata::unit_classes, UnitType *> graphics;
 };
 
 template<> class Attribute<attr_type::garrison>: public AttributeContainer {
@@ -240,6 +281,10 @@ public:
 	Attribute()
 		:
 		AttributeContainer{attr_type::garrison} {}
+
+	AttributeContainer *copy() const override {
+		return new Attribute<attr_type::garrison>(*this);
+	}
 
 	std::vector<UnitReference> content;
 };

--- a/cpp/unit/command.cpp
+++ b/cpp/unit/command.cpp
@@ -4,12 +4,12 @@
 
 namespace openage {
 
-Command::Command(const Player &p, Unit *unit, bool haspos, UnitProducer *producer)
+Command::Command(const Player &p, Unit *unit, bool haspos, UnitType *t)
 	:
 	player(p),
 	has_pos{haspos},
 	u{unit},
-	type{producer} {
+	unit_type{t} {
 	this->modifiers.set();
 }
 
@@ -27,17 +27,17 @@ Command::Command(const Player &p, coord::phys3 position)
 Command::Command(const Player &p, Unit *unit, coord::phys3 position)
 	:
 	Command{p, unit, true, nullptr} {
-	this->pos = position;	
+	this->pos = position;
 }
 
-Command::Command(const Player &p, UnitProducer *producer)
+Command::Command(const Player &p, UnitType *t)
 	:
-	Command{p, nullptr, false, producer} {
+	Command{p, nullptr, false, t} {
 }
 
-Command::Command(const Player &p, UnitProducer *producer, coord::phys3 position)
+Command::Command(const Player &p, UnitType *t, coord::phys3 position)
 	:
-	Command{p, nullptr, true, producer} {
+	Command{p, nullptr, true, t} {
 	this->pos = position;
 }
 
@@ -49,8 +49,8 @@ bool Command::has_position() const {
 	return this->has_pos;
 }
 
-bool Command::has_producer() const {
-	return this->type;
+bool Command::has_type() const {
+	return this->unit_type;
 }
 
 Unit *Command::unit() const {
@@ -61,13 +61,17 @@ coord::phys3 Command::position() const {
 	return this->pos;
 }
 
-UnitProducer *Command::producer() const {
-	return this->type;
+UnitType *Command::type() const {
+	return this->unit_type;
 }
 
 void Command::set_ability(ability_type t) {
 	this->modifiers = 0;
 	this->modifiers[t] = true;
+}
+
+void Command::set_ability_set(ability_set set) {
+	this->modifiers = set;
 }
 
 const ability_set &Command::ability() const {

--- a/cpp/unit/command.cpp
+++ b/cpp/unit/command.cpp
@@ -67,7 +67,7 @@ UnitType *Command::type() const {
 
 void Command::set_ability(ability_type t) {
 	this->modifiers = 0;
-	this->modifiers[t] = true;
+	this->modifiers[static_cast<int>(t)] = true;
 }
 
 void Command::set_ability_set(ability_set set) {

--- a/cpp/unit/command.h
+++ b/cpp/unit/command.h
@@ -16,7 +16,8 @@ namespace openage {
  * additional flags which may affect some abilities
  */
 enum class command_flag {
-	use_range // move command account for units range
+	use_range, // move command account for units range
+	attack_res // allow attack on a resource object
 };
 
 } // namespace openage
@@ -66,28 +67,34 @@ public:
 	/**
 	 * select a type
 	 */
-	Command(const Player &, UnitProducer *producer);
+	Command(const Player &, UnitType *t);
 
 	/** 
 	 * place building foundation
 	 */ 
-	Command(const Player &, UnitProducer *, coord::phys3);
+	Command(const Player &, UnitType *, coord::phys3);
 
 	bool has_unit() const;
 	bool has_position() const;
-	bool has_producer()const;
+	bool has_type()const;
 
 	Unit *unit() const;
 	coord::phys3 position() const;
-	UnitProducer *producer() const;
+	UnitType *type() const;
 
 	/**
-	 * the action can only be this ability
+	 * sets invoked ability type, no other type may be used if
+	 * this gets set
 	 *
 	 * @param type allows a specific ability type to be used
 	 * for example to set a unit to patrol rather than the default move
 	 */
 	void set_ability(ability_type t);
+
+	/**
+	 * restricts action to a set of possible ability types
+	 */
+	void set_ability_set(ability_set set);
 
 	/**
 	 * the ability types allowed to use this command
@@ -114,12 +121,12 @@ private:
 	/**
 	 * basic constructor, which shouldnt be used directly
 	 */
-	Command(const Player &, Unit *unit, bool haspos, UnitProducer *producer);
+	Command(const Player &, Unit *unit, bool haspos, UnitType *t);
 
 	bool has_pos;
 	Unit *u;
 	coord::phys3 pos;
-	UnitProducer *type;
+	UnitType *unit_type;
 
 	/**
 	 * additional options

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -80,7 +80,14 @@ ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 	}
 
 	// graphic set
-	this->graphics[graphic_type::standing] = dm.get_unit_texture(this->unit_data.graphic_standing0);
+	auto standing = dm.get_unit_texture(this->unit_data.graphic_standing0);
+	if (!standing) {
+
+		// indicates problems with data converion
+		throw util::Error(MSG(err) << "Unit id " << this->unit_data.id0 
+			<< " has invalid graphic data, try reconverting the data");
+	}
+	this->graphics[graphic_type::standing] = standing;
 	auto dying_tex = dm.get_unit_texture(this->unit_data.graphic_dying0);
 	if (dying_tex) {
 		this->graphics[graphic_type::dying] = dying_tex;

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -207,7 +207,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 				), 
 				true);
 		}
-		else {
+		else if (this->graphics.count(graphic_type::dying) > 0) {
 			unit->push_action(std::make_unique<DeadAction>(unit), true);
 		}
 
@@ -457,8 +457,8 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 
 	// convert the float to the discrete foundation size...
 	this->foundation_size = {
-		(int)(this->unit_data.radius_size0 * 2),
-		(int)(this->unit_data.radius_size1 * 2),
+		static_cast<int>(this->unit_data.radius_size0 * 2),
+		static_cast<int>(this->unit_data.radius_size1 * 2),
 	};
 	
 	// graphic set

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -84,7 +84,7 @@ ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 	if (!standing) {
 
 		// indicates problems with data converion
-		throw util::Error(MSG(err) << "Unit id " << this->unit_data.id0 
+		throw util::Error(MSG(err) << "Unit id " << this->unit_data.id0
 			<< " has invalid graphic data, try reconverting the data");
 	}
 	this->graphics[graphic_type::standing] = standing;
@@ -127,7 +127,7 @@ ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 			auto carry = dm.get_unit_texture(cmd->carrying_graphic_id);
 			this->graphics[graphic_type::carrying] = carry;
 			if (carry) {
-				
+
 			}
 		}
 	}
@@ -165,7 +165,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 	if (this->unit_data.hit_points > 0) {
 		unit->add_attribute(new Attribute<attr_type::hitpoints>(this->unit_data.hit_points));
 	}
-	
+
 	// collectable resources
 	if (this->unit_data.unit_class == gamedata::unit_classes::TREES) {
 		unit->add_attribute(new Attribute<attr_type::resource>(game_resource::wood, 125));
@@ -188,7 +188,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 	else if (this->unit_data.unit_class == gamedata::unit_classes::STONE_MINE) {
 		unit->add_attribute(new Attribute<attr_type::resource>(game_resource::stone, 350));
 	}
-	
+
 	// decaying units have a timed lifespan
 	if (decay) {
 		unit->push_action(std::make_unique<DecayAction>(unit), true);
@@ -198,13 +198,13 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 		if (this->dead_unit_producer) {
 			unit->push_action(
 				std::make_unique<DeadAction>(
-					unit, 
+					unit,
 					[this, unit, &player]() {
 
 						// modify unit to have  dead type
 						this->dead_unit_producer->initialise(unit, player);
 					}
-				), 
+				),
 				true);
 		}
 		else if (this->graphics.count(graphic_type::dying) > 0) {
@@ -214,7 +214,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 		// the default action
 		unit->push_action(std::make_unique<IdleAction>(unit), true);
 	}
-	
+
 	// give required abilitys
 	for (auto &a : this->type_abilities) {
 		unit->give_ability(a);
@@ -242,6 +242,9 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, std::shared_ptr<Te
 	std::weak_ptr<TerrainObject> obj_ptr = u->location;
 	std::weak_ptr<Terrain> terrain_ptr = terrain;
 	u->location->passable = [obj_ptr, terrain_ptr, terrains](const coord::phys3 &pos) -> bool {
+
+		// if location is deleted, then so is this lambda (deleting terrain implies location is deleted)
+		// so locking objects here will not return null
 		auto obj = obj_ptr.lock();
 		auto terrain = terrain_ptr.lock();
 
@@ -257,7 +260,7 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, std::shared_ptr<Te
 			// ensure no intersections with other objects
 			for (auto item : tc->obj) {
 				auto obj_cmp = item.lock();
-				if (obj != obj_cmp && 
+				if (obj != obj_cmp &&
 				    obj_cmp->check_collisions() &&
 				    obj->intersects(*obj_cmp, pos)) {
 					return false;
@@ -321,7 +324,7 @@ MovableProducer::MovableProducer(DataManager &dm, const gamedata::unit_movable *
 MovableProducer::~MovableProducer() {}
 
 void MovableProducer::initialise(Unit *unit, Player &player) {
-	
+
 	/*
 	 * call base function
 	 */
@@ -338,7 +341,7 @@ void MovableProducer::initialise(Unit *unit, Player &player) {
 	 * distance per millisecond -- consider original game speed
 	 * where 1.5 in game seconds pass in 1 real second
 	 */
-	coord::phys_t sp = this->unit_data.speed * coord::settings::phys_per_tile / 666; 
+	coord::phys_t sp = this->unit_data.speed * coord::settings::phys_per_tile / 666;
 	unit->add_attribute(new Attribute<attr_type::speed>(sp));
 
 	// projectile of melee attacks
@@ -363,7 +366,7 @@ LivingProducer::LivingProducer(DataManager &dm, const gamedata::unit_living *ud)
 	unit_data(*ud) {
 
 	// extra abilities
-	this->type_abilities.emplace_back(std::make_shared<GarrisonAbility>(this->on_move));	
+	this->type_abilities.emplace_back(std::make_shared<GarrisonAbility>(this->on_move));
 }
 
 LivingProducer::~LivingProducer() {}
@@ -396,7 +399,7 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 			gather_attr.graphics[gamedata::unit_classes::TREES] = this->datamanager.get_type(123); // woodcutter
 			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->datamanager.get_type(579); // gold miner
 			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->datamanager.get_type(124); // stone miner
-			
+
 		}
 		else {
 
@@ -435,8 +438,8 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 	unit_data{*ud},
 	texture{dm.get_unit_texture(ud->graphic_standing0)},
 	destroyed{dm.get_unit_texture(ud->graphic_dying0)},
-	trainable1{dm.get_type(83)}, // 83 = m villager 
-	trainable2{dm.get_type(293)}, // 293 = f villager 
+	trainable1{dm.get_type(83)}, // 83 = m villager
+	trainable2{dm.get_type(293)}, // 293 = f villager
 	projectile{dm.get_type(this->unit_data.projectile_unit_id)},
 	foundation_terrain{ud->terrain_id} {
 
@@ -460,7 +463,7 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 		static_cast<int>(this->unit_data.radius_size0 * 2),
 		static_cast<int>(this->unit_data.radius_size1 * 2),
 	};
-	
+
 	// graphic set
 	this->graphics[graphic_type::construct] = dm.get_unit_texture(ud->construction_graphic_id);
 	this->graphics[graphic_type::standing] = dm.get_unit_texture(ud->graphic_standing0);
@@ -562,7 +565,7 @@ std::shared_ptr<TerrainObject> BuldingProducer::place(Unit *u, std::shared_ptr<T
 	};
 
 	// try to place the obj, it knows best whether it will fit.
-	auto state = object_state::floating; //collisions? object_state::placed : object_state::placed_no_collision;
+	auto state = object_state::floating;
 	if (!u->location->place(terrain, init_pos, state)) {
 		return nullptr;
 	}
@@ -572,7 +575,7 @@ std::shared_ptr<TerrainObject> BuldingProducer::place(Unit *u, std::shared_ptr<T
 		const gamedata::building_annex &annex = this->unit_data.building_annex.data[i];
 		if (annex.unit_id > 0) {
 
-			// make objects for annex	
+			// make objects for annex
 			coord::phys3 a_pos = u->location->pos.draw;
 			a_pos.ne += annex.misplaced0 * coord::settings::phys_per_tile;
 			a_pos.se += annex.misplaced1 * coord::settings::phys_per_tile;
@@ -714,7 +717,7 @@ std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, std::shared_pt
 			// ensure no intersections with other objects
 			for (auto item : tc->obj) {
 				auto obj_cmp = item.lock();
-				if (obj != obj_cmp && 
+				if (obj != obj_cmp &&
 				    &obj_cmp->unit != launcher &&
 				    obj_cmp->check_collisions() &&
 				    obj->intersects(*obj_cmp, pos)) {

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -39,40 +39,13 @@ std::unordered_set<terrain_t> allowed_terrains(const gamedata::ground_type &rest
 	return result;
 }
 
-std::shared_ptr<TerrainObject> UnitProducer::place_beside(Unit *u, std::shared_ptr<TerrainObject> other) const {
-	if (!u || !other) {
-		return nullptr;
-	}
-
-	// find the range of possible tiles
-	tile_range outline{other->pos.start - coord::tile_delta{1, 1}, 
-	                   other->pos.end   + coord::tile_delta{1, 1}, 
-	                   other->pos.draw};
-
-	// find a free position adjacent to the object
-	auto terrain = other->get_terrain();
-	for (coord::tile temp_pos : tile_list(outline)) {
-		TerrainChunk *chunk = terrain->get_chunk(temp_pos);
-
-		if (chunk == nullptr) {
-			continue;
-		}
-
-		auto placed = this->place(u, *terrain, temp_pos.to_phys2().to_phys3());
-		if (placed) {
-			return placed;
-		}
-	}
-	return nullptr;
-}
-
 ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 	:
 	datamanager(dm),
 	unit_data(*ud),
 	terrain_outline{nullptr},
 	default_tex{dm.get_unit_texture(ud->graphic_standing0)},
-	dead_unit_producer{dm.get_producer(ud->dead_unit_id)} {
+	dead_unit_producer{dm.get_type(ud->dead_unit_id)} {
 
 	// for now just look for type names ending with "_D"
 	this->decay = unit_data.name.substr(unit_data.name.length() - 2) == "_D";
@@ -137,11 +110,11 @@ ObjectProducer::ObjectProducer(DataManager &dm, const gamedata::unit_object *ud)
 
 ObjectProducer::~ObjectProducer() {}
 
-int ObjectProducer::producer_id() const {
+int ObjectProducer::id() const {
 	return this->unit_data.id0;
 }
 
-std::string ObjectProducer::producer_name() const {
+std::string ObjectProducer::name() const {
 	return this->unit_data.name;
 }
 
@@ -156,7 +129,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 	unit->reset();
 
 	// initialise unit
-	unit->producer = this;
+	unit->unit_type = this;
 	unit->unit_class = this->unit_data.unit_class;
 	unit->graphics = &this->graphics;
 
@@ -223,15 +196,14 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 	}
 }
 
-std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, Terrain &terrain, coord::phys3 init_pos) const {
+std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 
 	// create new object with correct base shape
-	std::shared_ptr<TerrainObject> obj;
 	if (this->unit_data.selection_shape > 1) {
-		obj = std::make_shared<RadialObject>(*u, this->unit_data.radius_size0, this->terrain_outline, !this->decay);
+		u->make_location<RadialObject>(this->unit_data.radius_size0, this->terrain_outline);
 	}
 	else {
-		obj = std::make_shared<SquareObject>(*u, this->foundation_size, this->terrain_outline, !this->decay);
+		u->make_location<SquareObject>(this->foundation_size, this->terrain_outline);
 	}
 
 	// find set of allowed terrains
@@ -242,11 +214,15 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, Terrain &terrain, 
 	 * currently unit avoids water and tiles with another unit
 	 * this function should be true if pos is a valid position of the object
 	 */
-	obj->passable = [obj, &terrain, terrains](const coord::phys3 &pos) -> bool {
+	std::weak_ptr<TerrainObject> obj_ptr = u->location;
+	std::weak_ptr<Terrain> terrain_ptr = terrain;
+	u->location->passable = [obj_ptr, terrain_ptr, terrains](const coord::phys3 &pos) -> bool {
+		auto obj = obj_ptr.lock();
+		auto terrain = terrain_ptr.lock();
 
 		// look at all tiles in the bases range
 		for (coord::tile check_pos : tile_list(obj->get_range(pos))) {
-			TileContent *tc = terrain.get_data(check_pos);
+			TileContent *tc = terrain->get_data(check_pos);
 
 			// invalid tile types
 			if (!tc || terrains.count(tc->terrain_id) == 0) {
@@ -257,7 +233,7 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, Terrain &terrain, 
 			for (auto item : tc->obj) {
 				auto obj_cmp = item.lock();
 				if (obj != obj_cmp && 
-				    obj_cmp->check_collisions &&
+				    obj_cmp->check_collisions() &&
 				    obj->intersects(*obj_cmp, pos)) {
 					return false;
 				}
@@ -266,21 +242,20 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, Terrain &terrain, 
 		return true;
 	};
 
-	obj->draw = [=]() {
+	u->location->draw = [u, obj_ptr]() {
 		if (u->selected) {
-			obj->draw_outline();
+			obj_ptr.lock()->draw_outline();
 		}
 		u->draw();
 	};
 
 	// try to place the obj, it knows best whether it will fit.
-	bool obj_placed = obj->place(&terrain, init_pos);
-	if (obj_placed) {
-		obj->initialise();
+	auto state = this->decay? object_state::placed_no_collision : object_state::placed;
+	if (u->location->place(terrain, init_pos, state)) {
 		if (this->on_create) {
 			this->on_create->play();
 		}
-		return obj;
+		return u->location;
 	}
 
 	// placing at the given position failed
@@ -288,18 +263,13 @@ std::shared_ptr<TerrainObject> ObjectProducer::place(Unit *u, Terrain &terrain, 
 	return nullptr;
 }
 
-UnitTexture *ObjectProducer::default_texture() {
-	return this->default_tex.get();
-}
-
-
 MovableProducer::MovableProducer(DataManager &dm, const gamedata::unit_movable *um)
 	:
 	ObjectProducer(dm, um),
 	unit_data(*um),
 	on_move{dm.get_sound(this->unit_data.move_sound)},
 	on_attack{dm.get_sound(this->unit_data.move_sound)},
-	projectile{dm.get_producer(this->unit_data.projectile_unit_id)} {
+	projectile{dm.get_type(this->unit_data.projectile_unit_id)} {
 
 	// extra graphics
 	this->graphics[graphic_type::walking] = dm.get_unit_texture(this->unit_data.walking_graphics0);
@@ -345,7 +315,7 @@ void MovableProducer::initialise(Unit *unit, Player &player) {
 	}
 }
 
-std::shared_ptr<TerrainObject> MovableProducer::place(Unit *unit, Terrain &terrain, coord::phys3 init_pos) const {
+std::shared_ptr<TerrainObject> MovableProducer::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	return ObjectProducer::place(unit, terrain, init_pos);
 }
 
@@ -382,23 +352,23 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 		if (this->unit_data.id0 == 83) {
 
 			// male graphics
-			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->datamanager.get_producer(156); // builder 118
-			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->datamanager.get_producer(120); // forager
-			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->datamanager.get_producer(592); // sheperd
-			gather_attr.graphics[gamedata::unit_classes::TREES] = this->datamanager.get_producer(123); // woodcutter
-			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->datamanager.get_producer(579); // gold miner
-			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->datamanager.get_producer(124); // stone miner
+			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->datamanager.get_type(156); // builder 118
+			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->datamanager.get_type(120); // forager
+			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->datamanager.get_type(592); // sheperd
+			gather_attr.graphics[gamedata::unit_classes::TREES] = this->datamanager.get_type(123); // woodcutter
+			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->datamanager.get_type(579); // gold miner
+			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->datamanager.get_type(124); // stone miner
 			
 		}
 		else {
 
 			// female graphics
-			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->datamanager.get_producer(222); // builder 212
-			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->datamanager.get_producer(354); // forager
-			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->datamanager.get_producer(590); // sheperd
-			gather_attr.graphics[gamedata::unit_classes::TREES] = this->datamanager.get_producer(218); // woodcutter
-			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->datamanager.get_producer(581); // gold miner
-			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->datamanager.get_producer(220); // stone miner
+			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->datamanager.get_type(222); // builder 212
+			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->datamanager.get_type(354); // forager
+			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->datamanager.get_type(590); // sheperd
+			gather_attr.graphics[gamedata::unit_classes::TREES] = this->datamanager.get_type(218); // woodcutter
+			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->datamanager.get_type(581); // gold miner
+			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->datamanager.get_type(220); // stone miner
 		}
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 		unit->give_ability(std::make_shared<BuildAbility>(this->on_attack));
@@ -417,7 +387,7 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 	}
 }
 
-std::shared_ptr<TerrainObject> LivingProducer::place(Unit *unit, Terrain &terrain, coord::phys3 init_pos) const {
+std::shared_ptr<TerrainObject> LivingProducer::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	return MovableProducer::place(unit, terrain, init_pos);
 }
 
@@ -427,9 +397,9 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 	unit_data{*ud},
 	texture{dm.get_unit_texture(ud->graphic_standing0)},
 	destroyed{dm.get_unit_texture(ud->graphic_dying0)},
-	trainable1{dm.get_producer(83)}, // 83 = m villager 
-	trainable2{dm.get_producer(293)}, // 293 = f villager 
-	projectile{dm.get_producer(this->unit_data.projectile_unit_id)},
+	trainable1{dm.get_type(83)}, // 83 = m villager 
+	trainable2{dm.get_type(293)}, // 293 = f villager 
+	projectile{dm.get_type(this->unit_data.projectile_unit_id)},
 	foundation_terrain{ud->terrain_id} {
 
 	// find suitable sounds
@@ -467,11 +437,11 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 
 BuldingProducer::~BuldingProducer() {}
 
-int BuldingProducer::producer_id() const {
+int BuldingProducer::id() const {
 	return this->unit_data.id0;
 }
 
-std::string BuldingProducer::producer_name() const {
+std::string BuldingProducer::name() const {
 	return this->unit_data.name;
 }
 
@@ -483,30 +453,24 @@ void BuldingProducer::initialise(Unit *unit, Player &player) {
 		this->unit_data.name);
 
 	// initialize graphic set
-	unit->producer = this;
+	unit->unit_type = this;
 	unit->unit_class = this->unit_data.unit_class;
 	unit->graphics = &this->graphics;
 
 	auto player_attr = new Attribute<attr_type::owner>(player);
 	unit->add_attribute(player_attr);
-	unit->add_attribute(new Attribute<attr_type::building>());
+	auto build_attr = new Attribute<attr_type::building>();
+	build_attr->foundation_terrain = this->foundation_terrain;
+	build_attr->pp = trainable2;
+	unit->add_attribute(build_attr);
 	unit->add_attribute(new Attribute<attr_type::garrison>());
 	unit->add_attribute(new Attribute<attr_type::hitpoints>(this->unit_data.hit_points));
-
-	// basic attributes on annexes
-	for (auto obj : unit->location->get_children()) {
-		obj->unit.add_attribute(player_attr);
-		obj->unit.push_action(std::make_unique<IdleAction>(&obj->unit), true);
-	}
-
-	auto &bl_attr = unit->get_attribute<attr_type::building>();
-	bl_attr.pp = trainable2;
 
 	// if a destroyed texture exists
 	if (this->destroyed) {
 		unit->push_action(std::make_unique<DeadAction>(unit), true);
 	}
-	unit->push_action(std::make_unique<IdleAction>(unit), true);
+	unit->push_action(std::make_unique<FoundationAction>(unit), true);
 
 	if (this->unit_data.projectile_unit_id > 0 && this->projectile) {
 		coord::phys_t range_phys = coord::settings::phys_per_tile * this->unit_data.max_range;
@@ -519,49 +483,51 @@ void BuldingProducer::initialise(Unit *unit, Player &player) {
 	unit->give_ability(std::make_shared<UngarrisonAbility>());
 }
 
-std::shared_ptr<TerrainObject> BuldingProducer::place(Unit *u, Terrain &terrain, coord::phys3 init_pos) const {
-
-	// not a tc --- hacks / fix me
-	bool collisions = this->unit_data.id0 != 109;
+std::shared_ptr<TerrainObject> BuldingProducer::place(Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 
 	// buildings have a square base
-	auto obj = std::make_shared<SquareObject>(*u, this->foundation_size, this->terrain_outline, collisions);
+	u->make_location<SquareObject>(this->foundation_size, this->terrain_outline);
 
 	/*
 	 * decide what terrain is passable using this lambda
 	 * currently unit avoids water and tiles with another unit
 	 * this function should be true if pos is a valid position of the object
 	 */
-	obj->passable = [obj, &terrain](const coord::phys3 &pos) -> bool {
+	std::weak_ptr<TerrainObject> obj_ptr = u->location;
+	std::weak_ptr<Terrain> terrain_ptr = terrain;
+	u->location->passable = [obj_ptr, terrain_ptr](const coord::phys3 &pos) -> bool {
+		auto obj = obj_ptr.lock();
+		auto terrain = terrain_ptr.lock();
 
 		// look at all tiles in the bases range
 		for (coord::tile check_pos : tile_list(obj->get_range(pos))) {
-			TileContent *tc = terrain.get_data(check_pos);
+			TileContent *tc = terrain->get_data(check_pos);
 			if (!tc) {
 				return false;
 			}
 			for (auto item : tc->obj) {
 				auto tobj = item.lock();
-				if (tobj->check_collisions) return false;
+				if (tobj->check_collisions()) return false;
 			}
 		}
 		return true;
 	};
 
 	// drawing function
-	obj->draw = [=]() {
+	// not a tc --- hacks / fix me
+	bool collisions = this->unit_data.id0 != 109;
+	u->location->draw = [u, obj_ptr, collisions]() {
 		if (u->selected && collisions) {
-			obj->draw_outline();
+			obj_ptr.lock()->draw_outline();
 		}
 		u->draw();
 	};
 
 	// try to place the obj, it knows best whether it will fit.
-	bool obj_placed = obj->place(&terrain, init_pos);
-	if (!obj_placed) {
+	auto state = object_state::floating; //collisions? object_state::placed : object_state::placed_no_collision;
+	if (!u->location->place(terrain, init_pos, state)) {
 		return nullptr;
 	}
-	obj->initialise();
 
 	// annex objects
 	for (unsigned i = 0; i < 4; ++i) {
@@ -569,29 +535,22 @@ std::shared_ptr<TerrainObject> BuldingProducer::place(Unit *u, Terrain &terrain,
 		if (annex.unit_id > 0) {
 
 			// make objects for annex	
-			coord::phys3 a_pos = obj->pos.draw;
+			coord::phys3 a_pos = u->location->pos.draw;
 			a_pos.ne += annex.misplaced0 * coord::settings::phys_per_tile;
 			a_pos.se += annex.misplaced1 * coord::settings::phys_per_tile;
-			auto annex_obj = this->make_annex(*u, terrain, annex.unit_id, a_pos, i == 0);
-			obj->annex(annex_obj);
+			this->make_annex(*u, terrain, annex.unit_id, a_pos, i == 0);
 		}
 	}
 
+	// TODO: play sound once built
 	if (this->on_create) {
 		this->on_create->play();
 	}
-	if (this->foundation_terrain > 0) {
-		// TODO: use the gamedata terrain lookup!
-		obj->set_ground(this->foundation_terrain, 0);
-	}
-	return obj;
+	return u->location;
 }
 
-UnitTexture *BuldingProducer::default_texture() {
-	return this->texture.get();
-}
-
-std::shared_ptr<TerrainObject> BuldingProducer::make_annex(Unit &u, Terrain &t, int annex_id, coord::phys3 annex_pos, bool c) const {
+std::shared_ptr<TerrainObject> BuldingProducer::make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const {
+	u.log(MSG(dbg) << "adding annex " << annex_id);
 
 	// find annex foundation size
 	auto b = datamanager.get_building_data(annex_id);
@@ -601,44 +560,35 @@ std::shared_ptr<TerrainObject> BuldingProducer::make_annex(Unit &u, Terrain &t, 
 	};
 
 	// producers place by the nw tile
-	auto p = datamanager.get_producer(annex_id);
 	coord::phys3 start_tile = annex_pos;
 	start_tile.ne -= b->radius_size0 * coord::settings::phys_per_tile;
 	start_tile.se -= b->radius_size1 * coord::settings::phys_per_tile;
 
-	// place on terrain
-	// TODO: less hacks
-	Unit *annex_unit = u.get_container()->new_unit().get();
-	annex_unit->producer = p;
-	annex_unit->graphics = &p->graphics;
-	auto annex_obj = std::make_shared<SquareObject>(*annex_unit, annex_foundation, c);
-	annex_obj->place(&t, start_tile);
+	// create and place on terrain
+	auto annex_loc = u.make_location_annex<SquareObject>(annex_foundation);
+	annex_loc->place(t, start_tile, object_state::floating);
 
-	if (c) {
-		annex_obj->draw = [annex_obj, annex_pos, p, &u]() {
+	// weak ptr for use in lambda drawing functions
+	std::weak_ptr<TerrainObject> annex_weak_ptr = annex_loc;
+	auto annex_type = datamanager.get_type(annex_id);
 
-			// draws the outline in the right order
-			if (u.selected) {
-				annex_obj->get_parent()->draw_outline();
-			}
+	// create special drawing functions for annexes,
+	annex_loc->draw = [annex_weak_ptr, annex_type, &u, c]() {
+		auto annex_location = annex_weak_ptr.lock();
 
-			if (u.has_attribute(attr_type::building) &&
-			    u.get_attribute<attr_type::building>().completed >= 1.0f) {
-				annex_obj->unit.draw();
-			}
-			
-		};
-	}
-	else {
-		annex_obj->draw = [annex_obj, annex_pos, p, &u]() {
-			if (u.has_attribute(attr_type::building) &&
-			    u.get_attribute<attr_type::building>().completed >= 1.0f) {
-				annex_obj->unit.draw();
-			}
-		};
-	}
+		// hack which draws the outline in the right order
+		// removable once rendering system is improved
+		if (c && u.selected) {
+			annex_location->get_parent()->draw_outline();
+		}
 
-	return annex_obj;
+		// only draw if building is completed
+		if (u.has_attribute(attr_type::building) &&
+		    u.get_attribute<attr_type::building>().completed >= 1.0f) {
+			u.draw(annex_location, &annex_type->graphics);
+		}
+	};
+	return annex_loc;
 }
 
 ProjectileProducer::ProjectileProducer(DataManager &dm, const gamedata::unit_projectile *pd)
@@ -661,18 +611,18 @@ ProjectileProducer::ProjectileProducer(DataManager &dm, const gamedata::unit_pro
 
 ProjectileProducer::~ProjectileProducer() {}
 
-int ProjectileProducer::producer_id() const {
+int ProjectileProducer::id() const {
 	return this->unit_data.id0;
 }
 
-std::string ProjectileProducer::producer_name() const {
+std::string ProjectileProducer::name() const {
 	return this->unit_data.name;
 }
 
 void ProjectileProducer::initialise(Unit *unit, Player &) {
 
 	// initialize graphic set
-	unit->producer = this;
+	unit->unit_type = this;
 	unit->unit_class = this->unit_data.unit_class;
 	unit->graphics = &this->graphics;
 
@@ -688,19 +638,23 @@ void ProjectileProducer::initialise(Unit *unit, Player &) {
 	}
 }
 
-std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, Terrain &terrain, coord::phys3 init_pos) const {
+std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	/*
 	 * radial base shape without collision checking
 	 */
-	auto obj = std::make_shared<RadialObject>(*u, this->unit_data.radius_size1, this->terrain_outline, false);
+	u->make_location<RadialObject>(this->unit_data.radius_size1, this->terrain_outline);
 
-	obj->passable = [obj, u, &terrain](const coord::phys3 &pos) -> bool {
+	std::weak_ptr<TerrainObject> obj_ptr = u->location;
+	std::weak_ptr<Terrain> terrain_ptr = terrain;
+	u->location->passable = [obj_ptr, u, terrain_ptr](const coord::phys3 &pos) -> bool {
 		if (pos.up > 64000) {
 			return true;
 		}
 
 		// avoid intersections with launcher
 		Unit *launcher = nullptr;
+		auto obj = obj_ptr.lock();
+		auto terrain = terrain_ptr.lock();
 		if (u->has_attribute(attr_type::projectile)) {
 			auto &pr_attr = u->get_attribute<attr_type::projectile>();
 			if (pr_attr.launched && pr_attr.launcher.is_valid()) {
@@ -716,7 +670,7 @@ std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, Terrain &terra
 
 		// look at all tiles in the bases range
 		for (coord::tile check_pos : tile_list(obj->get_range(pos))) {
-			TileContent *tc = terrain.get_data(check_pos);
+			TileContent *tc = terrain->get_data(check_pos);
 			if (!tc) return false;
 
 			// ensure no intersections with other objects
@@ -724,7 +678,7 @@ std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, Terrain &terra
 				auto obj_cmp = item.lock();
 				if (obj != obj_cmp && 
 				    &obj_cmp->unit != launcher &&
-				    obj_cmp->check_collisions &&
+				    obj_cmp->check_collisions() &&
 				    obj->intersects(*obj_cmp, pos)) {
 					return false;
 				}
@@ -733,22 +687,15 @@ std::shared_ptr<TerrainObject> ProjectileProducer::place(Unit *u, Terrain &terra
 		return true;
 	};
 
-	obj->draw = [=]() {
+	u->location->draw = [u]() {
 		u->draw();
 	};
 
-
 	// try to place the obj, it knows best whether it will fit.
-	bool obj_placed = obj->place(&terrain, init_pos);
-	if (obj_placed) {
-		obj->initialise();
-		return obj;
+	if (u->location->place(terrain, init_pos, object_state::placed_no_collision)) {
+		return u->location;
 	}
 	return nullptr;
-}
-
-UnitTexture *ProjectileProducer::default_texture() {
-	return this->tex.get();
 }
 
 } /* namespace openage */

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -41,7 +41,7 @@ public:
 	int id() const override;
 	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	DataManager &datamanager;
@@ -60,7 +60,7 @@ protected:
 	std::shared_ptr<Texture> terrain_outline;
 	std::shared_ptr<UnitTexture> default_tex;
 	UnitType *dead_unit_producer;
-	
+
 };
 
 /**
@@ -72,7 +72,7 @@ public:
 	virtual ~MovableProducer();
 
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const gamedata::unit_movable unit_data;
@@ -95,7 +95,7 @@ public:
 	virtual ~LivingProducer();
 
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_living unit_data;
@@ -115,7 +115,7 @@ public:
 	int id() const override;
 	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	DataManager &datamanager;
@@ -134,7 +134,7 @@ private:
 	UnitType *projectile;
 	int foundation_terrain;
 
-	std::shared_ptr<TerrainObject> make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
+	TerrainObject *make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
 };
 
 /**
@@ -149,7 +149,7 @@ public:
 	int id() const override;
 	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_projectile unit_data;

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -7,12 +7,12 @@
 #include <unordered_map>
 #include <vector>
 
-
 #include "../coord/tile.h"
 #include "../gamedata/gamedata.gen.h"
 #include "../gamedata/graphic.gen.h"
 #include "../player.h"
 #include "unit.h"
+#include "unit_type.h"
 
 namespace openage {
 
@@ -31,83 +31,17 @@ class UnitTexture;
 std::unordered_set<terrain_t> allowed_terrains(const gamedata::ground_type &restriction);
 
 /**
- * A partial implementation of unit types 
- *
- * Initializes a unit with the required attributes, each unit type should implement these funcrtions
- * initialise should be called on construction of units 'new Unit(some_unit_producer)'
- * place is called to customise how the unit gets added to the world -- used to setup the TerrainObject position
- */
-class UnitProducer {
-public:
-	virtual ~UnitProducer() {}
-
-	/**
-	 * gets the id of the unit type being produced
-	 * TODO: make const
-	 */
-	virtual int producer_id() const = 0;
-
-	/**
-	 * gets the name of the unit type being produced
-	 */
-	virtual std::string producer_name() const = 0;
-
-	/**
-	 * Initialize units attributes
-	 * This can be called using existing units to modify type
-	 * TODO: make const
-	 */
-	virtual void initialise(Unit *, Player &) = 0;
-
-	/**
-	 * set unit in place -- return if placement was successful
-	 *
-	 * This should be used when initially creating a unit or
-	 * when a unit is ungarrsioned from a building or object
-	 * TODO: make const
-	 */
-	virtual std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const = 0;
-
-	/**
-	 * Get a default texture for HUD drawing
-	 */
-	virtual UnitTexture *default_texture() = 0;
-
-	/**
-	 * similiar to place but places adjacent to an existing object
-	 */
-	std::shared_ptr<TerrainObject> place_beside(Unit *, std::shared_ptr<TerrainObject>) const;
-
-	/**
-	 * all instances of units made from this producer
-	 * this could allow all units of a type to be upgraded
-	 */
-	std::vector<UnitReference> instances;
-
-	/**
-	 * The set of graphics used for this type
-	 */
-	graphic_set graphics;
-
-	/**
-	 * abilities given to all instances
-	 */
-	std::vector<std::shared_ptr<UnitAbility>> type_abilities;
-};
-
-/**
  * base game data unit type
  */
-class ObjectProducer: public UnitProducer {
+class ObjectProducer: public UnitType {
 public:
 	ObjectProducer(DataManager &dm, const gamedata::unit_object *ud);
 	virtual ~ObjectProducer();
 
-	int producer_id() const override;
-	std::string producer_name() const override;
+	int id() const override;
+	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const override;
-	UnitTexture *default_texture() override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	DataManager &datamanager;
@@ -125,7 +59,7 @@ protected:
 	Sound *on_destroy;
 	std::shared_ptr<Texture> terrain_outline;
 	std::shared_ptr<UnitTexture> default_tex;
-	UnitProducer *dead_unit_producer;
+	UnitType *dead_unit_producer;
 	coord::tile_delta foundation_size;
 	
 };
@@ -139,7 +73,7 @@ public:
 	virtual ~MovableProducer();
 
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const gamedata::unit_movable unit_data;
@@ -147,7 +81,7 @@ protected:
 	UnitTexture *attacking;
 	Sound *on_move;
 	Sound *on_attack;
-	UnitProducer *projectile;
+	UnitType *projectile;
 
 };
 
@@ -162,7 +96,7 @@ public:
 	virtual ~LivingProducer();
 
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_living unit_data;
@@ -174,16 +108,15 @@ private:
  * Will be replaced with nyan system in future
  * in aoe buildings are derived from living units
  */
-class BuldingProducer: public UnitProducer {
+class BuldingProducer: public UnitType {
 public:
 	BuldingProducer(DataManager &dm, const gamedata::unit_building *ud);
 	virtual ~BuldingProducer();
 
-	int producer_id() const override;
-	std::string producer_name() const override;
+	int id() const override;
+	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const override;
-	UnitTexture *default_texture() override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	DataManager &datamanager;
@@ -197,29 +130,28 @@ private:
 	std::shared_ptr<Texture> terrain_outline;
 	std::shared_ptr<UnitTexture> texture;
 	std::shared_ptr<UnitTexture> destroyed;
-	UnitProducer *trainable1;
-	UnitProducer *trainable2;
-	UnitProducer *projectile;
+	UnitType *trainable1;
+	UnitType *trainable2;
+	UnitType *projectile;
 	coord::tile_delta foundation_size;
 	int foundation_terrain;
 
-	std::shared_ptr<TerrainObject> make_annex(Unit &u, Terrain &t, int annex_id, coord::phys3 annex_pos, bool c) const;
+	std::shared_ptr<TerrainObject> make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
 };
 
 /**
  * creates projectiles
  * todo use MovableProducer as base class
  */
-class ProjectileProducer: public UnitProducer {
+class ProjectileProducer: public UnitType {
 public:
 	ProjectileProducer(DataManager &dm, const gamedata::unit_projectile *);
 	virtual ~ProjectileProducer();
 
-	int producer_id() const override;
-	std::string producer_name() const override;
+	int id() const override;
+	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, Terrain &, coord::phys3) const override;
-	UnitTexture *default_texture() override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_projectile unit_data;

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -60,7 +60,6 @@ protected:
 	std::shared_ptr<Texture> terrain_outline;
 	std::shared_ptr<UnitTexture> default_tex;
 	UnitType *dead_unit_producer;
-	coord::tile_delta foundation_size;
 	
 };
 
@@ -133,7 +132,6 @@ private:
 	UnitType *trainable1;
 	UnitType *trainable2;
 	UnitType *projectile;
-	coord::tile_delta foundation_size;
 	int foundation_terrain;
 
 	std::shared_ptr<TerrainObject> make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;

--- a/cpp/unit/selection.cpp
+++ b/cpp/unit/selection.cpp
@@ -206,7 +206,7 @@ void UnitSelection::show_attributes(Unit *u) {
 	// render text
 	Engine &engine = Engine::get();
 	int vpos = 120;
-	engine.render_text({0, vpos}, 20, u->producer->producer_name().c_str());
+	engine.render_text({0, vpos}, 20, u->unit_type->name().c_str());
 	for (auto &s : lines) {
 		vpos -= this->font_size;
 		engine.render_text({0, vpos}, this->font_size, s.c_str());

--- a/cpp/unit/selection.cpp
+++ b/cpp/unit/selection.cpp
@@ -178,6 +178,18 @@ void UnitSelection::all_invoke(Command &cmd) {
 	}
 }
 
+Player *UnitSelection::owner() {
+	for (auto u : this->units) {
+		if (u.second.is_valid()) {
+			auto unit_ptr = u.second.get();
+			if (unit_ptr->has_attribute(attr_type::owner)) {
+				return &unit_ptr->get_attribute<attr_type::owner>().player;
+			}
+		}
+	}
+	return nullptr;
+}
+
 void UnitSelection::show_attributes(Unit *u) {
 	std::vector<std::string> lines;
 	lines.push_back(u->top()->name());

--- a/cpp/unit/selection.cpp
+++ b/cpp/unit/selection.cpp
@@ -151,8 +151,7 @@ void UnitSelection::select_space(Terrain *terrain, coord::camgame p1, coord::cam
 		TileContent *tc = terrain->get_data(check_pos);
 		if (tc) {
 			// find objects within selection box
-			for (auto o : tc->obj) {
-				auto unit_location = o.lock();
+			for (auto unit_location : tc->obj) {
 				coord::camgame pos = unit_location->pos.draw.to_camgame();
 				if ((min.x < pos.x && pos.x < max.x) &&
 				     (min.y < pos.y && pos.y < max.y)) {

--- a/cpp/unit/selection.h
+++ b/cpp/unit/selection.h
@@ -47,6 +47,12 @@ public:
 	 */
 	void all_invoke(Command &cmd);
 
+	/**
+	 * player who owns units in the selection
+	 * returns nullptr if no owned units are selected
+	 */ 
+	Player *owner();
+
 private:
 
 	/**

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -107,10 +107,10 @@ void Unit::update_secondary(int64_t time_elapsed) {
 }
 
 void Unit::draw() {
-	this->draw(this->location, this->graphics);
+	this->draw(this->location.get(), this->graphics);
 }
 
-void Unit::draw(std::shared_ptr<TerrainObject> loc, graphic_set *grpc) {
+void Unit::draw(TerrainObject *loc, graphic_set *grpc) {
 
 	// there should always be a location
 	if (!loc) {

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -54,6 +54,7 @@ UnitAction *Unit::top() const {
 }
 
 bool Unit::update() {
+
 	// if unit is not on the map then do nothing
 	if (!this->location) {
 		return true;

--- a/cpp/unit/unit.cpp
+++ b/cpp/unit/unit.cpp
@@ -111,18 +111,23 @@ void Unit::draw() {
 }
 
 void Unit::draw(std::shared_ptr<TerrainObject> loc, graphic_set *grpc) {
+
+	// there should always be a location
+	if (!loc) {
+		this->log(MSG(warn) << "Cannot draw unit with no location");
+	}
 	auto top_action = this->top();
 	auto &draw_pos = loc->pos.draw;
 	auto draw_graphic = top_action->type();
-	if (grpc->count(draw_graphic) == 0) {
-		this->log(MSG(warn) << "graphic not available");
+	if (!grpc || grpc->count(draw_graphic) == 0) {
+		this->log(MSG(warn) << "Graphic not available");
 		return;
 	}
 
 	// the texture to draw with
 	auto draw_texture = grpc->at(draw_graphic);
 	if (!draw_texture) {
-		this->log(MSG(warn) << "graphic null");
+		this->log(MSG(warn) << "Graphic null");
 		return;
 	}
 
@@ -196,11 +201,11 @@ bool Unit::invoke(const Command &cmd, bool direct_command) {
 
 	// find suitable ability for this target if available
 	for (auto &action : this->ability_available) {
-		if (cmd.ability()[action.first] && action.second->can_invoke(*this, cmd)) {
+		if (cmd.ability()[static_cast<int>(action.first)] && action.second->can_invoke(*this, cmd)) {
 			if (direct_command) {
 
 				// drop other actions if a new action is found
-				this->stop_actions(); 
+				this->stop_actions();
 			}
 			action.second->invoke(*this, cmd, direct_command);
 			return true;

--- a/cpp/unit/unit.h
+++ b/cpp/unit/unit.h
@@ -65,7 +65,7 @@ public:
 	 * null if the object is not yet placed or garrisoned
 	 * TODO: make private field
 	 */
-	std::shared_ptr<TerrainObject> location;
+	std::unique_ptr<TerrainObject> location;
 
 	/**
 	 * graphics sets which can be modified for gathering
@@ -82,14 +82,14 @@ public:
 	template<class T, typename ... Arg>
 	void make_location(Arg ... args) {
 
-		// remove any existing location
+		// remove any existing location first
 		if (this->location) {
 			this->location->remove();
 		}
 
 		// since Unit is a friend of the location
 		// make_shared will not work
-		this->location = std::shared_ptr<T>(new T(*this, args ...));
+		this->location = std::unique_ptr<T>(new T(*this, args ...));
 	}
 
 	/**
@@ -98,11 +98,10 @@ public:
 	 * this does not replace the units location
 	 */
 	template<class T, typename ... Arg>
-	std::shared_ptr<T> make_location_annex(Arg ... args) {
+	T *make_location_annex(Arg ... args) {
 
-		// since Unit is a friend of the location
-		// make_shared will not work
-		auto annex_ptr = std::shared_ptr<T>(new T(*this, args ...));
+		// Unit is a friend of the location
+		auto annex_ptr = new T(*this, args ...);
 		this->location->annex(annex_ptr);
 		return annex_ptr;
 	}
@@ -143,7 +142,7 @@ public:
 	/**
 	 * an generalized draw function which is useful for drawing annexes
 	 */
-	void draw(std::shared_ptr<TerrainObject> loc, graphic_set *graphics);
+	void draw(TerrainObject *loc, graphic_set *graphics);
 
 	/**
 	 * adds an available ability to this unit

--- a/cpp/unit/unit.h
+++ b/cpp/unit/unit.h
@@ -43,7 +43,8 @@ public:
 	const id_t id;
 
 	/**
-	 * type which was used to create this object
+	 * type of this object, this is set by the the UnitType which
+	 * was most recently applied to this unit
 	 */
 	UnitType *unit_type;
 
@@ -56,7 +57,7 @@ public:
 	 * should selection features be drawn
 	 * TODO: should be a pointer to selection to be updated
 	 * when unit is removed, or null if not selected
-	 */	
+	 */
 	bool selected;
 
 	/**
@@ -81,7 +82,7 @@ public:
 	template<class T, typename ... Arg>
 	void make_location(Arg ... args) {
 
-		// remove any existing location	
+		// remove any existing location
 		if (this->location) {
 			this->location->remove();
 		}
@@ -106,7 +107,7 @@ public:
 		return annex_ptr;
 	}
 
-	/** 
+	/**
 	 * removes all actions and abilities
 	 * current attributes are kept
 	 */
@@ -276,7 +277,8 @@ private:
 	 * erase from action specified by func to the end of the stack
 	 * all actions erased will have the on_complete function called
 	 *
-	 * popped actions on_complete function is ignored when run_completed is false
+	 * @param run_completed usually each action has an on_complete() function called when it is removed
+	 * but when run_completed is false this on_complete() function is not called for all popped actions
 	 */
 	void erase_after(std::function<bool(std::unique_ptr<UnitAction> &)> func, bool run_completed=true);
 

--- a/cpp/unit/unit_container.cpp
+++ b/cpp/unit/unit_container.cpp
@@ -84,7 +84,7 @@ UnitReference UnitContainer::new_unit() {
 	return this->live_units[id]->get_ref();
 }
 
-UnitReference UnitContainer::new_unit(UnitType &type, 
+UnitReference UnitContainer::new_unit(UnitType &type,
                                       Player &owner,
                                       coord::phys3 position) {
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
@@ -101,20 +101,20 @@ UnitReference UnitContainer::new_unit(UnitType &type,
 	return UnitReference(); // is not valid
 }
 
-UnitReference UnitContainer::new_unit(UnitType &type, 
-                                      Player &owner, 
+UnitReference UnitContainer::new_unit(UnitType &type,
+                                      Player &owner,
                                       std::shared_ptr<TerrainObject> other) {
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
 
 	// try placing unit
-	auto placed = type.place_beside(newobj.get(), other);
+	std::shared_ptr<TerrainObject> placed = type.place_beside(newobj.get(), other);
 	if (placed) {
 		type.initialise(newobj.get(), owner);
 		auto id = newobj->id;
 		this->live_units.emplace(id, std::move(newobj));
 		return this->live_units[id]->get_ref();
 	}
-	return UnitReference(); // is not valid	
+	return UnitReference(); // is not valid
 }
 
 

--- a/cpp/unit/unit_container.cpp
+++ b/cpp/unit/unit_container.cpp
@@ -103,11 +103,11 @@ UnitReference UnitContainer::new_unit(UnitType &type,
 
 UnitReference UnitContainer::new_unit(UnitType &type,
                                       Player &owner,
-                                      std::shared_ptr<TerrainObject> other) {
+                                      TerrainObject *other) {
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
 
 	// try placing unit
-	std::shared_ptr<TerrainObject> placed = type.place_beside(newobj.get(), other);
+	TerrainObject *placed = type.place_beside(newobj.get(), other);
 	if (placed) {
 		type.initialise(newobj.get(), owner);
 		auto id = newobj->id;

--- a/cpp/unit/unit_container.cpp
+++ b/cpp/unit/unit_container.cpp
@@ -84,16 +84,16 @@ UnitReference UnitContainer::new_unit() {
 	return this->live_units[id]->get_ref();
 }
 
-UnitReference UnitContainer::new_unit(UnitProducer &producer, 
+UnitReference UnitContainer::new_unit(UnitType &type, 
                                       Player &owner,
                                       coord::phys3 position) {
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
 
 	// try placing unit at this location
 	auto terrain_shared = this->get_terrain();
-	auto placed = producer.place(newobj.get(), *terrain_shared, position);
+	auto placed = type.place(newobj.get(), terrain_shared, position);
 	if (placed) {
-		producer.initialise(newobj.get(), owner);
+		type.initialise(newobj.get(), owner);
 		auto id = newobj->id;
 		this->live_units.emplace(id, std::move(newobj));
 		return this->live_units[id]->get_ref();
@@ -101,15 +101,15 @@ UnitReference UnitContainer::new_unit(UnitProducer &producer,
 	return UnitReference(); // is not valid
 }
 
-UnitReference UnitContainer::new_unit(UnitProducer &producer, 
+UnitReference UnitContainer::new_unit(UnitType &type, 
                                       Player &owner, 
                                       std::shared_ptr<TerrainObject> other) {
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
 
 	// try placing unit
-	auto placed = producer.place_beside(newobj.get(), other);
+	auto placed = type.place_beside(newobj.get(), other);
 	if (placed) {
-		producer.initialise(newobj.get(), owner);
+		type.initialise(newobj.get(), owner);
 		auto id = newobj->id;
 		this->live_units.emplace(id, std::move(newobj));
 		return this->live_units[id]->get_ref();
@@ -121,7 +121,6 @@ UnitReference UnitContainer::new_unit(UnitProducer &producer,
 bool dispatch_command(id_t, const Command &) {
 	return true;
 }
-
 
 bool UnitContainer::on_tick() {
 	// update everything and find objects with no actions
@@ -137,7 +136,6 @@ bool UnitContainer::on_tick() {
 	for (auto &obj : to_remove) {
 
 		// unique pointer triggers cleanup
-		log::log(MSG(info) << "remove object " << obj);
 		this->live_units.erase(obj);
 	}
 	return true;

--- a/cpp/unit/unit_container.h
+++ b/cpp/unit/unit_container.h
@@ -56,7 +56,7 @@ public:
 	 */
 	void set_terrain(std::shared_ptr<Terrain> &t);
 
-	/** 
+	/**
 	 * returns the terrain which units are placed on
 	 */
 	std::shared_ptr<Terrain> get_terrain() const;
@@ -85,7 +85,7 @@ public:
 	 * adds a new unit to the container and initialises using a unit type
 	 * places outside an existing object using the player of that object
 	 */
-	UnitReference new_unit(UnitType &type, Player &owner, std::shared_ptr<TerrainObject> other);
+	UnitReference new_unit(UnitType &type, Player &owner, TerrainObject *other);
 
 	/**
 	 * give a command to a unit -- unit creation and deletion should be done as commands

--- a/cpp/unit/unit_container.h
+++ b/cpp/unit/unit_container.h
@@ -77,12 +77,12 @@ public:
 	UnitReference new_unit();
 
 	/**
-	 * adds a new unit to the container and initialises using a producer
+	 * adds a new unit to the container and initialises using a unit type
 	 */
 	UnitReference new_unit(UnitType &type, Player &owner, coord::phys3 position);
 
 	/**
-	 * adds a new unit to the container and initialises using a producer
+	 * adds a new unit to the container and initialises using a unit type
 	 * places outside an existing object using the player of that object
 	 */
 	UnitReference new_unit(UnitType &type, Player &owner, std::shared_ptr<TerrainObject> other);

--- a/cpp/unit/unit_container.h
+++ b/cpp/unit/unit_container.h
@@ -15,8 +15,8 @@ class Command;
 class Player;
 class Terrain;
 class Unit;
-class UnitProducer;
 class UnitContainer;
+class UnitType;
 
 using id_t = unsigned long int;
 
@@ -79,13 +79,13 @@ public:
 	/**
 	 * adds a new unit to the container and initialises using a producer
 	 */
-	UnitReference new_unit(UnitProducer &producer, Player &owner, coord::phys3 position);
+	UnitReference new_unit(UnitType &type, Player &owner, coord::phys3 position);
 
 	/**
 	 * adds a new unit to the container and initialises using a producer
 	 * places outside an existing object using the player of that object
 	 */
-	UnitReference new_unit(UnitProducer &producer, Player &owner, std::shared_ptr<TerrainObject> other);
+	UnitReference new_unit(UnitType &type, Player &owner, std::shared_ptr<TerrainObject> other);
 
 	/**
 	 * give a command to a unit -- unit creation and deletion should be done as commands

--- a/cpp/unit/unit_type.cpp
+++ b/cpp/unit/unit_type.cpp
@@ -11,14 +11,14 @@ UnitTexture *UnitType::default_texture() {
 	return this->graphics[graphic_type::standing].get();
 }
 
-std::shared_ptr<TerrainObject> UnitType::place_beside(Unit *u, std::shared_ptr<TerrainObject> other) const {
+TerrainObject *UnitType::place_beside(Unit *u, TerrainObject const *other) const {
 	if (!u || !other) {
 		return nullptr;
 	}
 
 	// find the range of possible tiles
-	tile_range outline{other->pos.start - coord::tile_delta{1, 1}, 
-	                   other->pos.end   + coord::tile_delta{1, 1}, 
+	tile_range outline{other->pos.start - coord::tile_delta{1, 1},
+	                   other->pos.end   + coord::tile_delta{1, 1},
 	                   other->pos.draw};
 
 	// find a free position adjacent to the object
@@ -46,7 +46,7 @@ NyanType::~NyanType() {}
 
 int NyanType::id() const {
 	return 1;
-}	
+}
 
 std::string NyanType::name() const {
 	return "Nyan";
@@ -75,7 +75,7 @@ void NyanType::initialise(Unit *unit, Player &) {
 	unit->push_action(std::make_unique<IdleAction>(unit), true);
 }
 
-std::shared_ptr<TerrainObject> NyanType::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *NyanType::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	// the parsed nyan data gives the rules for terrain placement
 	// which includes valid terrains, base radius and shape
 
@@ -88,7 +88,7 @@ std::shared_ptr<TerrainObject> NyanType::place(Unit *unit, std::shared_ptr<Terra
 
 	// try to place the obj, it knows best whether it will fit.
 	if (unit->location->place(terrain, init_pos, object_state::placed)) {
-		return unit->location;
+		return unit->location.get();
 	}
 
 	// placing at the given position failed

--- a/cpp/unit/unit_type.cpp
+++ b/cpp/unit/unit_type.cpp
@@ -1,0 +1,99 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#include "../terrain/terrain_object.h"
+#include "action.h"
+#include "unit.h"
+#include "unit_type.h"
+
+namespace openage {
+
+UnitTexture *UnitType::default_texture() {
+	return this->graphics[graphic_type::standing].get();
+}
+
+std::shared_ptr<TerrainObject> UnitType::place_beside(Unit *u, std::shared_ptr<TerrainObject> other) const {
+	if (!u || !other) {
+		return nullptr;
+	}
+
+	// find the range of possible tiles
+	tile_range outline{other->pos.start - coord::tile_delta{1, 1}, 
+	                   other->pos.end   + coord::tile_delta{1, 1}, 
+	                   other->pos.draw};
+
+	// find a free position adjacent to the object
+	auto terrain = other->get_terrain();
+	for (coord::tile temp_pos : tile_list(outline)) {
+		TerrainChunk *chunk = terrain->get_chunk(temp_pos);
+
+		if (chunk == nullptr) {
+			continue;
+		}
+
+		auto placed = this->place(u, terrain, temp_pos.to_phys2().to_phys3());
+		if (placed) {
+			return placed;
+		}
+	}
+	return nullptr;
+}
+
+NyanType::NyanType() {
+	// TODO: the type should be given attributes and abilities
+}
+
+NyanType::~NyanType() {}
+
+int NyanType::id() const {
+	return 1;
+}	
+
+std::string NyanType::name() const {
+	return "Nyan";
+}
+
+void NyanType::initialise(Unit *unit, Player &) {
+	// reset any existing attributes and type
+	unit->reset();
+
+	// initialise unit
+	unit->unit_type = this;
+	unit->graphics = &this->graphics;
+
+	// the parsed nyan data gives the list of attributes
+	// and abilities which are given to the unit
+	for (auto &ability : this->type_abilities) {
+		unit->give_ability(ability);
+	}
+
+	// these are copied to the unit
+	for (auto &attr : this->default_attributes) {
+		unit->add_attribute(attr->copy());
+	}
+
+	// give idle action
+	unit->push_action(std::make_unique<IdleAction>(unit), true);
+}
+
+std::shared_ptr<TerrainObject> NyanType::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+	// the parsed nyan data gives the rules for terrain placement
+	// which includes valid terrains, base radius and shape
+
+	unit->make_location<SquareObject>(coord::tile_delta{1, 1});
+
+	// allow unit to go anywhere
+	unit->location->passable = [](const coord::phys3 &) {
+		return true;
+	};
+
+	// try to place the obj, it knows best whether it will fit.
+	if (unit->location->place(terrain, init_pos, object_state::placed)) {
+		return unit->location;
+	}
+
+	// placing at the given position failed
+	unit->log(MSG(dbg) << "failed to place object");
+	return nullptr;
+}
+
+} /* namespace openage */

--- a/cpp/unit/unit_type.h
+++ b/cpp/unit/unit_type.h
@@ -1,0 +1,115 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#ifndef OPENAGE_UNIT_UNIT_TYPE_H_
+#define OPENAGE_UNIT_UNIT_TYPE_H_
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "../coord/phys3.h"
+#include "attribute.h"
+
+namespace openage {
+
+class Player;
+class Terrain;
+class TerrainObject;
+class Unit;
+class UnitAbility;
+class UnitContainer;
+class UnitReference;
+class UnitTexture;
+
+/**
+ * Initializes a unit with the required attributes, each unit type should implement these funcrtions
+ * initialise should be called on construction of units 'new Unit(some_unit_producer)'
+ * place is called to customise how the unit gets added to the world -- used to setup the TerrainObject position
+ */
+class UnitType {
+public:
+	virtual ~UnitType() {}
+
+	/**
+	 * gets the unique id of this unit type
+	 */
+	virtual int id() const = 0;
+
+	/**
+	 * gets the name of the unit type being produced
+	 */
+	virtual std::string name() const = 0;
+
+	/**
+	 * Initialize units attributes to this type spec
+	 *
+	 * This can be called using existing units to modify type
+	 * Ensure that the unit has been placed before seting the units type
+	 *
+	 * TODO: make const
+	 */
+	virtual void initialise(Unit *, Player &) = 0;
+
+	/**
+	 * set unit in place -- return if placement was successful
+	 *
+	 * This should be used when initially creating a unit or
+	 * when a unit is ungarrsioned from a building or object
+	 * TODO: make const
+	 */
+	virtual std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
+
+	/**
+	 * Get a default texture for HUD drawing
+	 */
+	UnitTexture *default_texture();
+
+	/**
+	 * similiar to place but places adjacent to an existing object
+	 */
+	std::shared_ptr<TerrainObject> place_beside(Unit *, std::shared_ptr<TerrainObject>) const;
+
+	/**
+	 * all instances of units made from this producer
+	 * this could allow all units of a type to be upgraded
+	 */
+	std::vector<UnitReference> instances;
+
+	/**
+	 * abilities given to all instances
+	 */
+	std::vector<std::shared_ptr<UnitAbility>> type_abilities;
+
+	/**
+	 * default attributes which get copied to new units
+	 */
+	std::vector<std::shared_ptr<AttributeContainer>> default_attributes;
+
+	/**
+	 * The set of graphics used for this type
+	 */
+	graphic_set graphics;
+};
+
+/**
+ * An example of how nyan can work with the type system
+ */
+class NyanType: public UnitType {
+public:
+	/**
+	 * TODO: give the parsed nyan attributes
+	 * to the constructor 
+	 */
+	NyanType();
+	virtual ~NyanType();
+
+	int id() const override;
+	std::string name() const override;
+	void initialise(Unit *, Player &) override;
+	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+
+};
+
+} // namespace openage
+
+#endif

--- a/cpp/unit/unit_type.h
+++ b/cpp/unit/unit_type.h
@@ -22,9 +22,12 @@ class UnitContainer;
 class UnitTexture;
 
 /**
- * Initializes a unit with the required attributes, each unit type should implement these funcrtions
- * initialise should be called on construction of units 'new Unit(some_unit_producer)'
- * place is called to customise how the unit gets added to the world -- used to setup the TerrainObject position
+ * UnitType has to main roles:
+ *
+ * initialise(unit, player) should be called on a unit to give it a type and the required attributes, abilities and initial actions
+ * of that type
+ *
+ * place(unit, terrain, initial position) is called to customise how the unit gets added to the world -- used to setup the TerrainObject location
  */
 class UnitType {
 public:
@@ -70,7 +73,7 @@ public:
 	std::shared_ptr<TerrainObject> place_beside(Unit *, std::shared_ptr<TerrainObject>) const;
 
 	/**
-	 * all instances of units made from this producer
+	 * all instances of units made from this unit type
 	 * this could allow all units of a type to be upgraded
 	 */
 	std::vector<UnitReference> instances;
@@ -103,7 +106,7 @@ class NyanType: public UnitType {
 public:
 	/**
 	 * TODO: give the parsed nyan attributes
-	 * to the constructor 
+	 * to the constructor
 	 */
 	NyanType();
 	virtual ~NyanType();

--- a/cpp/unit/unit_type.h
+++ b/cpp/unit/unit_type.h
@@ -60,7 +60,7 @@ public:
 	 * when a unit is ungarrsioned from a building or object
 	 * TODO: make const
 	 */
-	virtual std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
+	virtual TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
 
 	/**
 	 * Get a default texture for HUD drawing
@@ -70,7 +70,7 @@ public:
 	/**
 	 * similiar to place but places adjacent to an existing object
 	 */
-	std::shared_ptr<TerrainObject> place_beside(Unit *, std::shared_ptr<TerrainObject>) const;
+	TerrainObject *place_beside(Unit *, TerrainObject const *) const;
 
 	/**
 	 * all instances of units made from this unit type
@@ -114,7 +114,7 @@ public:
 	int id() const override;
 	std::string name() const override;
 	void initialise(Unit *, Player &) override;
-	std::shared_ptr<TerrainObject> place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 };
 

--- a/cpp/unit/unit_type.h
+++ b/cpp/unit/unit_type.h
@@ -9,6 +9,7 @@
 
 #include "../coord/phys3.h"
 #include "attribute.h"
+#include "unit_container.h"
 
 namespace openage {
 
@@ -18,7 +19,6 @@ class TerrainObject;
 class Unit;
 class UnitAbility;
 class UnitContainer;
-class UnitReference;
 class UnitTexture;
 
 /**

--- a/cpp/unit/unit_type.h
+++ b/cpp/unit/unit_type.h
@@ -89,6 +89,11 @@ public:
 	 * The set of graphics used for this type
 	 */
 	graphic_set graphics;
+
+	/**
+	 * the square dimensions of the placement
+	 */
+	coord::tile_delta foundation_size;
 };
 
 /**


### PR DESCRIPTION
* Rename Producer to UnitType
* Terrain objects are now actually cleaned up
* Annex terrain object are cleaned up
* Many more bug fixes
* Idle units find nearby units to attack
* Faster searching for dropsites
* Buildings now placed as floating outlines 
* Floating buildings do not block units
* The terrain objects can now only be constructed via units:
```c++
unit->make_location<SquareObject>(...)
```

