### PR TITLE
Remove deadlock in JobManager/Worker

### DIFF
--- a/libopenage/job/worker.h
+++ b/libopenage/job/worker.h
@@ -26,7 +26,7 @@ private:
 	JobManager *manager;
 
 	/** Whether this worker thread is still running. */
-	std::atomic_bool is_running;
+	bool is_running;
 
 	/** The executing thread. */
 	std::unique_ptr<std::thread> executor;


### PR DESCRIPTION
This pull request removes a deadlock when stopping the worker-threads of the JobManager.