### PR TITLE
GL debug option

### DIFF
--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -11,6 +11,7 @@
 #include <SDL2/SDL_image.h>
 
 #include "error/error.h"
+#include "error/gl_debug.h"
 #include "log/log.h"
 #include "config.h"
 #include "gui_basic.h"
@@ -47,11 +48,11 @@ coord_data* Engine::get_coord_data() {
 // engine singleton instance allocation
 Engine *Engine::instance = nullptr;
 
-void Engine::create(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle) {
+void Engine::create(util::Dir *data_dir, int32_t fps_limit, bool gl_debug, const char *windowtitle) {
 	// only create the singleton instance if it was not created before..
 	if (Engine::instance == nullptr) {
 		// reset the pointer to the new engine
-		Engine::instance = new Engine(data_dir, fps_limit, windowtitle);
+		Engine::instance = new Engine(data_dir, fps_limit, gl_debug, windowtitle);
 	} else {
 		throw Error{MSG(err) << "You tried to create another singleton engine instance!!111"};
 	}
@@ -71,7 +72,7 @@ Engine &Engine::get() {
 }
 
 
-Engine::Engine(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle)
+Engine::Engine(util::Dir *data_dir, int32_t fps_limit, bool gl_debug, const char *windowtitle)
 	:
 	OptionNode{"Engine"},
 	running{false},
@@ -137,7 +138,10 @@ Engine::Engine(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle)
 		throw Error(MSG(err) << "Failed to init PNG support: " << IMG_GetError());
 	}
 
-	this->glcontext = SDL_GL_CreateContext(this->window);
+	if (gl_debug)
+		this->glcontext = error::create_debug_context(this->window);
+	else
+		this->glcontext = SDL_GL_CreateContext(this->window);
 
 	if (this->glcontext == nullptr) {
 		throw Error(MSG(err) << "Failed creating OpenGL context: " << SDL_GetError());

--- a/libopenage/engine.h
+++ b/libopenage/engine.h
@@ -111,7 +111,7 @@ public:
 	/**
 	 * singleton constructor, use this to create the engine instance.
 	 */
-	static void create(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle);
+	static void create(util::Dir *data_dir, int32_t fps_limit, bool gl_debug, const char *windowtitle);
 
 	/**
 	 * singleton destructor, use when the program is shutting down.
@@ -129,7 +129,7 @@ private:
 	 * engine initialization method.
 	 * opens a window and initializes the OpenGL context.
 	 */
-	Engine(util::Dir *data_dir, int32_t fps_limit, const char *windowtitle);
+	Engine(util::Dir *data_dir, int32_t fps_limit, bool gl_debug, const char *windowtitle);
 
 	/**
 	 * engine copy constructor.

--- a/libopenage/error/CMakeLists.txt
+++ b/libopenage/error/CMakeLists.txt
@@ -2,6 +2,7 @@ add_sources(libopenage
 	backtrace.cpp
 	demo.cpp
 	error.cpp
+	gl_debug.cpp
 	handlers.cpp
 	stackanalyzer.cpp
 )

--- a/libopenage/error/gl_debug.cpp
+++ b/libopenage/error/gl_debug.cpp
@@ -1,0 +1,69 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "gl_debug.h"
+
+#include <epoxy/gl.h>
+
+#include "error.h"
+
+namespace openage {
+namespace error {
+
+namespace {
+void callback(GLenum source, GLenum, GLuint, GLenum, GLsizei, const GLchar *message, const void*) {
+	const char *source_name;
+
+	switch (source) {
+	case GL_DEBUG_SOURCE_API:
+		source_name = "API";
+		break;
+	case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+		source_name = "window system";
+		break;
+	case GL_DEBUG_SOURCE_SHADER_COMPILER:
+		source_name = "shader compiler";
+		break;
+	case GL_DEBUG_SOURCE_THIRD_PARTY:
+		source_name = "third party";
+		break;
+	case GL_DEBUG_SOURCE_APPLICATION:
+		source_name = "application";
+		break;
+	case GL_DEBUG_SOURCE_OTHER:
+		source_name = "other";
+		break;
+	default:
+		source_name = "unknown";
+		break;
+	}
+
+	throw Error(MSG(err) << "OpenGL error from " << source_name << ": '" << message << "'.");
+}
+
+}
+
+SDL_GLContext create_debug_context(SDL_Window *window) {
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
+
+	auto ctx = SDL_GL_CreateContext(window);
+
+	if (ctx != nullptr) {
+		GLint flags;
+		glGetIntegerv(GL_CONTEXT_FLAGS, &flags);
+
+		if (!(flags & GL_CONTEXT_FLAG_DEBUG_BIT))
+			throw Error(MSG(err)<< "Failed creating a debug OpenGL context.");
+
+		glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, GL_FALSE);
+
+		glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_ERROR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
+		glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
+
+		glDebugMessageCallback(callback, nullptr);
+		glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+	}
+
+	return ctx;
+}
+
+}} // openage::error

--- a/libopenage/error/gl_debug.h
+++ b/libopenage/error/gl_debug.h
@@ -1,0 +1,12 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <SDL2/SDL.h>
+
+namespace openage {
+namespace error {
+
+SDL_GLContext create_debug_context(SDL_Window *window);
+
+}} // openage::error

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -22,7 +22,7 @@ int run_game(const main_arguments &args) {
 
 	util::Dir data_dir{args.data_directory.c_str()};
 
-	Engine::create(&data_dir, args.fps_limit, "openage");
+	Engine::create(&data_dir, args.fps_limit, args.gl_debug, "openage");
 	Engine &engine = Engine::get();
 	engine.get_cvar_manager().load_main_config();
 

--- a/libopenage/main.h
+++ b/libopenage/main.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+// pxd: from libcpp cimport bool
 // pxd: from libcpp.string cimport string
 #include <string>
 // pxd: from libc.stdint cimport int32_t
@@ -20,10 +21,12 @@ namespace openage {
  * cppclass main_arguments:
  *     string data_directory
  *     int32_t fps_limit
+ *     bool gl_debug
  */
 struct main_arguments {
 	std::string data_directory;
 	std::int32_t fps_limit;
+	bool gl_debug;
 };
 
 

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -15,6 +15,10 @@ def init_subparser(cli):
         "--fps", type=int,
         help="upper limit for fps. this limit is imposed on top of vsync")
 
+    cli.add_argument(
+        "--gl-debug", action='store_true',
+        help="throw exceptions directly from the OpenGL calls")
+
 
 def main(args, error):
     """

--- a/openage/game/main_cpp.pyx
+++ b/openage/game/main_cpp.pyx
@@ -18,6 +18,8 @@ def run_game(args, assets):
     else:
         args_cpp.fps_limit = 0
 
+    args_cpp.gl_debug = args.gl_debug
+
     cdef int result
 
     with nogil:


### PR DESCRIPTION
A `--gl-debug` option that creates a debug context instead of a normal one. Gets a more precise backtrace when error occurs.