### PR TITLE
Require harfbuzz version >= 1.x.x

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -79,6 +79,7 @@ _the openage authors_ are:
 | Johan Klokkhammer Helsing   | johanhelsing                | johanhelsing@gmail.com                |
 | Jasper v. Blanckenburg      | jazzpi                      | jasper@mezzo.de                       |
 | Alexej Disterhoft           | nobbs                       | disterhoft@uni-mainz.de               |
+| Sebastian Brodehl           | sbrodehl                    | sbrodehl@students.uni-mainz.de        |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/building.md
+++ b/doc/building.md
@@ -37,7 +37,7 @@ Dependency list:
      R    dejavu font
     CR    freetype2
     CR    fontconfig
-    CR    harfbuzz
+    CR    harfbuzz >= 1.0.0
     CR    sdl2
     CR    sdl2_image
     CR    opusfile

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -78,7 +78,7 @@ find_package(SDL2 REQUIRED)
 find_package(SDL2Image REQUIRED)
 find_package(Opusfile REQUIRED)
 find_package(Epoxy REQUIRED)
-find_package(HarfBuzz REQUIRED)
+find_package(HarfBuzz 1.0.0 REQUIRED)
 
 if(WANT_BACKTRACE)
 	find_package(GCCBacktrace)

--- a/libopenage/renderer/font/font.cpp
+++ b/libopenage/renderer/font/font.cpp
@@ -118,7 +118,7 @@ void Font::initialize(FT_Library ft_library) {
 	}
 
 	// TODO Replace this trickery with hb_ft_font_create_referenced for harfbuzz version > 1.0
-	FT_Reference_Face(ft_face);
+	hb_ft_font_create_referenced(ft_face);
 	this->hb_font = hb_ft_font_create(ft_face, (hb_destroy_func_t) FT_Done_Face);
 }
 


### PR DESCRIPTION
Fixes compile error on OS X with clang 3.8 in debug mode.

Other things we need to take care of if we require a newer harfbuzz version?