### PR TITLE
Improvments of the team colors shader

### DIFF
--- a/assets/shaders/alphamask.frag.glsl
+++ b/assets/shaders/alphamask.frag.glsl
@@ -1,5 +1,3 @@
-#version 120
-
 // alpha masking shader
 //
 // applies an alpha mask texture to a base texture,

--- a/assets/shaders/alphamask.vert.glsl
+++ b/assets/shaders/alphamask.vert.glsl
@@ -1,5 +1,4 @@
 // vertex shader for applying an alpha mask to a texture
-#version 120
 
 // modelview*projection matrix
 uniform mat4 mvp_matrix;

--- a/assets/shaders/equalsEpsilon.glsl
+++ b/assets/shaders/equalsEpsilon.glsl
@@ -1,0 +1,15 @@
+bool equalsEpsilon(vec4 left, vec4 right, float epsilon) {
+	return all(lessThanEqual(abs(left - right), vec4(epsilon)));
+}
+
+bool equalsEpsilon(vec3 left, vec3 right, float epsilon) {
+	return all(lessThanEqual(abs(left - right), vec3(epsilon)));
+}
+
+bool equalsEpsilon(vec2 left, vec2 right, float epsilon) {
+	return all(lessThanEqual(abs(left - right), vec2(epsilon)));
+}
+
+bool equalsEpsilon(float left, float right, float epsilon) {
+    return (abs(left - right) <= epsilon);
+}

--- a/assets/shaders/maptexture.frag.glsl
+++ b/assets/shaders/maptexture.frag.glsl
@@ -1,5 +1,3 @@
-#version 120
-
 //total basic standard texture drawing fragment shader
 
 //the texture data

--- a/assets/shaders/maptexture.vert.glsl
+++ b/assets/shaders/maptexture.vert.glsl
@@ -1,5 +1,4 @@
 //total basic standard texture mapping vertex shader
-#version 120
 
 //modelview*projection matrix
 uniform mat4 mvp_matrix;

--- a/assets/shaders/teamcolors.frag.glsl
+++ b/assets/shaders/teamcolors.frag.glsl
@@ -1,5 +1,3 @@
-#version 120
-
 //team color replacement shader
 //
 //looks for an alpha value specified by 'alpha_marker'
@@ -16,13 +14,13 @@ uniform int player_number;
 uniform float alpha_marker;
 
 //color entries for all players and their subcolors
-uniform vec4 player_color[64];
+uniform vec4 player_color[NUM_OF_PLAYER_COLORS];
 
 //interpolated texture coordinates sent from vertex shader
 varying vec2 tex_position;
 
 //create epsilon environment for float comparison
-const float epsilon = 0.001;
+const float EPSILON = 0.001;
 
 //do the lookup in the player color table
 //for a playernumber (red, blue, etc)
@@ -31,49 +29,26 @@ vec4 get_color(int playernum, int subcolor) {
 	return player_color[((playernum-1) * 8) + subcolor];
 }
 
-//compare color c1 to a reference color
-bool is_color(vec4 c1, vec4 reference) {
-	if (all(greaterThanEqual(c1, reference - epsilon)) && all(lessThanEqual(c1, reference + epsilon))) {
-		return true;
-	}
-	else {
-		return false;
-	}
-}
-
-
 void main() {
 	//get the texel from the uniform texture.
 	vec4 pixel = texture2D(texture, tex_position);
 
 	//check if this texel has an alpha marker, so we can replace it's rgb values.
-	if (pixel[3] >= alpha_marker - epsilon && pixel[3] <= alpha_marker + epsilon) {
-
-		//set alpha to 1 for the comparison
-		pixel[3] = 1.0;
-
-		//don't replace the colors if it's already player 1 (blue)
-		//as the media convert scripts generates blue-player sprites
-		if (player_number != 1) {
-			bool found = false;
-
-			//try to find the base color, there are 8 of them.
-			for(int i = 0; i <= 7; i++) {
-				if (is_color(pixel, player_color[i])) {
-					//base color found, now replace it with the same color
-					//but player_number tinted.
-					pixel = get_color(player_number, i);
-					found = true;
-					break;
-				}
-			}
-			if (!found) {
-				//unknown base color gets pink muhahaha
-				pixel = vec4(255.0/255.0, 20.0/255.0, 147.0/255.0, 1.0);
+	if (player_number != 1 && equalsEpsilon(pixel[3], alpha_marker, EPSILON)) {
+		//try to find the base color, there are 8 of them.
+		for(int i = 0; i <= 7; i++) {
+			if (equalsEpsilon(vec3(pixel), vec3(player_color[i]), EPSILON)) {
+				//base color found, now replace it with the same color
+				//but player_number tinted.
+				gl_FragColor = get_color(player_number, i);
+				return;
 			}
 		}
-	}
-	//else the texel had no marker so we can just draw it without player coloring
 
+		//unknown base color gets pink muhahaha
+		pixel = vec4(255.0/255.0, 20.0/255.0, 147.0/255.0, 1.0);
+	}
+
+	//else the texel had no marker so we can just draw it without player coloring
 	gl_FragColor = pixel;
 }

--- a/assets/shaders/texturefont.frag.glsl
+++ b/assets/shaders/texturefont.frag.glsl
@@ -1,5 +1,3 @@
-#version 120
-
 varying vec2 tex_position;
 uniform sampler2D texture;
 uniform vec4 color;

--- a/assets/shaders/texturefont.vert.glsl
+++ b/assets/shaders/texturefont.vert.glsl
@@ -1,5 +1,3 @@
-#version 120
-
 attribute vec4 vertex_position;
 attribute vec2 tex_coordinates;
 varying vec2 tex_position;

--- a/copying.md
+++ b/copying.md
@@ -64,6 +64,7 @@ _the openage authors_ are:
 | Jonathan Biegert            | azrdev                      | azrdev@qrdn.de                        |
 | Hadrien Mary                | hadim                       | hadrien.mary@gmail.com                        |
 | Sachin Kelkar               | s4chin                      | sachinkel19@gmail.com                 |
+| Camillo Dell'mour           | spjoe                       | cdellmour@gmail.com                   |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/game_renderer.cpp
+++ b/libopenage/game_renderer.cpp
@@ -66,42 +66,48 @@ GameRenderer::GameRenderer(openage::Engine *e)
 
 	// shader initialisation
 	// read shader source codes and create shader objects for wrapping them.
+	const char *shader_header_code = "#version 120\n";
+	char *equalsEpsilon_code;
+	util::read_whole_file(&equalsEpsilon_code, data_dir->join("shaders/equalsEpsilon.glsl"));
 
 	char *texture_vert_code;
 	util::read_whole_file(&texture_vert_code, data_dir->join("shaders/maptexture.vert.glsl"));
-	auto plaintexture_vert = new shader::Shader(GL_VERTEX_SHADER, texture_vert_code);
+	auto plaintexture_vert = new shader::Shader(GL_VERTEX_SHADER, { shader_header_code, texture_vert_code });
 	delete[] texture_vert_code;
 
 	char *texture_frag_code;
 	util::read_whole_file(&texture_frag_code, data_dir->join("shaders/maptexture.frag.glsl"));
-	auto plaintexture_frag = new shader::Shader(GL_FRAGMENT_SHADER, texture_frag_code);
+	auto plaintexture_frag = new shader::Shader(GL_FRAGMENT_SHADER, { shader_header_code, texture_frag_code });
 	delete[] texture_frag_code;
 
 	char *teamcolor_frag_code;
 	util::read_whole_file(&teamcolor_frag_code, data_dir->join("shaders/teamcolors.frag.glsl"));
-	auto teamcolor_frag = new shader::Shader(GL_FRAGMENT_SHADER, teamcolor_frag_code);
+	std::stringstream ss;
+	ss << player_color_lines.size();
+	auto teamcolor_frag = new shader::Shader(GL_FRAGMENT_SHADER, { shader_header_code, ("#define NUM_OF_PLAYER_COLORS " + ss.str() + "\n").c_str(), equalsEpsilon_code, teamcolor_frag_code });
 	delete[] teamcolor_frag_code;
 
 	char *alphamask_vert_code;
 	util::read_whole_file(&alphamask_vert_code, data_dir->join("shaders/alphamask.vert.glsl"));
-	auto alphamask_vert = new shader::Shader(GL_VERTEX_SHADER, alphamask_vert_code);
+	auto alphamask_vert = new shader::Shader(GL_VERTEX_SHADER, { shader_header_code, alphamask_vert_code });
 	delete[] alphamask_vert_code;
 
 	char *alphamask_frag_code;
 	util::read_whole_file(&alphamask_frag_code, data_dir->join("shaders/alphamask.frag.glsl"));
-	auto alphamask_frag = new shader::Shader(GL_FRAGMENT_SHADER, alphamask_frag_code);
+	auto alphamask_frag = new shader::Shader(GL_FRAGMENT_SHADER, { shader_header_code, alphamask_frag_code });
 	delete[] alphamask_frag_code;
 
 	char *texturefont_vert_code;
 	util::read_whole_file(&texturefont_vert_code, data_dir->join("shaders/texturefont.vert.glsl"));
-	auto texturefont_vert = new shader::Shader(GL_VERTEX_SHADER, texturefont_vert_code);
+	auto texturefont_vert = new shader::Shader(GL_VERTEX_SHADER, { shader_header_code, texturefont_vert_code });
 	delete[] texturefont_vert_code;
 
 	char *texturefont_frag_code;
 	util::read_whole_file(&texturefont_frag_code, data_dir->join("shaders/texturefont.frag.glsl"));
-	auto texturefont_frag = new shader::Shader(GL_FRAGMENT_SHADER, texturefont_frag_code);
+	auto texturefont_frag = new shader::Shader(GL_FRAGMENT_SHADER, { shader_header_code, texturefont_frag_code });
 	delete[] texturefont_frag_code;
 
+	delete[] equalsEpsilon_code;
 
 	// create program for rendering simple textures
 	texture_shader::program = new shader::Program(plaintexture_vert, plaintexture_frag);

--- a/libopenage/shader/shader.cpp
+++ b/libopenage/shader/shader.cpp
@@ -27,7 +27,7 @@ const char *type_to_string(GLenum type) {
 	}
 }
 
-Shader::Shader(GLenum type, const char *source) {
+Shader::Shader(GLenum type, std::initializer_list<const char *> sources) {
 	//create shader
 	this->id = glCreateShader(type);
 
@@ -35,7 +35,8 @@ Shader::Shader(GLenum type, const char *source) {
 	this->type = type;
 
 	//load shader source
-	glShaderSource(this->id, 1, &source, NULL);
+	std::vector<const char*> x = std::vector<const char*>(sources);
+	glShaderSource(this->id, x.size(), x.data(), NULL);
 
 	//compile shader source
 	glCompileShader(this->id);

--- a/libopenage/shader/shader.h
+++ b/libopenage/shader/shader.h
@@ -3,6 +3,8 @@
 #ifndef OPENAGE_SHADER_SHADER_H_
 #define OPENAGE_SHADER_SHADER_H_
 
+#include <initializer_list>
+
 #include <epoxy/gl.h>
 
 namespace openage {
@@ -12,7 +14,7 @@ const char *type_to_string(GLenum type);
 
 class Shader {
 public:
-	Shader(GLenum type, const char *source);
+	Shader(GLenum type, std::initializer_list<const char *> sources);
 	~Shader();
 
 	GLuint id;


### PR DESCRIPTION
+ Made the number of possible player colors variable (assets/converted/player_palette.docx)
+ Simplified equals with epsilon checks
+ Introduces a way to share common functions between shaders
 + Shader constructor takes a list of shader code snippets instead of on code char array
 + removed shader header from shaders.
 + add equalsEpsilon.glsl as first shared shader code.
+ game_renderer derives number of player colors from player_color_lines