### PR TITLE
in-game console UTF-8 backspace support

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -57,6 +57,7 @@ _the openage authors_ are:
 | Franz-Niclas Muschter       | fm                          | fm@stusta.net                         |
 | Valentin Gagarin            | frickler01                  | valentin@fricklerhandwerk.de          |
 | Emmanouil Kampitakis        | madonius                    | emmanouil@kampitakis.de               |
+| Thomas Oltmann              | tomolt                      | thomas.oltmann.hhg@gmail.com          |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/console/buf.cpp
+++ b/libopenage/console/buf.cpp
@@ -385,6 +385,29 @@ void Buf::write(char c) {
 	}
 }
 
+void Buf::pop_last_char() {
+	if (this->cursorpos.x > 0) {
+		if (this->cursor_special_lastcol) {
+			this->cursor_special_lastcol = false;
+		}
+		else {
+			this->cursorpos.x -= 1;
+		}
+
+		buf_char *ptr = this->chrdataptr(this->cursorpos);
+		*ptr = this->current_char_fmt;
+		ptr->cp = ' ';
+
+		if (this->cursorpos.x == 0 && this->linedataptr(this->cursorpos.y - 1)->type == LINE_WRAPPED) {
+			this->linedataptr(this->cursorpos.y)->type = LINE_EMPTY;
+			this->cursorpos.y--;
+			this->linedataptr(this->cursorpos.y)->type = LINE_REGULAR;
+			this->cursorpos.x = this->dims.x - 1;
+			this->cursor_special_lastcol = true;
+		}
+	}
+}
+
 void Buf::process_codepoint(int cp) {
 	//if the terminal is currently in escaped state, tread the codepoint as
 	//part of the current escape sequence.

--- a/libopenage/console/buf.h
+++ b/libopenage/console/buf.h
@@ -328,6 +328,14 @@ public:
 	 */
 	void write(char c);
 
+	/**
+	 * Pop the last char of the current line
+	 *
+	 * Will correctly handle UTF-8 chars and wrapped lines.
+	 */
+	void pop_last_char();
+
+
 	Buf(coord::term dims, coord::term_t scrollback_lines, coord::term_t min_width,
 	 buf_char default_char_fmt = {0x20, 254, 0, 0});
 	~Buf();

--- a/libopenage/util/unicode.cpp
+++ b/libopenage/util/unicode.cpp
@@ -2,6 +2,8 @@
 
 #include "unicode.h"
 
+#include <string.h>
+
 namespace openage {
 namespace util {
 
@@ -147,6 +149,23 @@ size_t utf8_encode(int cp, char *outbuf) {
 		outbuf[0] = '\0';
 		return 0;
 	}
+}
+
+size_t utf8_last_char_size(char *str) {
+	int r = 0;
+	int i = strlen(str) - 1;
+	while ((i >= 0) && (str[i] & 0x80) && !(str[i] & 0x40)) {
+		i--;
+		r++;
+	}
+	if (i >= 0) {
+		r++;
+	}
+	return r;
+}
+
+void utf8_pop_back(std::string &str) {
+	str.erase(str.size() - utf8_last_char_size(&str[0]));
 }
 
 }} // openage::util

--- a/libopenage/util/unicode.h
+++ b/libopenage/util/unicode.h
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 
 namespace openage {
 namespace util {
@@ -91,6 +92,21 @@ size_t utf8_decode(const unsigned char *s, size_t len, codepoint_t *outbuf);
  *   strlen(outbuf)
  */
 size_t utf8_encode(int cp, char *outbuf);
+
+/**
+ * computes the length of the last character in a given UTF-8 string.
+ *
+ * str
+ *   the UTF-8 string
+ * returns
+ *   the length of the last character in bytes
+ */
+size_t utf8_last_char_size(char *str);
+
+/**
+ * pops back (deletes) the last UTF-8 character in a std::string.
+ */
+void utf8_pop_back(std::string &str);
 
 }} // openage::util
 


### PR DESCRIPTION
Supports UTF-8 characters and line-wrapping just fine.