### PR TITLE
Buildsystem improvements, once again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ If you have installed all the dependencies that are conveniently listed in
 If it doesn't, consider reporting the issue/asking for help in #sfttech on freenode.net.
 ")
 
-project(openage C CXX)
+project(openage CXX)
 
 # Ensure CMAKE_BUILD_TYPE is set correctly.
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ include(codegen)
 include(version)
 include(doxygen)
 
+
+# now that all modules and settings are loaded,
+# apply those to the project:
+
 # create documentation
 doxygen_configure(libopenage/ openage/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ project(openage C CXX)
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Debug")
 endif()
+string(TOUPPER "CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}" BUILD_TYPE_CXX_FLAGS)
 
 # options: keep up to date with those in ./configure!
 if(NOT DEFINED WANT_BACKTRACE)
@@ -93,7 +94,9 @@ print_config_options()
 message("${PROJECT_NAME} ${PROJECT_VERSION}
 
          compiler | ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}
+       build type | ${CMAKE_BUILD_TYPE}
          cxxflags | ${CMAKE_CXX_FLAGS}
+ build type flags | ${${BUILD_TYPE_CXX_FLAGS}}
         build dir | ${CMAKE_BINARY_DIR}
    install prefix | ${CMAKE_INSTALL_PREFIX}
 py install prefix | ${CMAKE_PY_INSTALL_PREFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,19 @@ If you have installed all the dependencies that are conveniently listed in
 If it doesn't, consider reporting the issue/asking for help in #sfttech on freenode.net.
 ")
 
-project(openage CXX)
+# cmake < 3.4.0 has problems with projects that use C++ but not C,
+# especially in the FindThreads module (when header files are checked).
+if(CMAKE_VERSION VERSION_LESS "3.4.0")
+	message(WARNING "using cmake ${CMAKE_VERSION} < 3.4.0, falling back and setting CC=CXX.")
+	project(openage C CXX)
+
+	# simple hack to set CC=CXX because
+	# older cmake requires CC for some header tests
+	set(CMAKE_C_COMPILER "${CMAKE_CXX_COMPILER}")
+	set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
+else()
+	project(openage CXX)
+endif()
 
 # Ensure CMAKE_BUILD_TYPE is set correctly.
 if(NOT CMAKE_BUILD_TYPE)

--- a/buildsystem/compilepy.py
+++ b/buildsystem/compilepy.py
@@ -1,0 +1,65 @@
+# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+"""
+Compiles python modules with cpython to pyc/pyo files.
+"""
+
+import argparse
+import importlib.util
+import os
+import py_compile
+
+
+def main():
+    """ CLI entry point """
+    cli = argparse.ArgumentParser()
+    cli.add_argument("pymodule_list_file", help=(
+        "semicolon-separated list of all modules that shall be compiled"
+    ))
+    cli.add_argument("input_dir", help=(
+        "base directory where files from the above list are in."
+    ))
+    cli.add_argument("output_dir", help=(
+        "base directory where output files will be created."
+    ))
+    args = cli.parse_args()
+
+    with open(args.pymodule_list_file) as fileobj:
+        modules = fileobj.read().strip().split(';')
+        if modules == ['']:
+            modules = []
+
+    if not os.path.isdir(args.output_dir):
+        cli.error("not a directory: '%s'" % args.output_dir)
+
+    to_compile = []
+
+    for module in modules:
+        sourcefile = module
+        relsource = os.path.relpath(sourcefile, args.input_dir)
+        reloutput = importlib.util.cache_from_source(relsource)
+        outputfile = os.path.join(args.output_dir, reloutput)
+
+        if os.path.exists(outputfile):
+            if os.path.getmtime(outputfile) >= os.path.getmtime(sourcefile):
+                continue
+
+            os.remove(outputfile)
+
+        to_compile.append((module, outputfile))
+
+    maxwidth = len(str(len(to_compile)))
+    for idx, (module, outputfile) in enumerate(to_compile):
+        try:
+            print("[%*d/%d] Compiling %s to %s" % (maxwidth, idx + 1,
+                                                   len(to_compile), module,
+                                                   outputfile))
+            py_compile.compile(module, cfile=outputfile, doraise=True)
+
+        except py_compile.PyCompileError as exc:
+            print("FAILED to compile '%s':" % exc.file)
+            print(exc.msg)
+            exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -19,17 +19,19 @@ function(py_exec STATEMENTS RESULTVAR)
 	# executes some python statement(s), and returns the result in RESULTVAR.
 	# aborts with a fatal error on error.
 	# no single quotes are allowed in STATEMENTS.
-	exec_program(
-		"${PYTHON}" ARGS -c "\"${STATEMENTS}\""
+	execute_process(
+		COMMAND "${PYTHON}" -c "${STATEMENTS}"
 		OUTPUT_VARIABLE PY_OUTPUT
-		RETURN_VALUE PY_RETVAL
+		RESULT_VARIABLE PY_RETVAL
 	)
 
 	if (NOT PY_RETVAL EQUAL 0)
 		message(FATAL_ERROR "failed:\n${PYTHON} -c '${STATEMENTS}'\n${PY_OUTPUT}")
 	endif()
 
-	set("${RESULTVAR}" "${PY_OUTPUT}" PARENT_SCOPE)
+	string(STRIP "${PY_OUTPUT}" PY_OUTPUT_STRIPPED)
+
+	set("${RESULTVAR}" "${PY_OUTPUT_STRIPPED}" PARENT_SCOPE)
 endfunction()
 
 function(py_get_config_var VAR RESULTVAR)
@@ -47,7 +49,7 @@ function(py_get_lib_name RESULTVAR)
 	py_get_config_var(VERSION PYTHON_VERSION)
 	if(NOT "${PYTHON_VERSION}" VERSION_LESS "3.2")
 		py_exec(
-			"import sys; print(sys.abiflags, end='')"
+			"import sys; print(sys.abiflags)"
 			ABIFLAGS
 		)
 	else()
@@ -116,35 +118,43 @@ list(REMOVE_DUPLICATES PYTHON_INTERPRETERS)
 
 # Retain only the proper python interpreters
 foreach(INTERPRETER ${PYTHON_INTERPRETERS})
-	exec_program("${INTERPRETER}" ARGS -c True OUTPUT_VARIABLE TEST_OUTPUT RETURN_VALUE TEST_RETVAL)
-	if (NOT TEST_RETVAL EQUAL 0)
+	set(PY_OUTPUT_TEST "rofl, lol")
+	execute_process(COMMAND
+		"${INTERPRETER}" -c "print('${PY_OUTPUT_TEST}'); exit(42)"
+		OUTPUT_VARIABLE TEST_OUTPUT
+		RESULT_VARIABLE TEST_RETVAL
+	)
+	if(NOT TEST_OUTPUT STREQUAL "${PY_OUTPUT_TEST}\n" OR NOT TEST_RETVAL EQUAL 42)
+		message(WARNING "Dropping invalid python interpreter '${INTERPRETER}'")
 		list(REMOVE_ITEM PYTHON_INTERPRETERS INTERPRETER)
 	endif()
 endforeach()
 
 # test all the found interpreters; break on success.
 foreach(PYTHON ${PYTHON_INTERPRETERS})
+	# TODO: sort interpreters by version
+
 	# ask the interpreter for the essential extension-building flags
 	py_get_config_var(INCLUDEPY PYTHON_INCLUDE_DIR)
 	py_get_config_var(LIBDIR PYTHON_LIBRARY_DIR)
 	py_get_lib_name(PYTHON_LIBRARY_NAME)
-	set(PYTHON_LIBRARY "-L${PYTHON_LIBRARY_DIR} -l${PYTHON_LIBRARY_NAME}")
 
 	# there's a static_assert that tests the Python version.
 	try_compile(PYTHON_TEST_RESULT
 		"${CMAKE_BINARY_DIR}"
-		"${CMAKE_CURRENT_LIST_DIR}/FindPython_test.cpp"
-		LINK_LIBRARIES "${PYTHON_LIBRARY}"
-		CMAKE_FLAGS
-			"-DINCLUDE_DIRECTORIES=${PYTHON_INCLUDE_DIR}"
+		SOURCES "${CMAKE_CURRENT_LIST_DIR}/FindPython_test.cpp"
+		LINK_LIBRARIES "${PYTHON_LIBRARY_NAME}"
+		CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${PYTHON_INCLUDE_DIR}" "-DLINK_DIRECTORIES=${PYTHON_LIBRARY_DIR}"
 		OUTPUT_VARIABLE PYTHON_TEST_OUTPUT
 	)
 
 	if(PYTHON_TEST_RESULT)
+		message("-- Looking for suitable python3 - Success: ${PYTHON}")
 		set(PYTHON_INTERP "${PYTHON}")
+		set(PYTHON_LIBRARY "-l${PYTHON_LIBRARY_NAME} -L${PYTHON_LIBRARY_DIR}")
 		break()
 	else()
-		set(PYTHON_TEST_ERRORS "${PYTHON_TEST_ERRORS}candidate ${PYTHON}:\n${PYTHON_TEST_OUTPUT}\n\n")
+		set(PYTHON_TEST_ERRORS "${PYTHON_TEST_ERRORS}python candidate ${PYTHON}:\n${PYTHON_TEST_OUTPUT}\n\n")
 	endif()
 endforeach()
 

--- a/buildsystem/modules/FindSDL2.cmake
+++ b/buildsystem/modules/FindSDL2.cmake
@@ -1,7 +1,7 @@
 # This file was taken from openmw,
 # Copyright 2003-2009 Kitware, Inc.
 # It's licensed under the terms of the 3-clause OpenBSD license.
-# Modifications Copyright 2014-2015 the openage authors.
+# Modifications Copyright 2014-2016 the openage authors.
 # See copying.md for further legal info.
 
 # Locate SDL2 library
@@ -94,7 +94,7 @@ if(NOT APPLE)
 endif()
 
 # MinGW needs an additional library, mwindows
-# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# Its total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
 # (Actually on second look, I think it only needs one of the m* libraries.)
 if(MINGW)
 	set(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")

--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -219,7 +219,7 @@ function(python_finalize)
 
 	get_property(pxdgen_sources GLOBAL PROPERTY SFT_PXDGEN_SOURCES)
 	get_property(generated_pxd_list GLOBAL PROPERTY SFT_GENERATED_PXD_FILES)
-	file(WRITE "${CMAKE_BINARY_DIR}/py/pxdgen_sources" "${pxdgen_sources}")
+	write_on_change("${CMAKE_BINARY_DIR}/py/pxdgen_sources" "${pxdgen_sources}")
 	set(PXDGEN_TIMEFILE "${CMAKE_BINARY_DIR}/py/pxdgen_timefile")
 	add_custom_command(OUTPUT "${PXDGEN_TIMEFILE}" ${generated_pxd_list}
 		COMMAND "${PYTHON}" -m buildsystem.pxdgen
@@ -235,11 +235,11 @@ function(python_finalize)
 	# cythonize (.pyx -> .cpp)
 
 	get_property(cython_modules GLOBAL PROPERTY SFT_CYTHON_MODULES)
-	file(WRITE "${CMAKE_BINARY_DIR}/py/cython_modules" "${cython_modules}")
+	write_on_change("${CMAKE_BINARY_DIR}/py/cython_modules" "${cython_modules}")
 	get_property(cython_modules_embed GLOBAL PROPERTY SFT_CYTHON_MODULES_EMBED)
-	file(WRITE "${CMAKE_BINARY_DIR}/py/cython_modules_embed" "${cython_modules_embed}")
+	write_on_change("${CMAKE_BINARY_DIR}/py/cython_modules_embed" "${cython_modules_embed}")
 	get_property(pxd_list GLOBAL PROPERTY SFT_PXD_FILES)
-	file(WRITE "${CMAKE_BINARY_DIR}/py/pxd_list" "${pxd_list}")
+	write_on_change("${CMAKE_BINARY_DIR}/py/pxd_list" "${pxd_list}")
 	set(CYTHONIZE_TIMEFILE "${CMAKE_BINARY_DIR}/py/cythonize_timefile")
 	add_custom_command(OUTPUT "${CYTHONIZE_TIMEFILE}"
 		COMMAND "${PYTHON}" -m buildsystem.cythonize
@@ -269,7 +269,7 @@ function(python_finalize)
 	get_property(py_files_srcdirs GLOBAL PROPERTY SFT_PY_FILES_RELSRCDIRS)
 	get_property(py_files_noinstall GLOBAL PROPERTY SFT_PY_FILES_NOINSTALL)
 
-	file(WRITE "${CMAKE_BINARY_DIR}/py/py_files" "${py_files}")
+	write_on_change("${CMAKE_BINARY_DIR}/py/py_files" "${py_files}")
 	set(COMPILEPY_TIMEFILE "${CMAKE_BINARY_DIR}/py/compilepy_timefile")
 	add_custom_command(OUTPUT "${COMPILEPY_TIMEFILE}"
 		COMMAND "${PYTHON}" -m buildsystem.compilepy

--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -19,11 +19,14 @@ function(python_init)
 	# filled with all .py filenames; used for installing.
 	set_property(GLOBAL PROPERTY SFT_PY_FILES)
 
+	# filled with the relative source dirs of the above py files.
+	set_property(GLOBAL PROPERTY SFT_PY_FILES_RELSRCDIRS)
+
+	# filled with all .py filenames that should not be installed
+	set_property(GLOBAL PROPERTY SFT_PY_FILES_NOINSTALL)
+
 	# filled with all cython module target names; used for in-place creation.
 	set_property(GLOBAL PROPERTY SFT_CYTHON_MODULE_TARGETS)
-
-	# filled with all __pycache__ folders that have already been selected for installation.
-	set_property(GLOBAL PROPERTY SFT_INSTALLED_PYCACHE_FOLDERS)
 endfunction()
 
 
@@ -186,35 +189,26 @@ function(add_py_modules)
 
 	file(RELATIVE_PATH REL_CURRENT_SOURCE_DIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
+	set(NOINSTALL_NEXT FALSE)
 	foreach(source ${ARGN})
-		if(NOT ${source} MATCHES ".*\\.py$")
-			message(FATAL_ERROR "non-Python file given to add_py_modules: ${source}")
-		endif()
-
-		if(NOT IS_ABSOLUTE ${source})
-			set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
-		endif()
-
-		set_property(GLOBAL APPEND PROPERTY SFT_PY_FILES "${source}")
-
-		get_source_file_property(DONT_INSTALL ${source} NOINSTALL)
-		if(NOT DONT_INSTALL)
-			install(
-				FILES "${source}"
-				DESTINATION  "${CMAKE_PY_INSTALL_PREFIX}/${REL_CURRENT_SOURCE_DIR}"
-			)
-
-			# install the corresponding __pycache__ folder, but at most once.
-			get_filename_component(DIR_NAME "${source}" DIRECTORY)
-			get_property(installed_pycache_folders GLOBAL PROPERTY SFT_INSTALLED_PYCACHE_FOLDERS)
-			list(FIND installed_pycache_folders "${DIR_NAME}" idx)
-			if(idx LESS 0)
-				install(
-					DIRECTORY "${DIR_NAME}/__pycache__"
-					DESTINATION  "${CMAKE_PY_INSTALL_PREFIX}/${REL_CURRENT_SOURCE_DIR}"
-				)
-				set_property(GLOBAL APPEND PROPERTY SFT_INSTALLED_PYCACHE_FOLDERS "${DIR_NAME}")
+		if(source STREQUAL "NOINSTALL")
+			set(NOINSTALL_NEXT TRUE)
+		else()
+			if(NOT ${source} MATCHES ".*\\.py$")
+				message(FATAL_ERROR "non-Python file given to add_py_modules: ${source}")
 			endif()
+
+			if(NOT IS_ABSOLUTE ${source})
+				set(source "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
+			endif()
+
+			if(NOINSTALL_NEXT)
+				set_property(GLOBAL APPEND PROPERTY SFT_PY_FILES_NOINSTALL "${source}")
+				set(NOINSTALL_NEXT FALSE)
+			endif()
+
+			set_property(GLOBAL APPEND PROPERTY SFT_PY_FILES "${source}")
+			set_property(GLOBAL APPEND PROPERTY SFT_PY_FILES_RELSRCDIRS "${REL_CURRENT_SOURCE_DIR}")
 		endif()
 	endforeach()
 endfunction()
@@ -269,17 +263,53 @@ function(python_finalize)
 
 	# py compile (.py -> .pyc)
 
+	set_property(GLOBAL APPEND PROPERTY SFT_PY_FILES_RELSRCDIRS "lol test")
+
 	get_property(py_files GLOBAL PROPERTY SFT_PY_FILES)
+	get_property(py_files_srcdirs GLOBAL PROPERTY SFT_PY_FILES_RELSRCDIRS)
+	get_property(py_files_noinstall GLOBAL PROPERTY SFT_PY_FILES_NOINSTALL)
+
 	file(WRITE "${CMAKE_BINARY_DIR}/py/py_files" "${py_files}")
 	set(COMPILEPY_TIMEFILE "${CMAKE_BINARY_DIR}/py/compilepy_timefile")
 	add_custom_command(OUTPUT "${COMPILEPY_TIMEFILE}"
-		COMMAND "${PYTHON}" -m compileall openage
+		COMMAND "${PYTHON}" -m buildsystem.compilepy
+		"${CMAKE_BINARY_DIR}/py/py_files"
+		"${CMAKE_SOURCE_DIR}"
+		"${CMAKE_SOURCE_DIR}"
 		COMMAND "${CMAKE_COMMAND}" -E touch "${COMPILEPY_TIMEFILE}"
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-		DEPENDS ${py_files}
-		COMMENT "compiling .py files to .pyc files in __pycache__"
+		DEPENDS "${CMAKE_BINARY_DIR}/py/py_files" "${py_files}"
+		COMMENT "compiling .py files to .pyc files"
 	)
 	add_custom_target(compilepy ALL DEPENDS "${COMPILEPY_TIMEFILE}")
+
+	# determine the compiled file name for all source files
+	# avoid doing this call for each file, instead, batch-process.
+	# BUT: i'm unsure when exactly this is called again
+	#      (if a new file was added to the py_files?)
+	py_exec("from importlib import util; print(';'.join(util.cache_from_source(f) for f in open('${CMAKE_BINARY_DIR}/py/py_files').read().split(';')))" py_compiled_files)
+
+	list(LENGTH py_files py_files_count)
+	math(EXPR py_files_count_range "${py_files_count} - 1")
+
+	foreach(idx RANGE ${py_files_count_range})
+		list(GET py_files ${idx} pyfile)
+		list(GET py_compiled_files ${idx} pycfile)
+		list(GET py_files_srcdirs ${idx} pyrelsrcdir)
+
+		# install if it's not in that list.
+		list(FIND py_files_noinstall "${pyfile}" do_install)
+		if(do_install)
+			install(
+				FILES "${pyfile}"
+				DESTINATION  "${CMAKE_PY_INSTALL_PREFIX}/${pyrelsrcdir}"
+			)
+			install(
+				FILES "${pycfile}"
+				DESTINATION "${CMAKE_PY_INSTALL_PREFIX}/${pyrelsrcdir}/__pycache__"
+			)
+		endif()
+	endforeach()
 
 
 	# inplace module install (bin/module.so -> module.so)

--- a/buildsystem/util.cmake
+++ b/buildsystem/util.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 set(AUTOGEN_WARNING "warning: auto-generated file by cmake. look at the template file instead.")
 
@@ -22,4 +22,21 @@ function(pretty_print_target type targetname targetproperties)
 	set(pretty_message "${targetname} ${targetproperties}")
 	string(STRIP "${pretty_message}" pretty_message)
 	message("\t${pretty_message}")
+endfunction()
+
+
+function(write_on_change filename content)
+	# write the content to filename if it is different than
+	# what's already in that file (if exists)
+	# if the file doesn't exist, create it.
+
+	unset(current_content)
+
+	if(EXISTS ${filename})
+		file(READ ${filename} current_content)
+	endif()
+
+	if(NOT current_content STREQUAL content)
+		file(WRITE "${filename}" "${content}")
+	endif()
 endfunction()

--- a/configure
+++ b/configure
@@ -83,10 +83,10 @@ ap.add_argument("--compiler", "-c",
                 help="compiler suite")
 ap.add_argument("--c-compiler",
                 default=getenv("CC"),
-                help="c compiler executable")
+                help="c compiler executable, default=$ENV[CC]")
 ap.add_argument("--cpp-compiler",
                 default=getenv("CXX"),
-                help="c++ compiler executable")
+                help="c++ compiler executable, default=$ENV[CXX]")
 ap.add_argument("--with", action='append', dest='with_', metavar='OPTION',
                 help="enable optional functionality")
 ap.add_argument("--without", action='append', metavar='OPTION',

--- a/configure
+++ b/configure
@@ -81,9 +81,6 @@ ap.add_argument("--sanitize-fatal", action='store_true',
 ap.add_argument("--compiler", "-c",
                 default="",
                 help="compiler suite")
-ap.add_argument("--c-compiler",
-                default=getenv("CC"),
-                help="c compiler executable, default=$ENV[CC]")
 ap.add_argument("--cpp-compiler",
                 default=getenv("CXX"),
                 help="c++ compiler executable, default=$ENV[CXX]")
@@ -152,8 +149,11 @@ elif mode == 'release':
 
 defines.update(build_type=build_type)
 
-# maps csuite names to lists of (cc, cxx, other aliases...)
-csuites = {"gnu": ("gcc", "g++"), "llvm": ("clang", "clang++")}
+# maps suite name -> (cxxname, aliases...)
+csuites = {
+    "gnu": ("g++", "gcc"),
+    "llvm": ("clang++", "clang"),
+}
 
 
 def getcsuite(name):
@@ -164,53 +164,15 @@ def getcsuite(name):
     else:
         raise ValueError("unknown compiler: %s" % name)
 
-# determine compiler binaries from args.{c_compiler, cxx_compiler, compiler}
-if args.compiler and (args.c_compiler or args.cpp_compiler):
+# determine compiler binaries from args.{cxx_compiler, compiler}
+if args.compiler and args.cpp_compiler:
     ap.error("""either specify a compiler suite via --compiler, or manually \
-specify the C and C++ compilers via --c-compiler and --cpp-compiler""")
+specify the C++ compiler via --cpp-compiler""")
 
-if args.c_compiler or args.cpp_compiler:
-    cc = args.c_compiler
+if args.cpp_compiler:
     cxx = args.cpp_compiler
-    if cc and cxx:
-        # both CC and CXX have been specified manually
-        try:
-            csuite = getcsuite(cc)
-        except ValueError:
-            print("warning: could not identify compiler: %s" % cc)
-            csuite = 'unknown'
-    else:
-        # only one has been specified manually; auto-determine the other
-        if cc:
-            known = cc
-            unknownindex = 1
-        else:
-            known = cxx
-            unknownindex = 0
-
-        knowndir, knownbasename = os.path.split(known)
-        knownbasename, knownext = os.path.splitext(knownbasename)
-        try:
-            knownbasename, knownver = knownbasename.split('-', maxsplit=1)
-            knownver = "-%s" % knownver
-        except ValueError:
-            knownver = ""
-
-        try:
-            csuite = getcsuite(knownbasename)
-        except ValueError:
-            ap.error("could not identify compiler: %s" % known)
-
-        unknownbasename = csuites[csuite.lower()][unknownindex]
-        unknownbasename = "".join((unknownbasename, knownver, knownext))
-        unknown = os.path.join(knowndir, unknownbasename)
-
-        if not cc:
-            cc = unknown
-        if not cxx:
-            cxx = unknown
 else:
-    # neither CC, nor CXX has been specified
+    # CXX has not been specified
     compiler = args.compiler
     if not compiler:
         if sys.platform.startswith('darwin'):
@@ -223,24 +185,23 @@ else:
         # look up csuite name (e.g. gcc -> gnu)
         csuite = getcsuite(compiler)
     except ValueError:
-        ap.error("unknown compiler suite: %s. manually specify --c-compiler \
-and --cpp-compiler, or use one of [%s]" % (compiler, ", ".join(csuites)))
+        ap.error("unknown compiler suite: %s. "
+                 "manually specify --cpp-compiler, or use one of [%s]" % (
+                     compiler, ", ".join(csuites)))
 
-    cc, cxx = csuites[csuite][:2]
+    cxx = csuites[csuite][0]
 
-# test whether the specified compilers actually exist
-if not shutil.which(cc):
-    ap.error('could not find c compiler executable: %s' % cc)
-
+# test whether the specified compiler actually exists
 if not shutil.which(cxx):
     ap.error('could not find c++ compiler executable: %s' % cxx)
 
 print('compiler suite: %s\n' % csuite)
 
-defines.update(c_compiler=cc, cxx_compiler=cxx)
+defines.update(cxx_compiler=cxx)
 
-defines.update(c_flags=args.flags, cxx_flags=args.flags, exe_linker_flags=args.ldflags,
-               module_linker_flags=args.ldflags, shared_linker_flags=args.ldflags)
+defines.update(cxx_flags=args.flags, exe_linker_flags=args.ldflags,
+               module_linker_flags=args.ldflags,
+               shared_linker_flags=args.ldflags)
 
 if args.sanitize == 'none' and args.sanitize_fatal:
     ap.error('--sanitize-fatal only valid with --sanitize')
@@ -272,7 +233,7 @@ def sanitize_for_filename(s, fallback='-'):
     return "".join(yieldsanitizedchars())
 
 bindir = ".bin/%s-%s-%s" % (
-    sanitize_for_filename(cc),
+    sanitize_for_filename(cxx),
     sanitize_for_filename(mode),
     sanitize_for_filename("-O%s -sanitize=%s" % (args.optimize, args.sanitize)))
 
@@ -306,7 +267,7 @@ maxkeylen = max(len(k) for k in defines)
 for k, v in sorted(defines.items()):
     print('%s | %s' % (k.rjust(maxkeylen), v))
 
-    if k in ('c_compiler', 'cxx_compiler'):
+    if k in ('cxx_compiler',):
         # work around this cmake 'feature':
         # when run in an existing build directory, if CC or CXX are given,
         # all other arguments are ignored... this is retarded.

--- a/configure
+++ b/configure
@@ -1,21 +1,37 @@
 #!/usr/bin/env python3
 
-# Copyright 2013-2015 the openage authors. See copying.md for legal info.
+# Copyright 2013-2016 the openage authors. See copying.md for legal info.
 
-# Together with the Makefile, ./configure provides an autotools-like build
-# experience. For more info, see --help and doc/buildsystem.
+"""
+openage autocancer-like cmake frontend.
 
-import sys
-if not sys.version_info >= (3, 4):
-    print("openage requires Python 3.4 or higher")
-    exit(1)
+Together with the Makefile, ./configure provides an autotools-like build
+experience. For more info, see --help and doc/buildsystem.
+"""
 
 import argparse
 import os
-import subprocess
-import shutil
 import shlex
-shlex.join = lambda args: ' '.join(shlex.quote(a) for a in args)
+import shutil
+import subprocess
+import sys
+
+if sys.version_info < (3, 4):
+    print("openage requires Python 3.4 or higher")
+    exit(1)
+
+
+# argparsing
+DESCRIPTION = """./configure is a convenience script:
+it creates the build directory,  symlinks it,
+and invokes cmake for an out-of-source build.
+
+Nobody is stopping you from skipping ./configure and our Makefile,
+and using CMake directly (e.g. when packaging, or using an IDE).
+For your convenience, ./configure even prints the direct CMake invocation!"""
+
+EPILOG = """environment variables like CXX, CXXFLAGS, LDFLAGS are honored, \
+but overwritten by command-line arguments."""
 
 
 def getenv(*varnames, default=""):
@@ -24,9 +40,9 @@ def getenv(*varnames, default=""):
     tries all given varnames until it finds an existing one.
     if none fits, returns default.
     """
-    for v in varnames:
-        if v in os.environ:
-            return os.environ[v]
+    for var in varnames:
+        if var in os.environ:
+            return os.environ[var]
 
     return default
 
@@ -43,280 +59,303 @@ def getenv_bool(varname):
     return bool(value)
 
 
-# argparsing
-description = """./configure is a convenience script that creates the build \
-directory,
-symlinks it, and invokes cmake for an out-of-source build.
+def features(args, parser):
+    """
+    Enable or disable optional features.
+    If a feature is not explicitly enabled/disabled,
+    the defaults below will be used.
+    """
 
-Nobody is stopping you from skipping ./configure and Makefile,
-and using CMake directly (e.g. when packaging, or using an IDE).
-For your convenience, ./configure even prints the direct CMake invocation!"""
+    options = {
+        "backtrace": "if_available",
+        "inotify": "if_available",
+        "gperftools-tcmalloc": False,
+        "gperftools-profiler": "if_available",
+    }
 
-epilog = """environment variables like CXX and CXXFLAGS are honored, \
-but overwritten by command-line arguments."""
+    def sanitize_option_name(option):
+        """ Check if the given feature exists """
+        if option not in options:
+            parser.error("unknown feature: '{}'.\n"
+                         "available features:\n   {}".format(
+                             option, '\n   '.join(options)))
 
-ap = argparse.ArgumentParser(
-    description=description,
-    epilog=epilog,
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    if args.with_:
+        for arg in args.with_:
+            sanitize_option_name(arg)
+            options[arg] = True
 
-ap.add_argument("--mode", "-m",
-                choices=["debug", "release"],
-                default=getenv("BUILDMODE", default="debug"),
-                help="controls cmake build mode")
-ap.add_argument("--optimize", "-O",
-                choices=["auto", "0", "1", "g", "2", "max"],
-                default=getenv("OPTIMIZE", default="auto"),
-                help="controls optimization-related flags. " +
-                     "is set according to mode if 'auto'. " +
-                     "conflicts with --flags")
-ap.add_argument("--sanitize",
-                choices=["none", "yes", "mem", "thread"],
-                default=getenv("SANITIZER", default="none"),
-                help=("enable one of those (run-time) code sanitizers."
-                      "'yes' enables the address and undefined sanitizers."))
-ap.add_argument("--sanitize-fatal", action='store_true',
-                default=getenv_bool("SANITIZER_FATAL"),
-                help="With --sanitize, abort program execution on first find.")
-ap.add_argument("--compiler", "-c",
-                default="",
-                help="compiler suite")
-ap.add_argument("--cpp-compiler",
-                default=getenv("CXX"),
-                help="c++ compiler executable, default=$ENV[CXX]")
-ap.add_argument("--with", action='append', dest='with_', metavar='OPTION',
-                help="enable optional functionality")
-ap.add_argument("--without", action='append', metavar='OPTION',
-                help="disable optional functionality")
-ap.add_argument("--flags", "-f",
-                default=getenv("CXXFLAGS", "CCFLAGS", "CFLAGS"),
-                help="compiler flags")
-ap.add_argument("--ldflags", "-l",
-                default=getenv("LDFLAGS"),
-                help="linker flags")
-ap.add_argument("--prefix", "-p", default="/usr/local",
-                help="installation directory prefix")
-ap.add_argument("--py-prefix", default=None,
-                help="python module installation directory prefix")
-ap.add_argument("--dry-run", action='store_true',
-                help="do not actually invoke cmake or create any directories")
-ap.add_argument("--cmake-binary", default="cmake",
-                help="path to the cmake binary")
-ap.add_argument("--raw-cmake-args", nargs=argparse.REMAINDER, default=[],
-                help="everything that follows is passed to cmake directly")
+    if args.without:
+        for arg in args.without:
+            sanitize_option_name(arg)
+            options[arg] = False
 
-args = ap.parse_args()
-
-try:
-    subprocess.call(['cowsay', '--', description])
-    print("")
-except:
-    print(description)
-    print("")
-
-defines = {}
-
-options = {
-    "backtrace":           "if_available",
-    "inotify":             "if_available",
-    "gperftools-tcmalloc": False,
-    "gperftools-profiler": "if_available",
-}
+    return options
 
 
-def sanitize_option_name(option):
-    if option not in options:
-        ap.error("unknown option: '{}'.\navailable options:\n\t{}".format(
-            option, '\n\t'.join(options)))
+def build_type(args):
+    """ Set the cmake build type """
+    mode = args.mode
+    if mode == 'debug':
+        ret = 'Debug'
+    elif mode == 'release':
+        ret = 'Release'
 
-if args.with_:
-    for x in args.with_:
-        sanitize_option_name(x)
-        options[x] = True
-
-if args.without:
-    for x in args.without:
-        sanitize_option_name(x)
-        options[x] = False
+    return {
+        "build_type": ret
+    }
 
 
-# args.mode
-mode = args.mode
-if mode == 'debug':
-    build_type = 'Debug'
-elif mode == 'release':
-    build_type = 'Release'
+def get_compiler(args, parser):
+    """
+    Compute the compiler executable name
+    """
 
-defines.update(build_type=build_type)
-
-# maps suite name -> (cxxname, aliases...)
-csuites = {
-    "gnu": ("g++", "gcc"),
-    "llvm": ("clang++", "clang"),
-}
-
-
-def getcsuite(name):
-    name = name.lower().strip()
-    for csuite, aliases in csuites.items():
-        if name == csuite or name in aliases:
-            return csuite
+    # determine compiler binaries from args.compiler
+    if args.compiler:
+        cxx = args.compiler
     else:
-        raise ValueError("unknown compiler: %s" % name)
-
-# determine compiler binaries from args.{cxx_compiler, compiler}
-if args.compiler and args.cpp_compiler:
-    ap.error("""either specify a compiler suite via --compiler, or manually \
-specify the C++ compiler via --cpp-compiler""")
-
-if args.cpp_compiler:
-    cxx = args.cpp_compiler
-else:
-    # CXX has not been specified
-    compiler = args.compiler
-    if not compiler:
+        # CXX has not been specified
         if sys.platform.startswith('darwin'):
-            compiler = 'llvm'
+            cxx = 'clang++'
         else:
             # default to gnu compiler suite
-            compiler = 'gnu'
+            cxx = 'g++'
 
+    # test whether the specified compiler actually exists
+    if not shutil.which(cxx):
+        parser.error('could not find c++ compiler executable: %s' % cxx)
+
+    return {
+        "cxx_compiler": cxx,
+        "cxx_flags": args.flags,
+        "exe_linker_flags": args.ldflags,
+        "module_linker_flags": args.ldflags,
+        "shared_linker_flags": args.ldflags,
+    }
+
+
+def get_install_prefixes(args):
+    """
+    Determine the install prefix configuration.
+    """
+
+    ret = {
+        "install_prefix": args.prefix,
+    }
+
+    if args.py_prefix is not None:
+        ret["py_install_prefix"] = args.py_prefix
+
+    return ret
+
+
+def bindir_creation(args, defines):
+    """
+    configuration for the sanitizer addons for gcc and clang.
+    """
+
+    def sanitize_for_filename(txt, fallback='-'):
+        """
+        sanitizes a string for safe usage in a filename
+        """
+
+        def yieldsanitizedchars():
+            """ generator for sanitizing the output folder name """
+            # False if the previous char was regular.
+            fallingback = True
+            for char in txt:
+                if char == fallback and fallingback:
+                    fallingback = False
+                elif char.isalnum() or char in "+-_,":
+                    fallingback = False
+                    yield char
+                elif not fallingback:
+                    fallingback = True
+                    yield fallback
+
+        return "".join(yieldsanitizedchars())
+
+    bindir = ".bin/%s-%s-%s" % (
+        sanitize_for_filename(defines["cxx_compiler"]),
+        sanitize_for_filename(args.mode),
+        sanitize_for_filename("-O%s -sanitize=%s" % (
+            args.optimize, args.sanitize)))
+
+    if not args.dry_run:
+        os.makedirs(bindir, exist_ok=True)
+
+
+    def forcesymlink(linkto, name):
+        """ similar in function to ln -sf """
+        if args.dry_run:
+            return
+
+        try:
+            os.unlink(name)
+        except FileNotFoundError:
+            pass
+
+        os.symlink(linkto, name)
+
+    # create the build dir and symlink it to 'bin'
+    forcesymlink(bindir, 'bin')
+
+    return bindir
+
+
+def invoke_cmake(args, bindir, defines, options):
+    """
+    run cmake.
+    """
+
+    # the project root directory contains this configure file.
+    project_root = os.path.dirname(os.path.realpath(__file__))
+
+    # calculate cmake invocation from defines dict
+    invocation = [args.cmake_binary]
+    maxkeylen = max(len(k) for k in defines)
+    for key, val in sorted(defines.items()):
+        print('%s | %s' % (key.rjust(maxkeylen), val))
+
+        if key in {'cxx_compiler',}:
+            # work around this cmake 'feature':
+            # when run in an existing build directory, if CXX is given,
+            # all other arguments are ignored... this is retarded.
+            if os.path.exists(os.path.join(bindir, 'CMakeCache.txt')):
+                continue
+
+        invocation.append('-DCMAKE_%s=%s' % (key.upper(), shlex.quote(val)))
+
+    cxx_options = dict()
+    cxx_options["CXX_OPTIMIZATION_LEVEL"] = args.optimize
+    cxx_options["CXX_SANITIZE_MODE"] = args.sanitize
+    cxx_options["CXX_SANITIZE_FATAL"] = args.sanitize_fatal
+    for key, val in sorted(cxx_options.items()):
+        invocation.append('-D%s=%s' % (key, val))
+
+    print("\nconfig options:\n")
+
+    maxkeylen = max(len(k) for k in options)
+    for key, val in sorted(options.items()):
+        print('%s | %s' % (key.rjust(maxkeylen), val))
+
+        invocation.append('-DWANT_%s=%s' % (
+            key.upper().replace('-', '_'), val))
+
+    for raw_cmake_arg in args.raw_cmake_args:
+        invocation.append(raw_cmake_arg)
+
+    invocation.append('--')
+    invocation.append(project_root)
+
+    # look for traces of an in-source build
+
+    if os.path.isfile('CMakeCache.txt'):
+        print("\nwarning: found traces of an in-source build.")
+        print("CMakeCache.txt was deleted to make building possible.")
+        print("run 'make cleaninsourcebuild' to fully wipe the traces.")
+        os.remove('CMakeCache.txt')
+
+    # switch to build directory
+    print('\nbindir:\n%s/\n' % os.path.join(project_root, bindir))
+    if not args.dry_run:
+        os.chdir(bindir)
+
+    # invoke cmake
     try:
-        # look up csuite name (e.g. gcc -> gnu)
-        csuite = getcsuite(compiler)
-    except ValueError:
-        ap.error("unknown compiler suite: %s. "
-                 "manually specify --cpp-compiler, or use one of [%s]" % (
-                     compiler, ", ".join(csuites)))
-
-    cxx = csuites[csuite][0]
-
-# test whether the specified compiler actually exists
-if not shutil.which(cxx):
-    ap.error('could not find c++ compiler executable: %s' % cxx)
-
-print('compiler suite: %s\n' % csuite)
-
-defines.update(cxx_compiler=cxx)
-
-defines.update(cxx_flags=args.flags, exe_linker_flags=args.ldflags,
-               module_linker_flags=args.ldflags,
-               shared_linker_flags=args.ldflags)
-
-if args.sanitize == 'none' and args.sanitize_fatal:
-    ap.error('--sanitize-fatal only valid with --sanitize')
-
-# args.prefix
-defines.update(install_prefix=args.prefix)
-if args.py_prefix is not None:
-    defines.update(py_install_prefix=args.py_prefix)
-
-
-def sanitize_for_filename(s, fallback='-'):
-    """
-    sanitizes a string for safe usage in a filename
-    """
-
-    def yieldsanitizedchars():
-        # False if the previous char was regular.
-        fallingback = True
-        for c in s:
-            if c == fallback and fallingback:
-                fallingback = False
-            elif c.isalnum() or c in "+-_,":
-                fallingback = False
-                yield c
-            elif not fallingback:
-                fallingback = True
-                yield fallback
-
-    return "".join(yieldsanitizedchars())
-
-bindir = ".bin/%s-%s-%s" % (
-    sanitize_for_filename(cxx),
-    sanitize_for_filename(mode),
-    sanitize_for_filename("-O%s -sanitize=%s" % (args.optimize, args.sanitize)))
-
-if not args.dry_run:
-    os.makedirs(bindir, exist_ok=True)
-
-
-def forcesymlink(linkto, name):
-    """
-    similar in function to ln -sf
-    """
-    if args.dry_run:
-        return
-
-    try:
-        os.unlink(name)
+        print('invocation:\n%s\n' % ' '.join(invocation))
+        if args.dry_run:
+            exit(0)
+        else:
+            exit(subprocess.call(invocation))
     except FileNotFoundError:
-        pass
-
-    os.symlink(linkto, name)
-
-# create the build dir and symlink it to 'bin'
-forcesymlink(bindir, 'bin')
-
-# the project root directory contains this configure file.
-project_root = os.path.dirname(os.path.realpath(__file__))
-
-# calculate cmake invocation from defines dict
-invocation = [args.cmake_binary]
-maxkeylen = max(len(k) for k in defines)
-for k, v in sorted(defines.items()):
-    print('%s | %s' % (k.rjust(maxkeylen), v))
-
-    if k in ('cxx_compiler',):
-        # work around this cmake 'feature':
-        # when run in an existing build directory, if CC or CXX are given,
-        # all other arguments are ignored... this is retarded.
-        if os.path.exists(os.path.join(bindir, 'CMakeCache.txt')):
-            continue
-
-    invocation.append('-DCMAKE_%s=%s' % (k.upper(), shlex.quote(v)))
-
-cxx_options = dict()
-cxx_options["CXX_OPTIMIZATION_LEVEL"] = args.optimize
-cxx_options["CXX_SANITIZE_MODE"] = args.sanitize
-cxx_options["CXX_SANITIZE_FATAL"] = args.sanitize_fatal
-for k, v in sorted(cxx_options.items()):
-    invocation.append('-D%s=%s' % (k, v))
-
-print("\nconfig options:\n")
-
-maxkeylen = max(len(k) for k in options)
-for k, v in sorted(options.items()):
-    print('%s | %s' % (k.rjust(maxkeylen), v))
-
-    invocation.append('-DWANT_%s=%s' % (k.upper().replace('-', '_'), v))
+        print("cmake was not found")
+        exit(1)
 
 
-for raw_cmake_arg in args.raw_cmake_args:
-    invocation.append(raw_cmake_arg)
+def main(args, parser):
+    """
+    Compose the cmake invocation.
+    Basically does what many distro package managers do as well.
+    """
 
-invocation.append('--')
-invocation.append(project_root)
+    try:
+        subprocess.call(['cowsay', '--', DESCRIPTION])
+        print("")
+    except (FileNotFoundError, PermissionError):
+        print(DESCRIPTION)
+        print("")
 
-# look for traces of an in-source build
-if os.path.isfile('CMakeCache.txt'):
-    print("\nwarning: found traces of an in-source build.")
-    print("CMakeCache.txt was deleted to make building possible.")
-    print("run 'make cleaninsourcebuild' to fully wipe the traces.")
-    os.remove('CMakeCache.txt')
+    defines = {}
 
-# switch to build directory
-print('\nbindir:\n%s/\n' % os.path.join(project_root, bindir))
-if not args.dry_run:
-    os.chdir(bindir)
+    options = features(args, parser)
+    defines.update(build_type(args))
+    defines.update(get_compiler(args, parser))
+    defines.update(get_install_prefixes(args))
 
-# invoke cmake
-try:
-    print('invocation:\n%s\n' % ' '.join(invocation))
-    if args.dry_run:
-        exit(0)
-    else:
-        exit(subprocess.call(invocation))
-except FileNotFoundError:
-    print("cmake was not found")
-    exit(1)
+    bindir = bindir_creation(args, defines)
+    invoke_cmake(args, bindir, defines, options)
+
+
+def parse_args():
+    """ argument parsing """
+
+    cli = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        epilog=EPILOG,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    cli.add_argument("--mode", "-m",
+                     choices=["debug", "release"],
+                     default=getenv("BUILDMODE", default="debug"),
+                     help="controls cmake build mode")
+    cli.add_argument("--optimize", "-O",
+                     choices=["auto", "0", "1", "g", "2", "3", "max"],
+                     default=getenv("OPTIMIZE", default="auto"),
+                     help=("controls optimization-related flags. " +
+                           "is set according to mode if 'auto'. " +
+                           "conflicts with --flags"))
+    cli.add_argument("--sanitize",
+                     choices=["none", "yes", "mem", "thread"],
+                     default=getenv("SANITIZER", default="none"),
+                     help=("enable one of those (run-time) code sanitizers."
+                           "'yes' enables the address and "
+                           "undefined sanitizers."))
+    cli.add_argument("--sanitize-fatal", action='store_true',
+                     default=getenv_bool("SANITIZER_FATAL"),
+                     help="With --sanitize, stop execution on first problem.")
+    cli.add_argument("--compiler", "-c",
+                     default=getenv("CXX"),
+                     help="c++ compiler executable, default=$ENV[CXX]")
+    cli.add_argument("--with", action='append', dest='with_', metavar='OPTION',
+                     help="enable optional functionality")
+    cli.add_argument("--without", action='append', metavar='OPTION',
+                     help="disable optional functionality")
+    cli.add_argument("--flags", "-f",
+                     default=getenv("CXXFLAGS", "CCFLAGS", "CFLAGS"),
+                     help="compiler flags")
+    cli.add_argument("--ldflags", "-l",
+                     default=getenv("LDFLAGS"),
+                     help="linker flags")
+    cli.add_argument("--prefix", "-p", default="/usr/local",
+                     help="installation directory prefix")
+    cli.add_argument("--py-prefix", default=None,
+                     help="python module installation directory prefix")
+    cli.add_argument("--dry-run", action='store_true',
+                     help="just print the cmake invocation without callint it")
+    cli.add_argument("--cmake-binary", default="cmake",
+                     help="path to the cmake binary")
+    cli.add_argument("--raw-cmake-args", nargs=argparse.REMAINDER, default=[],
+                     help="all following args are passed directly to cmake")
+
+    args = cli.parse_args()
+
+    if args.sanitize == 'none' and args.sanitize_fatal:
+        cli.error('--sanitize-fatal only valid with --sanitize')
+
+    return args, cli
+
+
+if __name__ == "__main__":
+    main(*parse_args())

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -57,6 +57,7 @@ add_sources(libopenage GENERATED ${CODEGEN_TARGET_TUS})
 
 # after this point, no further sources can be added to the executable
 finalize_binary(libopenage openage library allow_no_undefined)
+set_target_properties(libopenage PROPERTIES VERSION 0)
 
 # library dependency specification
 

--- a/libopenage/renderer/font/font.cpp
+++ b/libopenage/renderer/font/font.cpp
@@ -227,7 +227,7 @@ std::unique_ptr<unsigned char> Font::load_glyph(codepoint_t codepoint, Glyph &gl
 			ft_face->glyph->bitmap.buffer + (glyph.height - i - 1) * glyph.width,
 			glyph.width * sizeof(unsigned char));
 	}
-	return std::move(glyph_data);
+	return glyph_data;
 }
 
 }} // openage::renderer

--- a/libopenage/util/stringformatter.cpp
+++ b/libopenage/util/stringformatter.cpp
@@ -8,9 +8,7 @@ namespace openage {
 namespace util {
 
 
-CachableOSStream::CachableOSStream()
-	:
-	flag(ATOMIC_FLAG_INIT) {}
+CachableOSStream::CachableOSStream() {}
 
 
 CachableOSStream::CachableOSStream(std::string &output)

--- a/libopenage/util/stringformatter.h
+++ b/libopenage/util/stringformatter.h
@@ -67,8 +67,10 @@ private:
 	 * true if all of the following are true:
 	 *  - object is part of a larger cache
 	 *  - object is currently in use (-> unavailable)
+	 * http://en.cppreference.com/w/cpp/atomic/ATOMIC_FLAG_INIT
+	 * https://stackoverflow.com/questions/24437396/stdatomic-flag-as-member-variable
 	 */
-	std::atomic_flag flag;
+	std::atomic_flag flag = ATOMIC_FLAG_INIT;
 };
 
 

--- a/openage/CMakeLists.txt
+++ b/openage/CMakeLists.txt
@@ -2,14 +2,12 @@
 get_config_option_string()
 configure_file(config.py.in "${CMAKE_SOURCE_DIR}/openage/config.py")
 
-set_source_files_properties(devmode.py PROPERTIES NOINSTALL TRUE)
-
 add_py_modules(
 	__init__.py
 	__main__.py
 	assets.py
 	config.py
-	devmode.py
+	NOINSTALL devmode.py
 )
 
 add_subdirectory(cabextract)


### PR DESCRIPTION
* Mainly fixes the devmode installation.
* Python files are now compiled by a python script and not by `compileall`
* the `configure` script is now pylint compliant
* We no longer need a c compiler (I hope it's not just because of my cmake `>=3.4.0`)
  * ok, i was wrong. but i "fixed" it by reusing cxx as the c compiler if cmake is `<3.4.0`
* Compiler flags are no longer duplicated
* 2 random warning fixes for move-optimization and atomic_flag initialization
