### PR TITLE
Clear the selection after exiting the ActionMode instead of after entering it

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -80,6 +80,7 @@ _the openage authors_ are:
 | Jasper v. Blanckenburg      | jazzpi                      | jasper@mezzo.de                       |
 | Alexej Disterhoft           | nobbs                       | disterhoft@uni-mainz.de               |
 | Sebastian Brodehl           | sbrodehl                    | sbrodehl@students.uni-mainz.de        |
+| Gaith Hallak                | ghallak                     | gaithhallak@gmail.com                 |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -564,13 +564,18 @@ Player* GameControl::get_current_player() const {
 
 void GameControl::set_mode(int mode_index) {
 	if (mode_index != -1) {
-		if (mode_index < std::distance(std::begin(this->modes), std::end(this->modes)) &&this->modes[mode_index]->available()) {
+		if (mode_index < std::distance(std::begin(this->modes), std::end(this->modes))
+		    && this->modes[mode_index]->available()
+		    && this->active_mode_index != mode_index) {
+
 			engine->get_input_manager().remove_context(this->active_mode);
 
-			// set the new active mode
+			// exit from the old mode
 			if (this->active_mode) {
 				this->active_mode->on_exit();
 			}
+
+			// set the new active mode
 			this->active_mode_index = mode_index;
 			this->active_mode = this->modes[mode_index];
 			this->active_mode->on_enter();

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -36,6 +36,8 @@ std::string CreateMode::name() const {
 
 void CreateMode::on_enter() {}
 
+void CreateMode::on_exit() {}
+
 void CreateMode::render() {}
 
 ActionMode::ActionMode(qtsdl::GuiItemLink *gui_link)
@@ -190,7 +192,9 @@ bool ActionMode::available() const {
 	}
 }
 
-void ActionMode::on_enter() {
+void ActionMode::on_enter() {}
+
+void ActionMode::on_exit() {
 	this->selection.clear();
 }
 
@@ -337,6 +341,8 @@ bool EditorMode::available() const {
 }
 
 void EditorMode::on_enter() {}
+
+void EditorMode::on_exit() {}
 
 void EditorMode::render() {}
 
@@ -562,6 +568,9 @@ void GameControl::set_mode(int mode_index) {
 			engine->get_input_manager().remove_context(this->active_mode);
 
 			// set the new active mode
+			if (this->active_mode) {
+				this->active_mode->on_exit();
+			}
 			this->active_mode_index = mode_index;
 			this->active_mode = this->modes[mode_index];
 			this->active_mode->on_enter();

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -48,6 +48,7 @@ public:
 	 * used when switching modes
 	 */
 	virtual void on_enter() = 0;
+	virtual void on_exit() = 0;
 	virtual void render() = 0;
 
 	/**
@@ -76,6 +77,7 @@ public:
 
 	bool available() const override;
 	void on_enter() override;
+	void on_exit() override;
 	void render() override;
 	std::string name() const override;
 };
@@ -98,6 +100,7 @@ public:
 
 	bool available() const override;
 	void on_enter() override;
+	void on_exit() override;
 	void render() override;
 	std::string name() const override;
 
@@ -176,6 +179,7 @@ public:
 
 	bool available() const override;
 	void on_enter() override;
+	void on_exit() override;
 	void render() override;
 	std::string name() const override;
 


### PR DESCRIPTION
Fixes #531.
When ending the game the selection doesn't get cleared, so changing to Action Mode after starting a new game will call `selection.clear()` which tries to access selected units from previous game.
My fix is to call `selection.clear()` when leaving the Action Mode so that the current selection will be cleared before ending the game.