### PR TITLE
util: fixes wrong priority handling in Union

### DIFF
--- a/openage/util/fslike/union.py
+++ b/openage/util/fslike/union.py
@@ -45,7 +45,7 @@ class Union(FSLikeObject):
         while idx >= 0 and priority >= self.mounts[idx][2]:
             idx -= 1
 
-        self.mounts.insert(idx, (mountpoint, pathobj, priority))
+        self.mounts.insert(idx + 1, (mountpoint, pathobj, priority))
 
         # 'create' parent directories as needed.
         dirstructure = self.dirstructure


### PR DESCRIPTION
Due to an off-by-one error in `Union.add_mount()`, new mounts overlay the lowest mount, that had a _higher_ priority than the new one. This bug becomes really critical, when the new mount has a priority higher than any other mount. In this case the new mount is inserted at index '-1' (it becomes the second last mount), and not at '0'.

To test this with your own eyes, execute the *.sh once and then unionbug.py (read the in-source comment). 
https://github.com/castilma/openage/blob/unionbug/preptest.sh
https://github.com/castilma/openage/blob/unionbug/unionbug.py

edit: I wonder if the overlapping feature from Union is even used by the convert script. Or why didn't we notice this? This bug is over 2 years old. I found it while reading the source, trying to understand how Union works.