### PR TITLE
add test for log::FileSink

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -52,6 +52,7 @@ _the openage authors_ are:
 | Niklas Fiekas               | niklasf                     | niklas.fiekas@tu-clausthal.de         |
 | Charles Gould               | charlesrgould               | charles.r.gould@gmail.com             |
 | Wilco Kusee                 | detrumi                     | wilcokusee@gmail.com                  |
+| Lucas Texier-Atger          | kukinsula                   | l.texier10@gmail.com                  |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/cpp/log/test.cpp
+++ b/cpp/log/test.cpp
@@ -1,6 +1,8 @@
 // Copyright 2014-2015 the openage authors. See copying.md for legal info.
 
 #include "log.h"
+#include "file_logsink.h"
+#include "level.h"
 
 #include <iostream>
 #include <iomanip>
@@ -34,8 +36,10 @@ private:
 	}
 };
 
-
-void test() {
+/**
+ * Tests log Messages through the standard output.
+ */
+void std_out_log_sink () {
 	TestLogSource logger;
 	TestLogSink sink{std::cout};
 
@@ -59,6 +63,33 @@ void test() {
 
 	t0.join();
 	t1.join();
+}
+
+/**
+ * Creates a FileSink to also write log Messages
+ * into /tmp/openage-log-test.
+ * Only Messages with a level equals or higher
+ * than level::err will be printed in that file.
+ */
+void file_log_sink () {
+	TestLogSource logger;
+	FileSink filelog("/tmp/openage-log-test", true);
+
+	filelog.loglevel = log::level::err;
+
+	// filelog should ignore these Messages
+	logger.log(MSG(dbg) << "This message should not appear in openage-log-test");
+	logger.log(MSG(info) << "This message should not appear in openage-log-test");
+	logger.log(MSG(warn) << "This message should not appear in openage-log-test");
+
+	// filelog should write these Messages
+	logger.log(MSG(err) << "This message should appear in openage-log-test");
+	logger.log(MSG(crit) << "This message should appear in openage-log-test");
+}
+
+void test() {
+	std_out_log_sink();
+	file_log_sink();
 }
 
 }}} // openage::log::tests

--- a/cpp/log/test.cpp
+++ b/cpp/log/test.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <sstream>
 #include <string>
+#include <algorithm>
 
 #include "../util/strings.h"
 
@@ -103,9 +104,40 @@ void file_log_sink () {
 	remove(filelog_name);
 }
 
+/**
+ * Tests that the FileSink doesn't write any
+ * message into the the filelog because it
+ * has a too low log level.
+ */
+void empty_file_log_sink () {
+	const char *filelog_name = "/tmp/openage-log-test";
+	TestLogSource logger;
+	FileSink filelog(filelog_name, true);
+
+	filelog.loglevel = log::level::crit;
+
+	// filelog should ignore all these Messages
+	logger.log(MSG(dbg) << "This message should not appear in openage-log-test");
+	logger.log(MSG(info) << "This message should not appear in openage-log-test");
+	logger.log(MSG(warn) << "This message should not appear in openage-log-test");
+	logger.log(MSG(err) << "This message should not appear in openage-log-test");
+
+	std::ifstream infile(filelog_name); 
+	int lines = std::count(std::istreambuf_iterator<char>(infile), std::istreambuf_iterator<char>(), '\n');
+
+	if (lines != 0) {
+		remove(filelog_name);
+		log::log(MSG(err) << "empty_file_log_sink failed");
+		throw "failed log tests";
+	}
+
+	remove(filelog_name);
+}
+
 void test() {
 	std_out_log_sink();
 	file_log_sink();
+	empty_file_log_sink();
 }
 
 }}} // openage::log::tests

--- a/cpp/log/test.cpp
+++ b/cpp/log/test.cpp
@@ -76,16 +76,10 @@ int std_out_log_sink () {
  * than level::err will be printed in that file.
  */
 int file_log_sink () {
-	char filelog_name[20];
-	char buffer[256];
-	int filedes = -1, result = 0;
+	char filelog_name[L_tmpnam];
+	int result = 0;
 
-	memset(filelog_name, 0, sizeof(filelog_name));
-	memset(buffer, 0, sizeof(buffer));
-
-	strncpy(filelog_name, "/tmp/log-test-XXXXXX", 20);
-
-	filedes = mkstemp(filelog_name);
+	tmpnam(filelog_name);
 
 	TestLogSource logger;
 	FileSink filelog(filelog_name, false);
@@ -121,16 +115,10 @@ int file_log_sink () {
  * has a too low log level.
  */
 int empty_file_log_sink () {
-	char filelog_name[20];
-	char buffer[256];
-	int filedes = -1, result = 0;
+	char filelog_name[L_tmpnam];
+	int result = 0;
 
-	memset(filelog_name, 0, sizeof(filelog_name));
-	memset(buffer, 0, sizeof(buffer));
-
-	strncpy(filelog_name, "/tmp/log-test-XXXXXX", 20);
-
-	filedes = mkstemp(filelog_name);
+	tmpnam(filelog_name);
 
 	TestLogSource logger;
 	FileSink filelog(filelog_name, false);
@@ -155,7 +143,7 @@ int empty_file_log_sink () {
 }
 
 
-void test() {
+void test () {
 	const char *testname;
 
 	if (std_out_log_sink() == -1) {

--- a/cpp/log/test.cpp
+++ b/cpp/log/test.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <iomanip>
 #include <thread>
+#include <sstream>
+#include <string>
 
 #include "../util/strings.h"
 
@@ -72,8 +74,9 @@ void std_out_log_sink () {
  * than level::err will be printed in that file.
  */
 void file_log_sink () {
+	const char *filelog_name = "/tmp/openage-log-test";
 	TestLogSource logger;
-	FileSink filelog("/tmp/openage-log-test", true);
+	FileSink filelog(filelog_name, true);
 
 	filelog.loglevel = log::level::err;
 
@@ -85,6 +88,19 @@ void file_log_sink () {
 	// filelog should write these Messages
 	logger.log(MSG(err) << "This message should appear in openage-log-test");
 	logger.log(MSG(crit) << "This message should appear in openage-log-test");
+
+	std::string line;
+	std::ifstream infile(filelog_name);
+
+	while (std::getline(infile, line)) {
+		if ((line.find("ERR") == std::string::npos) && (line.find("CRIT") == std::string::npos)) {
+			remove(filelog_name);
+			log::log(MSG(err) << "file_log_sink failed");
+			throw "failed log tests";
+		}
+	}
+
+	remove(filelog_name);
 }
 
 void test() {


### PR DESCRIPTION
I managed to test log messages through a FileSink: messages are written in /tmp/openage-log-test (maybe I should change that file name because there's already /tmp/openage-log and it can get ambiguous). So to see the messages you just need to read that file (cat /tmp/openage-log-test).

I set the FileSink's loglevel to err to ignore messages with a lower loglevel and it works fine.