### PR TITLE
Command queue, and fix building placement segfault

### DIFF
--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -165,6 +165,7 @@ ActionMode::ActionMode()
 		auto player = engine.player_focus();
 		auto type = player->get_type(this->rng.probability(0.5)? 83 : 293);
 		Command cmd(*player, type);
+		cmd.add_flag(command_flag::direct);
 		this->selection.all_invoke(cmd);
 	});
 	this->bind(action.get("ENABLE_BUILDING_PLACEMENT"), [this](const input::action_arg_t &) {
@@ -263,6 +264,7 @@ ActionMode::ActionMode()
 		auto mousepos_phys3 = mousepos_camgame.to_phys3();
 
 		auto cmd = this->get_action(mousepos_phys3);
+		cmd.add_flag(command_flag::direct);
 		this->selection.all_invoke(cmd);
 		this->use_set_ability = false;
 	});
@@ -333,6 +335,7 @@ bool ActionMode::place_selection(coord::phys3 point) {
 		if (new_building.is_valid()) {
 			Command cmd(*engine.player_focus(), new_building.get());
 			cmd.set_ability(ability_type::build);
+			cmd.add_flag(command_flag::direct);
 			this->selection.all_invoke(cmd);
 			return true;
 		}

--- a/libopenage/terrain/terrain_object.cpp
+++ b/libopenage/terrain/terrain_object.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 the openage authors. See copying.md for legal info.
+// Copyright 2013-2016 the openage authors. See copying.md for legal info.
 
 #include "terrain_object.h"
 

--- a/libopenage/terrain/terrain_object.cpp
+++ b/libopenage/terrain/terrain_object.cpp
@@ -77,8 +77,8 @@ bool TerrainObject::place(object_state init_state) {
 	// which intersect with the new placement
 	// if non-floating objects are on the foundation
 	// then this placement will fail
-	std::vector<TerrainObject *> to_remove;
 	for (coord::tile temp_pos : tile_list(this->pos)) {
+		std::vector<TerrainObject *> to_remove;
 		TerrainChunk *chunk = this->get_terrain()->get_chunk(temp_pos);
 
 		if (chunk == nullptr) {
@@ -103,11 +103,11 @@ bool TerrainObject::place(object_state init_state) {
 				}
 			}
 		}
-	}
 
-	// all obstructing objects get deleted
-	for (auto remove_obj : to_remove) {
-		remove_obj->unit.location = nullptr;
+		// all obstructing objects get deleted
+		for (auto remove_obj : to_remove) {
+			remove_obj->unit.location = nullptr;
+		}
 	}
 
 	// set new state

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -107,7 +107,7 @@ void UnitAction::move_to(Unit &target, bool use_range) {
 	if (use_range) {
 		cmd.add_flag(command_flag::use_range);
 	}
-	this->entity->invoke(cmd);
+	this->entity->queue_cmd(cmd);
 }
 
 TargetAction::TargetAction(Unit *u, graphic_type gt, UnitReference r, coord::phys_t rad)
@@ -193,7 +193,7 @@ void TargetAction::on_completion() {
 		this->entity->log(MSG(dbg) << "auto retasking");
 		auto &pl_attr = this->entity->get_attribute<attr_type::owner>();
 		Command cmd(pl_attr.player, &new_target->unit);
-		this->entity->invoke(cmd);
+		this->entity->queue_cmd(cmd);
 	}
 }
 
@@ -372,7 +372,7 @@ void IdleAction::update(unsigned int time) {
 
 			// only allow abilities in the set of auto ability types
 			to_object.set_ability_set(auto_abilities);
-			if (this->entity->invoke(to_object)) {
+			if (this->entity->queue_cmd(to_object)) {
 				break;
 			}
 		}
@@ -646,7 +646,7 @@ void UngarrisonAction::update(unsigned int) {
 					auto &player = this->entity->get_attribute<attr_type::owner>().player;
 					Command cmd(player, this->position);
 					cmd.set_ability(ability_type::move);
-					unit_ptr->invoke(cmd);
+					unit_ptr->queue_cmd(cmd);
 					return true;
 				}
 			}
@@ -689,7 +689,7 @@ void TrainAction::update(unsigned int time) {
 				auto &build_attr = this->entity->get_attribute<attr_type::building>();
 				Command cmd(player, build_attr.gather_point);
 				cmd.set_ability(ability_type::move);
-				uref.get()->invoke(cmd);
+				uref.get()->queue_cmd(cmd);
 			}
 			this->complete = true;
 		}
@@ -837,7 +837,7 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 				Command cmd(pl_attr.player, targeted_resource);
 				cmd.set_ability(ability_type::attack);
 				cmd.add_flag(command_flag::attack_res);
-				this->entity->invoke(cmd);
+				this->entity->queue_cmd(cmd);
 				return;
 			}
 		}

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -428,9 +428,8 @@ public:
 private:
 	bool complete, target_resource;
 	UnitReference target;
-	game_resource resource_type;
 	gamedata::unit_classes resource_class;
-	UnitReference nearest_dropsite();
+	UnitReference nearest_dropsite(game_resource res_type);
 };
 
 /**

--- a/libopenage/unit/command.h
+++ b/libopenage/unit/command.h
@@ -15,6 +15,7 @@ namespace openage {
  * additional flags which may affect some abilities
  */
 enum class command_flag {
+	direct, // the user directly issued this command
 	use_range, // move command account for units range
 	attack_res // allow attack on a resource object
 };

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -247,7 +247,7 @@ void UnitSelection::all_invoke(Command &cmd) {
 		if (u.second.is_valid() && u.second.get()->is_own_unit()) {
 
 			// allow unit to find best use of the command
-			u.second.get()->invoke(cmd, true);
+			u.second.get()->queue_cmd(cmd);
 		}
 	}
 }

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -247,6 +247,7 @@ void UnitSelection::all_invoke(Command &cmd) {
 		if (u.second.is_valid() && u.second.get()->is_own_unit()) {
 
 			// allow unit to find best use of the command
+			// TODO: queue_cmd returns ability which allows playing of sound
 			u.second.get()->queue_cmd(cmd);
 		}
 	}

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -252,7 +252,7 @@ bool Unit::has_attribute(attr_type type) const {
 	return (this->attribute_map.count(type) > 0);
 }
 
-bool Unit::queue_cmd(const Command &cmd) {
+std::shared_ptr<UnitAbility> Unit::queue_cmd(const Command &cmd) {
 	std::lock_guard<std::mutex> lock(this->command_queue_lock);
 
 	// following the specified ability priority
@@ -262,10 +262,10 @@ bool Unit::queue_cmd(const Command &cmd) {
 		if (pair != this->ability_available.end() &&
 		    cmd.ability()[static_cast<int>(pair->first)] && pair->second->can_invoke(*this, cmd)) {
 			command_queue.push(std::make_pair(pair->second, cmd));
-			return true;
+			return pair->second;
 		}
 	}
-	return false;
+	return nullptr;
 }
 
 void Unit::delete_unit() {

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -184,14 +184,12 @@ public:
 	}
 
 	/**
-	 * applies the command to this unit
+	 * queues a command to be applied to this unit on the next update
 	 *
-	 * a direct command discards all interruptible tasks and sets a new target
-	 * for this entity to complete, and play action sound if available
-	 *
-	 * @return true if an action was created
+	 * @return the ability which will apply the command if an action was created
+	 * otherwise nullptr is returned when no ability can handle the command
 	 */
-	bool queue_cmd(const Command &cmd);
+	std::shared_ptr<UnitAbility> queue_cmd(const Command &cmd);
 
 	/**
 	 * removes all gather actions without calling their on_complete actions
@@ -202,6 +200,7 @@ public:
 	/**
 	 * removes all actions above and including the first interuptable action
 	 * this will stop any of the units current moving or attacking actions
+	 * a direct command from the user will invoke this function
 	 */
 	void stop_actions();
 


### PR DESCRIPTION
Replace `unit.invoke(Command &)` with `unit.queue_cmd(Command &)` which queues commands to be applied at the next update. queue_cmd is safe to call from multiple threads.
 Building placement is fixed, as described in https://github.com/SFTtech/openage/issues/535
Also fixed an issue where gatherers would only return wood.