### PR TITLE
Fix: Civilian holding ressources when idled

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -65,6 +65,7 @@ _the openage authors_ are:
 | Hadrien Mary                | hadim                       | hadrien.mary@gmail.com                        |
 | Sachin Kelkar               | s4chin                      | sachinkel19@gmail.com                 |
 | Camillo Dell'mour           | spjoe                       | cdellmour@gmail.com                   |
+| Timothee Behety             | tim2000                     | tim.behety@gmail.com                  |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -407,8 +407,18 @@ void IdleAction::update(unsigned int time) {
 		}
 	}
 
-	// inc frame
-	this->frame += time * this->frame_rate / 20.0f;
+	// unit carrying ressources take the carrying sprite when idle
+	// we're not updating frames because the carying sprite is walking
+	if (entity->has_attribute(attr_type::gatherer)) {
+		auto gatherer_attrib = entity->get_attribute<attr_type::gatherer>();
+		if (gatherer_attrib.amount > 0) {
+			this->graphic = graphic_type::carrying;
+		}
+	}
+	else {
+		// inc frame
+		this->frame += time * this->frame_rate / 20.0f;
+	}
 }
 
 void IdleAction::on_completion() {}


### PR DESCRIPTION
Civilian where taking theirs idle sprite even when holding resources.
Since the carrying sprite is walking, we have to stop the frame update when it happened.

It's my first contribution, and I have some difficulties with git, so I've made just a tiny commit for the first time.