### PR TITLE
Remove user input (file path) from regular expression extension check.

### DIFF
--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -109,7 +109,7 @@ function(add_cython_modules)
 				set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
 			endif()
 
-			if(NOT "${source}" MATCHES "${CMAKE_CURRENT_SOURCE_DIR}/.*\\.pyx?$")
+			if(NOT "${source}" MATCHES ".*\\.pyx?$")
 				message(FATAL_ERROR "non-.py/.pyx file given to add_cython_modules: ${source}")
 			endif()
 
@@ -187,7 +187,7 @@ function(pxdgen)
 			set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
 		endif()
 
-		if(NOT "${source}" MATCHES "${CMAKE_CURRENT_SOURCE_DIR}/.*\\.h$")
+		if(NOT "${source}" MATCHES ".*\\.h$")
 			message(FATAL_ERROR "non-.h file given to pxdgen: ${source}")
 		endif()
 
@@ -207,7 +207,7 @@ function(add_pxds)
 			set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
 		endif()
 
-		if(NOT "${source}" MATCHES "${CMAKE_CURRENT_SOURCE_DIR}/.*\\.px[id]$")
+		if(NOT "${source}" MATCHES ".*\\.px[id]$")
 			message(FATAL_ERROR "non-pxd/pxi file given to add_pyd: ${source}")
 		endif()
 
@@ -232,7 +232,7 @@ function(add_py_modules)
 				set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
 			endif()
 
-			if(NOT "${source}" MATCHES "${CMAKE_CURRENT_SOURCE_DIR}/.*\\.py$")
+			if(NOT "${source}" MATCHES ".*\\.py$")
 				message(FATAL_ERROR "non-Python file given to add_py_modules: ${source}")
 			endif()
 


### PR DESCRIPTION
In general it is a bad idea to place user input in a regular expression for similar reasons as sql injection. In this case the open build system places the full package name in path which in my case includes a plus (+).

```
/home/abuild/rpmbuild/BUILD/openage-v0.3.0+git20150728.5eccd7e/libopenage/main.h
/home/abuild/rpmbuild/BUILD/openage-v0.3.0+git20150728.5eccd7e/libopenage/.*\.h$
```

The plus is interpreted as a modifier for the 0 which is fine since it finds one or more zeros, but after that it looks for 'g' and instead finds '+'.

Since the only thing being checked is that the path file name ends with `.h` that is all that should be checked.