### PR TITLE
Limit building completion to 1.0

### DIFF
--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -745,6 +745,7 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 		this->complete = build.completed;
 
 		if (this->complete >= 1.0f) {
+			this->complete = build.completed = 1.0f;
 			target_location->place(build.completion_state);
 		}
 	}


### PR DESCRIPTION
Currently, when completing a building it will usually display as a little bit more than 1.0 completed. This just sets the `completed` property to `1.0f` when the building is fully completed.