### PR TITLE
Doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Our goals *include*:
     and guessing/experimenting can only get you this close
   * We will not implement useless artificial limitations (max 30 selectable units...))
 * Multiplayer (obviously)
-* Optionally, [Improvements](doc/ideas/) over the original game
+* Optionally, [Improvements](/doc/ideas/) over the original game
 * AI
 * Re-creating free game assets
 * An easily-moddable content format
@@ -52,26 +52,26 @@ Current State of the Project
 
  - What features are currently implemented?
 
-See [doc/status.md](doc/status.md).
+See [doc/status.md](/doc/status.md).
 
  - What can I do once I start the game?
 
-See [docs/usage.md](doc/usage.md).
+See [docs/usage.md](/doc/usage.md).
 
  - What's the plan?
 
-See [doc/milestones.md](doc/milestones.md). We also have a [list of crazy xor good ideas](doc/ideas).
+See [doc/milestones.md](/doc/milestones.md). We also have a [list of crazy xor good ideas](/doc/ideas).
 
 Dependencies, Building and Running
 ----------------------------------
 
  - How do I get this to run on my box?
 
-See [doc/building.md](doc/building.md).
+See [doc/building.md](/doc/building.md).
 
  - I compiled everything. Now how do I run it?
 
-You first need to use [the convert script](doc/media_convert.md) (will be automated in the near future!) to convert the original game assets to the (a lot saner and more moddable) openage format. Then, you can simply run the game using `./openage --data=assets`.
+You first need to use [the convert script](/doc/media_convert.md) (will be automated in the near future!) to convert the original game assets to the (a lot saner and more moddable) openage format. Then, you can simply run the game using `./openage --data=assets`.
 
  - Waaaaaah! It
   - segfaults
@@ -93,13 +93,13 @@ Development Process
 * Can I help?
   * Yes, please!
 
-See [doc/development.md](doc/development.md).
+See [doc/development.md](/doc/development.md).
 
 
 Project documentation is accompanying the source code in the `doc/` folder:
 
-- Have a look at the [doc directory](doc/).
-- We use Doxygen, as described in the [doc readme](doc/README.md)
+- Have a look at the [doc directory](/doc/).
+- We use Doxygen, as described in the [doc readme](/doc/README.md)
 - Have a look at the source.
 
 
@@ -130,7 +130,7 @@ Guidelines:
 * Don't implement any features, your code is crap.
 * Don't even think about sending a **pull request**
 * Don't note the irony, you idiot
-* We even have a [list of tasks](doc/tasks.md) that definitely don't need your work.
+* We even have a [list of tasks](/doc/tasks.md) that definitely don't need your work.
 
 To prevent accidential violation of one of those guidelines, you should *never*
 
@@ -154,7 +154,7 @@ There's no openage mailing list, but the github issue tracker comes pretty close
 
 License
 -------
-**GNU GPLv3** or later; see [copying.md](copying.md) and [legal/GPLv3](legal/GPLv3).
+**GNU GPLv3** or later; see [copying.md](copying.md) and [legal/GPLv3](/legal/GPLv3).
 
 I know that probably nobody is ever gonna look at the `copying.md` file,
 but if you want to contribute code to openage, please take the time to

--- a/copying.md
+++ b/copying.md
@@ -2,7 +2,7 @@ Any file in this project that doesn't state otherwise, and isn't listed as an
 exception below, is Copyright 2013-2015 The openage authors, and licensed
 under the terms of the GNU General Public License Version 3, or
 (at your option) any later version ("GPL3+").
-A copy of the license can be found in [legal/GPLV3](legal/GPLv3).
+A copy of the license can be found in [legal/GPLV3](/legal/GPLv3).
 
 _the openage authors_ are:
 
@@ -105,7 +105,7 @@ source projects, require the following, longer header:
     (Modifications|Other (data|code)|Everything else) Copyright 2014-2014 the openage authors.
     See copying.md for further legal info.
 
-For even more details, see the [regular expressions](py/openage/codecompliance/legal.py).
+For even more details, see the [regular expressions](/py/openage/codecompliance/legal.py).
 
 In addition to the openage header, the file's original license header should
 be retained if in doubt.
@@ -120,12 +120,12 @@ All 3rd-party files **must** be included in the following list:
 
 List of all 3rd-party files in openage:
 
-From [cabextract/libmspack](http://www.cabextract.org.uk/) ([LGPL 2.0](legal/LGPLv2.0))
+From [cabextract/libmspack](http://www.cabextract.org.uk/) ([LGPL 2.0](/legal/LGPLv2.0))
 
  - `py/openage/convert/cabextract/lzxd/lzxd.cpp`
  - `py/openage/convert/cabextract/lzxd/lzx_compression_info`
 
-cmake modules ([3-clause BSD license](legal/BSD-3-clause))
+cmake modules ([3-clause BSD license](/legal/BSD-3-clause))
 
  - `buildsystem/modules/FindSDL2.cmake` (taken from [openmw](https://github.com/OpenMW/openmw))
  - `buildsystem/modules/FindFTGL.cmake` (taken from [ulrichard's FTGL fork](https://github.com/ulrichard/ftgl))

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
 Documentation
 =============
 
-Most readers love documentation, it's creators hate it.
+Most readers love documentation, its creators hate it.
 
 Unfortunately, nobody can look inside your head and have the same ingenious
 thoughts as you do. To ensure your thoughts also reach the afterworld, please

--- a/doc/building.md
+++ b/doc/building.md
@@ -20,7 +20,7 @@ script is a _cmake wrapper_ that will create a build directory and
 invoke cmake with the appropriate flags. The `Makefile` in the project
 root acts as a wrapper around several useful features.
 
-For more build system internals, see [doc/buildsystem.md](doc/buildsystem.md).
+For more build system internals, see [doc/buildsystem.md](/doc/buildsystem.md).
 
 
 ## Dependencies
@@ -177,7 +177,7 @@ Maybe you've found a bug... `irc.freenode.net/#sfttech`
 
 Why did you make the simple task of invoking a compiler so incredibly
 complicated? Seriously. I've been trying to get this pile of utter
-crap you call a 'build system' to simply do it's job for half an hour
+crap you call a 'build system' to simply do its job for half an hour
 now, but all it does is sputter unreadable error messages. I hate
 CMake. I'm fed up with you. Why are you doing this to me? I thought we
 were friends. I'm the most massive collection of wisdom that has ever
@@ -191,5 +191,5 @@ existed, and now **I HATE YOU**. It can't be for no reason. You
 - Unfortunately, it's not as simple as invoking an compiler. Building
   `openage` involves code generation and the building of Python C++
   extension modules.
-- See [buildsystem/simple](buildsystem/simple), which does exactly
+- See [buildsystem/simple](/buildsystem/simple), which does exactly
   these three things, manually.

--- a/doc/implementation/convert/README.md
+++ b/doc/implementation/convert/README.md
@@ -45,7 +45,7 @@ Media Files
 -----------
 
 A media file is a sound or image file. In the original media files, they are
-stored in [drs archives](../../media/drs-files.md).
+stored in [drs archives](/doc/media/drs-files.md).
 
 Each media file has an id and a file extension.
 Files can be "redefined" by overlay archives.
@@ -66,7 +66,7 @@ archive each should be obtained from.
 
 The files can then be converted to the appropriate format, the conversion
 procedure is selected by their file extension. Graphics are stored in the
-[SLP format](../../media/slp-files.md) and are converted to *png*. Sounds are
+[SLP format](/doc/media/slp-files.md) and are converted to *png*. Sounds are
 *wav* files which are compressed to *opus*.
 
 
@@ -77,7 +77,7 @@ Gamedata means data describing the configuration and behavior of the game
 entities. Namely this defines the available buildings, units, their creation
 cost, etc.
 
-The [gamedata files](../../media/gamedata.md) are parsed and converted to a
+The [gamedata files](/doc/media/gamedata.md) are parsed and converted to a
 huge tree of *csv* files. This is not optimal and will be improved soon(tm).
 
 

--- a/doc/implementation/project_structure.md
+++ b/doc/implementation/project_structure.md
@@ -18,7 +18,7 @@ of the project.
 You may not believe it, but documentation stuff is in the `doc/` folder. For
 example, this document resides in there, because it documents something. wow.
 
-See [doc/README.md](../doc/README.md) for documentation guidelines.
+See [doc/README.md](/doc/README.md) for documentation guidelines.
 
 
 ### py/openage/convert/ ###
@@ -26,7 +26,7 @@ See [doc/README.md](../doc/README.md) for documentation guidelines.
 This is a *Python* module for the conversion of the original media, stored in
 the `convert/` folder. Documentation about media files being converted is in
 `doc/media/`. The entry point for finding information about the implementation
-and design thoughts can be found in the [convert/README.md](convert/README.md)
+and design thoughts can be found in the [doc/implementation/convert/README.md](/doc/implementation/convert/README.md)
 file.
 
 

--- a/doc/media/gamedata.md
+++ b/doc/media/gamedata.md
@@ -3,7 +3,7 @@ Game Data
 
 All data relevant for the game (e.g. how much costs building the castle)
 are stored in a binary format in the file `empires2_x1_p1.dat`.
-The format is descibed in the [doc/gamedata-struct.md](huge struct definiton).
+The format is descibed in the [huge struct definiton](/doc/media/gamedata-struct.md).
 
 The version the convert script currently is able to process: `"VER 5.7\x00"`
 

--- a/doc/media/terrain.md
+++ b/doc/media/terrain.md
@@ -103,7 +103,7 @@ frame_id = (x % tc) + ((y % tc) * tc)
 Terrain blending modes
 ----------------------
 
-blending mode: see the [doc/media/blendomatic.md](blendomatic docs) for
+blending mode: see the [blendomatic docs](/doc/media/blendomatic.md) for
 more information about terrain blending.
 
 blending mode id correction:

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -33,10 +33,10 @@ If you've never programmed before, or are inexperienced:
 3. You might have guessed it, we will still make fun of you, though.
 
 
-The [documentation tree description](doc/README.md) might be your first clue.
+The [documentation tree description](/doc/README.md) might be your first clue.
 
 To get an overview about where to find what in the code,
-take a look at [the project structure info documentation](doc/implementation/project_structure.md).
+take a look at [the project structure info documentation](/doc/implementation/project_structure.md).
 
 
 Task proposals


### PR DESCRIPTION
Half of the URLs in the `doc` folder gave 404 errors because they added a relative `doc/` while already in the `doc` folder.

To keep things consistent (and to avoid this error in the future), I changed such URLs to a absolute path like `/doc/usage.md`.