### PR TITLE
Expanded the critical section to include init()

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -67,6 +67,7 @@ _the openage authors_ are:
 | Camillo Dell'mour           | spjoe                       | cdellmour@gmail.com                   |
 | Timothee Behety             | tim2000                     | tim.behety@gmail.com                  |
 | Vyacheslav Davydov          | tombouctou                  | vissi@vissi.su                        |
+| Lyle Nel                    | lyle-nel                    | pt20100938@gmail.com                  |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/log/message.cpp
+++ b/libopenage/log/message.cpp
@@ -24,9 +24,9 @@ void message::init_with_metadata_copy(const std::string &filename, const std::st
 	static std::unordered_set<std::string> stringconstants;
 	static std::mutex stringconstants_mutex;
 
-	this->init();
-
 	std::lock_guard<std::mutex> lock{stringconstants_mutex};
+
+	this->init();
 	this->filename = stringconstants.insert(filename).first->c_str();
 	this->functionname = stringconstants.insert(functionname).first->c_str();
 }

--- a/libopenage/log/message.cpp
+++ b/libopenage/log/message.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2015 the openage authors. See copying.md for legal info.
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
 
 #include "message.h"
 


### PR DESCRIPTION
Won't this init() interleave when multiple threads enter the function?
The potential result would be the wrong thread_id paired with the wrong timestamp.
Moving the guard up would mitigate it.