### PR TITLE
Limit fps

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -77,6 +77,7 @@ _the openage authors_ are:
 | Volodymyr Samokhatko        | ChipmunkV                   | velorums@gmail.com                    |
 | Guillaume Desquesnes        | elnabo                      | g.desquesnes@gmail.com                |
 | Johan Klokkhammer Helsing   | johanhelsing                | johanhelsing@gmail.com                |
+| Jasper v. Blanckenburg      | jazzpi                      | jasper@mezzo.de                       |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -456,12 +456,12 @@ void Engine::loop() {
 		// swap the drawing buffers to actually show the frame
 		SDL_GL_SwapWindow(window);
 
-		this->profiler.end_measure("idle");
-
 		int64_t ns_for_frame = cap_timer.getval();
 		if (ns_for_frame < NS_PER_FRAME) {
 			SDL_Delay((NS_PER_FRAME - ns_for_frame) / 1e6);
 		}
+
+		this->profiler.end_measure("idle");
 
 		this->profiler.end_frame_measure();
 	}

--- a/libopenage/engine.h
+++ b/libopenage/engine.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <cstdint>
+
 #include <SDL2/SDL.h>
 
 #include "log/log.h"
@@ -86,7 +88,7 @@ public:
 	/**
 	 * singleton constructor, use this to create the engine instance.
 	 */
-	static void create(util::Dir *data_dir, const char *windowtitle);
+	static void create(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle);
 
 	/**
 	 * singleton destructor, use when the program is shutting down.
@@ -104,7 +106,7 @@ private:
 	 * engine initialization method.
 	 * opens a window and initializes the OpenGL context.
 	 */
-	Engine(util::Dir *data_dir, const char *windowtitle);
+	Engine(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle);
 
 	/**
 	 * engine copy constructor.
@@ -302,6 +304,12 @@ private:
 	 * the current data directory for the engine.
 	 */
 	util::Dir *data_dir;
+
+	/**
+	 * how many nanoseconds are in a frame (1e9 / fps_limit).
+	 * 0 if there is no fps limit.
+	 */
+	uint64_t ns_per_frame;
 
 	/**
 	 * input event processor objects.

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -15,14 +15,14 @@ namespace openage {
 
 
 int run_game(const main_arguments &args) {
-	log::log(MSG(info) << "launching engine with data directory '" << args.data_directory << "'");
+	log::log(MSG(info) << "launching engine with data directory '" << args.data_directory << "' and fps limit " << args.fps_limit);
 
 	util::Timer timer;
 	timer.start();
 
 	util::Dir data_dir{args.data_directory.c_str()};
 
-	Engine::create(&data_dir, "openage");
+	Engine::create(&data_dir, args.fps_limit, "openage");
 	Engine &engine = Engine::get();
 
 	// initialize terminal colors

--- a/libopenage/main.h
+++ b/libopenage/main.h
@@ -4,6 +4,8 @@
 
 // pxd: from libcpp.string cimport string
 #include <string>
+// pxd: from libc.stdint cimport int32_t
+#include <cstdint>
 
 namespace openage {
 
@@ -17,9 +19,11 @@ namespace openage {
  *
  * cppclass main_arguments:
  *     string data_directory
+ *     int32_t fps_limit
  */
 struct main_arguments {
 	std::string data_directory;
+	std::int32_t fps_limit;
 };
 
 

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -11,6 +11,10 @@ def init_subparser(cli):
     """ Initializes the parser for game-specific args. """
     cli.set_defaults(entrypoint=main)
 
+    cli.add_argument(
+        "--fps", type=int,
+        help="upper limit for fps. this limit is imposed on top of vsync")
+
 
 def main(args, error):
     """

--- a/openage/game/main_cpp.pyx
+++ b/openage/game/main_cpp.pyx
@@ -13,6 +13,10 @@ def run_game(args, assets):
     cdef main_arguments args_cpp;
 
     args_cpp.data_directory = args.asset_dir.encode()
+    if args.fps is not None:
+        args_cpp.fps_limit = args.fps
+    else:
+        args_cpp.fps_limit = 0
 
     cdef int result
 


### PR DESCRIPTION
This adds a command line argument `--fps` (to the game subcommand).

When `--fps` is supplied and greater than 0, the main loop will delay after each frame until 1/`fps_limit` seconds have passed.

The FPS limit is applied on top of VSync so it should only come into effect when it is set below the refresh rate you'd need for VSync or if the window is in the background.