### PR TITLE
Multithreaded convert

### DIFF
--- a/doc/media_convert.md
+++ b/doc/media_convert.md
@@ -29,6 +29,13 @@ To convert ALL original media files to openage format, execute the following:
 You will then find the converted files in `./userassets`
 the conversion takes some time, so be patient.
 
+The conversion script is multithreaded, but bear in mind that the bottleneck can come from I/O of
+your storage device.
+
+By default the script will use all of available CPUs (Python's `os.cpu_count`). You can explicitly
+specify amount of processes to spawn for conversion with `-j`/`--jobs` option to `media` command:
+
+	python3 -m openage.convert media -j 666 …
 
 Try
 

--- a/py/openage/convert/__main__.py
+++ b/py/openage/convert/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 the openage authors. See copying.md for legal info.
+# Copyright 2013-2015 the openage authors. See copying.md for legal info.
 
 import argparse
 from openage.log import set_verbosity
@@ -39,6 +39,8 @@ def main():
                            help="Don't use opus conversion for audio files")
     media_cmd.add_argument("--use-dat-cache", action='store_true',
                            help="Use cache file for the empires.dat file")
+    media_cmd.add_argument("-j", "--jobs", type=int, default=0,
+                           help="How many jobs to use in parallel")
 
     mcmd_g0 = media_cmd.add_mutually_exclusive_group(required=True)
     mcmd_g0.add_argument("-o", "--output", metavar="output_directory",

--- a/py/openage/convert/__main__.py
+++ b/py/openage/convert/__main__.py
@@ -39,7 +39,7 @@ def main():
                            help="Don't use opus conversion for audio files")
     media_cmd.add_argument("--use-dat-cache", action='store_true',
                            help="Use cache file for the empires.dat file")
-    media_cmd.add_argument("-j", "--jobs", type=int, default=0,
+    media_cmd.add_argument("-j", "--jobs", type=int, default=None,
                            help="How many jobs to use in parallel")
 
     mcmd_g0 = media_cmd.add_mutually_exclusive_group(required=True)


### PR DESCRIPTION
Use '-j' option to 'media' command to specify amount of jobs to use.
Unfortunately, make cannot pass its own '-j' value.

Down to roughly 2m53s from 10m31s on 4-core (+HT) i7, with HDD.
Verified sha1sums for singlethreaded and multithreaded conversion the same.
Log on console can be out of order now.