### PR TITLE
fixes documentation issue #511

### DIFF
--- a/buildsystem/doxygen.cmake
+++ b/buildsystem/doxygen.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 # Doxygen integration
 
@@ -34,7 +34,7 @@ function(doxygen_configure)
 
 		# create doc folder name list
 		foreach(folder ${ARGN})
-			set(DOXYGEN_SCAN_FOLDERS "${DOXYGEN_SCAN_FOLDERS} ${CMAKE_CURRENT_SOURCE_DIR}/${folder}")
+			set(DOXYGEN_SCAN_FOLDERS "${DOXYGEN_SCAN_FOLDERS} \"${CMAKE_CURRENT_SOURCE_DIR}/${folder}\"")
 		endforeach()
 
 		# adapt doxygen config

--- a/copying.md
+++ b/copying.md
@@ -73,6 +73,7 @@ _the openage authors_ are:
 | Patrik Stutz                | VanCoding                   | patrik.stutz@gmail.com                |
 | James McMurray              | jamesmcm                    | jamesmcm03@gmail.com                  |
 | Łukasz Raszka               | lukky513                    | lukky513@gmail.com                    |
+| Martin Castillo             | castilma                    | castilma@uni-bremen.de                |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
If a parent directory of openage contains a space, 'make doc' (or better, doxygen)
splits the absolute path from the INPUT tag in bin/Doxygen in two directorys.
That way, the necessary files cannot be found and no documentation is created.

This commit adds quotation marks to the responsible cmake file.

	geändert:               buildsystem/doxygen.cmake