### PR TITLE
convert: support HD Edition 3.x, fixes #444

### DIFF
--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+# Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
 """
 Receives cleaned-up srcdir and targetdir objects from .main, and drives the
@@ -21,10 +21,13 @@ from .hardcoded.terrain_tile_size import TILE_HALFSIZE
 from .slp_converter_pool import SLPConverterPool
 
 
-def get_string_resources(srcdir):
+def get_string_resources(args):
     """ reads the (language) string resources """
     from .stringresource import StringResource
     stringres = StringResource()
+
+    srcdir = args.srcdir
+    count = 0
 
     # AoK:TC uses .DLL PE files for its string resources,
     # HD uses plaintext files
@@ -33,9 +36,10 @@ def get_string_resources(srcdir):
         for name in ["language.dll", "language_x1.dll", "language_x1_p1.dll"]:
             pefile = PEFile(srcdir[name].open('rb'))
             stringres.fill_from(pefile.resources().strings)
-    else:
-        count = 0
+            count += 1
+    elif GameVersion.age2_fe in args.game_versions:
         from .hdlanguagefile import read_hd_language_file
+
         for lang in srcdir["resources"].list():
             try:
                 if lang == b'_common':
@@ -50,9 +54,29 @@ def get_string_resources(srcdir):
             except FileNotFoundError:
                 # that's fine, there are no language files for every language.
                 pass
+    elif GameVersion.age2_hd_3x in args.game_versions:
+        from .hdlanguagefile import read_hd_language_file
 
-        if not count:
-            raise FileNotFoundError("could not find any language files")
+        # HD Edition 3.x and below store language .txt files in the Bin/ folder.
+        # Specific language strings are in Bin/$LANG/*.txt.
+        for lang in srcdir["bin"].list():
+            dirname = ["bin", lang.decode()]
+
+            # There are some .txt files immediately in bin/, but they don't seem
+            # to contain anything useful. (Everything is overridden by files in
+            # Bin/$LANG/.)
+            if not srcdir[dirname].is_dir():
+                continue
+
+            for basename in srcdir[dirname].list():
+                langfilename = ["bin", lang.decode(), basename]
+                with srcdir[langfilename].open('rb') as langfile:
+                    # No utf-8 :(
+                    stringres.fill_from(read_hd_language_file(langfile, lang, enc='iso-8859-1'))
+                count += 1
+
+    if not count:
+        raise FileNotFoundError("could not find any language files")
 
     # TODO transform and cleanup the read strings:
     #      convert formatting indicators from HTML to something sensible, etc
@@ -152,7 +176,7 @@ def convert_metadata(args):
     data_formatter.add_data(termcolortable.dump("termcolors"))
 
     yield "string resources"
-    stringres = get_string_resources(args.srcdir)
+    stringres = get_string_resources(args)
     data_formatter.add_data(stringres.dump("string_resources"))
 
     yield "writing gamespec csv files"

--- a/openage/convert/game_versions.py
+++ b/openage/convert/game_versions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2015 the openage authors. See copying.md for legal info.
+# Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
 """Detect the version of the original game"""
 
@@ -26,6 +26,11 @@ class GameVersion(enum.Enum):
         "Age of Empires 2: The Conquerors, Patch 1.0c",
         True,
         {'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat'},
+    )
+    age2_hd_3x = (
+        "Age of Empires 2: HD Edition (Version 3.x)",
+        True,
+        {'AoK HD.exe', 'data/empires2_x1_p1.dat'}
     )
     # HD edition version 4.0
     age2_fe = (

--- a/openage/convert/hdlanguagefile.py
+++ b/openage/convert/hdlanguagefile.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 """
 Module for reading AoeII HD Edition text-based language files.
@@ -8,14 +8,14 @@ from .hardcoded.langcodes_hd import LANGCODE_MAP_HD
 from ..log import dbg
 
 
-def read_hd_language_file(fileobj, langcode):
+def read_hd_language_file(fileobj, langcode, enc='utf-8'):
     """
     Takes a file object, and the file's language code.
     """
     dbg("HD Language file " + str(langcode))
     strings = {}
 
-    for line in fileobj.read().decode('utf-8').split('\n'):
+    for line in fileobj.read().decode(enc).split('\n'):
         line = line.strip()
 
         # skip comments & empty lines

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -62,9 +62,11 @@ def mount_drs_archives(srcdir, game_versions=None):
         mount_drs("data/sounds.drs", "sounds")
         mount_drs("data/sounds_x1.drs", "sounds")
         mount_drs("data/terrain.drs", "terrain")
-        mount_drs("data/gamedata.drs", "gamedata")
+        if GameVersion.age2_hd_3x not in game_versions:
+            mount_drs("data/gamedata.drs", "gamedata")
         mount_drs("data/gamedata_x1.drs", "gamedata")
         mount_drs("data/gamedata_x1_p1.drs", "gamedata")
+        # TODO mount gamedata_x2.drs and _x2_p1 if they exist?
 
     return result
 


### PR DESCRIPTION
HD Edition 3.x puts language files in a slightly different place,
and uses a funny encoding for them (i.e. not utf-8).

(At least, a funny encoding for the English language files. I'm
_assuming_ that it's the same for other languages.)

Otherwise it's largely the same as non-HD.

There are some additional SLP files in the `Data/Slp` directory,
apparently dealing with UI and fires too(?). There are some extra
palette files in the `Data/` directory too but I'm not sure how they
are mapped to their relevant SLP files.

e; now with copyright years :muscle: