### PR TITLE
convert: fix check for empty WINEPREFIX input, fixes #558

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 Michael Enßlin <michael@ensslin.cc>
 Jonas Jelten <jj@sft.mx> <jonas.jelten@gmail.com>
 Jonas Jelten <jj@sft.mx> <jelten@in.tum.de>
+René Kooi <rene@kooi.me> <renee@kooi.me>
 René Kooi <rene@kooi.me> <renekooi@outlook.com>
 Katharina Bogad <bogad@cs.tum.edu> <matthias@bogad.at>
 Katharina Bogad <bogad@cs.tum.edu> <matthias.bogad@tum.de>

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -202,10 +202,12 @@ def set_custom_wineprefix():
 
     print("Enter a custom value or leave empty to keep it as-is:")
     while True:
-        new_wineprefix = expand_relative_path(input("WINEPREFIX="))
+        new_wineprefix = input("WINEPREFIX=")
 
         if not new_wineprefix:
             break
+
+        new_wineprefix = expand_relative_path(new_wineprefix)
 
         # test if it probably is a wineprefix
         if (Path(new_wineprefix) / "drive_c").is_dir():


### PR DESCRIPTION
When an empty string is entered, `expand_relative_path` returns the current directory, so the `not new_wineprefix` check would always fail. This checks the input first before passing it to `expand_relative_path`.