### PR TITLE
Ignore empty gamedata.drs

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -49,6 +49,7 @@ _the openage authors_ are:
 | Jon Gelderloos              | jgelderloos                 | jgelderloos@gmail.com                 |
 | Emmanuel Gil Peyrot         | Link Mauve                  | linkmauve@linkmauve.fr                |
 | Danilo Bargen               | dbrgn                       | mail@dbrgn.ch                         |
+| Niklas Fiekas               | niklasf                     | niklas.fiekas@tu-clausthal.de         |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/py/openage/convert/mediafile.py
+++ b/py/openage/convert/mediafile.py
@@ -103,7 +103,7 @@ def media_convert(args):
     drsfiles = {
         k: DRS(p, drsmap[k])
         for k, p in drsfiles.items()
-        if p
+        if p and os.path.getsize(p) > 0
     }
 
     # this is the ingame color palette file id,


### PR DESCRIPTION
`gamedata.drs` does not exist in HD edition, but the Voobly compability patch
adds an empty file. So also check that the file is not empty.