### PR TITLE
buildsystem: set cxx_standard to fix qt bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.0.0)
-# required for finding Python 3.4.
-# (determined via git tag --contains)
+cmake_minimum_required(VERSION 3.1.0)
+# required for CMAKE_CXX_STANDARD
 
 # main build configuration file
 

--- a/buildsystem/HandleCXXOptions.cmake
+++ b/buildsystem/HandleCXXOptions.cmake
@@ -51,6 +51,8 @@ endmacro()
 
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 
 # check for compiler versions

--- a/doc/building.md
+++ b/doc/building.md
@@ -29,7 +29,7 @@ Dependency list:
     C     gcc >=4.9 or clang >=3.4 (clang >=3.5 for Mac OS X)
     CRA   python >=3.4
     C     cython >=0.23
-    C     cmake >=3.0.0
+    C     cmake >=3.1.0
       A   numpy
       A   python imaging library (PIL) -> pillow
     CR    opengl >=2.1


### PR DESCRIPTION
possibly fixes #590
it's a bit dirtier than before, because the flags are now:

```
(...)  -std=c++14 (.....) -g -Og -fPIC   -fPIC -std=gnu++14 -o (....)
```

If I remove the first `std=`, the compilations done in the configuration fail. And the second one seems to be unchangable from `gnu++14` to `c++14`.