### PR TITLE
Villagers bring their resources to the correct buildings

### DIFF
--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -232,7 +232,11 @@ void GatherAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound)
 	}
 
 	Unit *target = cmd.unit();
-	to_modify.push_action(std::make_unique<GatherAction>(&to_modify, target->get_ref()));
+	try {
+		to_modify.push_action(std::make_unique<GatherAction>(&to_modify, target->get_ref()));
+	} catch (const std::invalid_argument &e) {
+		to_modify.log(MSG(dbg) << "invoke gather action cancelled due to an exception. Reason: " << e.what());
+	}
 }
 
 AttackAbility::AttackAbility(Sound *s)

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -862,12 +862,21 @@ UnitReference GatherAction::nearest_dropsite() {
 	// find nearest dropsite from the targeted resource
 	auto ds = find_near(*this->target.get()->location,
 		[=](const TerrainObject &obj) {
-			return &obj.unit != this->entity &&
-			       &obj.unit != this->target.get() &&
-			       obj.unit.has_attribute(attr_type::building) &&
-			       obj.unit.get_attribute<attr_type::building>().completed >= 1.0f &&
+
+			if (not obj.unit.has_attribute(attr_type::building) or &obj.unit == this->entity or &obj.unit == this->target.get()) {
+				return false;
+			}
+
+			auto living_unit = static_cast<LivingProducer*>(this->entity->unit_type);
+			auto building_unit = static_cast<BuildingProducer*>(obj.unit.unit_type);
+
+			auto dropsite0_id = living_unit->unit_data.drop_site0;
+			auto dropsite1_id = living_unit->unit_data.drop_site1;
+
+			return obj.unit.get_attribute<attr_type::building>().completed >= 1.0f &&
 			       obj.unit.has_attribute(attr_type::owner) &&
-			       obj.unit.get_attribute<attr_type::owner>().player.owns(*this->entity);
+			       obj.unit.get_attribute<attr_type::owner>().player.owns(*this->entity) &&
+			       (building_unit->id() == dropsite0_id or building_unit->id() == dropsite1_id);
 	});
 
 	if (ds) {

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -772,14 +772,13 @@ GatherAction::GatherAction(Unit *e, UnitReference tar)
 	target_resource{true},
 	target{tar} {
 
-		Unit *target = this->target.get();
-		if (target->has_attribute(attr_type::resource)) {
-			auto &resource_attr = target->get_attribute<attr_type::resource>();
-			this->resource_type = resource_attr.resource_type;
-
-			//TODO toggle docks
-			this->docks = false;
-		}
+	Unit *target = this->target.get();
+	if (target->has_attribute(attr_type::resource)) {
+		auto &resource_attr = target->get_attribute<attr_type::resource>();
+		this->resource_type = resource_attr.resource_type;
+	} else {
+		throw std::invalid_argument("Unit reference has no resource attribute");
+	}
 }
 
 GatherAction::~GatherAction() {}

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -771,6 +771,15 @@ GatherAction::GatherAction(Unit *e, UnitReference tar)
 	complete{false},
 	target_resource{true},
 	target{tar} {
+
+		Unit *target = this->target.get();
+		if (target->has_attribute(attr_type::resource)) {
+			auto &resource_attr = target->get_attribute<attr_type::resource>();
+			this->resource_type = resource_attr.resource_type;
+
+			//TODO toggle docks
+			this->docks = false;
+		}
 }
 
 GatherAction::~GatherAction() {}
@@ -867,16 +876,11 @@ UnitReference GatherAction::nearest_dropsite() {
 				return false;
 			}
 
-			auto living_unit = static_cast<LivingProducer*>(this->entity->unit_type);
-			auto building_unit = static_cast<BuildingProducer*>(obj.unit.unit_type);
-
-			auto dropsite0_id = living_unit->unit_data.drop_site0;
-			auto dropsite1_id = living_unit->unit_data.drop_site1;
-
 			return obj.unit.get_attribute<attr_type::building>().completed >= 1.0f &&
 			       obj.unit.has_attribute(attr_type::owner) &&
 			       obj.unit.get_attribute<attr_type::owner>().player.owns(*this->entity) &&
-			       (building_unit->id() == dropsite0_id or building_unit->id() == dropsite1_id);
+			       obj.unit.has_attribute(attr_type::dropsite) &&
+			       obj.unit.get_attribute<attr_type::dropsite>().accepting_resource(this->resource_type);
 	});
 
 	if (ds) {

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -419,7 +419,6 @@ private:
 	bool complete, target_resource;
 	UnitReference target;
 	game_resource resource_type;
-	bool docks;
 	UnitReference nearest_dropsite();
 };
 

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -418,6 +418,8 @@ public:
 private:
 	bool complete, target_resource;
 	UnitReference target;
+	game_resource resource_type;
+	bool docks;
 	UnitReference nearest_dropsite();
 };
 

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -293,16 +293,16 @@ template<> class Attribute<attr_type::dropsite>: public AttributeContainer {
 public:
 
 	Attribute(std::vector<game_resource> types)
-			:
-			AttributeContainer{attr_type::dropsite},
-			resource_types{types} {}
+		:
+		AttributeContainer{attr_type::dropsite},
+		resource_types{types} {}
 
-		bool shared() const override {
-			return false;
-		}
+	bool shared() const override {
+		return false;
+	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
-			return std::make_shared<Attribute<attr_type::dropsite>>(*this);
+		return std::make_shared<Attribute<attr_type::dropsite>>(*this);
 	}
 
 	bool accepting_resource(game_resource res) {

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <algorithm>
 
 #include "../coord/tile.h"
 #include "../gamedata/unit.gen.h"
@@ -63,6 +64,7 @@ enum class attr_type {
 	direction,
 	projectile,
 	building,
+	dropsite,
 	resource,
 	gatherer,
 	garrison
@@ -285,6 +287,34 @@ public:
 	// TODO: list allowed trainable producers
 	UnitType *pp;
 	coord::phys3 gather_point;
+};
+
+template<> class Attribute<attr_type::dropsite>: public AttributeContainer {
+public:
+
+	Attribute(std::vector<game_resource> types)
+			:
+			AttributeContainer{attr_type::dropsite},
+			resource_types{types} {}
+
+		bool shared() const override {
+			return false;
+		}
+
+	std::shared_ptr<AttributeContainer> copy() const override {
+			return std::make_shared<Attribute<attr_type::dropsite>>(*this);
+	}
+
+	bool accepting_resource(game_resource res) {
+		if (std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end()) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+private:
+	std::vector<game_resource> resource_types;
 };
 
 /**

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -536,7 +536,7 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 	}
 
 	// dropsite attribute
-	std::vector<game_resource> accepted_resources = get_accepted_resources();
+	std::vector<game_resource> accepted_resources = this->get_accepted_resources();
 	if (accepted_resources.size() != 0) {
 		unit->add_attribute(std::make_shared<Attribute<attr_type::dropsite>>(accepted_resources));
 	}
@@ -550,33 +550,22 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 std::vector<game_resource> BuildingProducer::get_accepted_resources() {
 	//TODO use a more general approach instead of hard coded ids
 
-	auto id_in = [id = this->id()](std::initializer_list<int> ids){
-		return std::any_of(ids.begin(), ids.end(), [=](int n){ return n == id; });
+	auto id_in = [=](std::initializer_list<int> ids){
+		return std::any_of(ids.begin(), ids.end(), [=](int n){ return n == this->id(); });
 	};
 
 	if (this->id() == 109) { //Town center
 		return std::vector<game_resource>{game_resource::wood,
 			game_resource::food,
 			game_resource::gold,
-			game_resource::stone,
-			game_resource::fish};
-	}
-
-	if (id_in({584, 585, 586, 587})) { //Mine
+			game_resource::stone};
+	} else if (id_in({584, 585, 586, 587})) { //Mine
 		return std::vector<game_resource>{game_resource::gold,
 			game_resource::stone};
-	}
-
-	if (id_in({68, 129, 130, 131})) { //Mill
+	} else if (id_in({68, 129, 130, 131})) { //Mill
 		return std::vector<game_resource>{game_resource::food};
-	}
-
-	if (id_in({562, 563, 564, 565})) { //Lumberjack camp
+	} else if (id_in({562, 563, 564, 565})) { //Lumberjack camp
 		return std::vector<game_resource>{game_resource::wood};
-	}
-
-	if (id_in({45, 47, 51})) { //Docks
-		return std::vector<game_resource>{game_resource::fish};
 	}
 
 	return std::vector<game_resource>();

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -12,6 +12,7 @@
 #include "producer.h"
 #include "unit.h"
 #include "unit_texture.h"
+#include <initializer_list>
 
 /** @file
  * Many values in this file are hardcoded, due to limited understanding of how the original
@@ -534,10 +535,51 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 		unit->give_ability(std::make_shared<AttackAbility>());
 	}
 
+	// dropsite attribute
+	std::vector<game_resource> accepted_resources = get_accepted_resources();
+	if (accepted_resources.size() != 0) {
+		unit->add_attribute(std::make_shared<Attribute<attr_type::dropsite>>(accepted_resources));
+	}
+
 	// building can train new units and ungarrison
 	unit->give_ability(std::make_shared<SetPointAbility>());
 	unit->give_ability(std::make_shared<TrainAbility>());
 	unit->give_ability(std::make_shared<UngarrisonAbility>());
+}
+
+std::vector<game_resource> BuildingProducer::get_accepted_resources() {
+	//TODO use a more general approach instead of hard coded ids
+
+	auto id_in = [id = this->id()](std::initializer_list<int> ids){
+		return std::any_of(ids.begin(), ids.end(), [=](int n){ return n == id; });
+	};
+
+	if (this->id() == 109) { //Town center
+		return std::vector<game_resource>{game_resource::wood,
+			game_resource::food,
+			game_resource::gold,
+			game_resource::stone,
+			game_resource::fish};
+	}
+
+	if (id_in({584, 585, 586, 587})) { //Mine
+		return std::vector<game_resource>{game_resource::gold,
+			game_resource::stone};
+	}
+
+	if (id_in({68, 129, 130, 131})) { //Mill
+		return std::vector<game_resource>{game_resource::food};
+	}
+
+	if (id_in({562, 563, 564, 565})) { //Lumberjack camp
+		return std::vector<game_resource>{game_resource::wood};
+	}
+
+	if (id_in({45, 47, 51})) { //Docks
+		return std::vector<game_resource>{game_resource::fish};
+	}
+
+	return std::vector<game_resource>();
 }
 
 TerrainObject *BuildingProducer::place(Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -131,6 +131,7 @@ private:
 	UnitType *trainable2;
 	UnitType *projectile;
 	int foundation_terrain;
+	std::vector<game_resource> get_accepted_resources();
 
 	/**
 	 * used for objects like town centers or gates

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -97,6 +97,7 @@ public:
 	void initialise(Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
+private:
 	const gamedata::unit_living unit_data;
 };
 

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -97,9 +97,7 @@ public:
 	void initialise(Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
-private:
 	const gamedata::unit_living unit_data;
-
 };
 
 /**

--- a/libopenage/unit/resource.h
+++ b/libopenage/unit/resource.h
@@ -14,8 +14,7 @@ enum class game_resource {
 	wood,
 	food,
 	gold,
-	stone,
-	fish
+	stone
 };
 
 } // namespace openage

--- a/libopenage/unit/resource.h
+++ b/libopenage/unit/resource.h
@@ -14,7 +14,8 @@ enum class game_resource {
 	wood,
 	food,
 	gold,
-	stone
+	stone,
+	fish
 };
 
 } // namespace openage


### PR DESCRIPTION
I am working on the issue #377. 

- [x] villagers bring their resources not to random buildings any more.
- [x] according to the resource type, gather the information from the unit instead of casting to living producer to get the dropsite ids
- [x] cleanup