### PR TITLE
Do append selection with SHIFT key instead of CTRL

### DIFF
--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -246,7 +246,7 @@ ActionMode::ActionMode()
 				log::log(MSG(dbg) << "select");
 				Terrain *terrain = engine.get_game()->terrain.get();
 				this->selection.drag_update(mousepos_camgame);
-				this->selection.drag_release(terrain, engine.get_input_manager().is_mod_down(input::modifier::CTRL));
+				this->selection.drag_release(terrain, engine.get_input_manager().is_mod_down(input::modifier::SHIFT));
 			}
 			return true;
 		}


### PR DESCRIPTION
Title says it already. I am not sure if the implementation with CTRL is intended, but the original game uses SHIFT so I fixed it that way.