### PR TITLE
fix build on mac os mavericks

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -62,10 +62,11 @@ _the openage authors_ are:
 | Darren Strash               | darrenstrash                | darren.strash@gmail.com               |
 | Kyle Robbertze              | paddatrapper                | paddatrapper@gmail.com                |
 | Jonathan Biegert            | azrdev                      | azrdev@qrdn.de                        |
-| Hadrien Mary                | hadim                       | hadrien.mary@gmail.com                        |
+| Hadrien Mary                | hadim                       | hadrien.mary@gmail.com                |
 | Sachin Kelkar               | s4chin                      | sachinkel19@gmail.com                 |
 | Camillo Dell'mour           | spjoe                       | cdellmour@gmail.com                   |
 | Timothee Behety             | tim2000                     | tim.behety@gmail.com                  |
+| Vyacheslav Davydov          | tombouctou                  | vissi@vissi.su                        |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/game_renderer.cpp
+++ b/libopenage/game_renderer.cpp
@@ -1,10 +1,11 @@
-// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
 #include <epoxy/gl.h>
 #include <SDL2/SDL.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sstream>
 
 #include "console/console.h"
 #include "coord/vec2f.h"

--- a/libopenage/input/input_context.cpp
+++ b/libopenage/input/input_context.cpp
@@ -1,5 +1,6 @@
-// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
+#include <sstream>
 #include "input_context.h"
 #include "../engine.h"
 


### PR DESCRIPTION
I had a build error w/ sstream header missing, fixed:
```
/Users/user/git/openage/libopenage/input/input_context.cpp:15:21: error: implicit instantiation of undefined template 'std::__1::basic_stringstream<char,
      std::__1::char_traits<char>, std::__1::allocator<char> >'
                std::stringstream ss;
                                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:126:33: note: template is declared here
    class _LIBCPP_TYPE_VIS_ONLY basic_stringstream;
```