### PR TITLE
Reset the amount gathered upon switching resource type

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -69,6 +69,7 @@ _the openage authors_ are:
 | Vyacheslav Davydov          | tombouctou                  | vissi@vissi.su                        |
 | Lyle Nel                    | lyle-nel                    | pt20100938@gmail.com                  |
 | Michael Kilby               | kilbyjmichael               | kilbyjmichael@gmail.com               |
+| Michal Kováč                | mirelon                     | miso@github.ksp.sk                    |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include <algorithm>
 #include <cmath>
@@ -790,6 +790,9 @@ GatherAction::GatherAction(Unit *e, UnitReference tar)
 	Unit *target = this->target.get();
 	if (target->has_attribute(attr_type::resource)) {
 		auto &resource_attr = target->get_attribute<attr_type::resource>();
+		if (this->resource_type != resource_attr.resource_type) {
+			this->entity->get_attribute<attr_type::gatherer>().amount = 0;
+		}
 		this->resource_type = resource_attr.resource_type;
 	} else {
 		throw std::invalid_argument("Unit reference has no resource attribute");


### PR DESCRIPTION
When switching to different resource type for gathering, reset the amount already gathered. Fixed #364