### PR TITLE
'log-tail' in-game console command

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -57,6 +57,7 @@ _the openage authors_ are:
 | Franz-Niclas Muschter       | fm                          | fm@stusta.net                         |
 | Valentin Gagarin            | frickler01                  | valentin@fricklerhandwerk.de          |
 | Emmanouil Kampitakis        | madonius                    | emmanouil@kampitakis.de               |
+| Thomas Oltmann              | tomolt                      | thomas.oltmann.hhg@gmail.com          |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/console/console.cpp
+++ b/libopenage/console/console.cpp
@@ -42,7 +42,7 @@ Console::Console()
 	topright.y = charsize.y * buf.dims.y;
 }
 
-Console::~Console () {}
+Console::~Console() {}
 
 void Console::load_colors(std::vector<gamedata::palette_color> &colortable) {
 	for (auto &c : colortable) {
@@ -59,6 +59,9 @@ void Console::register_to_engine(Engine *engine) {
 	engine->register_tick_action(this);
 	engine->register_drawhud_action(this);
 	engine->register_resize_action(this);
+
+	// create & register the TailSink
+	this->tailsink = std::make_unique<log::TailSink>();
 
 	// TODO bind any needed input to InputContext
 
@@ -112,6 +115,10 @@ void Console::write(const char *text) {
 void Console::interpret(const std::string &command) {
 	if (command == "exit") {
 		this->set_visible(false);
+	}
+	else if (command == "log-tail") {
+		for (auto &line : tailsink->tail)
+			this->buf.write(line.c_str());
 	}
 	else if (command == "list") {
 		Engine &e = Engine::get();

--- a/libopenage/console/console.h
+++ b/libopenage/console/console.h
@@ -14,6 +14,7 @@
 #include "../util/color.h"
 #include "../font.h"
 #include "../gamedata/color.gen.h"
+#include "../log/tail_logsink.h"
 
 namespace openage {
 
@@ -26,7 +27,6 @@ class Console : InputHandler, TickHandler, HudHandler, ResizeHandler {
 
 public:
 	Console();
-	~Console();
 
 	coord::camhud bottomleft;
 	coord::camhud topright;
@@ -43,6 +43,11 @@ public:
 
 	// the command state
 	std::string command;
+
+	/**
+	 * the log sink used for the 'log-tail' command.
+	 */
+	std::unique_ptr<log::TailSink> tailsink;
 
 	/**
 	 * load the consoles color table

--- a/libopenage/log/CMakeLists.txt
+++ b/libopenage/log/CMakeLists.txt
@@ -7,6 +7,7 @@ add_sources(libopenage
 	message.cpp
 	named_logsource.cpp
 	stdout_logsink.cpp
+	tail_logsink.cpp
 	test.cpp
 )
 

--- a/libopenage/log/logsource.cpp
+++ b/libopenage/log/logsource.cpp
@@ -6,6 +6,7 @@
 
 #include "logsink.h"
 #include "stdout_logsink.h"
+#include "tail_logsink.h"
 
 namespace openage {
 namespace log {

--- a/libopenage/log/tail_logsink.cpp
+++ b/libopenage/log/tail_logsink.cpp
@@ -1,0 +1,35 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#include "tail_logsink.h"
+
+#include <sstream>
+#include <cstring>
+#include <iostream>
+
+#include "message.h"
+#include "logsource.h"
+
+namespace openage {
+namespace log {
+
+
+void TailSink::output_log_message(const message &msg, LogSource *source) {
+	// write log to str
+	// (mainly copied from StdOutSink).
+	std::stringstream ss;
+	ss << msg.lvl->name << "|";
+	ss << source->logsource_name() << "|";
+	ss << msg.filename << ":" << msg.lineno << "|";
+	ss << "T" << msg.thread_id << "|";
+	ss << std::setprecision(7) << std::fixed << msg.timestamp / 1e9 << "|";
+	ss << msg.text << std::endl;
+	std::string str = ss.str();
+
+	if (tail.size() > tail_size) {
+		tail.pop_front();
+	}
+	tail.push_back(str);
+}
+
+
+}} // namespace openage::log

--- a/libopenage/log/tail_logsink.h
+++ b/libopenage/log/tail_logsink.h
@@ -1,0 +1,27 @@
+// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+#ifndef OPENAGE_LOG_TAIL_LOGSINK_H_
+#define OPENAGE_LOG_TAIL_LOGSINK_H_
+
+#include <list>
+
+#include "logsink.h"
+
+namespace openage {
+namespace log {
+
+
+class TailSink : public LogSink {
+public:
+	const static unsigned int tail_size = 8;
+	std::list<std::string> tail;
+
+private:
+	void output_log_message(const message &msg, LogSource *source) override;
+};
+
+
+}} // namespace openage::log
+
+
+#endif


### PR DESCRIPTION
It's an in-game console command that shows you the 8 latest log messages.
BTW, The log sink I created for this (TailSink) doesn't store any older messages than these 8 since openage's logs get big really fast and it would just litter the user's RAM.

P.S.:I've reuploaded this pull request because I accidentally pushed my master branch in the first request. Sorry!