### PR TITLE
Prefer plain text over language.dll (fixes #461)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -10,3 +10,4 @@ Jonathan Remnant <jono4728@gmail.com>
 Henry Snoek <?> <snoek09@users.noreply.github.com>
 coop shell (Michael Enßlin, Jonas Jelten, Andre Kupka) <coop@sft.mx>
 Franz-Niclas Muschter <fm@stusta.net> <franz-niclas.muschter@stusta.net>
+Niklas Fiekas <niklas.fiekas@backscattering.de> <niklas.fiekas@tu-clausthal.de>

--- a/copying.md
+++ b/copying.md
@@ -49,7 +49,7 @@ _the openage authors_ are:
 | Jon Gelderloos              | jgelderloos                 | jgelderloos@gmail.com                 |
 | Emmanuel Gil Peyrot         | Link Mauve                  | linkmauve@linkmauve.fr                |
 | Danilo Bargen               | dbrgn                       | mail@dbrgn.ch                         |
-| Niklas Fiekas               | niklasf                     | niklas.fiekas@tu-clausthal.de         |
+| Niklas Fiekas               | niklasf                     | niklas.fiekas@backscattering.de       |
 | Charles Gould               | charlesrgould               | charles.r.gould@gmail.com             |
 | Wilco Kusee                 | detrumi                     | wilcokusee@gmail.com                  |
 | Sreejith R                  | sreejithr                   | sreejith.r44@gmail.com                |

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -31,13 +31,7 @@ def get_string_resources(args):
 
     # AoK:TC uses .DLL PE files for its string resources,
     # HD uses plaintext files
-    if srcdir["language.dll"].is_file():
-        from .pefile import PEFile
-        for name in ["language.dll", "language_x1.dll", "language_x1_p1.dll"]:
-            pefile = PEFile(srcdir[name].open('rb'))
-            stringres.fill_from(pefile.resources().strings)
-            count += 1
-    elif GameVersion.age2_fe in args.game_versions:
+    if GameVersion.age2_fe in args.game_versions:
         from .hdlanguagefile import read_hd_language_file
 
         for lang in srcdir["resources"].list():
@@ -74,6 +68,12 @@ def get_string_resources(args):
                     # No utf-8 :(
                     stringres.fill_from(read_hd_language_file(langfile, lang, enc='iso-8859-1'))
                 count += 1
+    elif srcdir["language.dll"].is_file():
+        from .pefile import PEFile
+        for name in ["language.dll", "language_x1.dll", "language_x1_p1.dll"]:
+            pefile = PEFile(srcdir[name].open('rb'))
+            stringres.fill_from(pefile.resources().strings)
+            count += 1
 
     if not count:
         raise FileNotFoundError("could not find any language files")


### PR DESCRIPTION
Thanks @goto-bus-stop! Your suggested fix works.

---

Forgotten Empires uses plaintext files for language strings. There may
still be files from older versions, but with unexpected contents.

Also see #462.