### PR TITLE
Fixed keybind modifiers

### DIFF
--- a/cpp/game_main.cpp
+++ b/cpp/game_main.cpp
@@ -118,7 +118,6 @@ GameMain::GameMain(Engine *engine)
 	construct_mode{true},
 	building_placement{false},
 	use_set_ability{false},
-	keymod{KMOD_NONE},
 	assetmanager{engine->get_data_dir()},
 	engine{engine} {
 
@@ -427,7 +426,8 @@ bool GameMain::on_input(SDL_Event *e) {
 
 	case SDL_MOUSEBUTTONUP:
 		if (dragging_active and e->button.button == SDL_BUTTON_LEFT) {
-			selection.drag_release(terrain.get(), this->keymod == KMOD_LCTRL);
+			bool ctrl_down = engine.get_keybind_manager().is_keymod_down(KMOD_LCTRL);
+			selection.drag_release(terrain.get(), ctrl_down);
 			dragging_active = false;
 		}
 		else if (scrolling_active and e->button.button == SDL_BUTTON_MIDDLE) {
@@ -461,7 +461,7 @@ bool GameMain::on_input(SDL_Event *e) {
 	}
 
 	case SDL_MOUSEWHEEL:
-		if (this->keymod == KMOD_LCTRL && this->datamanager.producer_count() > 0) {
+		if (engine.get_keybind_manager().is_keymod_down(KMOD_LCTRL) && this->datamanager.producer_count() > 0) {
 			editor_current_building = util::mod<ssize_t>(editor_current_building + e->wheel.y, this->datamanager.producer_count());
 		}
 		else {
@@ -470,20 +470,18 @@ bool GameMain::on_input(SDL_Event *e) {
 		break;
 
 	case SDL_KEYUP: {
-		this->keymod = SDL_GetModState();
+		SDL_Keymod keymod = SDL_GetModState();
 
 		SDL_Keycode sym = reinterpret_cast<SDL_KeyboardEvent *>(e)->keysym.sym;
 		keybinds::KeybindManager &keybinds = engine.get_keybind_manager();
-		keybinds.set_key_state(sym, false);
+		keybinds.set_key_state(sym, keymod, false);
 		keybinds.press(keybinds::key_t(sym, keymod));
 		break;
 	}
 
 	case SDL_KEYDOWN: {
-		this->keymod = SDL_GetModState();
-
 		SDL_Keycode sym = reinterpret_cast<SDL_KeyboardEvent *>(e)->keysym.sym;
-		engine.get_keybind_manager().set_key_state(sym, true);
+		engine.get_keybind_manager().set_key_state(sym, SDL_GetModState(), true);
 		break;
 	}
 

--- a/cpp/game_main.h
+++ b/cpp/game_main.h
@@ -69,7 +69,6 @@ public:
 	bool building_placement;
 	bool use_set_ability;
 	ability_type ability;
-	SDL_Keymod keymod;
 
 	// mouse position
 	coord::camgame mousepos_camgame;

--- a/cpp/keybinds/keybind_manager.cpp
+++ b/cpp/keybinds/keybind_manager.cpp
@@ -25,7 +25,8 @@ KeybindManager::KeybindManager()
 		{ key_t(SDLK_z), action_t::DISABLE_SET_ABILITY },
 		{ key_t(SDLK_x), action_t::SET_ABILITY_MOVE },
 		{ key_t(SDLK_c), action_t::SET_ABILITY_GATHER },
-		{ key_t(SDLK_BACKQUOTE), action_t::TOGGLE_CONSOLE}} {
+		{ key_t(SDLK_BACKQUOTE), action_t::TOGGLE_CONSOLE}},
+	keymod{KMOD_NONE} {
 
 }
 
@@ -63,6 +64,9 @@ void KeybindManager::remove_context() {
 
 
 void KeybindManager::press(key_t k) {
+	// Remove modifiers like num lock and caps lock
+	k.mod = static_cast<SDL_Keymod>(k.mod & this->used_keymods);
+
 	// Check whether key combination is bound to an action
 	auto a = this->keys.find(k);
 	if (a == this->keys.end()) {
@@ -84,7 +88,8 @@ void KeybindManager::press(key_t k) {
 }
 
 
-void KeybindManager::set_key_state(SDL_Keycode k, bool is_down) {
+void KeybindManager::set_key_state(SDL_Keycode k, SDL_Keymod mod, bool is_down) {
+	this->keymod = mod;
 	this->key_states[k] = is_down;
 }
 
@@ -99,6 +104,10 @@ bool KeybindManager::is_key_down(SDL_Keycode k) {
 		this->key_states[k] = false;
 		return false;
 	}
+}
+
+bool KeybindManager::is_keymod_down(SDL_Keymod mod) const {
+	return (this->keymod & mod) == mod;
 }
 
 

--- a/cpp/keybinds/keybind_manager.h
+++ b/cpp/keybinds/keybind_manager.h
@@ -51,13 +51,19 @@ public:
 	/**
 	 * sets the state of a specific key
 	 */
-	void set_key_state(SDL_Keycode k, bool is_down);
+	void set_key_state(SDL_Keycode k, SDL_Keymod mod, bool is_down);
 
 	/**
 	 * query stored pressing stat for a key.
 	 * @return true when the key is pressed, false else.
 	 */
 	bool is_key_down(SDL_Keycode k);
+
+	/**
+	 * Checks whether a key modifier is held down.
+	 */
+	bool is_keymod_down(SDL_Keymod mod) const;
+
 private:
 	KeybindContext global_hotkeys;
 	std::unordered_map<key_t, action_t, key_hash> keys;
@@ -70,6 +76,19 @@ private:
 	 * false indicates the key is untouched.
 	 */
 	std::unordered_map<SDL_Keycode, bool> key_states;
+
+	/*
+	 * Current key modifiers.
+	 * Included ALL modifiers including num lock and caps lock.
+	 */
+	SDL_Keymod keymod;
+
+	/**
+	 * used key modifiers to check for.
+	 * this excludes keys like num lock and caps lock, which would
+	 * otherwise mess up key combinations
+	 */
+	static constexpr SDL_Keymod used_keymods = static_cast<SDL_Keymod>(KMOD_CTRL | KMOD_SHIFT | KMOD_ALT | KMOD_GUI);
 };
 
 } //namespace keybinds


### PR DESCRIPTION
Keybinds (#284) were influenced by keys like caps lock and num lock, and stopped working if one of those keys was active. That's fixed now.

I've also moved the modifier stuff from `GameMain` to `KeybindManager`, to keep things organized.