### PR TITLE
Villagers stop gathering resources

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -60,6 +60,7 @@ _the openage authors_ are:
 | Thomas Oltmann              | tomolt                      | thomas.oltmann.hhg@gmail.com          |
 | Miguel Kasparick            | miguellissimo               | miguellissimo@gmail.com               |
 | Darren Strash               | darrenstrash                | darren.strash@gmail.com               |
+| Kyle Robbertze              | paddatrapper                | paddatrapper@gmail.com                |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -216,6 +216,9 @@ bool Unit::invoke(const Command &cmd, bool direct_command) {
 			if (direct_command) {
 
 				// drop other actions if a new action is found
+				if (this->has_attribute(attr_type::gatherer)) {
+					this->stop_gather();
+				}
 				this->stop_actions();
 			}
 			pair->second->invoke(*this, cmd, direct_command);
@@ -227,6 +230,13 @@ bool Unit::invoke(const Command &cmd, bool direct_command) {
 
 void Unit::delete_unit() {
 	this->pop_destructables = true;
+}
+
+void Unit::stop_gather() {
+	this->erase_after(
+		[](std::unique_ptr<UnitAction> &e) {
+			return e->name() == "gather";
+		}, false);
 }
 
 void Unit::stop_actions() {

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -190,6 +190,12 @@ public:
 	bool invoke(const Command &cmd, bool direct_command=false);
 
 	/**
+	 * removes all gather actions without calling their on_complete actions
+	 * this cancels the gathering action completely
+	 */
+	void stop_gather();
+
+	/**
 	 * removes all actions above and including the first interuptable action
 	 * this will stop any of the units current moving or attacking actions
 	 */


### PR DESCRIPTION
Fixes #386  - when the user moves a villager away from gathering a resource the villager will not go back to collecting it.