### PR TITLE
convert: fixed checking for hd version availability

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,3 +9,4 @@ Jimmy Berry <jimmy@boombatower.com>
 Jonathan Remnant <jono4728@gmail.com>
 Henry Snoek <?> <snoek09@users.noreply.github.com>
 coop shell (Michael Enßlin, Jonas Jelten, Andre Kupka) <coop@sft.mx>
+Franz-Niclas Muschter <fm@stusta.net> <franz-niclas.muschter@stusta.net>

--- a/copying.md
+++ b/copying.md
@@ -54,6 +54,7 @@ _the openage authors_ are:
 | Wilco Kusee                 | detrumi                     | wilcokusee@gmail.com                  |
 | Sreejith R                  | sreejithr                   | sreejith.r44@gmail.com                |
 | Jens Feodor Nielsen         | jfeo                        | xws747@alumni.ku.dk                   |
+| Franz-Niclas Muschter       | fm                          | fm@stusta.net                         |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -120,7 +120,7 @@ def convert_metadata(args):
     # required for player palette and color lookup during SLP conversion.
     yield "palette"
     # `.bin` files are renamed `.bina` in HD version 4
-    if args.srcdir["AoK HD.exe"].exists:
+    if args.srcdir["AoK HD.exe"].exists():
         palette_path = "interface/50500.bina"
     else:
         palette_path = "interface/50500.bin"


### PR DESCRIPTION
Fixed a bug where checking for the AOE2 HD version would always return true, leading to failed conversion of the original AOE2 game files.