### PR TITLE
Documentation updates to gamedata structs

### DIFF
--- a/doc/media/gamedata-struct.md
+++ b/doc/media/gamedata-struct.md
@@ -12,10 +12,10 @@ struct {
 	struct {
 		float terrain_accessible[terrain_count];
 		struct {
-			int32_t buildable;
-			int32_t graphic_id0;
-			int32_t graphic_id1;
-			int32_t replication_amount;
+			int32_t slp_id_exit_tile;
+			int32_t slp_id_enter_tile;
+			int32_t slp_id_walk_tile;
+			int32_t walk_sprite_rate;
 		} terrain_pass_graphic[terrain_count];
 	} terrain_restriction[terrain_restriction_count];
 
@@ -29,25 +29,26 @@ struct {
 		int32_t minimap_color;
 		int32_t unknown;
 		int32_t unknown;
-		int32_t unknown;
+		int32_t statistics_text_color;
 	} player_color[player_color_count];
 
 	uint16_t sound_count;
 	struct {
 		int32_t id;
+		int16_t play_at_update_count;
 		uint16_t item_count;
-		int32_t unknown;
+		int32_t cache_time;
 		struct {
 			char filename[13];
 			int32_t resource_id;
 			int16_t probability;
 			int16_t civilisation;
-			int16_t unknown;
+			int16_t player_id;
 		} sound_item[item_count];
 	} sound[sound_count];
 
 	int16_t graphic_count;
-	int32_t graphic_offset[graphic_count];
+	int32_t graphic_offsets[graphic_count];
 	struct {
 		struct {
 			char name0[21];
@@ -57,19 +58,21 @@ struct {
 			int8_t unknown;
 			int8_t layer;
 			int16_t player_color;
+			int8_t adapt_color;
 			bool replay;
 			int16_t coordinates[4];
 			uint16_t delta_count;
 			int16_t sound_id;
-			bool attack_sound_used;
+			uint8_t attack_sound_used;
 			uint16_t frame_count;
 			uint16_t angle_count;
-			float new_speed;
+			float speed_adjust;
 			float frame_rate;
 			float replay_delay;
 			int8_t sequence_type;
 			int16_t id;
 			int16_t mirroring_mode;
+			int8_t unknown;
 		} graphic_header;
 
 		struct {
@@ -94,6 +97,19 @@ struct {
 	} graphic[graphic_count];
 	int8_t[138] rendering_data;
 
+	int32_t map_pointer;
+	int32_t unknown;
+	int32_t map_width;
+	int32_t map_height;
+	int32_t world_width;
+	int32_t world_height;
+	struct {
+		int16_t width;
+		int16_t height;
+		int16_t delta_z;
+	} tile_size[19];
+
+	int16_t unknown;
 	struct {
 		int16_t unknown;
 		int16_t unknown;
@@ -118,7 +134,7 @@ struct {
 		int8_t terrain_border_id[84];
 		int16_t terrain_unit_id[30];
 		int16_t terrain_unit_density[30];
-		int8_t terrain_unit_priority[30];
+		int8_t terrain_placement_flag[30];
 		int16_t terrain_units_used_count;
 	} terrain[terrain_count];
 
@@ -146,9 +162,120 @@ struct {
 		int16_t unknown;
 	} terrain_border[16];
 
-	int8_t zero[28];
+	uint32_t unknown;
+	float map_min_x;
+	float map_min_y;
+	float map_max_x;
+	float map_max_y;
+	float map_max_xplus1;
+	float map_min_yplus1;
 	uint16_t terrain_count_additional;
-	int8_t rendering_etc[12722];
+	uint16_t borders_used;
+	int16_t max_terrain;
+	int16_t tile_width;
+	int16_t tile_height;
+	int16_t tile_half_height;
+	int16_t tile_half_width;
+	int16_t elev_height;
+	int16_t current_row;
+	int16_t current_column;
+	int16_t block_beginn_row;
+	int16_t block_end_row;
+	int16_t block_begin_column;
+	int16_t block_end_column;
+	uint32_t unknown;
+	uint32_t unknown;
+	int8_t any_frame_change;
+	int8_t map_visible_flag;
+	int8_t fog_flag;
+
+	uint8_t terrain_blob0[21];
+	uint32_t terrain_blob1[157];
+
+	uint32_t random_map_count;
+	uint32_t random_map_ptr;
+
+	struct {
+		int32_t script_number;
+		int32_t border_south_west;
+		int32_t border_north_west;
+		int32_t border_north_east;
+		int32_t border_south_east;
+		int32_t border_usage;
+		int32_t water_shape;
+		int32_t non_base_terrain;
+		int32_t base_zone_coverage;
+		int32_t unknown;
+		uint32_t base_zone_count;
+		int32_t base_zone_ptr;
+		uint32_t map_terrain_count;
+		int32_t map_terrain_ptr;
+		uint32_t map_unit_count;
+		int32_t map_unit_ptr;
+		uint32_t unknown;
+		int32_t unknown;
+	} map_header[random_map_count];
+
+	struct {
+		int32_t border_south_west;
+		int32_t border_north_west;
+		int32_t border_north_east;
+		int32_t border_south_east;
+		int32_t border_usage;
+		int32_t water_shape;
+		int32_t non_base_terrain;
+		int32_t base_zone_terrain;
+		int32_t unknown;
+
+		uint32_t base_zone_count;
+		int32_t base_zone_ptr;
+		struct {
+			int32_t unknown;
+			int32_t base_terrain;
+			int32_t spacing_between_players;
+			int32_t unknown;
+			int8_t unknown[4];
+			int32_t unknown;
+			int32_t unknown;
+			int8_t unknown[4];
+			int32_t start_area_radius;
+			int32_t unknown;
+			int32_t unknown;
+		} base_zone[base_zone_count];
+
+		uint32_t map_terrain_count;
+		int32_t map_terrain_ptr;
+		struct {
+			int32_t proportion;
+			int32_t terrain;
+			int32_t number_of_clumps;
+			int32_t spacing_to_other_terrains;
+			int32_t placement_zone;
+			int32_t unknown;
+		} map_terrain[map_terrain_count];
+
+		uint32_t map_unit_count;
+		int32_t map_unit_ptr;
+		struct {
+			int32_t unit;
+			int32_t host_terrain;
+			int8_t unknown[4];
+			int32_t objects_per_group;
+			int32_t fluctuation;
+			int32_t groups_per_player;
+			int32_t group_radius;
+			int32_t own_at_start;
+			int32_t set_place_for_all_players;
+			int32_t min_distance_to_players;
+			int32_t max_distance_to_players;
+		} map_unit[map_unit_count];
+
+		uint32_t map_unknown_count;
+		int32_t map_unknown_ptr;
+		struct {
+			int32_t unknown[6];
+		} map_unknown[map_unknown_count];
+	} map[random_map_count];
 
 	uint32_t tech_count;
 	struct {
@@ -157,54 +284,60 @@ struct {
 		struct {
 			int8_t type_id;
 			int16_t unit;
-			int16_t class_id;
-			int16_t attribute;
+			int16_t unit_class_id;
+			int16_t attribute_id;
 			float amount;
-		} effect[effect_count];
+		} effects[effect_count];
 	} tech[tech_count];
 
 	uint32_t unit_count;
 	struct {
-		bool exists;
+		uint8_t exists;
 		//if(exists) {
-		uint16_t command_count;
+		uint16_t unit_command_count;
 		struct {
-			int16_t one;
-			int16_t uid;
+			int16_t command_used;
+			int16_t id;
 			int8_t unknown;
-			int16_t type_id;
+			int16_t type;
 			int16_t class_id;
 			int16_t unit_id;
-			int16_t unknown;
+			int16_t terrain_id;
 			int16_t resource_in;
-			int16_t sub_type_id;
+			int16_t resource_productivity;
 			int16_t resource_out;
-			int16_t unknown;
-			float work_rate_multiplier;
+			int16_t resource;
+			float quantity;
 			float execution_radius;
 			float extra_range;
 			int8_t unknown;
-			float unknown;
+			float scaring_radius;
 			int8_t selection_enabled;
 			int8_t unknown;
-			int32_t unknown;
+			int16_t plunder_source;
+			int16_t unknown;
+			int8_t targets_allowed;
+			int8_t right_click_mode;
 			int8_t unknown;
-			int8_t unknown;
-			int8_t unknown;
-			int16_t graphic[6];
+			int16_t tool_graphic_id;
+			int16_t proceed_graphic_id;
+			int16_t action_graphic_id;
+			int16_t carrying_graphic_id;
+			int16_t execution_sound_id;
+			int16_t resource_deposit_sound_id;
 		} unit_command[command_count];
 		//}
 	} unit_header[unit_count];
 
 	uint16_t civ_count;
 	struct {
-		int8_t one;
+		int8_t enabled;
 		char name[20];
 		uint16_t resources_count;
 		int16_t tech_tree_id;
 		int16_t team_bonus_id;
 		float[resources_count] resources;
-		int8_t graphic_set;
+		int8_t icon_set;
 		uint16_t unit_count;
 		int32_t unit_offsets[unit_count];
 
@@ -237,11 +370,11 @@ struct {
 				int16_t hit_points;
 				float line_of_sight;
 				int8_t garnison_capacity;
-				float radius_size0;
-				float radius_size1;
-				float hp_bar_height0;
-				int16_t sound_train0;
-				int16_t sound_train1;
+				float radius_x;
+				float radius_y;
+				float radius_z;
+				int16_t sound_creation0;
+				int16_t sound_creation1;
 				int16_t dead_unit_id;
 				int8_t placement_mode;
 				int8_t air_mode;
@@ -249,62 +382,63 @@ struct {
 				int8_t hidden_in_editor;
 				int16_t unknown;
 				int16_t enabled;
-				int16_t placement_by_pass_terrain0;
-				int16_t placement_by_pass_terrain1;
+				int16_t placement_side_terrain0;
+				int16_t placement_side_terrain1;
 				int16_t placement_terrain0;
 				int16_t placement_terrain1;
-				float editor_radius0;
-				float editor_radius1;
+				float clearance_size_x;
+				float clearance_size_y;
 				int8_t building_mode;
 				int8_t visible_in_fog;
 				int16_t terrain_restriction;
 				int8_t fly_mode;
 				int16_t resource_capacity;
 				float resource_decay;
-				int8_t blast_type_id;
-				int8_t unknown;
+				int8_t blast_defense_level;
+				int8_t sub_type;
 				int8_t interaction_mode;
 				int8_t minimap_mode;
 				int16_t command_attribute;
-				int16_t unknown;
-				int16_t unknown;
+				float unknown;
+				int8_t minimap_color;
 				uint16_t language_dll_help;
 				int16_t[4] hot_keys;
 				int8_t unknown;
 				int8_t unknown;
-				bool unselectable;
+				uint8_t unselectable;
 				int8_t unknown;
 				int8_t unknown;
 				int8_t unknown;
 				int8_t selection_mask;
-				int8_t selection_shape_type_id;
+				int8_t selection_shape_type;
 				int8_t selection_shape;
-				int8_t attribute;
+				uint8_t attribute;
 				int8_t civilisation;
-				int16_t unknown;
+				int16_t attribute_piece;
 				int8_t selection_effect;
 				uint8_t editor_selection_color;
-				float selection_radius0;
-				float selection_radius1;
-				float hp_bar_height1;
+				float selection_shape_x;
+				float selection_shape_y;
+				float selection_shape_z;
 
 				struct {
-					int16_t a;
-					float b;
-					int8_t c;
+					int16_t type;
+					float amount;
+					int8_t used_mode;
 				} resource_storage[3];
 
 				int8_t damage_graphic_count;
 				struct {
 					int16_t graphic_id;
 					int8_t damage_percent;
-					int8_t unknown;
-					int8_t unknown;
+					int8_t apply_mode_old;
+					int8_t apply_mode;
 				} damage_graphic[damage_graphic_count];
 
 				int16_t sound_selection;
 				int16_t sound_dying;
-				int16_t attack_mode;
+				int8_t attack_mode;
+				int8_t unknown;
 				char name[name_length];
 				int16_t id1;
 				int16_t id2;
@@ -321,20 +455,20 @@ struct {
 				int16_t walking_graphics1;
 				float rotation_speed;
 				int8_t unknown;
-				int16_t tracking_unit;
-				bool tracking_unit_used;
+				int16_t tracking_unit_id;
+				uint8_t tracking_unit_used;
 				float tracking_unit_density;
 				float unknown;
-				int8_t unknown[17];
+				float rotation_angles[5];
 			}
 
 			if (type_id >= unit_type.bird = 40) {
-				int16_t sheep_conversion;
+				int16_t discovered_action_id;
 				float search_radius;
 				float work_rate;
 				int16_t drop_site0;
 				int16_t drop_site1;
-				int8_t villager_mode;
+				int8_t task_swap_group_id;
 				int16_t move_sound;
 				int16_t stop_sound;
 				int8_t animal_mode;
@@ -344,36 +478,38 @@ struct {
 				int16_t default_armor;
 				uint16_t attack_count;
 				struct {
-					int16_t used_for_class_id;
+					int16_t type_id;
 					int16_t amount;
 				} attack[attack_count];
 				uint16_t armor_count;
 				struct {
-					int16_t used_for_class_id;
+					int16_t type_id;
 					int16_t amount;
 				} armor[armor_count];
-				int16_t unknown;
+				int16_t interaction_type;
 				float max_range;
-				float blast_radius;
-				float reload_time0;
+				float blast_width;
+				float reload_time;
 				int16_t projectile_unit_id;
 				int16_t accuracy_percent;
 				int8_t tower_mode;
 				int16_t delay;
-				float graphics_displacement[3];
-				int8_t blast_level;
+				float graphics_displacement_lr;
+				float graphics_displacement_distance;
+				float graphics_displacement_height;
+				int8_t blast_attack_level;
 				float min_range;
-				float garnison_recovery_rate;
+				float accuracy_dispersion;
 				int16_t attack_graphic;
 				int16_t melee_armor_displayed;
 				int16_t attack_displayed;
 				float range_displayed;
-				float reload_time1;
+				float reload_time_displayed;
 			}
 
 			if (type_id == unit_type.projectile = 60) {
 				int8_t stretch_mode;
-				int8_t compensation_mode;
+				int8_t smart_mode;
 				int8_t drop_animation_mode;
 				int8_t penetration_mode;
 				int8_t unknown;
@@ -386,24 +522,22 @@ struct {
 					int16_t amount;
 					int16_t enabled;
 				} resource_cost[3];
-				int16_t train_time;
-				int16_t train_location_id;
-				int8_t button_id;
-				int8_t unknown;
-				int16_t unknown[3];
-				int8_t unknown;
-				int8_t missile_graphic_delay;
+				int16_t creation_time;
+				int16_t creation_location_id;
+				int8_t creation_button_id;
+				float unknown;
+				float unknown;
+				int8_t creatable_type;
 				int8_t hero_mode;
-				int16_t garnison_graphic0;
-				int16_t garnison_graphic1;
-				float attack_missile_duplication0;
-				int8_t attack_missile_duplication1;
-				float attack_missile_duplication_spawning_width;
-				float attack_missile_duplication_spawning_length;
-				float attack_missile_duplication_spawning_randomness;
-				int32_t attack_missile_duplication_unit;
-				int32_t attack_missile_duplication_graphic;
-				int8_t dynamic_image_update;
+				int32_t garrison_graphic;
+				float attack_projectile_count;
+				int8_t attack_projectile_max_count;
+				float attack_projectile_spawning_area_width;
+				float attack_projectile_spawning_area_length;
+				float attack_projectile_spawning_area_randomness;
+				int32_t attack_projectile_secondary_unit_id;
+				int32_t special_graphic_id;
+				int8_t special_activation;
 				int16_t pierce_armor_displayed;
 			}
 
@@ -411,11 +545,11 @@ struct {
 				int16_t construction_graphic_id;
 				int16_t snow_graphic_id;
 				int16_t adjacent_mode;
-				int8_t unknown;
-				int8_t unknown;
+				int16_t icon_disabler;
+				int8_t disappears_when_built;
 				int16_t stack_unit_id;
 				int16_t terrain_id;
-				int16_t unknown;
+				int16_t resource_id;
 				int16_t research_id;
 				int8_t unknown;
 				struct {
@@ -423,12 +557,12 @@ struct {
 					float misplaced0;
 					float misplaced1;
 				} building_annex[4];
-				int16_t head_unit;
-				int16_t transform_unit;
+				int16_t head_unit_id;
+				int16_t transform_unit_id;
 				int16_t unknown;
 				int16_t construction_sound_id;
-				int8_t garnison_type_id;
-				float garnison_heal_rate;
+				int8_t garrison_type;
+				float garrison_heal_rate;
 				int32_t unknown;
 				int16_t unknown;
 				int8_t unknown[6];
@@ -440,9 +574,9 @@ struct {
 	struct {
 		int16_t[6] required_techs;
 		struct {
-			int16_t a;
-			int16_t b;
-			int8_t c;
+			int16_t resource_id;
+			int16_t amount;
+			int8_t enabled;
 		} research_resource_cost[3];
 		int16_t required_tech_count;
 		int16_t civilisation_id;
@@ -451,16 +585,18 @@ struct {
 		uint16_t language_dll_name;
 		uint16_t language_dll_description;
 		int16_t research_time;
-		int16_t tech_id;
-		int16_t tech_type_id;
+		int16_t tech_effect_id;
+		int16_t tech_type;
 		int16_t icon_id;
 		int8_t button_id;
-		int32_t pointers[3];
+		int32_t language_dll_help;
+		int32_t language_dll_techtree;
+		int32_t unknown;
 		uint16_t name_length;
 		char name[name_length];
 	} research[research_count];
 
-	int32_t unknown[7];
+	uint32_t unknown[7];
 
 	struct {
 		int8_t age_entry_count;
@@ -470,7 +606,7 @@ struct {
 
 		struct {
 			int32_t unknown;
-			int32_t uid;
+			int32_t id;
 			int8_t unknown;
 			int8_t building_count;
 			int32_t buildings[building_count];
@@ -479,15 +615,15 @@ struct {
 			int8_t research_count;
 			int32_t research[research_count];
 			int32_t unknown;
-			int32_t unknown;
+			int32_t second_age_id;
 			int16_t zeroes[49];
 		} age_tech_tree[age_entry_count];
 
 		int32_t unknown;
 
 		struct {
-			int32_t uid;
-			int8_t unknown;
+			int32_t id;
+			int8_t status;
 			int8_t building_count;
 			int32_t building[building_count];
 			int8_t unit_count;
@@ -502,13 +638,13 @@ struct {
 			int32_t mode1;
 			int32_t unknown[8];
 			int8_t unknown[11];
-			int32_t connection;
-			int32_t enabling_research;
-		} building_connection[building_entry_count];
+			int32_t line_mode;
+			int32_t enabled_by_research_id;
+		} building_connection[building_connection_count];
 
 		struct {
-			int32_t uid;
-			int8_t unknown;
+			int32_t id;
+			int8_t status;
 			int32_t upper_building;
 			int32_t required_researches;
 			int32_t age;
@@ -518,18 +654,18 @@ struct {
 			int32_t mode0;
 			int32_t mode1;
 			int32_t unknown[7];
-			int32_t vertical_line;
+			int32_t vertical_lines;
 			int8_t unit_count;
 			int32_t unit[unit_count];
 			int32_t location_in_age;
 			int32_t required_research;
 			int32_t line_mode;
 			int32_t enabling_research;
-		} unit_connection[unit_entry_count];
+		} unit_connection[unit_connection_count];
 
 		struct {
-			int32_t uid;
-			int8_t unknown;
+			int32_t id;
+			int8_t status;
 			int32_t upper_building;
 			int8_t building_count;
 			int32_t building[building_count];
@@ -546,7 +682,7 @@ struct {
 			int32_t vertical_line;
 			int32_t location_in_age;
 			int32_t unknown;
-		} research_connection[research_entry_count];
+		} research_connection[research_connection_count];
 	} tech_tree;
 } empires2_x1_p1;
 ```


### PR DESCRIPTION
References #513. Updating the documentation in `gamedata-struct.md` to reflect the current implementation in the `openage/convert/gamedata` directory.

Resubmit of #521.