### PR TITLE
Issue 282: fixed argument parser

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -51,6 +51,7 @@ _the openage authors_ are:
 | Danilo Bargen               | dbrgn                       | mail@dbrgn.ch                         |
 | Niklas Fiekas               | niklasf                     | niklas.fiekas@tu-clausthal.de         |
 | Charles Gould               | charlesrgould               | charles.r.gould@gmail.com             |
+| Wilco Kusee                 | detrumi                     | wilcokusee@gmail.com                  |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -33,12 +33,11 @@ int main(int argc, char **argv) {
 	try {
 		Arguments args = parse_args(argc, argv);
 
+		if (args.error_occured) {
+			return 1;
+		} 
 		if (args.display_help) {
-			if (args.error_occured) {
-				return 1;
-			} else {
-				return 0;
-			}
+			return 0;
 		}
 
 		if (args.list_tests) {


### PR DESCRIPTION
- Fixed crashes for missing arguments
- Added shorthand `-v` for `--version`
- Added shorthand `-l` for `--list-tests`
- Added some comments for clarity

Fixes #282