### PR TITLE
Fixed osx clang compile errors.

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -78,6 +78,7 @@ _the openage authors_ are:
 | Guillaume Desquesnes        | elnabo                      | g.desquesnes@gmail.com                |
 | Johan Klokkhammer Helsing   | johanhelsing                | johanhelsing@gmail.com                |
 | Jasper v. Blanckenburg      | jazzpi                      | jasper@mezzo.de                       |
+| Alexej Disterhoft           | nobbs                       | disterhoft@uni-mainz.de               |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "../terrain/terrain_object.h"
+#include "../gamestate/player.h"
 #include "ability.h"
 #include "action.h"
 #include "command.h"

--- a/libopenage/unit/command.h
+++ b/libopenage/unit/command.h
@@ -6,8 +6,6 @@
 
 #include "../coord/phys3.h"
 #include "ability.h"
-#include "producer.h"
-#include "unit.h"
 
 namespace openage {
 
@@ -42,6 +40,8 @@ struct hash<openage::command_flag> {
 namespace openage {
 
 class Player;
+class Unit;
+class UnitType;
 
 /*
  * Game command from the ui

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -14,6 +14,7 @@
 #include "../handlers.h"
 #include "ability.h"
 #include "attribute.h"
+#include "command.h"
 #include "unit_container.h"
 
 namespace openage {


### PR DESCRIPTION
Cleanup of some include calls. Fixes #541.

Tested with current osx clang, osx g++ 5.3 (brew) as well as clang 3.5 and g++ 4.9.2 (both debian jessie).