### PR TITLE
Include -L<dir> flag for linking against python

### DIFF
--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -64,8 +64,8 @@ function(python_init)
 	set(CYTHON_VERSION "${CYTHON_VERSION}" PARENT_SCOPE)
 
 	set(PYEXT_CXXFLAGS "${PYEXT_CXXFLAGS}" PARENT_SCOPE)
-	set(PYEXT_PYLIB "${PYTHON_LIBRARY}" PARENT_SCOPE)
 	set(PYEXT_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}" PARENT_SCOPE)
+	set(PYEXT_LIBRARY "${PYTHON_LIBRARY}" PARENT_SCOPE)
 	set(PYEXT_SUFFIX "${PYEXT_SUFFIX}" PARENT_SCOPE)
 
 	if(NOT CMAKE_PY_INSTALL_PREFIX)
@@ -137,7 +137,8 @@ function(add_cython_modules)
 				set_property(GLOBAL APPEND PROPERTY SFT_CYTHON_MODULES_EMBED "${source}")
 				add_executable("${TARGETNAME}" "${CPPNAME}")
 
-				target_link_libraries("${TARGETNAME}" "${PYEXT_PYLIB}")
+				# TODO: use full ldflags and cflags provided by python${VERSION}-config
+				target_link_libraries("${TARGETNAME}" "${PYEXT_LIBRARY}")
 			else()
 				set_property(GLOBAL APPEND PROPERTY SFT_CYTHON_MODULES "${source}")
 				add_library("${TARGETNAME}" MODULE "${CPPNAME}")

--- a/copying.md
+++ b/copying.md
@@ -59,6 +59,7 @@ _the openage authors_ are:
 | Emmanouil Kampitakis        | madonius                    | emmanouil@kampitakis.de               |
 | Thomas Oltmann              | tomolt                      | thomas.oltmann.hhg@gmail.com          |
 | Miguel Kasparick            | miguellissimo               | miguellissimo@gmail.com               |
+| Darren Strash               | darrenstrash                | darren.strash@gmail.com               |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
This is a proposed fix for issue #379, in which the python library could not be found by the linker. Now we are grabbing the correct library directory using distutils, and also generating the library name the same way as the python-config tool. These are then given to the linker with -L and -l, respectively.

In the future, we should use the python-config tool to grab all ldflags and cflags. I currently don't use the python-config tool because it can include many flags (e.g, extra libraries) that we simply aren't ready to incorporate yet, and therefore would require much filtering. Since this is not currently a problem, it's a feature, not a bug.

I tested the fix on:

Mac OS X Yosemite 10.10.4 (14E46)
Python 3.4 installed with brew install python3
Using g++ version 5.2.0

and

Ubuntu 14.0.4-3
Python 3.4 installed with apt-get
Using both g++ version 4.9.2, and clang++ version 3.6.0