### PR TITLE
Cythonize determine_rgba_matrix() (see #431)

### DIFF
--- a/openage/convert/CMakeLists.txt
+++ b/openage/convert/CMakeLists.txt
@@ -14,15 +14,13 @@ add_py_modules(
 	pefile.py
 	peresource.py
 	singlefile.py
-	slp.py
 	slp_converter_pool.py
 	stringresource.py
 	texture.py
 )
 
 add_cython_modules(
-	# hoping that this will somewhat increase the horrible performance.
-	STANDALONE slp.py
+	slp.pyx
 )
 
 add_subdirectory(dataformat)


### PR DESCRIPTION
This improves total conversion time (`--no-sound`) from 4:36 to 3:11.

Benchmarks for `convert-file Age2HD/Data/graphics.drs 61.slp /tmp/test`:

                        | Old   | New
----------------------- | ----- | -----
SLP parsing/drawing     | 0.038 |
determine_rgba_matrix() | 0.136 | 0.053
Texture packing         | 0.002 |
PNG encoding/writing    | 0.031 |