### PR TITLE
[RFC] Add forbidden files to version detection (#461)

### DIFF
--- a/openage/convert/game_versions.py
+++ b/openage/convert/game_versions.py
@@ -16,21 +16,25 @@ class GameVersion(enum.Enum):
         "Age of Empires 2: The Age of Kings",
         False,
         {'empires2.exe', 'data/empires2.dat'},
+        {'resources/_common/dat/empires2_x1_p1.dat'},
     )
     age2_tc = (
         "Age of Empires 2: The Conquerors",
         True,
         {'age2_x1/age2_x1.exe', 'data/empires2_x1.dat'},
+        {'resources/_common/dat/empires2_x1_p1.dat'},
     )
     age2_tc_10c = (
         "Age of Empires 2: The Conquerors, Patch 1.0c",
         True,
         {'age2_x1/age2_x1.exe', 'data/empires2_x1_p1.dat'},
+        {'resources/_common/dat/empires2_x1_p1.dat'},
     )
     age2_hd_3x = (
         "Age of Empires 2: HD Edition (Version 3.x)",
         True,
-        {'AoK HD.exe', 'data/empires2_x1_p1.dat'}
+        {'AoK HD.exe', 'data/empires2_x1_p1.dat'},
+        {'resources/_common/dat/empires2_x1_p1.dat'},
     )
     # HD edition version 4.0
     age2_fe = (
@@ -39,10 +43,11 @@ class GameVersion(enum.Enum):
         {'AoK HD.exe', 'resources/_common/dat/empires2_x1_p1.dat'},
     )
 
-    def __init__(self, description, openage_supported, required_files=None):
+    def __init__(self, description, openage_supported, required_files=None, forbidden_files=None):
         self.description = description
         self.openage_supported = openage_supported
         self.required_files = required_files or frozenset()
+        self.forbidden_files = forbidden_files or frozenset()
 
     def __str__(self):
         return self.description
@@ -54,6 +59,14 @@ def get_game_versions(srcdir):
     GameVersion values.
     """
     for version in GameVersion:
-        if all(srcdir.joinpath(path).is_file()
-               for path in version.required_files):
-            yield version
+        # Check required files.
+        if not all(srcdir.joinpath(path).is_file()
+                   for path in version.required_files):
+            continue
+
+        # Check forbidden files.
+        if any(srcdir.joinpath(path).is_file()
+               for path in version.forbidden_files):
+            continue
+
+        yield version


### PR DESCRIPTION
Trying to solve issue #461, now `Forgotten Empires` is detected as the only available version. However the same thing happens during conversion.

```
$ ./run convert --force
media conversion is required.
using AGE2DIR: /media/niklas/E4DE307EDE304AD6/Program Files (x86)/Steam/SteamApps/common/Age2HD
INFO [py] Game version(s) detected: Forgotten Empires
INFO [py] converting metadata
INFO [py] [0] palette
INFO [py] [1] empires.dat
INFO [py] using cached gamespec: /tmp/empires2_x1_p1.dat.pickle
INFO [py] [2] blendomatic.dat
INFO [py] blending masks successfully exported
INFO [py] [3] player color palette
INFO [py] [4] terminal color palette
INFO [py] [5] string resources
Traceback (most recent call last):
  File "run.py", line 15, in init run (/home/niklas/Projekte/openage/run.cpp:832)
    main()
  File "/home/niklas/Projekte/openage/openage/__main__.py", line 94, in main
    return args.entrypoint(args, cli.error)
  File "/home/niklas/Projekte/openage/openage/convert/main.py", line 283, in main
    if not convert_assets(assets, args, srcdir):
  File "/home/niklas/Projekte/openage/openage/convert/main.py", line 125, in convert_assets
    for current_item in convert(args):
  File "/home/niklas/Projekte/openage/openage/convert/driver.py", line 126, in convert
    yield from convert_metadata(args)
  File "/home/niklas/Projekte/openage/openage/convert/driver.py", line 179, in convert_metadata
    stringres = get_string_resources(args)
  File "/home/niklas/Projekte/openage/openage/convert/driver.py", line 37, in get_string_resources
    pefile = PEFile(srcdir[name].open('rb'))
  File "/home/niklas/Projekte/openage/openage/convert/pefile.py", line 191, in __init__
    raise Exception("Invalid section name: " + section.name)
Exception: Invalid section name: CODE
```