### PR TITLE
config: rebind STOP_GAME to Shift+ESCAPE

### DIFF
--- a/cfg/keybinds.oac
+++ b/cfg/keybinds.oac
@@ -2,7 +2,7 @@
 
 set TOGGLE_CONSOLE `
 set START_GAME Return
-set STOP_GAME Escape
+set STOP_GAME Shift Escape
 set TOGGLE_HUD F1
 set SCREENSHOT F2
 set TOGGLE_DEBUG_OVERLAY F3


### PR DESCRIPTION
ESC should just be the key to cancel things like building placement etc., pressing it to find the game closed is annoying 😄 