### PR TITLE
Documentation for openage nyan usage

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,7 +2,8 @@ Michael Enßlin <michael@ensslin.cc>
 Jonas Jelten <jj@sft.mx> <jonas.jelten@gmail.com>
 Jonas Jelten <jj@sft.mx> <jelten@in.tum.de>
 René Kooi <rene@kooi.me> <renekooi@outlook.com>
-Matthias Bogad <matthias@bogad.at> <matthias.bogad@tum.de>
+Katharina Bogad <bogad@cs.tum.edu> <matthias@bogad.at>
+Katharina Bogad <bogad@cs.tum.edu> <matthias.bogad@tum.de>
 James Mintram <jamesmintram@gmail.com> <james@lemonmoosegames.com>
 Sam Schetterer <samschet@gmail.com> <schets@users.noreply.github.com>
 Jimmy Berry <jimmy@boombatower.com>

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Our goals *include*:
 * Optionally, [improvements](/doc/ideas/) over the original game
 * AI scripting in Python, you can use [machine learning](http://scikit-learn.org/stable/)
 * Re-creating [free game assets](https://github.com/SFTtech/openage-data)
-* An easily-moddable content format: **nyan**'s yet another notation
+* An easily-moddable content format: [**nyan** yet another notation](https://github.com/SFTtech/nyan)
 * A powerful integrated Python console and interface, comparable to [blender](http://blender.org/)
+* Awesome infrastructure such as our own [Kevin CI service](https://github.com/SFTtech/kevin)
 
 But beware, for sanity reasons:
 

--- a/copying.md
+++ b/copying.md
@@ -21,7 +21,7 @@ _the openage authors_ are:
 | Jimmy Berry                 | boombatower                 | jimmy@boombatower.com                 |
 | João Roque                  | joaoroque                   | joaoroque@gmail.com                   |
 | Julius Michaelis            | jcaesar                     | gitter@liftm.de                       |
-| Matthias Bogad              | delirium, masterofjellyfish | matthias@bogad.at                     |
+| Katharina Bogad             | delirium, masterofjellyfish | bogad@cs.tum.edu                      |
 | Oliver Fawcett-Griffiths    | ollyfg                      | olly@ollyfg.com                       |
 | Ross Murray                 | rossmurray                  | rm@egoorb.com                         |
 | Alexandre Arpin             | AlexandreArpin              | arpin.alexandre@gmail.com             |

--- a/doc/nyan/conversion.md
+++ b/doc/nyan/conversion.md
@@ -1,0 +1,20 @@
+nyan data conversion
+====================
+
+We depend on the original game.
+We have a converter which spits out a files in our formats
+by parsing the original data.
+
+Gamedata conversion
+-------------------
+
+* `openage/convert/gamedata/` specifies the format of `empires_x1_p1.dat`
+  * this format allows reading the binary file and storing it into tables
+  * these tables and the original format suck,
+    information is redundant and we can heavily improve it
+  * buuut: the file format is given (every original game has it.)
+  * :arrow_right: data transformation.
+* the original file will be read according to the original format (we can't help it)
+* a transformation is specified
+  * mapping:   original format -> our awesome format
+  * redundancy is purged (e.g. no more double huskarl unit (1x castle, 1x barracs))

--- a/doc/nyan/examples.md
+++ b/doc/nyan/examples.md
@@ -1,0 +1,7 @@
+openage nyan examples
+=====================
+
+openage will make excessive use of the nyan data storage.
+
+This file will help you understand how you'd create nyan files
+to modify or extend the behavior of openage.

--- a/doc/nyan/nyan.md
+++ b/doc/nyan/nyan.md
@@ -1,166 +1,49 @@
-nyan data format
-================
+nyan
+====
 
-**nyan** is the recursive acronym for **nyan: yet another notation**. It
-consists of two separate, but very similar file formats. Firstly, there is the
-nyan specification (short: nyanspec) which describes a domain of object types.
-Secondly, there is the data file format itself, which defines a set of objects,
-with their attribute values.
+nyan - yet another notation
 
-nyan specification (nyanspec)
------------------------------
+https://github.com/SFTtech/nyan
 
-The **nyanspec** is used to describe a domain of object types that exists and
-can be used in nyan data files. A **nyanspec** is defined in files with the
-extension `*.nyanspec`.
 
-### Basic nyanspec definition
+Idea
+----
 
-The **nyanspec** consists of definitions for multiple nyan types. Each object
-type has a name and a finite set of named attributes. For example the following
-part of a nyanspec describes a simple unit-type in **openage**.
+nyan is the data storage format for openage.
 
-    UNITTYPE {
-	    health_points : int,
-	    speed : float,
-	    can_build : set(BUILDING)
-    }
+We developed it because of the lack of any format suitable for storing
+the enormous complexity of the Age of Empires data in a sane and readable way.
 
-Each attribute must have a name and a type. An attribute is defined by its name,
-followed by a colon and its type. Allowed types are all nyan types and nyan
-built-in types. Possible built-in types are:
+Yes, the data could be written in `yaml`, `json`, `xml`, `csv` or a `docx`
+and contain the exact same information.
+But you could also use a hexeditor to write the bytes yourself,
+or even [use butterflies](https://xkcd.com/378/) to change the bits on disk.
 
-- `int`:  integers
-- `float`:  floating point numbers
-- `bool`:  boolean values, either true or false
-- `string`:  character sequences
+So we try to maximize the experience for both developers and modders.
+Users give a shit about how things work internally,
+and as we're doing this project for fun and not profit and quick results,
+we developed a data language to suit our needs.
 
-Further an attribute can be a finite set of nyan objects, which is specified
-with the `set` keyword. It is important to remember that we are really talking
-of sets and not of bags. Therefore no duplicates are allowed within a set and no
-order is guaranteed. For each attribute a default value can be specified after
-the attribute type separated by an equals sign.
+nyan allows us to have a typesafe hierarchical data storage,
+so all content data can be verified to be compatible at load time.
 
-### Dynamic attributes
+It is easy to read, write and modify, and most importantly,
+it can actually store unit upgrades, unit abilities, research,
+civ bonuses and age updates.
 
-Sometimes there are cases where nyan types need dynamic attributes.
-Imagine a unit in **openage** has multiple abilities. This would lead to the
-following definition:
 
-    ABILITY {
-	    name : string
-    }
+Technical specification
+-----------------------
 
-    UNIT {
-	    abilities : set(ABILITY)
-    }
+[nyan specification](https://github.com/SFTtech/nyan/blob/master/doc/nyan.md)
 
-This definition works, as every ability should have a name, but it is not really
-obvious what other attributes an ability has. The abilitiy to attack probably
-needs an attribute that describes an attack damage, while the ability to build a
-building needs a construction time attribute. Thus abilities should have dynamic
-attributes. Those can be specified with ellipsis:
 
-    ABILITY {
-    	name : string,
-    	...
-    }
-
-### Runtime deltas
-
-Currently we are able to define nyan types that consist of named attributes and
-dynamic attributes. Thus we are able to define types with static attribute
-values and relations. But this is not always the case in **openage**.
-Ingame technologies should have the ability to update other nyan objects
-attributes during runtime. For example the _loom_ technology should update the
-_villager_'s health points. Those so called _runtime-deltas_ can be specified in
-the **nyanspec** the following way:
-
-    TECHNOLOGY {
-    	name : string,
-    	^UNITTYPE
-    }
-
-    UNITTYPE {
-    	health_points : int
-    }
-
-A circumflex followed by a nyan types' name signals, that this nyan type is
-allowed to change the attributes of the specified type during runtime.
-
-nyan data file (nyan)
----------------------
-
-In contrast to the **nyanspec**, which describes all existing types, their
-relations and attributes, the nyan data files, describe the concrete nyan
-objects. Nyan data files have the file extension `*.nyan`.
-
-### Basic object definition
-
-All objects that are defined in nyan data files must be of a type defined in the
-**nyanspec**. Hereafter we will use the following **nyanspec** as a base for all
-nyan data files.
-
-    ABILITY {
-    	description : string,
-    	...
-    }
-    
-    UNITTYPE {
-    	health_points : int,
-    	abilities : set(ABILITY)
-    }
-    
-    TECHNOLOGY {
-    	^ABILITY,
-    	^UNITTYPE
-    }
-
-Firstly we define a few abilites and a unit type that makes use of them.
-
-    +ABILITY MOVE {
-    	description = "Allows units to move.",
-    	speed = 10.0
-    }
-    
-    +ABILITY FIGHT {
-    	description = "Allows units to fight.",
-    	damage = 20,
-    	ranged = false
-    }
-    
-    +UNIT VILLAGER {
-    	health_points = 50,
-    	abilites = [ MOVE, FIGHT ]
-    }
-
-New objects can be introduced using the `+`-operator combined with the object's
-nyan type. Each object must have a unique name within the whole nyan context
-(which will be explained later). Attribute values are assigned using `=` with a
-subsequent literal value or nyan object name. Literals for the different
-built-in types look like the following:
-
-- int: 1337
-- float: 13.37
-- bool: either true or false
-- string: "test" or 'test', with escape sequences
-
-Sets are defined using brackets. Values within the set are separated by commas.
-
-### Anonymous object definition
-
-### Runtime-delta definition
-
-### Delta definition and application
-
-nyanspec compiler
+openage specifics
 -----------------
 
-Using the generated code
-------------------------
+nyan is a general purpose data language,
+the following describes the openage specific usage of it.
 
-Questions
----------
-
-Why is there no inheritance between nyan types? This would avoid redefining same
-attributes for multiple types.
+* [data conversion](conversion.md)
+* [openage engine nyan interface](openage-lib.md)
+* [examples](examples.md)

--- a/doc/nyan/openage-lib.md
+++ b/doc/nyan/openage-lib.md
@@ -1,0 +1,7 @@
+openage nyan library
+====================
+
+The openage engine defines all kinds of *NyanObject*s
+so the nyan interpreter can verify data integrity.
+
+This interface will be described here.

--- a/libopenage/terrain/terrain_object.cpp
+++ b/libopenage/terrain/terrain_object.cpp
@@ -3,6 +3,7 @@
 #include "terrain_object.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "../engine.h"
 #include "../error/error.h"


### PR DESCRIPTION
This adds some documentation about our usage of nyan.
The documentation of nyan itself is in the nyan project repo, this is just about the openage specifics.