### PR TITLE
Media conversion fix for HD version 4.0

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -53,6 +53,7 @@ _the openage authors_ are:
 | Charles Gould               | charlesrgould               | charles.r.gould@gmail.com             |
 | Wilco Kusee                 | detrumi                     | wilcokusee@gmail.com                  |
 | Sreejith R                  | sreejithr                   | sreejith.r44@gmail.com                |
+| Jens Feodor Nielsen         | jfeo                        | xws747@alumni.ku.dk                   |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -36,11 +36,12 @@ def get_string_resources(srcdir):
     else:
         count = 0
         from .hdlanguagefile import read_hd_language_file
-        for lang in srcdir["bin"].list():
+        for lang in srcdir["resources"].list():
             try:
                 if lang == b'_common':
                     continue
-                langfilename = ["resources", lang.decode(), "strings", "key-value", "key-value-strings-utf8.txt"]
+                langfilename = ["resources", lang.decode(), "strings", "key-value",
+                                "key-value-strings-utf8.txt"]
 
                 with srcdir[langfilename].open('rb') as langfile:
                     stringres.fill_from(read_hd_language_file(langfile, lang))

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -36,10 +36,13 @@ def get_string_resources(srcdir):
     else:
         count = 0
         from .hdlanguagefile import read_hd_language_file
-        for lang in srcdir.listdirs("bin"):
+        for lang in srcdir["bin"].list():
             try:
-                langfilename = ["bin", lang, lang + "-language.txt"]
-                with srcdir.open(langfilename, 'rb') as langfile:
+                if lang == b'_common':
+                    continue
+                langfilename = ["resources", lang.decode(), "strings", "key-value", "key-value-strings-utf8.txt"]
+
+                with srcdir[langfilename].open('rb') as langfile:
                     stringres.fill_from(read_hd_language_file(langfile, lang))
 
                 count += 1
@@ -115,7 +118,13 @@ def convert_metadata(args):
 
     # required for player palette and color lookup during SLP conversion.
     yield "palette"
-    palette = ColorTable(args.srcdir["interface/50500.bin"].open("rb").read())
+    # `.bin` files are renamed `.bina` in HD version 4
+    if args.srcdir["AoK HD.exe"].exists:
+        palette_path = "interface/50500.bina"
+    else:
+        palette_path = "interface/50500.bin"
+
+    palette = ColorTable(args.srcdir[palette_path].open("rb").read())
     # store for use by convert_media
     args.palette = palette
 
@@ -169,6 +178,8 @@ def convert_media(args):
     for dirname in ['sounds', 'graphics', 'terrain']:
         for filepath in args.srcdir[dirname].iterdir():
             if filepath.suffix in ignored_suffixes:
+                continue
+            elif filepath.is_dir():
                 continue
 
             files_to_convert.append(filepath)

--- a/openage/convert/hdlanguagefile.py
+++ b/openage/convert/hdlanguagefile.py
@@ -12,10 +12,10 @@ def read_hd_language_file(fileobj, langcode):
     """
     Takes a file object, and the file's language code.
     """
-    dbg("HD Language file " + langcode)
+    dbg("HD Language file " + str(langcode))
     strings = {}
 
-    for line in fileobj.read().decode('iso-8859-1').split('\n'):
+    for line in fileobj.read().decode('utf-8').split('\n'):
         line = line.strip()
 
         # skip comments & empty lines

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -47,18 +47,23 @@ def mount_drs_archives(srcdir):
 
         result.joinpath(target).mount(DRS(drspath.open('rb')).root)
 
-    mount_drs("data/graphics.drs", "graphics")
-    mount_drs("data/interfac.drs", "interface")
+    if result['AoK HD'].exists():
+        # Mounts for HD edition version 4.0
+        result['graphics'].mount(srcdir['resources/_common/drs/graphics'])
+        result['interface'].mount(srcdir['resources/_common/drs/interface'])
+        result['sounds'].mount(srcdir['resources/_common/drs/sounds'])
+        result['gamedata'].mount(srcdir['resources/_common/drs/gamedata'])
+        result['terrain'].mount(srcdir['resources/_common/drs/terrain'])
+        result['data'].mount(srcdir['/resources/_common/dat'])
+    else:
+        # Mounts for AoC
+        mount_drs("data/graphics.drs", "graphics")
+        mount_drs("data/interfac.drs", "interface")
 
-    mount_drs("data/sounds.drs", "sounds")
-    mount_drs("data/sounds_x1.drs", "sounds")
+        mount_drs("data/sounds.drs", "sounds")
+        mount_drs("data/sounds_x1.drs", "sounds")
 
-    # In the HD edition, gamedata.drs has been merged into gamedata_x1.drs
-    mount_drs("data/gamedata.drs", "gamedata", ignore_nonexistant=True)
-    mount_drs("data/gamedata_x1.drs", "gamedata")
-    mount_drs("data/gamedata_x1_p1.drs", "gamedata")
-
-    mount_drs("data/terrain.drs", "terrain")
+        mount_drs("data/terrain.drs", "terrain")
 
     return result
 
@@ -109,6 +114,7 @@ def convert_assets(assets, args, srcdir=None):
     from .driver import convert
     converted_count = 0
     total_count = None
+
     for current_item in convert(args):
         if isinstance(current_item, int):
             # convert is informing us about the estimated number of remaining

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -47,7 +47,7 @@ def mount_drs_archives(srcdir):
 
         result.joinpath(target).mount(DRS(drspath.open('rb')).root)
 
-    if result['AoK HD'].exists():
+    if result['AoK HD.exe'].exists():
         # Mounts for HD edition version 4.0
         result['graphics'].mount(srcdir['resources/_common/drs/graphics'])
         result['interface'].mount(srcdir['resources/_common/drs/interface'])
@@ -59,11 +59,12 @@ def mount_drs_archives(srcdir):
         # Mounts for AoC
         mount_drs("data/graphics.drs", "graphics")
         mount_drs("data/interfac.drs", "interface")
-
         mount_drs("data/sounds.drs", "sounds")
         mount_drs("data/sounds_x1.drs", "sounds")
-
         mount_drs("data/terrain.drs", "terrain")
+        mount_drs("data/gamedata.drs", "gamedata")
+        mount_drs("data/gamedata_x1.drs", "gamedata")
+        mount_drs("data/gamedata_x1_p1.drs", "gamedata")
 
     return result
 
@@ -87,7 +88,10 @@ def convert_assets(assets, args, srcdir=None):
     if srcdir is None:
         srcdir = acquire_conversion_source_dir()
 
-    testfile = 'data/empires2_x1_p1.dat'
+    if srcdir['AoK HD.exe'].exists():
+        testfile = 'resources/_common/dat/empires2_x1_p1.dat'
+    else:
+        testfile = 'data/empires2_x1_p1.dat'
     if not srcdir.joinpath(testfile).is_file():
         print("file not found: " + testfile)
         return False
@@ -114,7 +118,6 @@ def convert_assets(assets, args, srcdir=None):
     from .driver import convert
     converted_count = 0
     total_count = None
-
     for current_item in convert(args):
         if isinstance(current_item, int):
             # convert is informing us about the estimated number of remaining


### PR DESCRIPTION
I know that Miguellissimo already made a pull request for fixing the bugs of the new asset system on HD (#338), but I was working on the same thing, and fixed it up so it works on my end. It would be good if someone with *regular* AoC could check if it worked on their end.

The changes are, as in the commit message:

* Conditional mounting of resource drs files/directories
* Conditional selection of palette file path (due to change in HD name)
* Makes sure directory are not added to `files_to_convert`
* New file paths for HD language files
* HD language files are decoded as utf-8