### PR TITLE
Fix annexed buildings

### DIFF
--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -69,13 +69,21 @@ bool TerrainObject::place(object_state init_state) {
 		}
 
 		for (auto obj : chunk->get_data(temp_pos)->obj) {
+
+			// ignore self and annexes of self
 			if (obj != this &&
-				obj->is_floating()) {
-				to_remove.push_back(obj);
-			}
-			else if (obj != this &&
-				     obj->check_collisions()) {
-				return false;
+				obj->get_parent() != this) {
+
+				if (obj->is_floating()) {
+
+					// floating objects get removed
+					to_remove.push_back(obj);
+				}
+				else if (obj->check_collisions()) {
+
+					// solid objects obstruct placement
+					return false;
+				}
 			}
 		}
 	}

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -103,8 +103,9 @@ bool TerrainObject::place(object_state init_state) {
 			}
 		}
 	}
+
+	// all obstructing objects get deleted
 	for (auto remove_obj : to_remove) {
-		this->unit.log(MSG(dbg) << "Removing...");
 		remove_obj->unit.location = nullptr;
 	}
 

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -24,7 +24,8 @@ TerrainObject::TerrainObject(Unit &u)
 	passable{[](const coord::phys3 &) -> bool {return true;}},
 	draw{[]() {}},
 	state{object_state::removed},
-	occupied_chunk_count{0} {
+	occupied_chunk_count{0},
+	parent{nullptr} {
 }
 
 TerrainObject::~TerrainObject() {
@@ -103,6 +104,7 @@ bool TerrainObject::place(object_state init_state) {
 		}
 	}
 	for (auto remove_obj : to_remove) {
+		this->unit.log(MSG(dbg) << "Removing...");
 		remove_obj->unit.location = nullptr;
 	}
 
@@ -207,17 +209,16 @@ void TerrainObject::set_ground(int id, int additional) {
 	}
 }
 
-void TerrainObject::annex(TerrainObject *other) {
-	this->children.push_back(other);
-	other->parent = this;
-}
-
 const TerrainObject *TerrainObject::get_parent() const {
 	return this->parent;
 }
 
 std::vector<TerrainObject *> TerrainObject::get_children() const {
-	return this->children;
+	std::vector<TerrainObject *> result;
+	for (auto &obj: this->children) {
+		result.push_back(obj.get());
+	}
+	return result;
 }
 
 bool TerrainObject::operator <(const TerrainObject &other) {

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -214,6 +214,11 @@ const TerrainObject *TerrainObject::get_parent() const {
 }
 
 std::vector<TerrainObject *> TerrainObject::get_children() const {
+
+	// TODO: a better performing way of doing this
+	// for example accept a lambda to use for each element
+	// or maintain a duplicate class field for raw pointers
+
 	std::vector<TerrainObject *> result;
 	for (auto &obj: this->children) {
 		result.push_back(obj.get());

--- a/cpp/terrain/terrain_object.cpp
+++ b/cpp/terrain/terrain_object.cpp
@@ -34,16 +34,31 @@ TerrainObject::~TerrainObject() {
 }
 
 bool TerrainObject::is_floating() const {
+
+	// if parent is floating then all children also are
+	if (this->parent && this->parent->is_floating()) {
+		return true;
+	}
 	return this->state == object_state::floating;
 }
 
 bool TerrainObject::is_placed() const {
+
+	// if object has a parent it must be placed
+	if (this->parent && !this->parent->is_placed()) {
+		return false;
+	}
 	return this->state == object_state::placed ||
 	       this->state == object_state::placed_no_collision;
 }
 
 
 bool TerrainObject::check_collisions() const {
+
+	// if object has a parent it must be placed
+	if (this->parent && !this->parent->is_placed()) {
+		return false;
+	}
 	return this->state == object_state::placed;
 }
 
@@ -52,8 +67,8 @@ void TerrainObject::draw_outline() const {
 }
 
 bool TerrainObject::place(object_state init_state) {
-	if (this->state != object_state::floating) {
-		throw util::Error(MSG(err) << "Building must be floating");
+	if (this->state == object_state::removed) {
+		throw util::Error(MSG(err) << "Building cannot change state with no position");
 	}
 
 	// remove any other floating objects

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -185,8 +185,22 @@ public:
 		return annex_ptr.get();
 	}
 
+	/**
+	 * Returns the parent terrain object,
+	 * if null the object has no parent which is
+	 * the case for most objects
+	 *
+	 * objects with a parent are owned by that object
+	 * and to be placed on the map the parent must also be placed
+	 */
 	const TerrainObject *get_parent() const;
 
+	/**
+	 * Returns a list of child objects, this is the inverse of the
+	 * get_parent() function
+	 *
+	 * TODO: this does not perform optimally and is likely to change
+	 */
 	std::vector<TerrainObject *> get_children() const;
 
 	/*

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -108,12 +108,15 @@ public:
 	bool is_floating() const;
 
 	/**
-	 * has the object been placed
+	 * has the object been placed which indicates the the object has a position and exists
+	 * on the map, floating buildings are not considered placed as they are only an indicator
+	 * for where something can begin construction
 	 */
 	bool is_placed() const;
 
 	/**
-	 * should this object be tested for collisions, arrows should not
+	 * should this object be tested for collisions, which decides whether another object is allowed
+	 * to overlap the location of this object. arrows and decaying objects will return false
 	 */
 	bool check_collisions() const;
 
@@ -134,7 +137,8 @@ public:
 	void draw_outline() const;
 
 	/**
-	 * upgrades a floating building to a placed state
+	 * changes the placement state of this object keeping the existing
+	 * position. this is useful for upgrading a floating building to a placed state
 	 */
 	bool place(object_state init_state);
 

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -170,10 +170,20 @@ public:
 	 */
 	void set_ground(int id, int additional=0);
 
+
 	/**
-	 * add a child terrain object
+	 * appends new annex location for this object
+	 *
+	 * this does not replace any existing annex
 	 */
-	void annex(TerrainObject *other);
+	template<class T, typename ... Arg>
+	TerrainObject *make_annex(Arg ... args) {
+
+		this->children.push_back(std::unique_ptr<T>(new T(this->unit, args ...)));
+		auto &annex_ptr = this->children.back();
+		annex_ptr->parent = this;
+		return annex_ptr.get();
+	}
 
 	const TerrainObject *get_parent() const;
 
@@ -237,7 +247,7 @@ protected:
 	 * annexes and grouped units
 	 */
 	TerrainObject *parent;
-	std::vector<TerrainObject *> children;
+	std::vector<std::unique_ptr<TerrainObject>> children;
 
 	/**
 	 * texture for drawing outline
@@ -297,6 +307,8 @@ private:
 	SquareObject(Unit &u, coord::tile_delta foundation_size);
 	SquareObject(Unit &u, coord::tile_delta foundation_size, std::shared_ptr<Texture> out_tex);
 
+
+	friend class TerrainObject;
 	friend class Unit;
 };
 
@@ -328,6 +340,7 @@ private:
 	RadialObject(Unit &u, float rad);
 	RadialObject(Unit &u, float rad, std::shared_ptr<Texture> out_tex);
 
+	friend class TerrainObject;
 	friend class Unit;
 };
 

--- a/cpp/terrain/terrain_object.h
+++ b/cpp/terrain/terrain_object.h
@@ -108,7 +108,7 @@ public:
 	bool is_floating() const;
 
 	/**
-	 * has the object been placed which indicates the the object has a position and exists
+	 * returns true if this object has been placed. this indicates that the object has a position and exists
 	 * on the map, floating buildings are not considered placed as they are only an indicator
 	 * for where something can begin construction
 	 */

--- a/cpp/unit/action.cpp
+++ b/cpp/unit/action.cpp
@@ -700,7 +700,7 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 			else {
 
 				// failed to start construction
-				this->complete = 1.0;
+				this->complete = 1.0f;
 				return;
 			}
 		}
@@ -708,9 +708,13 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 		// increment building completion
 		build.completed += build_rate * time;
 		this->complete = build.completed;
+
+		if (this->complete >= 1.0f) {
+			target_location->place(build.completion_state);
+		}
 	}
 	else {
-		this->complete = 1.0;
+		this->complete = 1.0f;
 	}
 
 	// inc frame

--- a/cpp/unit/attribute.h
+++ b/cpp/unit/attribute.h
@@ -8,6 +8,7 @@
 
 #include "../coord/tile.h"
 #include "../gamedata/unit.gen.h"
+#include "../terrain/terrain_object.h"
 #include "resource.h"
 #include "unit_container.h"
 
@@ -232,6 +233,10 @@ public:
 	float completed;
 	bool is_dropsite;
 	int foundation_terrain;
+
+	// set the TerrainObject to this state
+	// once building has been completed
+	object_state completion_state;
 
 	// TODO: use unit class, fish and forage have different dropsites
 	game_resource resource_type;

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -609,7 +609,7 @@ TerrainObject *BuldingProducer::make_annex(Unit &u, std::shared_ptr<Terrain> t, 
 	start_tile.se -= b->radius_size1 * coord::settings::phys_per_tile;
 
 	// create and place on terrain
-	TerrainObject *annex_loc = u.make_location_annex<SquareObject>(annex_foundation);
+	TerrainObject *annex_loc = u.location->make_annex<SquareObject>(annex_foundation);
 	object_state state = c? object_state::placed : object_state::placed_no_collision;
 	annex_loc->place(t, start_tile, state);
 

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -13,7 +13,7 @@
 #include "unit.h"
 #include "unit_texture.h"
 
-/**
+/** @file
  * Many values in this file are hardcoded, due to limited understanding of how the original
  * game files work -- as more becomes known these will be removed.
  *

--- a/cpp/unit/producer.cpp
+++ b/cpp/unit/producer.cpp
@@ -13,6 +13,14 @@
 #include "unit.h"
 #include "unit_texture.h"
 
+/**
+ * Many values in this file are hardcoded, due to limited understanding of how the original
+ * game files work -- as more becomes known these will be removed.
+ *
+ * It is likely the conversion from gamedata to openage units will be done by the nyan
+ * system in future
+ */
+
 namespace openage {
 
 std::unordered_set<terrain_t> allowed_terrains(const gamedata::ground_type &restriction) {
@@ -445,7 +453,7 @@ BuldingProducer::BuldingProducer(DataManager &dm, const gamedata::unit_building 
 	trainable2{dm.get_type(293)}, // 293 = f villager
 	projectile{dm.get_type(this->unit_data.projectile_unit_id)},
 	foundation_terrain{ud->terrain_id},
-	enable_collisions{this->unit_data.id0 == 109} {
+	enable_collisions{this->unit_data.id0 != 109} { // 109 = town center
 
 	// find suitable sounds
 	int creation_sound = this->unit_data.sound_creation0;
@@ -509,7 +517,7 @@ void BuldingProducer::initialise(Unit *unit, Player &player) {
 	auto build_attr = new Attribute<attr_type::building>();
 	build_attr->foundation_terrain = this->foundation_terrain;
 	build_attr->pp = trainable2;
-	build_attr->completion_state = this->enable_collisions? object_state::placed_no_collision : object_state::placed;
+	build_attr->completion_state = this->enable_collisions? object_state::placed : object_state::placed_no_collision;
 	unit->add_attribute(build_attr);
 
 	// garrison and hp for all buildings
@@ -559,7 +567,7 @@ TerrainObject *BuldingProducer::place(Unit *u, std::shared_ptr<Terrain> terrain,
 	};
 
 	// drawing function
-	bool draw_outline = this->enable_collisions;
+	bool draw_outline = !this->enable_collisions;
 	u->location->draw = [u, obj_ptr, draw_outline]() {
 		if (u->selected && draw_outline) {
 			obj_ptr->draw_outline();

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -133,6 +133,11 @@ private:
 	UnitType *trainable2;
 	UnitType *projectile;
 	int foundation_terrain;
+
+	/**
+	 * used for objects like town centers or gates
+	 * where the base does not apply collision checks
+	 */
 	bool enable_collisions;
 
 	TerrainObject *make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;

--- a/cpp/unit/producer.h
+++ b/cpp/unit/producer.h
@@ -133,6 +133,7 @@ private:
 	UnitType *trainable2;
 	UnitType *projectile;
 	int foundation_terrain;
+	bool enable_collisions;
 
 	TerrainObject *make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
 };

--- a/cpp/unit/unit.h
+++ b/cpp/unit/unit.h
@@ -93,20 +93,6 @@ public:
 	}
 
 	/**
-	 * constructs a new annex location for this unit
-	 *
-	 * this does not replace the units location
-	 */
-	template<class T, typename ... Arg>
-	T *make_location_annex(Arg ... args) {
-
-		// Unit is a friend of the location
-		auto annex_ptr = new T(*this, args ...);
-		this->location->annex(annex_ptr);
-		return annex_ptr;
-	}
-
-	/**
 	 * removes all actions and abilities
 	 * current attributes are kept
 	 */


### PR DESCRIPTION
Objects like the TC were not able to be built as the foundation got removed instantly (floating outlines for buildings get removed when a building begins construction, here the annex caused the TC to remove itself)

The TC has several stages wrt collisions, the floating stage causes no collisions, the construction stage allows no units on the foundation, and once completed construction parts of the tc are able to be walked over, this is now working.

Since the change to unique_ptr<TerrainObject> in Unit, the annex objects are not cleaned up (memleak), The solution is to allow TerrainObjects to also be owned by another TerrainObject, the make annex function is moved from Unit to TerrainObject. Deletion of the parent object will now cleanup all children.