### PR TITLE
[WIP] Bugfix of the convert script in the AoE HD edition

### DIFF
--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -36,10 +36,15 @@ def get_string_resources(srcdir):
     else:
         count = 0
         from .hdlanguagefile import read_hd_language_file
-        for lang in srcdir.listdirs("bin"):
+        
+        bin_path = srcdir.joinpath("bin") 
+        for lang in bin_path.list():
+            if bin_path.joinpath(lang).is_file():
+                continue
+            
             try:
-                langfilename = ["bin", lang, lang + "-language.txt"]
-                with srcdir.open(langfilename, 'rb') as langfile:
+                langfilename = [b"bin", lang, lang + b"-language.txt"]
+                with srcdir[langfilename].open('rb') as langfile:
                     stringres.fill_from(read_hd_language_file(langfile, lang))
 
                 count += 1

--- a/openage/convert/hdlanguagefile.py
+++ b/openage/convert/hdlanguagefile.py
@@ -12,7 +12,7 @@ def read_hd_language_file(fileobj, langcode):
     """
     Takes a file object, and the file's language code.
     """
-    dbg("HD Language file " + langcode)
+    dbg("HD Language file " + str(langcode))
     strings = {}
 
     for line in fileobj.read().decode('iso-8859-1').split('\n'):


### PR DESCRIPTION
The convert script is not working any more with the assets from the HD edition of Age of Empires (without the new update). The conversion terminates in an exception that the listdirs function is undefined. 

This error should be fixed with this first commit, but the asset conversion is still not running. 
```bash
...
INFO [py] [3128/3133] terrain/15030.slp
INFO [py] [3129/3133] terrain/15031.slp
INFO [py] [3130/3133] terrain/blends
Traceback (most recent call last):
  File "run.py", line 15, in init run (/home/miguel/git/openage/run.cpp:810)
    main()
...
File "/home/miguel/git/openage/openage/util/fslike/union.py", line 70, in open_r
    raise FileNotFoundError(b'/'.join(parts))
FileNotFoundError: b'terrain/blends'
```