### PR TITLE
Show the color of the active player in buildings preview

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -80,6 +80,7 @@ _the openage authors_ are:
 | Jasper v. Blanckenburg      | jazzpi                      | jasper@mezzo.de                       |
 | Alexej Disterhoft           | nobbs                       | disterhoft@uni-mainz.de               |
 | Sebastian Brodehl           | sbrodehl                    | sbrodehl@students.uni-mainz.de        |
+| Gaith Hallak                | ghallak                     | gaithhallak@gmail.com                 |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/unit/unit_texture.cpp
+++ b/libopenage/unit/unit_texture.cpp
@@ -46,7 +46,7 @@ void UnitTexture::sample(const coord::camhud &draw_pos, unsigned color) const {
 	// draw delta list first
 	for (auto &d : this->deltas) {
 		coord::camhud_delta dlt = coord::camhud_delta{d.second.x, d.second.y};
-		d.first->sample(draw_pos + dlt);
+		d.first->sample(draw_pos + dlt, color);
 	}
 
 	// draw texture


### PR DESCRIPTION
Fixed the issue #554 .
This issue applies only to (Mill, Mining camp and Lumber camp), other buildings preview color is determined by [this line](https://github.com/SFTtech/openage/blob/cb0afc9a29451ccb3efdd14e5103038a5c726276/libopenage/unit/unit_texture.cpp#L54).