### PR TITLE
Remove --data=assets from .desktop file command.

### DIFF
--- a/dist/openage.desktop
+++ b/dist/openage.desktop
@@ -2,7 +2,7 @@
 [Desktop Entry]
 Name=openage
 Comment=Free engine clone of Age of Empires II
-Exec=openage --data=assets %u
+Exec=openage %u
 Path=.openage
 Terminal=true
 Type=Application


### PR DESCRIPTION
Since the new python interface no longer provides this option it needs to be removed.