### PR TITLE
Added support for importing string data from HD 2.0

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -71,6 +71,7 @@ _the openage authors_ are:
 | Michael Kilby               | kilbyjmichael               | kilbyjmichael@gmail.com               |
 | Michal Kováč                | mirelon                     | miso@github.ksp.sk                    |
 | Patrik Stutz                | VanCoding                   | patrik.stutz@gmail.com                |
+| James McMurray              | jamesmcm                    | jamesmcm03@gmail.com                  |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
Added support for HD Edition 2.0, where string data is in DLLs in PATH/Data/LANG/*.dll

This might be better done by detecting that version explicitly, rather than checking for DLLs in the languages folder, but this works for now.

Prior to this fix, the importer would try to read the .dlls as text files, resulting in the following error:

    Traceback (most recent call last):
      File "run.py", line 15, in <module>
        main()
      File "/home/archie/openage/openage/__main__.py", line 94, in main
        return args.entrypoint(args, cli.error)
      File "/home/archie/openage/openage/game/main.py", line 33, in main
        if not convert_assets(assets, args):
      File "/home/archie/openage/openage/convert/main.py", line 125, in convert_assets
        for current_item in convert(args):
      File "/home/archie/openage/openage/convert/driver.py", line 126, in convert
        yield from convert_metadata(args)
      File "/home/archie/openage/openage/convert/driver.py", line 179, in convert_metadata
        stringres = get_string_resources(args)
      File "/home/archie/openage/openage/convert/driver.py", line 69, in get_string_resources
        stringres.fill_from(read_hd_language_file(langfile, lang, enc='iso-8859-1'))
      File "/home/archie/openage/openage/convert/hdlanguagefile.py", line 25, in read_hd_language_file
        num, string = line.split(None, 1)
    ValueError: not enough values to unpack (expected 2, got 1)
