### PR TITLE
Keep building after finishing a building

### DIFF
--- a/libopenage/terrain/terrain_search.cpp
+++ b/libopenage/terrain/terrain_search.cpp
@@ -9,8 +9,8 @@
 namespace openage {
 
 TerrainObject *find_near(const TerrainObject &start,
-                                         std::function<bool(const TerrainObject &)> found,
-                                         unsigned int search_limit) {
+                         std::function<bool(const TerrainObject &)> found,
+                         unsigned int search_limit) {
 
 	auto terrain = start.get_terrain();
 	auto tile = start.pos.draw.to_tile3().to_tile();
@@ -26,6 +26,29 @@ TerrainObject *find_near(const TerrainObject &start,
 		}
 		tile = search.next_tile();
 	}
+
+	return nullptr;
+}
+
+TerrainObject *find_in_radius(const TerrainObject &start,
+                              std::function<bool(const TerrainObject &)> found,
+                              float radius) {
+	auto terrain = start.get_terrain();
+	coord::tile start_tile = start.pos.draw.to_tile3().to_tile();
+	TerrainSearch search(terrain, start_tile, radius);
+
+	// next_tile will first return the starting tile, so we need to run it once. We also
+	// shouldn't discard this tile - if it isn't useful, ignore it in found
+	coord::tile tile = search.next_tile();
+	do {
+		for (auto o : terrain->get_data(tile)->obj) {
+			if (found(*o)) {
+				return o;
+			}
+		}
+		tile = search.next_tile();
+		// coord::tile doesn't have a != operator, so we need to use !(a==b)
+	} while (!(tile == start_tile));
 
 	return nullptr;
 }
@@ -52,6 +75,7 @@ void TerrainSearch::reset() {
 	std::swap(this->tiles, empty);
 	this->visited.clear();
 	this->tiles.push(this->start);
+	this->visited.insert(this->start);
 }
 
 coord::tile TerrainSearch::next_tile() {

--- a/libopenage/terrain/terrain_search.h
+++ b/libopenage/terrain/terrain_search.h
@@ -16,8 +16,11 @@ class Terrain;
 class TerrainObject;
 
 TerrainObject *find_near(const TerrainObject &start,
-                                         std::function<bool(const TerrainObject &)> found,
-                                         unsigned int search_limit=500);
+                         std::function<bool(const TerrainObject &)> found,
+                         unsigned int search_limit=500);
+TerrainObject *find_in_radius(const TerrainObject &start,
+                              std::function<bool(const TerrainObject &)> found,
+                              float radius);
 
 constexpr coord::tile_delta const neigh_tile[] = {
 	{0,  1},

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -793,7 +793,6 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 		if (this->complete >= 1.0f) {
 			this->complete = build.completed = 1.0f;
 			target_location->place(build.completion_state);
-			this->entity->build_next();
 		}
 	}
 	else {
@@ -802,6 +801,31 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 
 	// inc frame
 	this->frame += time * this->frame_rate / 2.5f;
+}
+
+void BuildAction::on_completion() {
+	if (this->get_target().get()->get_attribute<attr_type::building>().completed < 1.0f) {
+		// The BuildAction was just aborted and we shouldn't look for new buildings
+		return;
+	}
+	this->entity->log(MSG(dbg) << "Done building, searching for new building");
+	auto valid = [this](const TerrainObject &obj) {
+		if (!obj.unit.has_attribute(attr_type::building) ||
+		    obj.unit.get_attribute<attr_type::building>().completed >= 1.0f) {
+			return false;
+		}
+		this->entity->log(MSG(dbg) << "Found unit " << obj.unit.logsource_name());
+		return true;
+	};
+
+	TerrainObject *new_target = find_in_radius(*this->entity->location, valid, 9.0f);
+	if (new_target != nullptr) {
+		this->entity->log(MSG(dbg) << "Found new building, queueing command");
+		Command cmd(this->entity->get_attribute<attr_type::owner>().player, &new_target->unit);
+		this->entity->queue_cmd(cmd);
+	} else {
+		this->entity->log(MSG(dbg) << "Didn't find new building");
+	}
 }
 
 const graphic_set &BuildAction::current_graphics() const {

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -818,7 +818,7 @@ void BuildAction::on_completion() {
 		return true;
 	};
 
-	TerrainObject *new_target = find_in_radius(*this->entity->location, valid, 9.0f);
+	TerrainObject *new_target = find_in_radius(*this->entity->location, valid, BuildAction::search_tile_distance);
 	if (new_target != nullptr) {
 		this->entity->log(MSG(dbg) << "Found new building, queueing command");
 		Command cmd(this->entity->get_attribute<attr_type::owner>().player, &new_target->unit);

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -793,6 +793,7 @@ void BuildAction::update_in_range(unsigned int time, Unit *target_unit) {
 		if (this->complete >= 1.0f) {
 			this->complete = build.completed = 1.0f;
 			target_location->place(build.completion_state);
+			this->entity->build_next();
 		}
 	}
 	else {

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -394,6 +394,7 @@ public:
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
+	void on_completion() override;
 	std::string name() const override { return "build"; }
 	const graphic_set &current_graphics() const override;
 

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -400,6 +400,7 @@ public:
 
 private:
 	float complete, build_rate;
+	static constexpr float search_tile_distance = 9.0f;
 
 };
 

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -290,40 +290,6 @@ void Unit::stop_actions() {
 		});
 }
 
-bool Unit::build_next() {
-	this->log(MSG(dbg) << "Building next building...");
-
-	std::vector<Unit *> units = this->get_container()->all_units();
-	Unit *closest = nullptr;
-	coord::phys_t closest_distance = std::numeric_limits<coord::phys_t>::max();
-
-	for (Unit *unit : units) {
-		if (!unit->has_attribute(attr_type::building)) {
-			continue;
-		}
-		auto &build = unit->get_attribute<attr_type::building>();
-		if (build.completed == 1.0f) {
-			continue;
-		}
-		// TODO: Check range and building size and actually test this
-		coord::phys_t distance = unit->location->from_edge(this->location->pos.draw);
-		if (distance < closest_distance) {
-			closest = unit;
-			closest_distance = distance;
-		}
-	}
-
-	if (closest == nullptr) {
-		return false;
-	}
-
-	closest->log(MSG(info) << "Closest unfinished building with distance " << closest_distance);
-	Command cmd(this->get_attribute<attr_type::owner>().player, closest);
-	this->queue_cmd(cmd);
-
-	return true;
-}
-
 UnitReference Unit::get_ref() {
 	return UnitReference(&container, id, this);
 }

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "../terrain/terrain.h"
 #include "../engine.h"
@@ -287,6 +288,40 @@ void Unit::stop_actions() {
 		[](std::unique_ptr<UnitAction> &e) {
 			return e->allow_interupt();
 		});
+}
+
+bool Unit::build_next() {
+	this->log(MSG(dbg) << "Building next building...");
+
+	std::vector<Unit *> units = this->get_container()->all_units();
+	Unit *closest = nullptr;
+	coord::phys_t closest_distance = std::numeric_limits<coord::phys_t>::max();
+
+	for (Unit *unit : units) {
+		if (!unit->has_attribute(attr_type::building)) {
+			continue;
+		}
+		auto &build = unit->get_attribute<attr_type::building>();
+		if (build.completed == 1.0f) {
+			continue;
+		}
+		// TODO: Check range and building size and actually test this
+		coord::phys_t distance = unit->location->from_edge(this->location->pos.draw);
+		if (distance < closest_distance) {
+			closest = unit;
+			closest_distance = distance;
+		}
+	}
+
+	if (closest == nullptr) {
+		return false;
+	}
+
+	closest->log(MSG(info) << "Closest unfinished building with distance " << closest_distance);
+	Command cmd(this->get_attribute<attr_type::owner>().player, closest);
+	this->queue_cmd(cmd);
+
+	return true;
 }
 
 UnitReference Unit::get_ref() {

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -214,6 +214,13 @@ public:
 	void delete_unit();
 
 	/**
+	 * builds the nearest building (if it is in range)
+	 *
+	 * returns true if there is a building in range, false otherwise
+	 */
+	bool build_next();
+
+	/**
 	 * get a reference which can check against the container
 	 * to ensure this object still exists
 	 */

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -214,13 +214,6 @@ public:
 	void delete_unit();
 
 	/**
-	 * builds the nearest building (if it is in range)
-	 *
-	 * returns true if there is a building in range, false otherwise
-	 */
-	bool build_next();
-
-	/**
 	 * get a reference which can check against the container
 	 * to ensure this object still exists
 	 */


### PR DESCRIPTION
When a unit's current action is to build a building and that building
completes, it will now search for the closest building and then queue
building that.

~~Currently, there are no range limitations as explained in
doc/reverse_engineering/building_placement.md and it's horribly
inefficient (it searches through ALL units on the map).~~
