### PR TITLE
convert: Check for game version in only one place

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -61,6 +61,7 @@ _the openage authors_ are:
 | Miguel Kasparick            | miguellissimo               | miguellissimo@gmail.com               |
 | Darren Strash               | darrenstrash                | darren.strash@gmail.com               |
 | Kyle Robbertze              | paddatrapper                | paddatrapper@gmail.com                |
+| Jonathan Biegert            | azrdev                      | azrdev@qrdn.de                        |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/code/convert/README.md
+++ b/doc/code/convert/README.md
@@ -14,7 +14,7 @@ usable. This is what the convert script does.
 
 
 The convert script is divided into two parts:
-original media dependend and independend exports.
+original media dependent and independent exports.
 
 Converting Media
 ----------------

--- a/openage/convert/CMakeLists.txt
+++ b/openage/convert/CMakeLists.txt
@@ -7,6 +7,7 @@ add_py_modules(
 	drs.py
 	filelist.py
 	fix_data.py
+	game_versions.py
 	hdlanguagefile.py
 	main.py
 	pefile.py

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -10,8 +10,7 @@ from subprocess import Popen, PIPE
 from tempfile import gettempdir
 
 from ..log import info, dbg
-
-from .main import GameVersion
+from .game_versions import GameVersion
 from .blendomatic import Blendomatic
 from .changelog import ASSET_VERSION, ASSET_VERSION_FILENAME
 from .colortable import ColorTable, PlayerColorTable

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -11,6 +11,7 @@ from tempfile import gettempdir
 
 from ..log import info, dbg
 
+from .main import GameVersion
 from .blendomatic import Blendomatic
 from .changelog import ASSET_VERSION, ASSET_VERSION_FILENAME
 from .colortable import ColorTable, PlayerColorTable
@@ -120,7 +121,7 @@ def convert_metadata(args):
     # required for player palette and color lookup during SLP conversion.
     yield "palette"
     # `.bin` files are renamed `.bina` in HD version 4
-    if args.srcdir["AoK HD.exe"].exists():
+    if args.game_version is GameVersion.age2_fe:
         palette_path = "interface/50500.bina"
     else:
         palette_path = "interface/50500.bin"

--- a/openage/convert/game_versions.py
+++ b/openage/convert/game_versions.py
@@ -1,3 +1,7 @@
+# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+
+"""Detect the version of the original game"""
+
 import enum
 
 
@@ -8,11 +12,35 @@ class GameVersion(enum.Enum):
     and TC). We should usually distinguish versions only as far as we're
     concerned (i.e. assets changed).
     """
-    age2_aok = "Age of Empires 2: The Age of Kings"
-    age2_tc = "Age of Empires 2: The Conquerors"
-    age2_tc_10c = "Age of Empires 2: The Conquerors, Patch 1.0c"
+    age2_aok = (
+        "Age of Empires 2: The Age of Kings",
+        False,
+        {'empires2.exe', 'data/empires2.dat'},
+    )
+    age2_tc = (
+        "Age of Empires 2: The Conquerors",
+        True,
+        {'age2_x1/age2_x1.exe', 'data/empires2_x1.dat'},
+    )
+    age2_tc_10c = (
+        "Age of Empires 2: The Conquerors, Patch 1.0c",
+        True,
+        {'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat'},
+    )
     # HD edition version 4.0
-    age2_fe = "Forgotten Empires"
+    age2_fe = (
+        "Forgotten Empires",
+        True,
+        {'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat'},
+    )
+
+    def __init__(self, description, openage_supported, required_files=None):
+        self.description = description
+        self.openage_supported = openage_supported
+        self.required_files = required_files or frozenset()
+
+    def __str__(self):
+        return self.description
 
 
 def get_game_versions(srcdir):
@@ -20,29 +48,7 @@ def get_game_versions(srcdir):
     Determine what versions of the game are installed in srcdir. Yield
     GameVersion values.
     """
-    fixed_filenames = {
-        GameVersion.age2_aok: [
-            'empires2.exe', 'data/empires2.dat',
-        ],
-        GameVersion.age2_tc: [
-            'age2_x1/age2_x1.exe', 'data/empires2_x1.dat',
-        ],
-        GameVersion.age2_tc_10c: [
-            'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat',
-        ],
-        GameVersion.age2_fe: [
-            'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat',
-        ],
-    }
-
-    for version, paths in fixed_filenames.items():
-        if all(srcdir.joinpath(path).is_file() for path in paths):
+    for version in GameVersion:
+        if all(srcdir.joinpath(path).is_file()
+               for path in version.required_files):
             yield version
-
-
-SUPPORTED_GAME_VERSIONS = {
-    GameVersion.age2_aok,
-    GameVersion.age2_tc,
-    GameVersion.age2_tc_10c,
-    GameVersion.age2_fe,
-}

--- a/openage/convert/game_versions.py
+++ b/openage/convert/game_versions.py
@@ -1,0 +1,48 @@
+import enum
+
+
+@enum.unique
+class GameVersion(enum.Enum):
+    """
+    An installed version of the original game. Multiple may coexist (e.g. AoK
+    and TC). We should usually distinguish versions only as far as we're
+    concerned (i.e. assets changed).
+    """
+    age2_aok = "Age of Empires 2: The Age of Kings"
+    age2_tc = "Age of Empires 2: The Conquerors"
+    age2_tc_10c = "Age of Empires 2: The Conquerors, Patch 1.0c"
+    # HD edition version 4.0
+    age2_fe = "Forgotten Empires"
+
+
+def get_game_versions(srcdir):
+    """
+    Determine what versions of the game are installed in srcdir. Yield
+    GameVersion values.
+    """
+    fixed_filenames = {
+        GameVersion.age2_aok: [
+            'empires2.exe', 'data/empires2.dat',
+        ],
+        GameVersion.age2_tc: [
+            'age2_x1/age2_x1.exe', 'data/empires2_x1.dat',
+        ],
+        GameVersion.age2_tc_10c: [
+            'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat',
+        ],
+        GameVersion.age2_fe: [
+            'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat',
+        ],
+    }
+
+    for version, paths in fixed_filenames.items():
+        if all(srcdir.joinpath(path).is_file() for path in paths):
+            yield version
+
+
+SUPPORTED_GAME_VERSIONS = {
+    GameVersion.age2_aok,
+    GameVersion.age2_tc,
+    GameVersion.age2_tc_10c,
+    GameVersion.age2_fe,
+}

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -1,9 +1,10 @@
 # Copyright 2015-2015 the openage authors. See copying.md for legal info.
 
 """ Entry point for all of the asset conversion. """
-import enum
 import os
 
+from .game_versions import SUPPORTED_GAME_VERSIONS
+from .game_versions import GameVersion, get_game_versions
 from . import changelog
 
 from ..log import info, dbg
@@ -26,28 +27,6 @@ class DirectoryCreator(FSLikeObjWrapper):
 
     def __repr__(self):
         return "DirectoryCreator({})".format(self.obj)
-
-
-@enum.unique
-class GameVersion(enum.Enum):
-    """
-    An installed version of the original game. Multiple may coexist (e.g. AoK
-    and TC). We should usually distinguish versions only as far as we're
-    concerned (i.e. assets changed).
-    """
-    age2_aok = "Age of Empires 2: The Age of Kings"
-    age2_tc = "Age of Empires 2: The Conquerors"
-    age2_tc_10c = "Age of Empires 2: The Conquerors, Patch 1.0c"
-    # HD edition version 4.0
-    age2_fe = "Forgotten Empires"
-
-
-SUPPORTED_GAME_VERSIONS = {
-    GameVersion.age2_aok,
-    GameVersion.age2_tc,
-    GameVersion.age2_tc_10c,
-    GameVersion.age2_fe,
-}
 
 
 def mount_drs_archives(srcdir, game_version=None):
@@ -87,31 +66,6 @@ def mount_drs_archives(srcdir, game_version=None):
         mount_drs("data/gamedata_x1_p1.drs", "gamedata")
 
     return result
-
-
-def get_game_versions(srcdir):
-    """
-    Determine what versions of the game are installed in srcdir. Yield
-    GameVersion values.
-    """
-    fixed_filenames = {
-        GameVersion.age2_aok: [
-            'empires2.exe', 'data/empires2.dat',
-        ],
-        GameVersion.age2_tc: [
-            'age2_x1/age2_x1.exe', 'data/empires2_x1.dat',
-        ],
-        GameVersion.age2_tc_10c: [
-            'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat',
-        ],
-        GameVersion.age2_fe: [
-            'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat',
-        ],
-    }
-
-    for version, paths in fixed_filenames.items():
-        if all(srcdir.joinpath(path).is_file() for path in paths):
-            yield version
 
 
 def convert_assets(assets, args, srcdir=None):

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -2,12 +2,13 @@
 
 """ Entry point for all of the asset conversion. """
 import os
+# importing readline enables the raw_input calls to have history etc.
+import readline  # pylint: disable=unused-import
 
-from .game_versions import SUPPORTED_GAME_VERSIONS
 from .game_versions import GameVersion, get_game_versions
 from . import changelog
 
-from ..log import info, dbg
+from ..log import warn, info, dbg
 from ..util.fslike.wrapper import (
     Wrapper as FSLikeObjWrapper,
     Synchronizer as FSLikeObjSynchronizer
@@ -89,11 +90,13 @@ def convert_assets(assets, args, srcdir=None):
 
     args.game_version = set(get_game_versions(srcdir))
     if not args.game_version:
-        info("Game version(s) could not be detected in {}".format(srcdir))
-    if not args.game_version.issubset(SUPPORTED_GAME_VERSIONS):
-        info("None supported of the Game version(s) {}"
-             .format("; ".join([gv.value for gv in args.game_version])))
+        warn("Game version(s) could not be detected in {}".format(srcdir))
+    if not any(version.openage_supported for version in args.game_version):
+        warn("None supported of the Game version(s) {}"
+             .format("; ".join(args.game_version)))
         return False
+    info("Game version(s) detected: {}"
+         .format("; ".join(str(version) for version in args.game_version)))
 
     srcdir = mount_drs_archives(srcdir, args.game_version)
 

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -6,7 +6,7 @@ import os
 
 from . import changelog
 
-from ..log import warn, info, dbg
+from ..log import info, dbg
 from ..util.fslike.wrapper import (
     Wrapper as FSLikeObjWrapper,
     Synchronizer as FSLikeObjSynchronizer
@@ -30,6 +30,11 @@ class DirectoryCreator(FSLikeObjWrapper):
 
 @enum.unique
 class GameVersion(enum.Enum):
+    """
+    An installed version of the original game. Multiple may coexist (e.g. AoK
+    and TC). We should usually distinguish versions only as far as we're
+    concerned (i.e. assets changed).
+    """
     age2_aok = "Age of Empires 2: The Age of Kings"
     age2_tc = "Age of Empires 2: The Conquerors"
     age2_tc_10c = "Age of Empires 2: The Conquerors, Patch 1.0c"
@@ -86,22 +91,26 @@ def mount_drs_archives(srcdir, game_version=None):
 
 def get_game_versions(srcdir):
     """
-    Determine what versions of the game are installed in srcdir. Yield GameVersion values.
+    Determine what versions of the game are installed in srcdir. Yield
+    GameVersion values.
     """
     fixed_filenames = {
-        GameVersion.age2_aok:
-            ['empires2.exe', 'data/empires2.dat'],
-        GameVersion.age2_tc:
-            ['age2_x1/age2_x1.exe', 'data/empires2_x1.dat'],
-        GameVersion.age2_tc_10c:
-            ['age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat'],
-        GameVersion.age2_fe:
-            ['AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat'],
+        GameVersion.age2_aok: [
+            'empires2.exe', 'data/empires2.dat',
+        ],
+        GameVersion.age2_tc: [
+            'age2_x1/age2_x1.exe', 'data/empires2_x1.dat',
+        ],
+        GameVersion.age2_tc_10c: [
+            'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat',
+        ],
+        GameVersion.age2_fe: [
+            'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat',
+        ],
     }
 
     for version, paths in fixed_filenames.items():
-        if all(map(lambda path: srcdir.joinpath(path).is_file(),
-                   paths)):
+        if all(srcdir.joinpath(path).is_file() for path in paths):
             yield version
 
 


### PR DESCRIPTION
Introduce GameVersion enum, and store an instance once determined.
Everybody else can switch version-specific code upon it, instead of
reinventing the wheel

I'm using [enum](https://docs.python.org/3.4/library/enum.html), which is available as of python 3.4 - didn't find a note how backwards compatible you want to be.