### PR TITLE
Add a CMake 'doc' target that explains why doc generation won't work.

### DIFF
--- a/buildsystem/doxygen.cmake
+++ b/buildsystem/doxygen.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2014 the openage authors. See copying.md for legal info.
+# Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 # Doxygen integration
 
@@ -40,6 +40,13 @@ function(doxygen_configure)
 		# adapt doxygen config
 		configure_file("${BUILDSYSTEM_DIR}/templates/Doxyfile.in" "${CMAKE_BINARY_DIR}/Doxyfile" @ONLY)
 	else()
+		# add no-op doc target
+		add_custom_target(doc
+			COMMAND echo "When you configured openage, Doxygen could not be found."
+			COMMAND echo "Install Doxygen and `./configure` openage again, then try to generate docs."
+			COMMAND false
+			VERBATIM
+		)
 		message(WARNING "doxygen couldn't be found, you won't be able to generate docs")
 	endif()
 endfunction()

--- a/copying.md
+++ b/copying.md
@@ -50,6 +50,7 @@ _the openage authors_ are:
 | Emmanuel Gil Peyrot         | Link Mauve                  | linkmauve@linkmauve.fr                |
 | Danilo Bargen               | dbrgn                       | mail@dbrgn.ch                         |
 | Niklas Fiekas               | niklasf                     | niklas.fiekas@tu-clausthal.de         |
+| Charles Gould               | charlesrgould               | charles.r.gould@gmail.com             |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
#### ./configure (without Doxygen installed)

Some warnings, but you can proceed.

```
$ ./configure --mode=debug --compiler=gnu
...
-- Could NOT find Doxygen (missing:  DOXYGEN_EXECUTABLE) 
CMake Warning at buildsystem/doxygen.cmake:49 (message):
  doxygen couldn't be found, you won't be able to generate docs
Call Stack (most recent call first):
  CMakeLists.txt:64 (doxygen_configure)
...
```

#### make doc

now:

```
$ make doc
make --no-print-directory -C bin doc
When you configured openage, Doxygen could not be found.
Install Doxygen and `./configure` openage again, then try to generate docs.
Built target doc
$ 
```

before:

```
$ make doc
make --no-print-directory -C bin doc
make[1]: *** No rule to make target 'doc'.  Stop.
Makefile:73: recipe for target 'doc' failed
make: *** [doc] Error 2
$ 
```