### PR TITLE
History and interpolation

### DIFF
--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -34,6 +34,7 @@ pxdgen(
 add_subdirectory("audio")
 add_subdirectory("console")
 add_subdirectory("coord")
+add_subdirectory("curve")
 add_subdirectory("cvar")
 add_subdirectory("datastructure")
 add_subdirectory("gui")

--- a/libopenage/coord/CMakeLists.txt
+++ b/libopenage/coord/CMakeLists.txt
@@ -8,6 +8,7 @@ add_sources(libopenage
 	term.cpp
 	tests.cpp
 	tile.cpp
+	tile_serialization.cpp
 	tile3.cpp
 	vec2.cpp
 	vec2f.cpp

--- a/libopenage/coord/CMakeLists.txt
+++ b/libopenage/coord/CMakeLists.txt
@@ -4,6 +4,7 @@ add_sources(libopenage
 	chunk.cpp
 	phys2.cpp
 	phys3.cpp
+	phys3_serialization.cpp
 	term.cpp
 	tests.cpp
 	tile.cpp

--- a/libopenage/coord/phys3_serialization.cpp
+++ b/libopenage/coord/phys3_serialization.cpp
@@ -1,0 +1,30 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "phys3_serialization.h"
+
+namespace openage {
+namespace coord {
+
+std::ostream& operator<<(std::ostream &o, const phys3 &v) {
+	o << '(' << v.ne << ',' << v.se << ',' << v.up << ')';
+	return o;
+}
+
+std::ostream& operator<<(std::ostream &o, const phys3_delta &v) {
+	o << '(' << v.ne << ',' << v.se << ',' << v.up << ')';
+	return o;
+}
+
+std::istream& operator>>(std::istream &i, phys3 &v) {
+	char c;
+	i >> c >> v.ne >> c >> v.se >> c >> v.up >> c;
+	return i;
+}
+
+std::istream& operator>>(std::istream &i, phys3_delta &v) {
+	char c;
+	i >> c >> v.ne >> c >> v.se >> c >> v.up >> c;
+	return i;
+}
+
+}} // openage::coord

--- a/libopenage/coord/phys3_serialization.h
+++ b/libopenage/coord/phys3_serialization.h
@@ -1,0 +1,18 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <iostream>
+
+#include "phys3.h"
+
+namespace openage {
+namespace coord {
+
+std::ostream& operator<<(std::ostream &o, const phys3 &v);
+std::ostream& operator<<(std::ostream &o, const phys3_delta &v);
+
+std::istream& operator>>(std::istream &i, phys3 &v);
+std::istream& operator>>(std::istream &i, phys3_delta &v);
+
+}} // openage::coord

--- a/libopenage/coord/tile_serialization.cpp
+++ b/libopenage/coord/tile_serialization.cpp
@@ -1,0 +1,30 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "tile_serialization.h"
+
+namespace openage {
+namespace coord {
+
+std::ostream& operator<<(std::ostream &o, const tile &v) {
+	o << '(' << v.ne << ',' << v.se << ')';
+	return o;
+}
+
+std::ostream& operator<<(std::ostream &o, const tile_delta &v) {
+	o << '(' << v.ne << ',' << v.se << ')';
+	return o;
+}
+
+std::istream& operator>>(std::istream &i, tile &v) {
+	char c;
+	i >> c >> v.ne >> c >> v.se >> c;
+	return i;
+}
+
+std::istream& operator>>(std::istream &i, tile_delta &v) {
+	char c;
+	i >> c >> v.ne >> c >> v.se >> c;
+	return i;
+}
+
+}} // openage::coord

--- a/libopenage/coord/tile_serialization.h
+++ b/libopenage/coord/tile_serialization.h
@@ -1,0 +1,18 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <iostream>
+
+#include "tile.h"
+
+namespace openage {
+namespace coord {
+
+std::ostream& operator<<(std::ostream &o, const tile &v);
+std::ostream& operator<<(std::ostream &o, const tile_delta &v);
+
+std::istream& operator>>(std::istream &i, tile &v);
+std::istream& operator>>(std::istream &i, tile_delta &v);
+
+}} // openage::coord

--- a/libopenage/curve/CMakeLists.txt
+++ b/libopenage/curve/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_sources(libopenage
+	entities_conductor.cpp
+	entities_conductor_interpolator.cpp
+	occurence_curve.cpp
+)

--- a/libopenage/curve/CMakeLists.txt
+++ b/libopenage/curve/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_sources(libopenage
+	curve_record_replay.cpp
 	entities_conductor.cpp
 	entities_conductor_interpolator.cpp
 	occurence_curve.cpp

--- a/libopenage/curve/curve_record_replay.cpp
+++ b/libopenage/curve/curve_record_replay.cpp
@@ -1,0 +1,75 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "curve_record_replay.h"
+
+#include <iostream>
+#include <fstream>
+
+#include "../unit/attribute_setter.h"
+
+namespace openage {
+namespace curve {
+
+CurveRecordReplay::CurveRecordReplay(qtsdl::GuiItemLink *gui_link, bool recorder)
+	:
+	stream{std::make_unique<std::iostream>(recorder ? std::cerr.rdbuf() : std::cin.rdbuf())},
+	current_frame{},
+	recorder{recorder},
+	gui_link{gui_link} {
+}
+
+CurveRecordReplay::~CurveRecordReplay() {
+
+}
+
+std::string CurveRecordReplay::get_file_name() const {
+	return this->file_name;
+}
+
+void CurveRecordReplay::set_file_name(const std::string &file_name) {
+	if (this->file_name != file_name) {
+		this->stream = std::make_unique<std::fstream>(file_name, this->recorder ? std::ios_base::out : std::ios_base::in);
+		this->file_name = file_name;
+	}
+}
+
+CurveRecord::CurveRecord(qtsdl::GuiItemLink *gui_link)
+	:
+	CurveRecordReplay{gui_link, true} {
+}
+
+CurveRecord::~CurveRecord() {
+}
+
+void CurveRecord::perform(UnitContainer &placed_units) {
+	placed_units.update_all(*this);
+	++this->current_frame;
+}
+
+CurveReplay::CurveReplay(qtsdl::GuiItemLink *gui_link)
+	:
+	CurveRecordReplay{gui_link, false},
+	started{},
+	next_available_frame{} {
+}
+
+CurveReplay::~CurveReplay() {
+}
+
+void CurveReplay::perform(UnitContainer &placed_units) {
+	if (!this->started) {
+		*this->stream >> this->next_available_frame;
+		this->started = true;
+	}
+
+	while (this->next_available_frame <= this->current_frame) {
+		int id;
+		*this->stream >> id;
+		read_attr(*this->stream, id, placed_units);
+		*this->stream >> this->next_available_frame;
+	}
+
+	++this->current_frame;
+}
+
+}} // namespace openage::curve

--- a/libopenage/curve/curve_record_replay.h
+++ b/libopenage/curve/curve_record_replay.h
@@ -1,0 +1,78 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <iostream>
+#include <memory>
+
+namespace qtsdl {
+class GuiItemLink;
+} // qtsdl
+
+namespace openage {
+
+class UnitContainer;
+
+namespace curve {
+
+class CurveRecord;
+
+class CurveRecordReplay {
+public:
+	explicit CurveRecordReplay(qtsdl::GuiItemLink *gui_link, bool recorder);
+	virtual ~CurveRecordReplay();
+
+	std::string get_file_name() const;
+	void set_file_name(const std::string &file_name);
+
+	virtual void perform(UnitContainer &placed_units) = 0;
+
+	virtual CurveRecord* get_record() {
+		return nullptr;
+	}
+
+protected:
+	std::string file_name;
+	std::unique_ptr<std::iostream> stream;
+	size_t current_frame;
+	const bool recorder;
+
+public:
+	qtsdl::GuiItemLink *gui_link;
+};
+
+class CurveRecord : public CurveRecordReplay {
+public:
+	explicit CurveRecord(qtsdl::GuiItemLink *gui_link);
+	virtual ~CurveRecord();
+
+	virtual void perform(UnitContainer &placed_units) override;
+
+	virtual CurveRecord* get_record() override {
+		return this;
+	}
+
+	template<typename T>
+	void write_out(id_t id, T value, const char *name) {
+		*this->stream << this->current_frame << " " << id << " " << name << " " << value << "\n";
+		this->stream->flush();
+	}
+
+private:
+};
+
+class CurveReplay : public CurveRecordReplay {
+public:
+	explicit CurveReplay(qtsdl::GuiItemLink *gui_link);
+	virtual ~CurveReplay();
+
+	virtual void perform(UnitContainer &placed_units) override;
+
+private:
+	bool started;
+	size_t next_available_frame;
+};
+
+}} // namespace openage::curve

--- a/libopenage/curve/entities_conductor.cpp
+++ b/libopenage/curve/entities_conductor.cpp
@@ -1,0 +1,68 @@
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+#include "entities_conductor.h"
+
+#include <algorithm>
+
+#include "../error/error.h"
+
+namespace openage {
+namespace curve {
+
+EntitiesConductor::EntitiesConductor(std::function<void(int, int, coord::phys2)> emerge, std::function<void(int)> vanish)
+	:
+	emerge{emerge},
+	vanish{vanish} {
+}
+
+void EntitiesConductor::jump(GameClock::moment from, GameClock::moment to) {
+	// TODO: call appear/vanish for every SPAWN/DIE (depending on the time direction)
+	// TODO: for each property find closest curve to 'to' that changes it, then apply the last value or a value that is sampled from curve at the 'to' moment
+}
+
+Prediction EntitiesConductor::predict_migration(GameClock::moment current_time, GameClock::moment other_time) const {
+	const auto prior = std::min(current_time, other_time);
+	const auto forth = std::max(current_time, other_time);
+
+	const auto cmp_start_cp = [](const OccurenceCurve &c, GameClock::moment p) { return c.origin.time < p; };
+	const auto cmp_start_pc = [](GameClock::moment p, const OccurenceCurve &c) { return p < c.origin.time; };
+
+	const auto cmp_end_ip = [this](size_t index, GameClock::moment p) { return end_time(this->history[index]) < p; };
+	const auto cmp_end_pi = [this](GameClock::moment p, size_t index) { return p < end_time(this->history[index]); };
+
+	ENSURE(this->history.size() == this->history_sorted_by_ends.size(), "index array out of sync");
+
+	const auto occurences_that_start_inside_begin_it = std::lower_bound(std::begin(this->history), std::end(this->history), prior, cmp_start_cp);
+	const auto occurences_that_start_inside_end_it = std::upper_bound(std::begin(this->history), std::end(this->history), forth, cmp_start_pc);
+
+	const auto occurencesthat_finish_inside_begin_it = std::lower_bound(std::begin(this->history_sorted_by_ends), std::end(this->history_sorted_by_ends), prior, cmp_end_ip);
+	const auto occurencesThat_finish_inside_end_it = std::upper_bound(std::begin(this->history_sorted_by_ends), std::end(this->history_sorted_by_ends), forth, cmp_end_pi);
+
+	decltype(this->history_sorted_by_ends) occurences_that_only_finish_inside;
+	const size_t completely_inside_begin_index = std::distance(std::begin(this->history), occurences_that_start_inside_begin_it);
+
+	std::copy_if(occurencesthat_finish_inside_begin_it, occurencesThat_finish_inside_end_it, std::back_inserter(occurences_that_only_finish_inside), [completely_inside_begin_index](size_t index) { return index < completely_inside_begin_index; });
+	std::sort(std::begin(occurences_that_only_finish_inside), std::end(occurences_that_only_finish_inside));
+
+	const auto occurences_that_start_inside_count = std::distance(occurences_that_start_inside_begin_it, occurences_that_start_inside_end_it);
+	std::vector<OccurenceCurve> trimmed(occurences_that_start_inside_count + occurences_that_only_finish_inside.size());
+
+	using namespace std::placeholders;
+	std::transform(occurences_that_start_inside_begin_it, occurences_that_start_inside_end_it, std::begin(trimmed), std::bind(&trim, _1, prior, forth));
+	std::transform(std::begin(occurences_that_only_finish_inside), std::end(occurences_that_only_finish_inside), std::begin(trimmed) + occurences_that_start_inside_count, [this, prior, forth](size_t index) {
+		return trim(this->history[index], prior, forth);
+	});
+
+	return trimmed;
+}
+
+void EntitiesConductor::converge(GameClock::moment current_time) {
+	// TODO: perform silently all rollbacks that unapplied_history causes (simplest: jump() back, fix history, jump() forward)
+	return;
+}
+
+void EntitiesConductor::append_history(const Prediction &unapplied_history) {
+	this->unapplied_history.insert(std::end(this->unapplied_history), std::begin(unapplied_history), std::end(unapplied_history));
+}
+
+}} // namespace openage::curve

--- a/libopenage/curve/entities_conductor.h
+++ b/libopenage/curve/entities_conductor.h
@@ -1,0 +1,69 @@
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "../coord/phys2.h"
+
+#include "game_clock.h"
+#include "occurence_curve.h"
+
+namespace openage {
+namespace curve {
+/**
+ * Stores history, gives segments of it, can immediately mutate the world to the given moment.
+ */
+class EntitiesConductor
+{
+public:
+	/**
+	 * @param emerge function to add a unit
+	 * @param vanish function to remove a unit
+	 */
+	EntitiesConductor(std::function<void(int, int, coord::phys2)> emerge, std::function<void(int)> vanish);
+
+	/**
+	 * Immediately mutate the world to the state of specified moment.
+	 *
+	 * @param current_time current time of the world
+	 * @param to desired time
+	 */
+	void jump(GameClock::moment current_time, GameClock::moment to);
+
+	/**
+	 * Output what happens between two moments.
+	 *
+	 * @param current_time current time of the world
+	 * @param other_time other point in time
+	 * @return sorted timed occurrences from the past to the future
+	 */
+	Prediction predict_migration(GameClock::moment current_time, GameClock::moment other_time) const;
+
+	/**
+	 * Update the history and mutate the world to eliminate the divergence.
+	 *
+	 * @param current_time current time of the world
+	 */
+	void converge(GameClock::moment current_time);
+
+	/**
+	 * Queue up some new history.
+	 *
+	 * It needs to be converged to take effect.
+	 *
+	 * @param list of curves
+	 */
+	void append_history(const Prediction &unapplied_history);
+
+private:
+	std::function<void(int, int, coord::phys2)> emerge;
+	std::function<void(int)> vanish;
+
+	Prediction history;
+	std::vector<size_t> history_sorted_by_ends;
+	Prediction unapplied_history;
+};
+
+}} // namespace openage::curve

--- a/libopenage/curve/entities_conductor_interpolator.cpp
+++ b/libopenage/curve/entities_conductor_interpolator.cpp
@@ -1,0 +1,100 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "entities_conductor_interpolator.h"
+
+#include <cmath>
+#include <algorithm>
+#include <tuple>
+
+#include "../error/error.h"
+#include "../testing/testing.h"
+
+#include "entities_conductor.h"
+
+namespace openage {
+namespace curve {
+
+namespace {
+GameClock::moment calc_new_frame_border(GameClock::moment desired_moment, GameClock::moment behind, GameClock::moment infront, GameClock::duration min_frame_duration) {
+	ENSURE(std::max(behind, infront) - std::min(behind, infront) >= min_frame_duration, "behind..infront must be at least min_frame_duration");
+	ENSURE((desired_moment < infront && infront < behind) || (behind < infront && infront <= desired_moment), "the behind..infront segment must be oriented towards the desired_moment");
+
+	const auto frame_count = decltype(min_frame_duration)(desired_moment - infront + decltype(min_frame_duration)(infront > behind ? 1 : 0)) / (1. * min_frame_duration);
+	const auto int_frame_count = infront > behind ? std::ceil(frame_count) : std::floor(frame_count);
+
+	const auto direction_unit = infront > behind ? 1 : -1;
+	const auto delta = (decltype(min_frame_duration)::rep(int_frame_count + direction_unit)) * min_frame_duration;
+	static_assert(std::is_signed<decltype(delta)::rep>::value, "time representation must be a signed number");
+
+	const auto new_infront = behind + delta > std::decay<decltype(behind)>::type{} ? behind + delta : std::decay<decltype(behind)>::type{};
+
+	return new_infront;
+}
+} // namespace
+
+EntitiesConductorInterpolator::EntitiesConductorInterpolator(EntitiesConductor &conductor, GameClock::duration min_frame_duration)
+	:
+	conductor{conductor},
+	min_frame_duration{min_frame_duration},
+	current_logic_frame_start{},
+	current_logic_frame_end{},
+	current_time{} {
+}
+
+void EntitiesConductorInterpolator::migrate(GameClock::moment m) {
+	ENSURE(this->current_logic_frame_start <= this->current_logic_frame_end, "time frame bounds are messed up");
+
+	if (m >= this->current_logic_frame_end || m < this->current_logic_frame_start)
+		this->expand_time_segment(m);
+
+	this->play(m);
+}
+
+void EntitiesConductorInterpolator::jump(GameClock::moment m) {
+	ENSURE(this->current_logic_frame_start <= this->current_logic_frame_end, "time frame bounds are messed up");
+
+	this->conductor.converge(this->current_time);
+
+	this->conductor.jump(this->current_time, m);
+	this->predictions_since_current_logic_frame_start.clear();
+	this->current_logic_frame_start = this->current_logic_frame_end = m;
+}
+
+void EntitiesConductorInterpolator::expand_time_segment(GameClock::moment m) {
+	ENSURE(this->current_logic_frame_start <= this->current_logic_frame_end, "time frame bounds are messed up");
+
+	GameClock::moment *behind = nullptr;
+	GameClock::moment *infront = nullptr;
+
+	if (m >= this->current_logic_frame_end)
+		std::tie(behind, infront) = std::make_tuple(&this->current_logic_frame_start, &this->current_logic_frame_end);
+	else if (m < this->current_logic_frame_start)
+		std::tie(behind, infront) = std::make_tuple(&this->current_logic_frame_end, &this->current_logic_frame_start);
+	else
+		ENSURE(false, "the moment is not outside of the current frame, so no frame moving needed");
+
+	std::tie(*behind, *infront) = std::make_pair(this->current_time, calc_new_frame_border(m, *behind, *infront, this->min_frame_duration));
+
+	this->conductor.converge(*behind);
+	this->predictions_since_current_logic_frame_start = this->conductor.predict_migration(*behind, *infront);
+}
+
+void EntitiesConductorInterpolator::play(GameClock::moment m) {
+}
+
+namespace tests {
+void advance_frame() {
+	calc_new_frame_border(GameClock::moment{5}, GameClock::moment{0}, GameClock::moment{5}, GameClock::duration{5}) == GameClock::moment{10} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{10}, GameClock::moment{0}, GameClock::moment{5}, GameClock::duration{5}) == GameClock::moment{15} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{35}, GameClock::moment{10}, GameClock::moment{30}, GameClock::duration{20}) == GameClock::moment{50} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{58}, GameClock::moment{10}, GameClock::moment{30}, GameClock::duration{20}) == GameClock::moment{70} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{70}, GameClock::moment{10}, GameClock::moment{30}, GameClock::duration{20}) == GameClock::moment{90} || TESTFAIL;
+
+	calc_new_frame_border(GameClock::moment{29}, GameClock::moment{40}, GameClock::moment{30}, GameClock::duration{10}) == GameClock::moment{20} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{20}, GameClock::moment{40}, GameClock::moment{30}, GameClock::duration{10}) == GameClock::moment{20} || TESTFAIL;
+	calc_new_frame_border(GameClock::moment{5}, GameClock::moment{40}, GameClock::moment{30}, GameClock::duration{10}) == GameClock::moment{0} || TESTFAIL;
+}
+
+} // tests
+
+}} // namespace openage::curve

--- a/libopenage/curve/entities_conductor_interpolator.h
+++ b/libopenage/curve/entities_conductor_interpolator.h
@@ -1,0 +1,71 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <functional>
+
+#include "game_clock.h"
+#include "occurence_curve.h"
+
+namespace openage {
+namespace curve {
+
+class EntitiesConductor;
+
+/**
+ * Obtains segments of history and interpolates them.
+ *
+ * Holds the current game time.
+ */
+class EntitiesConductorInterpolator
+{
+public:
+	/**
+	 * @param conductor holds the history of the world and can jump between moments in time
+	 * @param min_frame_duration minimal length of a time segment to hold
+	 */
+	explicit EntitiesConductorInterpolator(EntitiesConductor &conductor, GameClock::duration min_frame_duration);
+
+	/**
+	 * Move the world to the specific moment by performing everything between current time and that moment.
+	 *
+	 * Does converge when loading different segment.
+	 *
+	 * @param m target moment
+	 */
+	void migrate(GameClock::moment m);
+
+	/**
+	 * Immediately mutate the world to the state of specified moment.
+	 *
+	 * Does converge before jumping.
+	 *
+	 * @param m target moment
+	 */
+	void jump(GameClock::moment m);
+
+private:
+	/**
+	 * @param m target moment (must be outside of the current time segment)
+	 */
+	void expand_time_segment(GameClock::moment m);
+
+	void play(GameClock::moment m);
+
+	EntitiesConductor &conductor;
+
+	GameClock::duration min_frame_duration;
+
+	/**
+	 * 'start' is included into the segment, but the 'end' is not.
+	 * 'Start' <= 'end'.
+	 */
+	GameClock::moment current_logic_frame_start;
+	GameClock::moment current_logic_frame_end;
+
+	GameClock::moment current_time;
+
+	Prediction predictions_since_current_logic_frame_start;
+};
+
+}} // namespace openage::curve

--- a/libopenage/curve/game_clock.h
+++ b/libopenage/curve/game_clock.h
@@ -1,0 +1,22 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <chrono>
+#include <type_traits>
+
+namespace openage {
+namespace curve {
+
+struct GameClock {
+	using moment = std::chrono::milliseconds;
+	static_assert(std::is_trivially_default_constructible<moment>::value, "instance should be trivially-default-constructible since we use it everywhere");
+
+	using duration = std::chrono::milliseconds;
+	using rep = duration::rep;
+	using period = duration::period;
+	using time_point = std::chrono::time_point<GameClock>;
+	static const bool is_steady = false;
+};
+
+}} // namespace openage::curve

--- a/libopenage/curve/occurence.h
+++ b/libopenage/curve/occurence.h
@@ -1,0 +1,25 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+namespace openage {
+namespace curve {
+
+class Occurence
+{
+public:
+	enum class kind
+	{
+		ATTACK,
+		BUILD,
+		DIE,
+		GARRISON,
+		GATHER,
+		HEAL,
+		MOVE,
+		PRODUCE,
+		SPAWN,
+	};
+};
+
+}} // namespace openage::curve

--- a/libopenage/curve/occurence_curve.cpp
+++ b/libopenage/curve/occurence_curve.cpp
@@ -1,0 +1,110 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "occurence_curve.h"
+
+#include <array>
+#include <algorithm>
+#include <string>
+#include <type_traits>
+
+#include "../error/error.h"
+
+namespace openage {
+namespace curve {
+
+namespace
+{
+template <typename T, typename ...ArgTypes>
+bool has(T u, ArgTypes ...args) {
+	const std::array<T, sizeof...(args)> v{args...};
+	return std::find(std::begin(v), std::end(v), u) != std::end(v);
+}
+
+template<Shape>
+bool is(const OccurenceCurve& c);
+
+template<>
+bool is<Shape::POINT>(const OccurenceCurve& c) {
+	return has(
+		c.meta.kind,
+		Occurence::kind::ATTACK,
+		Occurence::kind::BUILD,
+		Occurence::kind::DIE,
+		Occurence::kind::GATHER,
+		Occurence::kind::GARRISON,
+		Occurence::kind::PRODUCE,
+		Occurence::kind::SPAWN
+	);
+}
+
+template<>
+bool is<Shape::SEGMENT>(const OccurenceCurve& c) {
+	return has(
+		c.meta.kind,
+		Occurence::kind::HEAL,
+		Occurence::kind::MOVE
+	);
+}
+
+void assert_failure(const OccurenceCurve& c, const char *message) {
+	const auto kindVal = "'" + std::to_string(static_cast<std::underlying_type_t<decltype(c.meta.kind)>>(c.meta.kind)) + "'";
+	ENSURE(false, message + kindVal);
+}
+
+template<typename T>
+Values<Shape::SEGMENT, T> trim(const Values<Shape::SEGMENT, T>& v, GameClock::moment begin_time, GameClock::moment end_time, GameClock::moment prior, GameClock::moment forth) {
+	const T new_initial = begin_time < prior ? v.initial + (v.final - v.initial) / ((end_time - begin_time) / (prior - begin_time)) : v.initial;
+	const T new_final = end_time < forth ? v.initial + (v.final - v.initial) / ((end_time - begin_time) / (forth - begin_time)) : v.final;
+	return {new_initial, new_final};
+}
+
+} // namespace
+
+GameClock::moment end_time(const OccurenceCurve& c) {
+	if (is<Shape::POINT>(c)) {
+		return c.origin.time;
+	} else if (is<Shape::SEGMENT>(c)) {
+		return c.desc.segment.time_instances.end_time;
+	} else {
+		assert_failure(c, "can not deduce the end time of the curve because of its unknown kind: ");
+		return c.origin.time;
+	}
+}
+
+OccurenceCurve trim(const OccurenceCurve& c, GameClock::moment prior, GameClock::moment forth) {
+	ENSURE(prior < forth, "non-normalized time segment");
+
+	const auto end = end_time(c);
+	ENSURE(prior <= c.origin.time && end < forth, "curve does not intersect the time segment");
+
+	auto result = c;
+
+	if (is<Shape::POINT>(c)) {
+		/**
+		 * The curve intersects the time segment and curve is a point, therefore it's inside it.
+		 */
+	} else if (is<Shape::SEGMENT>(c)) {
+		result.origin.time = std::min(c.origin.time, prior);
+		result.desc.segment.time_instances.end_time = std::max(c.desc.segment.time_instances.end_time, forth);
+
+		switch (c.meta.kind) {
+		case Occurence::kind::HEAL:
+			result.desc.segment.value.amount = trim(c.desc.segment.value.amount, c.origin.time, end, prior, forth);
+			break;
+
+		case Occurence::kind::MOVE:
+			result.desc.segment.value.pos = trim(c.desc.segment.value.pos, c.origin.time, end, prior, forth);
+			break;
+
+		default:
+			assert_failure(c, "can not trim segment-curve because of its wrong kind: ");
+			break;
+		}
+	} else {
+		assert_failure(c, "can not trim curve because of its unknown kind: ");
+	}
+
+	return result;
+}
+
+}} // namespace openage::curve

--- a/libopenage/curve/occurence_curve.h
+++ b/libopenage/curve/occurence_curve.h
@@ -1,0 +1,112 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <utility>
+#include <type_traits>
+#include <cstdint>
+#include <vector>
+
+#include "../coord/phys2.h"
+
+#include "game_clock.h"
+#include "occurence.h"
+
+namespace openage {
+namespace curve {
+
+/**
+ * TODO: establish int sizes
+ */
+struct OccurenceCurveMetadata {
+	/**
+	 * id of the concerned unit (optional)
+	 */
+	uint32_t unit_id;
+
+	/**
+	 * id of an additional unit (optional)
+	 */
+	uint32_t aux_unit_id;
+
+	/**
+	 * type like 'move', 'attack', etc.
+	 */
+	Occurence::kind kind;
+};
+
+enum class Shape {
+	POINT,
+	SEGMENT,
+};
+
+struct Origin {
+	GameClock::moment time;
+};
+
+template<Shape>
+struct TimeInstances;
+
+template<>
+struct TimeInstances<Shape::POINT> {
+};
+
+template<>
+struct TimeInstances<Shape::SEGMENT> {
+	GameClock::moment end_time;
+};
+
+template<Shape, typename T = void, typename N = std::integral_constant<bool, false>::type>
+struct Values {
+};
+
+template<typename T>
+struct Values<Shape::POINT, T, typename std::integral_constant<bool, std::is_same<T, void>::value>::type> {
+	T val;
+};
+
+
+template<typename T>
+struct Values<Shape::SEGMENT, T, typename std::integral_constant<bool, std::is_same<T, void>::value>::type> {
+	T initial;
+	T final;
+};
+
+/**
+ * TODO: replace with a std::variant
+ */
+template<Shape S>
+struct ControlPoints {
+	TimeInstances<S> time_instances;
+	union Value {
+		Values<S> empty;
+		Values<S, int> amount;
+		Values<S, coord::phys2> pos;
+	} value;
+};
+
+/**
+ * TODO: replace with a std::variant
+ * TODO: establish int sizes
+ */
+struct OccurenceCurve {
+	OccurenceCurveMetadata meta;
+
+	Origin origin;
+
+	union {
+		ControlPoints<Shape::POINT> point;
+		ControlPoints<Shape::SEGMENT> segment;
+	} desc;
+};
+
+using Prediction = std::vector<OccurenceCurve>;
+
+GameClock::moment end_time(const OccurenceCurve& c);
+
+/**
+ * The curve must intersect the time segment.
+ */
+OccurenceCurve trim(const OccurenceCurve& c, GameClock::moment prior, GameClock::moment forth);
+
+}} // namespace openage::curve

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -112,10 +112,9 @@ ActionMode::ActionMode(qtsdl::GuiItemLink *gui_link)
 		if (player->type_count() > 0) {
 			UnitType &type = *player->get_type(590);
 
-			// TODO: store pointer to the printer as a member, make bindable
-			AttributeWatcher printer;
 			// TODO tile position
-			engine.get_game()->placed_units.new_unit(printer, type, *player, this->mousepos_phys3);
+			if (curve::CurveRecord *record = engine.get_game()->get_record())
+				engine.get_game()->placed_units.new_unit(*record, type, *player, this->mousepos_phys3);
 		}
 	});
 	this->bind(action.get("KILL_UNIT"), [this](const input::action_arg_t &) {
@@ -335,18 +334,19 @@ bool ActionMode::place_selection(coord::phys3 point) {
 		// first create foundation using the producer
 		Engine &engine = Engine::get();
 		UnitContainer *container = &engine.get_game()->placed_units;
-		// TODO: store pointer to the printer as a member, make bindable
-		AttributeWatcher printer;
-		UnitReference new_building = container->new_unit(printer, *this->type_focus, *this->game_control->get_current_player(), point);
 
-		// task all selected villagers to build
-		// TODO: editor placed objects are completed already
-		if (new_building.is_valid()) {
-			Command cmd(*this->game_control->get_current_player(), new_building.get());
-			cmd.set_ability(ability_type::build);
-			cmd.add_flag(command_flag::direct);
-			this->selection->all_invoke(cmd);
-			return true;
+		if (curve::CurveRecord *record = engine.get_game()->get_record()) {
+			UnitReference new_building = container->new_unit(*record, *this->type_focus, *this->game_control->get_current_player(), point);
+
+			// task all selected villagers to build
+			// TODO: editor placed objects are completed already
+			if (new_building.is_valid()) {
+				Command cmd(*this->game_control->get_current_player(), new_building.get());
+				cmd.set_ability(ability_type::build);
+				cmd.add_flag(command_flag::direct);
+				this->selection->all_invoke(cmd);
+				return true;
+			}
 		}
 	}
 	return false;
@@ -531,9 +531,9 @@ void EditorMode::paint_entity_at(const coord::window &point, const bool del) {
 
 		// tile is empty so try creating a unit
 		UnitContainer *container = &engine.get_game()->placed_units;
-		// TODO: store pointer to the printer as a member, make bindable
-		AttributeWatcher printer;
-		container->new_unit(printer, *selected_type, *this->game_control->get_current_player(), mousepos_phys3);
+
+		if (curve::CurveRecord *record = engine.get_game()->get_record())
+			container->new_unit(*record, *selected_type, *this->game_control->get_current_player(), mousepos_phys3);
 	}
 }
 

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -4,6 +4,7 @@
 #include "util/strings.h"
 #include "terrain/terrain_chunk.h"
 #include "game_control.h"
+#include "unit/attribute_watcher.h"
 
 namespace openage {
 
@@ -111,8 +112,10 @@ ActionMode::ActionMode(qtsdl::GuiItemLink *gui_link)
 		if (player->type_count() > 0) {
 			UnitType &type = *player->get_type(590);
 
+			// TODO: store pointer to the printer as a member, make bindable
+			AttributeWatcher printer;
 			// TODO tile position
-			engine.get_game()->placed_units.new_unit(type, *player, this->mousepos_phys3);
+			engine.get_game()->placed_units.new_unit(printer, type, *player, this->mousepos_phys3);
 		}
 	});
 	this->bind(action.get("KILL_UNIT"), [this](const input::action_arg_t &) {
@@ -332,7 +335,9 @@ bool ActionMode::place_selection(coord::phys3 point) {
 		// first create foundation using the producer
 		Engine &engine = Engine::get();
 		UnitContainer *container = &engine.get_game()->placed_units;
-		UnitReference new_building = container->new_unit(*this->type_focus, *this->game_control->get_current_player(), point);
+		// TODO: store pointer to the printer as a member, make bindable
+		AttributeWatcher printer;
+		UnitReference new_building = container->new_unit(printer, *this->type_focus, *this->game_control->get_current_player(), point);
 
 		// task all selected villagers to build
 		// TODO: editor placed objects are completed already
@@ -526,7 +531,9 @@ void EditorMode::paint_entity_at(const coord::window &point, const bool del) {
 
 		// tile is empty so try creating a unit
 		UnitContainer *container = &engine.get_game()->placed_units;
-		container->new_unit(*selected_type, *this->game_control->get_current_player(), mousepos_phys3);
+		// TODO: store pointer to the printer as a member, make bindable
+		AttributeWatcher printer;
+		container->new_unit(printer, *selected_type, *this->game_control->get_current_player(), mousepos_phys3);
 	}
 }
 

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -291,7 +291,7 @@ public:
 
 	void set_modes(const std::vector<OutputMode*> &modes);
 
-	void set_mode(int mode);
+	void set_mode(int mode, bool signal_if_unchanged=false);
 	void announce_mode();
 	void announce_current_player_name();
 

--- a/libopenage/gamestate/game_main.cpp
+++ b/libopenage/gamestate/game_main.cpp
@@ -4,6 +4,8 @@
 #include "../terrain/terrain.h"
 #include "../unit/unit_type.h"
 #include "game_main.h"
+
+#include "../unit/attribute_watcher.h"
 #include "game_spec.h"
 #include "generator.h"
 
@@ -29,7 +31,9 @@ GameMain::GameMain(const Generator &generator)
 
 	// initialise units
 	this->placed_units.set_terrain(this->terrain);
-	generator.add_units(*this);
+	// TODO: store pointer to the printer as a member, make bindable
+	AttributeWatcher printer;
+	generator.add_units(*this, printer);
 }
 
 GameMain::~GameMain() {
@@ -49,7 +53,9 @@ GameSpec *GameMain::get_spec() {
 }
 
 void GameMain::update() {
-	this->placed_units.update_all();
+	// TODO: store pointer to the printer as a member, make bindable
+	AttributeWatcher printer;
+	this->placed_units.update_all(printer);
 }
 
 Civilisation *GameMain::add_civ(int civ_id) {

--- a/libopenage/gamestate/game_main.h
+++ b/libopenage/gamestate/game_main.h
@@ -17,6 +17,10 @@ namespace openage {
 class Generator;
 class Terrain;
 
+namespace curve {
+class CurveRecordReplay;
+} // namespace curve
+
 /**
  * Contains information for a single game
  * This information must be synced across network clients
@@ -49,6 +53,11 @@ public:
 	 */
 	void update();
 
+	curve::CurveRecordReplay* get_record_replay() const;
+	void set_record_replay(curve::CurveRecordReplay *record_replay);
+
+	curve::CurveRecord* get_record() const;
+
 	/**
 	 * map information
 	 */
@@ -78,6 +87,8 @@ private:
 	std::vector<std::shared_ptr<Civilisation>> civs;
 
 	std::shared_ptr<GameSpec> spec;
+
+	curve::CurveRecordReplay *record_replay;
 };
 
 } // openage
@@ -101,6 +112,9 @@ public:
 	explicit GameMainHandle(qtsdl::GuiItemLink *gui_link);
 
 	void set_engine(Engine *engine);
+
+	curve::CurveRecordReplay* get_record_replay() const;
+	void set_record_replay(curve::CurveRecordReplay *record_replay);
 
 	void clear();
 

--- a/libopenage/gamestate/game_save.cpp
+++ b/libopenage/gamestate/game_save.cpp
@@ -19,21 +19,19 @@ namespace openage {
 namespace gameio {
 
 void save_unit(std::ofstream &file, Unit *unit) {
-	// TODO: store pointer to the printer as a member, make bindable
-	AttributeWatcher printer;
 	file << unit->unit_type->id() << std::endl;
-	file << unit->get_attribute<attr_type::owner>(printer).player.player_number << std::endl;
+	file << unit->get_attribute<attr_type::owner>().player.player_number << std::endl;
 	coord::tile pos = unit->location->pos.start;
 	file << pos.ne << " " << pos.se << std::endl;
 
 	bool has_building_attr = unit->has_attribute(attr_type::building);
 	file << has_building_attr << std::endl;
 	if (has_building_attr) {
-		file << unit->get_attribute<attr_type::building>(printer).completed << std::endl;
+		file << unit->get_attribute<attr_type::building>().completed << std::endl;
 	}
 }
 
-void load_unit(std::ifstream &file, openage::GameMain *game, AttributeWatcher &watcher) {
+void load_unit(std::ifstream &file, openage::GameMain *game, curve::CurveRecord &watcher) {
 	int pr_id;
 	int player_no;
 	coord::phys_t ne, se;
@@ -143,10 +141,10 @@ void load(openage::GameMain *game, std::string fname) {
 	game->placed_units.reset();
 	unsigned int num_units;
 	file >> num_units;
-	// TODO: pass pointer to the printer, make bindable
-	AttributeWatcher printer;
+
+	curve::CurveRecord watcher{nullptr};
 	for (unsigned int u = 0; u < num_units; ++u) {
-		load_unit(file, game, printer);
+		load_unit(file, game, watcher);
 	}
 }
 

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -242,7 +242,7 @@ std::shared_ptr<Terrain> Generator::terrain() const {
 	return terrain;
 }
 
-void Generator::add_units(GameMain &m, AttributeWatcher &watcher) const {
+void Generator::add_units(GameMain &m, curve::CurveRecord &watcher) const {
 	for (auto &r : this->regions) {
 
 		// Regions filled with resource objects

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -242,7 +242,7 @@ std::shared_ptr<Terrain> Generator::terrain() const {
 	return terrain;
 }
 
-void Generator::add_units(GameMain &m) const {
+void Generator::add_units(GameMain &m, AttributeWatcher &watcher) const {
 	for (auto &r : this->regions) {
 
 		// Regions filled with resource objects
@@ -254,7 +254,7 @@ void Generator::add_units(GameMain &m) const {
 				break;
 			}
 			for (auto &tile : r.get_tiles()) {
-				m.placed_units.new_unit(*otype, p, tile.to_tile3().to_phys3());
+				m.placed_units.new_unit(watcher, *otype, p, tile.to_tile3().to_phys3());
 			}
 		}
 
@@ -273,18 +273,18 @@ void Generator::add_units(GameMain &m) const {
 			tile.se -= 1;
 
 			// Place a completed town center
-			auto ref = m.placed_units.new_unit(*tctype, p, tile.to_tile3().to_phys3());
+			auto ref = m.placed_units.new_unit(watcher, *tctype, p, tile.to_tile3().to_phys3());
 			if (ref.is_valid()) {
-				complete_building(*ref.get());
+				complete_building(watcher, *ref.get());
 			}
 
 			// Place three villagers
 			tile.ne -= 1;
-			m.placed_units.new_unit(*fvtype, p, tile.to_tile3().to_phys3());
+			m.placed_units.new_unit(watcher, *fvtype, p, tile.to_tile3().to_phys3());
 			tile.se += 1;
-			m.placed_units.new_unit(*mvtype, p, tile.to_tile3().to_phys3());
+			m.placed_units.new_unit(watcher, *mvtype, p, tile.to_tile3().to_phys3());
 			tile.se += 1;
-			m.placed_units.new_unit(*fvtype, p, tile.to_tile3().to_phys3());
+			m.placed_units.new_unit(watcher, *fvtype, p, tile.to_tile3().to_phys3());
 		}
 	}
 }

--- a/libopenage/gamestate/generator.h
+++ b/libopenage/gamestate/generator.h
@@ -19,7 +19,10 @@ class GameSpec;
 class Terrain;
 class GameMain;
 class Engine;
-class AttributeWatcher;
+
+namespace curve {
+class CurveRecord;
+} // namespace curve
 
 namespace rng {
 class RNG;
@@ -157,7 +160,7 @@ public:
 	/**
 	 * places all initial objects
 	 */
-	void add_units(GameMain &m, AttributeWatcher &watcher) const;
+	void add_units(GameMain &m, curve::CurveRecord &watcher) const;
 
 	std::unique_ptr<GameMain> create(std::shared_ptr<GameSpec> spec);
 

--- a/libopenage/gamestate/generator.h
+++ b/libopenage/gamestate/generator.h
@@ -19,6 +19,7 @@ class GameSpec;
 class Terrain;
 class GameMain;
 class Engine;
+class AttributeWatcher;
 
 namespace rng {
 class RNG;
@@ -156,7 +157,7 @@ public:
 	/**
 	 * places all initial objects
 	 */
-	void add_units(GameMain &m) const;
+	void add_units(GameMain &m, AttributeWatcher &watcher) const;
 
 	std::unique_ptr<GameMain> create(std::shared_ptr<GameSpec> spec);
 

--- a/libopenage/gui/CMakeLists.txt
+++ b/libopenage/gui/CMakeLists.txt
@@ -2,6 +2,7 @@ add_sources(libopenage
 	assetmanager_link.cpp
 	actions_list_model.cpp
 	category_contents_list_model.cpp
+	curve_record_replay_link.cpp
 	engine_link.cpp
 	game_control_link.cpp
 	game_creator.cpp

--- a/libopenage/gui/curve_record_replay_link.cpp
+++ b/libopenage/gui/curve_record_replay_link.cpp
@@ -1,0 +1,50 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "curve_record_replay_link.h"
+
+#include <QtQml>
+
+namespace openage {
+namespace gui {
+
+namespace {
+const int registration = qmlRegisterUncreatableType<CurveRecordReplayLink>("yay.sfttech.openage", 1, 0, "CurveRecordReplay", "CurveRecordReplay is an abstract uncreatable base");
+const int registration_recorder = qmlRegisterType<CurveRecordLink>("yay.sfttech.openage", 1, 0, "CurveRecord");
+const int registration_player = qmlRegisterType<CurveReplayLink>("yay.sfttech.openage", 1, 0, "CurveReplay");
+}
+
+CurveRecordReplayLink::CurveRecordReplayLink(QObject *parent)
+	:
+	GuiItemQObject{parent},
+	GuiItemInterface{} {
+	Q_UNUSED(registration);
+}
+
+QString CurveRecordReplayLink::get_file_name() const {
+	return this->file_name;
+}
+
+void CurveRecordReplayLink::set_file_name(const QString &file_name) {
+	static auto f = [] (curve::CurveRecordReplay *_this, const QString &file_name) {
+		_this->set_file_name(file_name.toStdString());
+	};
+	this->s(f, this->file_name, file_name);
+}
+
+void CurveRecordReplayLink::on_core_adopted() {
+	this->file_name = QString::fromStdString(unwrap(this)->get_file_name());
+}
+
+CurveRecordLink::CurveRecordLink(QObject *parent)
+	:
+	Inherits{parent} {
+	Q_UNUSED(registration_recorder);
+}
+
+CurveReplayLink::CurveReplayLink(QObject *parent)
+	:
+	Inherits{parent} {
+	Q_UNUSED(registration_player);
+}
+
+}} // namespace openage::gui

--- a/libopenage/gui/curve_record_replay_link.h
+++ b/libopenage/gui/curve_record_replay_link.h
@@ -1,0 +1,82 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include "guisys/link/gui_item.h"
+
+#include "../curve/curve_record_replay.h"
+
+namespace openage {
+namespace gui {
+class CurveRecordReplayLink;
+class CurveRecordLink;
+class CurveReplayLink;
+}} // namespace openage::gui
+
+namespace qtsdl {
+template<>
+struct Wrap<openage::curve::CurveRecordReplay> {
+	using Type = openage::gui::CurveRecordReplayLink;
+};
+
+template<>
+struct Unwrap<openage::gui::CurveRecordReplayLink> {
+	using Type = openage::curve::CurveRecordReplay;
+};
+
+template<>
+struct Wrap<openage::curve::CurveRecord> {
+	using Type = openage::gui::CurveRecordLink;
+};
+
+template<>
+struct Unwrap<openage::gui::CurveRecordLink> {
+	using Type = openage::curve::CurveRecord;
+};
+
+template<>
+struct Wrap<openage::curve::CurveReplay> {
+	using Type = openage::gui::CurveReplayLink;
+};
+
+template<>
+struct Unwrap<openage::gui::CurveReplayLink> {
+	using Type = openage::curve::CurveReplay;
+};
+
+} // namespace qtsdl
+
+namespace openage {
+namespace gui {
+
+class CurveRecordReplayLink : public qtsdl::GuiItemQObject, public qtsdl::GuiItemInterface<CurveRecordReplayLink> {
+	Q_OBJECT
+
+	Q_PROPERTY(QString fileName READ get_file_name WRITE set_file_name)
+
+public:
+	explicit CurveRecordReplayLink(QObject *parent=nullptr);
+
+	QString get_file_name() const;
+	void set_file_name(const QString &file_name);
+
+private:
+	virtual void on_core_adopted() override;
+
+protected:
+	QString file_name;
+};
+
+class CurveRecordLink : public qtsdl::Inherits<CurveRecordReplayLink, CurveRecordLink> {
+	Q_OBJECT
+public:
+	explicit CurveRecordLink(QObject *parent=nullptr);
+};
+
+class CurveReplayLink : public qtsdl::Inherits<CurveRecordReplayLink, CurveReplayLink> {
+	Q_OBJECT
+public:
+	explicit CurveReplayLink(QObject *parent=nullptr);
+};
+
+}} // namespace openage::gui

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -198,7 +198,7 @@ GameControlLink::GameControlLink(QObject *parent)
 	GuiItem{this},
 	mode{},
 	effective_mode_index{-1},
-	mode_index{},
+	mode_index{-1},
 	engine{},
 	game{},
 	current_civ_index{} {
@@ -241,7 +241,7 @@ int GameControlLink::get_mode_index() const {
 
 void GameControlLink::set_mode_index(int mode) {
 	static auto f = [] (GameControl *_this, int mode) {
-		_this->set_mode(mode);
+		_this->set_mode(mode, true);
 	};
 
 	this->sf(f, this->mode_index, mode);
@@ -312,6 +312,7 @@ void GameControlLink::on_modes_changed(OutputMode *mode, int mode_index) {
 	this->i(f, this->mode_index);
 
 	this->on_mode_changed(mode, mode_index);
+	emit this->modes_changed();
 }
 
 void GameControlLink::on_current_player_name_changed(const std::string &current_player_name) {

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -231,7 +231,7 @@ class GameControlLink : public qtsdl::GuiItemQObject, public QQmlParserStatus, p
 	Q_PROPERTY(openage::gui::OutputModeLink* mode READ get_mode NOTIFY mode_changed)
 	Q_PROPERTY(int effectiveModeIndex READ get_effective_mode_index NOTIFY mode_changed)
 	Q_PROPERTY(int modeIndex READ get_mode_index WRITE set_mode_index)
-	Q_PROPERTY(QVariantList modes READ get_modes WRITE set_modes)
+	Q_PROPERTY(QVariantList modes READ get_modes WRITE set_modes NOTIFY modes_changed)
 	Q_PROPERTY(openage::gui::EngineLink* engine READ get_engine WRITE set_engine)
 	Q_PROPERTY(openage::gui::GameMainLink* game READ get_game WRITE set_game)
 	Q_PROPERTY(QString currentPlayerName READ get_current_player_name NOTIFY current_player_name_changed)
@@ -261,6 +261,7 @@ public:
 
 signals:
 	void mode_changed();
+	void modes_changed();
 	void current_player_name_changed();
 	void current_civ_index_changed();
 

--- a/libopenage/gui/game_main_link.cpp
+++ b/libopenage/gui/game_main_link.cpp
@@ -6,6 +6,7 @@
 
 #include "../engine.h"
 #include "engine_link.h"
+#include "curve_record_replay_link.h"
 
 namespace openage {
 namespace gui {
@@ -55,6 +56,18 @@ void GameMainLink::set_engine(EngineLink *engine) {
 		_this->set_engine(engine);
 	};
 	this->s(f, this->engine, engine);
+}
+
+CurveRecordReplayLink* GameMainLink::get_record_replay() const {
+	return this->record_replay;
+}
+
+void GameMainLink::set_record_replay(CurveRecordReplayLink *record_replay) {
+	static auto f = [] (GameMainHandle *_this, curve::CurveRecordReplay *record_replay) {
+		if (auto game = _this->get_game())
+			game->set_record_replay(record_replay);
+	};
+	this->s(f, this->record_replay, record_replay);
 }
 
 void GameMainLink::clear() {

--- a/libopenage/gui/game_main_link.h
+++ b/libopenage/gui/game_main_link.h
@@ -13,6 +13,7 @@ namespace gui {
 
 class EngineLink;
 class GameMainLink;
+class CurveRecordReplayLink;
 
 }} // namespace openage::gui
 
@@ -39,6 +40,7 @@ class GameMainLink : public qtsdl::GuiItemQObject, public QQmlParserStatus, publ
 	Q_ENUMS(State)
 	Q_PROPERTY(State state READ get_state NOTIFY state_changed)
 	Q_PROPERTY(openage::gui::EngineLink* engine READ get_engine WRITE set_engine)
+	Q_PROPERTY(openage::gui::CurveRecordReplayLink* recordReplay READ get_record_replay WRITE set_record_replay)
 
 public:
 	explicit GameMainLink(QObject *parent=nullptr);
@@ -52,6 +54,9 @@ public:
 
 	EngineLink* get_engine() const;
 	void set_engine(EngineLink *engine);
+
+	CurveRecordReplayLink* get_record_replay() const;
+	void set_record_replay(CurveRecordReplayLink *record_replay);
 
 	Q_INVOKABLE	void clear();
 
@@ -69,6 +74,7 @@ private:
 	State state;
 	bool active;
 	EngineLink *engine;
+	CurveRecordReplayLink *record_replay;
 };
 
 }} // namespace openage::gui

--- a/libopenage/gui/qml/CreateGameWhenReady.qml
+++ b/libopenage/gui/qml/CreateGameWhenReady.qml
@@ -1,0 +1,28 @@
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+import QtQuick 2.4
+import yay.sfttech.openage 1.0
+
+GameCreator {
+	id: root
+
+	property bool enabled: false
+	property GameControl gameControl
+	property int gameControlTargetModeIndex
+
+	property int specState: gameSpec ? gameSpec.state : GameSpec.Null
+	property int gameState: game ? game.state : GameMain.Null
+
+	onSpecStateChanged: {
+		if (enabled && specState == GameSpec.Ready)
+			activate()
+	}
+
+	onGameStateChanged: {
+		if (enabled && gameState == GameMain.Running)
+			if (gameControl.modeIndex != -1)
+				gameControl.modeIndex = gameControlTargetModeIndex
+			else
+				console.error("CreateGameWhenReady: could not find the desired mode to switch to")
+	}
+}

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -124,6 +124,17 @@ Item {
 			LR.tag: "editorMode"
 		}
 
+		CreateGameWhenReady {
+			enabled: createWhenReady.checked
+
+			game: gameObj
+			gameSpec: specObj
+			generatorParameters: genParamsObj
+			gameControl: gameControlObj
+
+			gameControlTargetModeIndex: gameControlObj.modes.indexOf(actionModeObj)
+		}
+
 		states: [
 			State {
 				id: creationMode
@@ -140,6 +151,11 @@ Item {
 						generatorParameters: genParamsObj
 						gameSpec: specObj
 						game: gameObj
+					},
+					CheckBoxFlat {
+						id: createWhenReady
+						text: "create_when_ready"
+						visible: specObj.state == GameSpec.Loading
 					}
 				]
 

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -65,7 +65,13 @@ Item {
 		engine: Engine
 		game: gameObj
 
-		modes: [createModeObj, editorModeObj, actionModeObj]
+		/**
+		 * must be run after the engine is attached
+		 */
+		Component.onCompleted: {
+			modes = [createModeObj, editorModeObj, actionModeObj]
+			modeIndex = 0
+		}
 
 		LR.tag: "gamecontrol"
 	}

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -50,13 +50,34 @@ Item {
 	GameMain {
 		id: gameObj
 
+		property bool recording: true
+
 		/**
 		 * States: Null, Running
 		 */
+		 onStateChanged:
+			if (state == GameMain.Running)
+				recordReplay = recording ? recordObj : replayObj
 
 		engine: Engine
 
 		LR.tag: "game"
+	}
+
+	CurveRecord {
+		id: recordObj
+
+		fileName: gameObj.recording ? "replay.txt" : ""
+
+		LR.tag: "record"
+	}
+
+	CurveReplay {
+		id: replayObj
+
+		fileName: gameObj.recording ? "" : "replay.txt"
+
+		LR.tag: "replay"
 	}
 
 	GameControl {

--- a/libopenage/terrain/CMakeLists.txt
+++ b/libopenage/terrain/CMakeLists.txt
@@ -4,4 +4,5 @@ add_sources(libopenage
 	terrain_object.cpp
 	terrain_outline.cpp
 	terrain_search.cpp
+	tile_range_serialization.cpp
 )

--- a/libopenage/terrain/terrain_object.cpp
+++ b/libopenage/terrain/terrain_object.cpp
@@ -117,7 +117,7 @@ bool TerrainObject::place(object_state init_state) {
 	return true;
 }
 
-bool TerrainObject::place(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position, object_state init_state) {
+bool TerrainObject::place(curve::CurveRecord &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position, object_state init_state) {
 	if (this->state != object_state::removed) {
 		throw Error(MSG(err) << "This object has already been placed.");
 	}
@@ -138,7 +138,7 @@ bool TerrainObject::place(AttributeWatcher &watcher, std::shared_ptr<Terrain> t,
 	return true;
 }
 
-bool TerrainObject::move(AttributeWatcher &watcher, coord::phys3 &position) {
+bool TerrainObject::move(curve::CurveRecord &watcher, coord::phys3 &position) {
 	if (this->state == object_state::removed) {
 		return false;
 	}
@@ -258,10 +258,10 @@ bool TerrainObject::operator <(const TerrainObject &other) {
 	return true;
 }
 
-void TerrainObject::place_unchecked(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position) {
+void TerrainObject::place_unchecked(curve::CurveRecord &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position) {
 	// storing the position:
 	this->pos = get_range(position);
-	watcher.apply(this->unit.id, this->pos, "pos");
+	watcher.write_out(this->unit.id, this->pos, "pos");
 	this->terrain = t;
 	this->occupied_chunk_count = 0;
 
@@ -469,7 +469,7 @@ tile_range building_center(coord::phys3 west, coord::tile_delta size) {
 	return result;
 }
 
-bool complete_building(AttributeWatcher &watcher, Unit &u) {
+bool complete_building(curve::CurveRecord &watcher, Unit &u) {
 	if (u.has_attribute(attr_type::building)) {
 		auto &build = u.get_attribute<attr_type::building>(watcher);
 		build.completed = 1.0f;

--- a/libopenage/terrain/terrain_object.cpp
+++ b/libopenage/terrain/terrain_object.cpp
@@ -467,9 +467,9 @@ tile_range building_center(coord::phys3 west, coord::tile_delta size) {
 	return result;
 }
 
-bool complete_building(Unit &u) {
+bool complete_building(AttributeWatcher &watcher, Unit &u) {
 	if (u.has_attribute(attr_type::building)) {
-		auto &build = u.get_attribute<attr_type::building>();
+		auto &build = u.get_attribute<attr_type::building>(watcher);
 		build.completed = 1.0f;
 
 		// set ground under a completed building

--- a/libopenage/terrain/terrain_object.h
+++ b/libopenage/terrain/terrain_object.h
@@ -147,17 +147,18 @@ public:
 	/**
 	 * binds the TerrainObject to a certain TerrainChunk.
 	 *
+	 * @param watcher: observes position change
 	 * @param terrain: the terrain where the object will be placed onto.
 	 * @param pos: (tile) position of the (nw,sw) corner
 	 * @param init_state should be floating, placed or placed_no_collision
 	 * @returns true when the object was placed, false when it did not fit at pos.
 	 */
-	bool place(std::shared_ptr<Terrain> t, coord::phys3 &pos, object_state init_state);
+	bool place(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &pos, object_state init_state);
 
 	/**
 	 * moves the object -- returns false if object cannot be moved here
 	 */
-	bool move(coord::phys3 &pos);
+	bool move(AttributeWatcher &watcher, coord::phys3 &pos);
 
 	/**
 	 * remove this TerrainObject from the terrain chunks.
@@ -276,7 +277,7 @@ protected:
 	 * otherwise the place function should be used
 	 * this does not modify the units placement state
 	 */
-	void place_unchecked(std::shared_ptr<Terrain> t, coord::phys3 &position);
+	void place_unchecked(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position);
 };
 
 /**

--- a/libopenage/terrain/terrain_object.h
+++ b/libopenage/terrain/terrain_object.h
@@ -9,13 +9,18 @@
 #include "../coord/tile.h"
 #include "../coord/phys3.h"
 
+#include "tile_range.h"
+
 namespace openage {
 
 class Terrain;
 class TerrainChunk;
 class Texture;
 class Unit;
-class AttributeWatcher;
+
+namespace curve {
+class CurveRecord;
+} // namespace curve
 
 /**
  * only placed will enable collision checks
@@ -25,18 +30,6 @@ enum class object_state {
 	floating,
 	placed,
 	placed_no_collision
-};
-
-/**
- * A rectangle or square of tiles which is the minimim
- * space to fit the units foundation or radius
- * the end tile will have ne and se values greater or equal to
- * the start tile
- */
-struct tile_range {
-	coord::tile start;
-	coord::tile end;	// start <= end
-	coord::phys3 draw;	// gets used as center point of radial objects
 };
 
 /**
@@ -56,7 +49,7 @@ tile_range building_center(coord::phys3 west, coord::tile_delta size);
 /**
  * sets a building to a fully completed state
  */
-bool complete_building(AttributeWatcher &watcher, Unit &);
+bool complete_building(curve::CurveRecord &watcher, Unit &);
 
 /**
  * half a tile
@@ -153,12 +146,12 @@ public:
 	 * @param init_state should be floating, placed or placed_no_collision
 	 * @returns true when the object was placed, false when it did not fit at pos.
 	 */
-	bool place(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &pos, object_state init_state);
+	bool place(curve::CurveRecord &watcher, std::shared_ptr<Terrain> t, coord::phys3 &pos, object_state init_state);
 
 	/**
 	 * moves the object -- returns false if object cannot be moved here
 	 */
-	bool move(AttributeWatcher &watcher, coord::phys3 &pos);
+	bool move(curve::CurveRecord &watcher, coord::phys3 &pos);
 
 	/**
 	 * remove this TerrainObject from the terrain chunks.
@@ -277,7 +270,7 @@ protected:
 	 * otherwise the place function should be used
 	 * this does not modify the units placement state
 	 */
-	void place_unchecked(AttributeWatcher &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position);
+	void place_unchecked(curve::CurveRecord &watcher, std::shared_ptr<Terrain> t, coord::phys3 &position);
 };
 
 /**

--- a/libopenage/terrain/terrain_object.h
+++ b/libopenage/terrain/terrain_object.h
@@ -15,6 +15,7 @@ class Terrain;
 class TerrainChunk;
 class Texture;
 class Unit;
+class AttributeWatcher;
 
 /**
  * only placed will enable collision checks
@@ -55,7 +56,7 @@ tile_range building_center(coord::phys3 west, coord::tile_delta size);
 /**
  * sets a building to a fully completed state
  */
-bool complete_building(Unit &);
+bool complete_building(AttributeWatcher &watcher, Unit &);
 
 /**
  * half a tile

--- a/libopenage/terrain/tile_range.h
+++ b/libopenage/terrain/tile_range.h
@@ -1,0 +1,22 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include "../coord/tile.h"
+#include "../coord/phys3.h"
+
+namespace openage {
+
+/**
+ * A rectangle or square of tiles which is the minimim
+ * space to fit the units foundation or radius
+ * the end tile will have ne and se values greater or equal to
+ * the start tile
+ */
+struct tile_range {
+	coord::tile start;
+	coord::tile end;	// start <= end
+	coord::phys3 draw;	// gets used as center point of radial objects
+};
+
+}

--- a/libopenage/terrain/tile_range_serialization.cpp
+++ b/libopenage/terrain/tile_range_serialization.cpp
@@ -1,0 +1,22 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "tile_range_serialization.h"
+
+#include "terrain_object.h"
+#include "../coord/tile_serialization.h"
+#include "../coord/phys3_serialization.h"
+
+namespace openage {
+
+std::ostream& operator<<(std::ostream &o, const tile_range &v) {
+	o << '(' << v.start << ',' << v.end << ',' << v.draw << ')';
+	return o;
+}
+
+std::istream& operator>>(std::istream &i, tile_range &v) {
+	char c;
+	i >> c >> v.start >> c >> v.end >> c >> v.draw >> c;
+	return i;
+}
+
+} // openage

--- a/libopenage/terrain/tile_range_serialization.h
+++ b/libopenage/terrain/tile_range_serialization.h
@@ -1,0 +1,14 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <iostream>
+
+namespace openage {
+
+struct tile_range;
+
+std::ostream& operator<<(std::ostream &o, const tile_range &v);
+std::istream& operator>>(std::istream &i, tile_range &v);
+
+} // openage

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -69,7 +69,7 @@ bool MoveAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void MoveAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
+void MoveAbility::invoke(curve::CurveRecord&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke move action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -101,7 +101,7 @@ bool SetPointAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	       to_modify.has_attribute(attr_type::building);
 }
 
-void SetPointAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool) {
+void SetPointAbility::invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool) {
 	auto &build_attr = to_modify.get_attribute<attr_type::building>(watcher);
 	build_attr.gather_point = cmd.position();
 }
@@ -130,7 +130,7 @@ bool GarrisonAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	       is_ally(to_modify, target);
 }
 
-void GarrisonAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
+void GarrisonAbility::invoke(curve::CurveRecord&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke garrison action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -151,7 +151,7 @@ bool UngarrisonAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void UngarrisonAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
+void UngarrisonAbility::invoke(curve::CurveRecord&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke ungarrison action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -174,7 +174,7 @@ bool TrainAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void TrainAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
+void TrainAbility::invoke(curve::CurveRecord&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke train action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -198,7 +198,7 @@ bool BuildAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void BuildAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
+void BuildAbility::invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke build action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -225,7 +225,7 @@ bool GatherAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void GatherAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
+void GatherAbility::invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke gather action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -260,7 +260,7 @@ bool AttackAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void AttackAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
+void AttackAbility::invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke attack action");
 	if (play_sound && this->sound) {
 		this->sound->play();

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -69,7 +69,7 @@ bool MoveAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void MoveAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void MoveAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke move action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -101,8 +101,8 @@ bool SetPointAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	       to_modify.has_attribute(attr_type::building);
 }
 
-void SetPointAbility::invoke(Unit &to_modify, const Command &cmd, bool) {
-	auto &build_attr = to_modify.get_attribute<attr_type::building>();
+void SetPointAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool) {
+	auto &build_attr = to_modify.get_attribute<attr_type::building>(watcher);
 	build_attr.gather_point = cmd.position();
 }
 
@@ -130,7 +130,7 @@ bool GarrisonAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	       is_ally(to_modify, target);
 }
 
-void GarrisonAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void GarrisonAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke garrison action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -151,7 +151,7 @@ bool UngarrisonAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void UngarrisonAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void UngarrisonAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke ungarrison action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -174,7 +174,7 @@ bool TrainAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void TrainAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void TrainAbility::invoke(AttributeWatcher&, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke train action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -198,14 +198,14 @@ bool BuildAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void BuildAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void BuildAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke build action");
 	if (play_sound && this->sound) {
 		this->sound->play();
 	}
 
 	if (cmd.has_unit()) {
-		to_modify.push_action(std::make_unique<BuildAction>(&to_modify, cmd.unit()->get_ref()));
+		to_modify.push_action(std::make_unique<BuildAction>(&to_modify, cmd.unit()->get_ref(), watcher));
 	}
 }
 
@@ -225,7 +225,7 @@ bool GatherAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void GatherAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void GatherAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke gather action");
 	if (play_sound && this->sound) {
 		this->sound->play();
@@ -233,7 +233,7 @@ void GatherAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound)
 
 	Unit *target = cmd.unit();
 	try {
-		to_modify.push_action(std::make_unique<GatherAction>(&to_modify, target->get_ref()));
+		to_modify.push_action(std::make_unique<GatherAction>(&to_modify, target->get_ref(), watcher));
 	} catch (const std::invalid_argument &e) {
 		to_modify.log(MSG(dbg) << "invoke gather action cancelled due to an exception. Reason: " << e.what());
 	}
@@ -260,14 +260,14 @@ bool AttackAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	return false;
 }
 
-void AttackAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+void AttackAbility::invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound) {
 	to_modify.log(MSG(dbg) << "invoke attack action");
 	if (play_sound && this->sound) {
 		this->sound->play();
 	}
 
 	Unit *target = cmd.unit();
-	to_modify.push_action(std::make_unique<AttackAction>(&to_modify, target->get_ref()));
+	to_modify.push_action(std::make_unique<AttackAction>(watcher, &to_modify, target->get_ref()));
 }
 
 ability_set UnitAbility::set_from_list(const std::vector<ability_type> &items) {

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -19,6 +19,7 @@ class Unit;
 class UnitAction;
 class UnitTexture;
 class UnitType;
+class AttributeWatcher;
 
 /**
  * roughly the same as command_ability in game data
@@ -95,7 +96,7 @@ public:
 	/**
 	 * applies command to a given unit
 	 */
-	virtual void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
+	virtual void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
 
 	/**
  	 * some common functions
@@ -127,7 +128,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -146,7 +147,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 };
 
 
@@ -163,7 +164,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -182,7 +183,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -201,7 +202,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -220,7 +221,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -239,7 +240,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -258,7 +259,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -19,7 +19,10 @@ class Unit;
 class UnitAction;
 class UnitTexture;
 class UnitType;
-class AttributeWatcher;
+
+namespace curve {
+class CurveRecord;
+} // namespace curve
 
 /**
  * roughly the same as command_ability in game data
@@ -96,7 +99,7 @@ public:
 	/**
 	 * applies command to a given unit
 	 */
-	virtual void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
+	virtual void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) = 0;
 
 	/**
  	 * some common functions
@@ -128,7 +131,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -147,7 +150,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 };
 
 
@@ -164,7 +167,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -183,7 +186,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -202,7 +205,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -221,7 +224,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -240,7 +243,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;
@@ -259,7 +262,7 @@ public:
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;
 
-	void invoke(AttributeWatcher &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+	void invoke(curve::CurveRecord &watcher, Unit &to_modify, const Command &cmd, bool play_sound=false) override;
 
 private:
 	const Sound *sound;

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -91,7 +91,7 @@ void UnitAction::draw_debug() {
 
 void UnitAction::face_towards(curve::CurveRecord &watcher, const coord::phys3 pos) {
 	if (this->entity->has_attribute(attr_type::direction)) {
-		auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
+		auto d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
 		d_attr.unit_dir = pos - this->entity->location->pos.draw;
 	}
 }
@@ -538,8 +538,8 @@ void MoveAction::update(curve::CurveRecord &watcher, unsigned int time) {
 
 	// current position and direction
 	coord::phys3 new_position = this->entity->location->pos.draw;
-	auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
-	coord::phys3_delta new_direction = d_attr.unit_dir;
+	auto d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
+	coord::phys3_delta new_direction = coord::phys3_delta{(coord::phys_t)d_attr.unit_dir.ne, (coord::phys_t)d_attr.unit_dir.se, (coord::phys_t)d_attr.unit_dir.up};
 
 	while (distance_to_move > 0) {
 		if (this->path.waypoints.empty()) {
@@ -1131,7 +1131,7 @@ ProjectileAction::ProjectileAction(curve::CurveRecord &watcher, Unit *e, coord::
 	this->grav = 0.01f * (exp(pow(projectile_arc, 0.5f)) - 1) * projectile_speed;
 
 	// inital launch direction
-	auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
+	auto d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
 	d_attr.unit_dir = (projectile_speed * d) / distance_to_target;
 
 	// account for initial height
@@ -1142,7 +1142,7 @@ ProjectileAction::ProjectileAction(curve::CurveRecord &watcher, Unit *e, coord::
 ProjectileAction::~ProjectileAction() {}
 
 void ProjectileAction::update(curve::CurveRecord &watcher, unsigned int time) {
-	auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
+	auto d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
 
 	// apply gravity
 	d_attr.unit_dir.up -= this->grav * time;

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -507,8 +507,8 @@ void MoveAction::update(unsigned int time) {
 			this->end_action = true;
 			return;
 		}
-		coord::phys3 &target_pos = target_object->pos.draw;
-		coord::phys3 &unit_pos = this->entity->location->pos.draw;
+		const coord::phys3 &target_pos = target_object->pos.draw;
+		const coord::phys3 &unit_pos = this->entity->location->pos.draw;
 
 		// repath if target changes tiles by a threshold
 		// this repathing is more frequent when the unit is
@@ -638,7 +638,7 @@ void MoveAction::set_path() {
 void MoveAction::set_distance() {
 	if (this->unit_target.is_valid()) {
 		auto &target_object = this->unit_target.get()->location;
-		coord::phys3 &unit_pos = this->entity->location->pos.draw;
+		const coord::phys3 &unit_pos = this->entity->location->pos.draw;
 		this->distance_to_target = target_object->from_edge(unit_pos);
 	}
 	else {

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -575,7 +575,7 @@ void MoveAction::update(AttributeWatcher &watcher, unsigned int time) {
 	}
 
 	// check move collisions
-	bool move_completed = this->entity->location->move(new_position);
+	bool move_completed = this->entity->location->move(watcher, new_position);
 	if (move_completed) {
 		d_attr.unit_dir = new_direction;
 		this->set_distance();
@@ -685,7 +685,7 @@ void UngarrisonAction::update(AttributeWatcher &watcher, unsigned int) {
 				Unit *unit_ptr = u.get();
 
 				// make sure it was placed outside
-				if (unit_ptr->unit_type->place_beside(unit_ptr, this->entity->location.get())) {
+				if (unit_ptr->unit_type->place_beside(watcher, unit_ptr, this->entity->location.get())) {
 
 					// task unit to move to position
 					auto &player = this->entity->get_attribute<attr_type::owner>(watcher).player;
@@ -1148,7 +1148,7 @@ void ProjectileAction::update(AttributeWatcher &watcher, unsigned int time) {
 	d_attr.unit_dir.up -= this->grav * time;
 
 	coord::phys3 new_position = this->entity->location->pos.draw + d_attr.unit_dir * time;
-	if (!this->entity->location->move(new_position)) {
+	if (!this->entity->location->move(watcher, new_position)) {
 
 		// find object which was hit
 		auto terrain = this->entity->location->get_terrain();

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -89,7 +89,7 @@ void UnitAction::draw_debug() {
 	}
 }
 
-void UnitAction::face_towards(AttributeWatcher &watcher, const coord::phys3 pos) {
+void UnitAction::face_towards(curve::CurveRecord &watcher, const coord::phys3 pos) {
 	if (this->entity->has_attribute(attr_type::direction)) {
 		auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
 		d_attr.unit_dir = pos - this->entity->location->pos.draw;
@@ -97,7 +97,7 @@ void UnitAction::face_towards(AttributeWatcher &watcher, const coord::phys3 pos)
 }
 
 // TODO remove (keep for testing)
-void UnitAction::damage_object(AttributeWatcher &watcher, Unit &target, unsigned dmg) {
+void UnitAction::damage_object(curve::CurveRecord &watcher, Unit &target, unsigned dmg) {
 	if (target.has_attribute(attr_type::hitpoints)) {
 		auto hp = target.get_attribute<attr_type::hitpoints>(watcher);
 		if (hp.current > dmg) {
@@ -109,7 +109,7 @@ void UnitAction::damage_object(AttributeWatcher &watcher, Unit &target, unsigned
 	}
 }
 
-void UnitAction::damage_object(AttributeWatcher &watcher, Unit &target) {
+void UnitAction::damage_object(curve::CurveRecord &watcher, Unit &target) {
 	if (target.has_attribute(attr_type::hitpoints)) {
 		auto hp = target.get_attribute<attr_type::hitpoints>(watcher);
 
@@ -145,7 +145,7 @@ void UnitAction::damage_object(AttributeWatcher &watcher, Unit &target) {
 	}
 }
 
-void UnitAction::move_to(AttributeWatcher &watcher, Unit &target, bool use_range) {
+void UnitAction::move_to(curve::CurveRecord &watcher, Unit &target, bool use_range) {
 	auto &player = this->entity->get_attribute<attr_type::owner>(watcher).player;
 	Command cmd(player, &target);
 	cmd.set_ability(ability_type::move);
@@ -179,7 +179,7 @@ TargetAction::TargetAction(Unit *u, graphic_type gt, UnitReference r)
 	TargetAction(u, gt, r, adjacent_range(u)) {
 }
 
-void TargetAction::update(AttributeWatcher &watcher, unsigned int time) {
+void TargetAction::update(curve::CurveRecord &watcher, unsigned int time) {
 	auto target_ptr = update_distance();
 	if (!target_ptr) {
 		return; // target has become invalid
@@ -294,7 +294,7 @@ DecayAction::DecayAction(Unit *e)
 	}
 }
 
-void DecayAction::update(AttributeWatcher&, unsigned int time) {
+void DecayAction::update(curve::CurveRecord&, unsigned int time) {
 	this->frame += time * this->frame_rate / 10000.0f;
 }
 
@@ -316,7 +316,7 @@ DeadAction::DeadAction(Unit *e, std::function<void()> on_complete)
 	}
 }
 
-void DeadAction::update(AttributeWatcher &watcher, unsigned int time) {
+void DeadAction::update(curve::CurveRecord &watcher, unsigned int time) {
 	if (this->entity->has_attribute(attr_type::hitpoints)) {
 		auto h_attr = this->entity->get_attribute<attr_type::hitpoints>(watcher);
 		h_attr.current = 0;
@@ -353,7 +353,7 @@ FoundationAction::FoundationAction(Unit *e, bool add_destruction)
 	cancel{false} {
 }
 
-void FoundationAction::update(AttributeWatcher&, unsigned int) {
+void FoundationAction::update(curve::CurveRecord&, unsigned int) {
 	if (!this->entity->location) {
 		this->cancel = true;
 	}
@@ -390,7 +390,7 @@ IdleAction::IdleAction(Unit *e)
 	this->auto_abilities = UnitAbility::set_from_list({ability_type::attack, ability_type::heal});
 }
 
-void IdleAction::update(AttributeWatcher&, unsigned int time) {
+void IdleAction::update(curve::CurveRecord&, unsigned int time) {
 
 	// auto task searching
 	if (this->entity->location &&
@@ -497,7 +497,7 @@ void MoveAction::initialise() {
 
 MoveAction::~MoveAction() {}
 
-void MoveAction::update(AttributeWatcher &watcher, unsigned int time) {
+void MoveAction::update(curve::CurveRecord &watcher, unsigned int time) {
 	if (this->unit_target.is_valid()) {
 		// a unit is targeted, which may move
 		auto &target_object = this->unit_target.get()->location;
@@ -653,7 +653,7 @@ GarrisonAction::GarrisonAction(Unit *e, UnitReference build)
 	complete{false} {
 }
 
-void GarrisonAction::update_in_range(AttributeWatcher &watcher, unsigned int, Unit *target_unit) {
+void GarrisonAction::update_in_range(curve::CurveRecord &watcher, unsigned int, Unit *target_unit) {
 	auto &garrison_attr = target_unit->get_attribute<attr_type::garrison>(watcher);
 	garrison_attr.content.push_back(this->entity->get_ref());
 
@@ -671,7 +671,7 @@ UngarrisonAction::UngarrisonAction(Unit *e, const coord::phys3 &pos)
 	complete{false} {
 }
 
-void UngarrisonAction::update(AttributeWatcher &watcher, unsigned int) {
+void UngarrisonAction::update(curve::CurveRecord &watcher, unsigned int) {
 	auto &garrison_attr = this->entity->get_attribute<attr_type::garrison>(watcher);
 
 	// try unload all objects currently garrisoned
@@ -715,7 +715,7 @@ TrainAction::TrainAction(Unit *e, UnitType *pp)
 	train_percent{.0f} {
 }
 
-void TrainAction::update(AttributeWatcher &watcher, unsigned int time) {
+void TrainAction::update(curve::CurveRecord &watcher, unsigned int time) {
 
 	// place unit when ready
 	if (this->train_percent > 1.0f) {
@@ -746,7 +746,7 @@ void TrainAction::update(AttributeWatcher &watcher, unsigned int time) {
 
 void TrainAction::on_completion() {}
 
-BuildAction::BuildAction(Unit *e, UnitReference foundation, AttributeWatcher &watcher)
+BuildAction::BuildAction(Unit *e, UnitReference foundation, curve::CurveRecord &watcher)
 	:
 	TargetAction{e, graphic_type::work, foundation},
 	complete{.0f},
@@ -762,7 +762,7 @@ BuildAction::BuildAction(Unit *e, UnitReference foundation, AttributeWatcher &wa
 	}
 }
 
-void BuildAction::update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) {
+void BuildAction::update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) {
 	if (target_unit->has_attribute(attr_type::building)) {
 		auto &build = target_unit->get_attribute<attr_type::building>(watcher);
 
@@ -828,9 +828,9 @@ RepairAction::RepairAction(Unit *e, UnitReference tar)
 	complete{false} {
 }
 
-void RepairAction::update_in_range(AttributeWatcher &, unsigned int, Unit *) {}
+void RepairAction::update_in_range(curve::CurveRecord &, unsigned int, Unit *) {}
 
-GatherAction::GatherAction(Unit *e, UnitReference tar, AttributeWatcher &watcher)
+GatherAction::GatherAction(Unit *e, UnitReference tar, curve::CurveRecord &watcher)
 	:
 	TargetAction{e, graphic_type::work, tar},
 	complete{false},
@@ -862,7 +862,7 @@ GatherAction::GatherAction(Unit *e, UnitReference tar, AttributeWatcher &watcher
 
 GatherAction::~GatherAction() {}
 
-void GatherAction::update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *targeted_resource) {
+void GatherAction::update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *targeted_resource) {
 	auto &gatherer_attr = this->entity->get_attribute<attr_type::gatherer>(watcher);
 	if (this->target_resource) {
 
@@ -974,7 +974,7 @@ const graphic_set &GatherAction::current_graphics() const {
 	return this->entity->unit_type->graphics;
 }
 
-AttackAction::AttackAction(AttributeWatcher &watcher, Unit *e, UnitReference tar)
+AttackAction::AttackAction(curve::CurveRecord &watcher, Unit *e, UnitReference tar)
 	:
 	TargetAction{e, graphic_type::attack, tar, get_attack_range(e)},
 	strike_percent{0.0f},
@@ -991,7 +991,7 @@ AttackAction::AttackAction(AttributeWatcher &watcher, Unit *e, UnitReference tar
 
 AttackAction::~AttackAction() {}
 
-void AttackAction::update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_ptr) {
+void AttackAction::update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_ptr) {
 	if (this->strike_percent > 0.0) {
 		this->strike_percent -= this->rate_of_fire * time;
 	}
@@ -1009,7 +1009,7 @@ bool AttackAction::completed_in_range(Unit *target_ptr) const {
 	return h_attr.current < 1; // is unit still alive?
 }
 
-void AttackAction::attack(AttributeWatcher &watcher, Unit &target) {
+void AttackAction::attack(curve::CurveRecord &watcher, Unit &target) {
 	const auto &attack = this->entity->get_attribute<attr_type::attack>();
 	if (attack.ptype) {
 
@@ -1021,7 +1021,7 @@ void AttackAction::attack(AttributeWatcher &watcher, Unit &target) {
 	}
 }
 
-void AttackAction::fire_projectile(AttributeWatcher &watcher, const Attribute<attr_type::attack> &att, const coord::phys3 &target) {
+void AttackAction::fire_projectile(curve::CurveRecord &watcher, const Attribute<attr_type::attack> &att, const coord::phys3 &target) {
 
 	// container terrain and initial position
 	UnitContainer *container = this->entity->get_container();
@@ -1055,7 +1055,7 @@ HealAction::HealAction(Unit *e, UnitReference tar)
 
 HealAction::~HealAction() {}
 
-void HealAction::update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_ptr) {
+void HealAction::update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_ptr) {
 	auto heal = this->entity->get_attribute<attr_type::heal>(watcher);
 
 	if (this->heal_percent > 0.0) {
@@ -1075,7 +1075,7 @@ bool HealAction::completed_in_range(Unit *target_ptr) const {
 	return h_attr.current >= h_attr.max; // is unit at full hitpoints?
 }
 
-void HealAction::heal(AttributeWatcher &watcher, Unit &target) {
+void HealAction::heal(curve::CurveRecord &watcher, Unit &target) {
 	auto &heal = this->entity->get_attribute<attr_type::heal>();
 
 	// TODO move to seperate function heal_object (like damage_object)?
@@ -1099,9 +1099,9 @@ ConvertAction::ConvertAction(Unit *e, UnitReference tar)
 	complete{.0f} {
 }
 
-void ConvertAction::update_in_range(AttributeWatcher &, unsigned int, Unit *) {}
+void ConvertAction::update_in_range(curve::CurveRecord &, unsigned int, Unit *) {}
 
-ProjectileAction::ProjectileAction(AttributeWatcher &watcher, Unit *e, coord::phys3 target)
+ProjectileAction::ProjectileAction(curve::CurveRecord &watcher, Unit *e, coord::phys3 target)
 	:
 	UnitAction{e, graphic_type::standing},
 	has_hit{false} {
@@ -1141,7 +1141,7 @@ ProjectileAction::ProjectileAction(AttributeWatcher &watcher, Unit *e, coord::ph
 
 ProjectileAction::~ProjectileAction() {}
 
-void ProjectileAction::update(AttributeWatcher &watcher, unsigned int time) {
+void ProjectileAction::update(curve::CurveRecord &watcher, unsigned int time) {
 	auto &d_attr = this->entity->get_attribute<attr_type::direction>(watcher);
 
 	// apply gravity

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -44,7 +44,7 @@ public:
 	 * each action has its own update functionality which gets called when this
 	 * is the active action
 	 */
-	virtual void update(unsigned int) = 0;
+	virtual void update(AttributeWatcher &watcher, unsigned int) = 0;
 
 	/**
 	 * action to perform when popped from a units action stack
@@ -93,10 +93,10 @@ public:
 	/**
 	 * common functions for actions
 	 */
-	void face_towards(const coord::phys3 pos);
-	void damage_object(Unit &target, unsigned dmg); // TODO remove (keep for testing)
-	void damage_object(Unit &target);
-	void move_to(Unit &target, bool use_range=true);
+	void face_towards(AttributeWatcher &watcher, const coord::phys3 pos);
+	void damage_object(AttributeWatcher &watcher, Unit &target, unsigned dmg); // TODO remove (keep for testing)
+	void damage_object(AttributeWatcher &watcher, Unit &target);
+	void move_to(AttributeWatcher &watcher, Unit &target, bool use_range=true);
 
 	/**
 	 * produce debug info such as visualising paths
@@ -161,7 +161,7 @@ public:
 	TargetAction(Unit *e, graphic_type gt, UnitReference r);
 	virtual ~TargetAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -171,7 +171,7 @@ public:
 	/**
 	 * Control units action when in range of the target
 	 */
-	virtual void update_in_range(unsigned int, Unit *) = 0;
+	virtual void update_in_range(AttributeWatcher &watcher, unsigned int, Unit *) = 0;
 	virtual bool completed_in_range(Unit *) const = 0;
 
 	coord::phys_t distance_to_target();
@@ -202,7 +202,7 @@ public:
 	DecayAction(Unit *e);
 	virtual ~DecayAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -222,7 +222,7 @@ public:
 	DeadAction(Unit *e, std::function<void()> on_complete=[]() {});
 	virtual ~DeadAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -243,7 +243,7 @@ public:
 	FoundationAction(Unit *e, bool add_destuction=false);
 	virtual ~FoundationAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -263,7 +263,7 @@ public:
 	IdleAction(Unit *e);
 	virtual ~IdleAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -293,7 +293,7 @@ public:
 	MoveAction(Unit *e, UnitReference tar, coord::phys_t within_range);
 	virtual ~MoveAction();
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -335,7 +335,7 @@ public:
 	GarrisonAction(Unit *e, UnitReference build);
 	virtual ~GarrisonAction() {}
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "garrison"; }
 
@@ -351,7 +351,7 @@ public:
 	UngarrisonAction(Unit *e, const coord::phys3 &pos);
 	virtual ~UngarrisonAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override { return this->complete; }
 	bool allow_interupt() const override { return true; }
@@ -371,7 +371,7 @@ public:
 	TrainAction(Unit *e, UnitType *pp);
 	virtual ~TrainAction() {}
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override { return this->complete; }
 	bool allow_interupt() const override { return false; }
@@ -389,10 +389,10 @@ private:
  */
 class BuildAction: public TargetAction {
 public:
-	BuildAction(Unit *e, UnitReference foundation);
+	BuildAction(Unit *e, UnitReference foundation, AttributeWatcher &watcher);
 	virtual ~BuildAction() {}
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	std::string name() const override { return "build"; }
 	const graphic_set &current_graphics() const override;
@@ -410,7 +410,7 @@ public:
 	RepairAction(Unit *e, UnitReference tar);
 	virtual ~RepairAction() {}
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "repair"; }
 
@@ -424,10 +424,10 @@ private:
  */
 class GatherAction: public TargetAction {
 public:
-	GatherAction(Unit *e, UnitReference tar);
+	GatherAction(Unit *e, UnitReference tar, AttributeWatcher &watcher);
 	virtual ~GatherAction();
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "gather"; }
 	const graphic_set &current_graphics() const override;
@@ -444,10 +444,10 @@ private:
  */
 class AttackAction: public TargetAction {
 public:
-	AttackAction(Unit *e, UnitReference tar);
+	AttackAction(AttributeWatcher &watcher, Unit *e, UnitReference tar);
 	virtual ~AttackAction();
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "attack"; }
 
@@ -457,12 +457,12 @@ private:
 	/**
 	 * use attack action
 	 */
-	void attack(Unit &target);
+	void attack(AttributeWatcher &watcher, Unit &target);
 
 	/**
 	 * add a projectile game object which moves towards the target
 	 */
-	void fire_projectile(const Attribute<attr_type::attack> &att, const coord::phys3 &target);
+	void fire_projectile(AttributeWatcher &watcher, const Attribute<attr_type::attack> &att, const coord::phys3 &target);
 };
 
 /**
@@ -473,7 +473,7 @@ public:
 	HealAction(Unit *e, UnitReference tar);
 	virtual ~HealAction();
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "heal"; }
 
@@ -483,7 +483,7 @@ private:
 	/**
 	 * use heal action
 	 */
-	void heal(Unit &target);
+	void heal(AttributeWatcher &watcher, Unit &target);
 };
 
 /**
@@ -494,7 +494,7 @@ public:
 	ConvertAction(Unit *e, UnitReference tar);
 	virtual ~ConvertAction() {}
 
-	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	std::string name() const override { return "convert"; }
 
@@ -508,10 +508,10 @@ private:
  */
 class ProjectileAction: public UnitAction {
 public:
-	ProjectileAction(Unit *e, coord::phys3 target);
+	ProjectileAction(AttributeWatcher &watcher, Unit *e, coord::phys3 target);
 	virtual ~ProjectileAction();
 
-	void update(unsigned int) override;
+	void update(AttributeWatcher &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -44,7 +44,7 @@ public:
 	 * each action has its own update functionality which gets called when this
 	 * is the active action
 	 */
-	virtual void update(AttributeWatcher &watcher, unsigned int) = 0;
+	virtual void update(curve::CurveRecord &watcher, unsigned int) = 0;
 
 	/**
 	 * action to perform when popped from a units action stack
@@ -93,10 +93,10 @@ public:
 	/**
 	 * common functions for actions
 	 */
-	void face_towards(AttributeWatcher &watcher, const coord::phys3 pos);
-	void damage_object(AttributeWatcher &watcher, Unit &target, unsigned dmg); // TODO remove (keep for testing)
-	void damage_object(AttributeWatcher &watcher, Unit &target);
-	void move_to(AttributeWatcher &watcher, Unit &target, bool use_range=true);
+	void face_towards(curve::CurveRecord &watcher, const coord::phys3 pos);
+	void damage_object(curve::CurveRecord &watcher, Unit &target, unsigned dmg); // TODO remove (keep for testing)
+	void damage_object(curve::CurveRecord &watcher, Unit &target);
+	void move_to(curve::CurveRecord &watcher, Unit &target, bool use_range=true);
 
 	/**
 	 * produce debug info such as visualising paths
@@ -161,7 +161,7 @@ public:
 	TargetAction(Unit *e, graphic_type gt, UnitReference r);
 	virtual ~TargetAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -171,7 +171,7 @@ public:
 	/**
 	 * Control units action when in range of the target
 	 */
-	virtual void update_in_range(AttributeWatcher &watcher, unsigned int, Unit *) = 0;
+	virtual void update_in_range(curve::CurveRecord &watcher, unsigned int, Unit *) = 0;
 	virtual bool completed_in_range(Unit *) const = 0;
 
 	coord::phys_t distance_to_target();
@@ -202,7 +202,7 @@ public:
 	DecayAction(Unit *e);
 	virtual ~DecayAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -222,7 +222,7 @@ public:
 	DeadAction(Unit *e, std::function<void()> on_complete=[]() {});
 	virtual ~DeadAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -243,7 +243,7 @@ public:
 	FoundationAction(Unit *e, bool add_destuction=false);
 	virtual ~FoundationAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -263,7 +263,7 @@ public:
 	IdleAction(Unit *e);
 	virtual ~IdleAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }
@@ -293,7 +293,7 @@ public:
 	MoveAction(Unit *e, UnitReference tar, coord::phys_t within_range);
 	virtual ~MoveAction();
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return true; }
@@ -335,7 +335,7 @@ public:
 	GarrisonAction(Unit *e, UnitReference build);
 	virtual ~GarrisonAction() {}
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "garrison"; }
 
@@ -351,7 +351,7 @@ public:
 	UngarrisonAction(Unit *e, const coord::phys3 &pos);
 	virtual ~UngarrisonAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override { return this->complete; }
 	bool allow_interupt() const override { return true; }
@@ -371,7 +371,7 @@ public:
 	TrainAction(Unit *e, UnitType *pp);
 	virtual ~TrainAction() {}
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override { return this->complete; }
 	bool allow_interupt() const override { return false; }
@@ -389,10 +389,10 @@ private:
  */
 class BuildAction: public TargetAction {
 public:
-	BuildAction(Unit *e, UnitReference foundation, AttributeWatcher &watcher);
+	BuildAction(Unit *e, UnitReference foundation, curve::CurveRecord &watcher);
 	virtual ~BuildAction() {}
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	std::string name() const override { return "build"; }
 	const graphic_set &current_graphics() const override;
@@ -410,7 +410,7 @@ public:
 	RepairAction(Unit *e, UnitReference tar);
 	virtual ~RepairAction() {}
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "repair"; }
 
@@ -424,10 +424,10 @@ private:
  */
 class GatherAction: public TargetAction {
 public:
-	GatherAction(Unit *e, UnitReference tar, AttributeWatcher &watcher);
+	GatherAction(Unit *e, UnitReference tar, curve::CurveRecord &watcher);
 	virtual ~GatherAction();
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "gather"; }
 	const graphic_set &current_graphics() const override;
@@ -444,10 +444,10 @@ private:
  */
 class AttackAction: public TargetAction {
 public:
-	AttackAction(AttributeWatcher &watcher, Unit *e, UnitReference tar);
+	AttackAction(curve::CurveRecord &watcher, Unit *e, UnitReference tar);
 	virtual ~AttackAction();
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "attack"; }
 
@@ -457,12 +457,12 @@ private:
 	/**
 	 * use attack action
 	 */
-	void attack(AttributeWatcher &watcher, Unit &target);
+	void attack(curve::CurveRecord &watcher, Unit &target);
 
 	/**
 	 * add a projectile game object which moves towards the target
 	 */
-	void fire_projectile(AttributeWatcher &watcher, const Attribute<attr_type::attack> &att, const coord::phys3 &target);
+	void fire_projectile(curve::CurveRecord &watcher, const Attribute<attr_type::attack> &att, const coord::phys3 &target);
 };
 
 /**
@@ -473,7 +473,7 @@ public:
 	HealAction(Unit *e, UnitReference tar);
 	virtual ~HealAction();
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "heal"; }
 
@@ -483,7 +483,7 @@ private:
 	/**
 	 * use heal action
 	 */
-	void heal(AttributeWatcher &watcher, Unit &target);
+	void heal(curve::CurveRecord &watcher, Unit &target);
 };
 
 /**
@@ -494,7 +494,7 @@ public:
 	ConvertAction(Unit *e, UnitReference tar);
 	virtual ~ConvertAction() {}
 
-	void update_in_range(AttributeWatcher &watcher, unsigned int time, Unit *target_unit) override;
+	void update_in_range(curve::CurveRecord &watcher, unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	std::string name() const override { return "convert"; }
 
@@ -508,10 +508,10 @@ private:
  */
 class ProjectileAction: public UnitAction {
 public:
-	ProjectileAction(AttributeWatcher &watcher, Unit *e, coord::phys3 target);
+	ProjectileAction(curve::CurveRecord &watcher, Unit *e, coord::phys3 target);
 	virtual ~ProjectileAction();
 
-	void update(AttributeWatcher &watcher, unsigned int) override;
+	void update(curve::CurveRecord &watcher, unsigned int) override;
 	void on_completion() override;
 	bool completed() const override;
 	bool allow_interupt() const override { return false; }

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -11,7 +11,7 @@
 #include "../terrain/terrain_object.h"
 #include "../gamestate/resource.h"
 #include "unit_container.h"
-#include "attribute_watcher.h"
+#include "../curve/curve_record_replay.h"
 
 namespace std {
 
@@ -70,7 +70,8 @@ enum class attr_type {
 	dropsite,
 	resource,
 	gatherer,
-	garrison
+	garrison,
+	position
 };
 
 enum class attack_stance {
@@ -162,12 +163,12 @@ public:
 
 template<> class Attribute<attr_type::hitpoints>: public AttributeContainer {
 public:
-	Attribute(AttributeWatcher &watcher, id_t id, unsigned int i)
+	Attribute(curve::CurveRecord &watcher, id_t id, unsigned int i)
 		:
 		AttributeContainer{attr_type::hitpoints},
 		current{i},
 		max{i} {
-			watcher.apply(id, i, "hitpoints");
+			watcher.write_out(id, i, "hitpoints");
 		}
 
 	bool shared() const override {

--- a/libopenage/unit/attribute_setter.h
+++ b/libopenage/unit/attribute_setter.h
@@ -1,0 +1,44 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <algorithm>
+
+#include "attribute_spy.h"
+#include "unit.h"
+
+namespace openage {
+
+using AttributeSetter = void(*)(std::istream&, id_t, UnitContainer&);
+
+template<attr_type T>
+void apply_to_attr(std::istream &stream, id_t id, UnitContainer &placed_units) {
+	AttributeSpy<T>::val_ref(placed_units.get_unit(id).get()->get_attribute_unwatched<T>()) = parse_attr<T>(stream);
+}
+
+template<attr_type T>
+struct ApplyToAttr {
+	static constexpr std::tuple<const char*, AttributeSetter> named_setter = std::make_tuple(AttributeSpy<T>::name, apply_to_attr<T>);
+};
+
+template<>
+void apply_to_attr<attr_type::position>(std::istream &stream, id_t id, UnitContainer &placed_units) {
+	placed_units.get_unit(id).get()->location->pos = parse_attr<attr_type::position>(stream);
+}
+
+const std::tuple<const char*, AttributeSetter> parse_funcs[] = {
+	ApplyToAttr<attr_type::hitpoints>::named_setter,
+	ApplyToAttr<attr_type::position>::named_setter,
+};
+
+void read_attr(std::istream &stream, id_t id, UnitContainer &placed_units) {
+	const auto attr_name = parse_attr_name(stream);
+	const auto foundIt = std::find_if(std::begin(parse_funcs), std::end(parse_funcs), [&attr_name](const std::tuple<const char*, AttributeSetter> &named_setter) {
+		return std::get<const char*>(named_setter) == attr_name;
+	});
+
+	if (foundIt != std::end(parse_funcs))
+		(std::get<AttributeSetter>(*foundIt))(stream, id, placed_units);
+}
+
+} // namespace openage

--- a/libopenage/unit/attribute_setter.h
+++ b/libopenage/unit/attribute_setter.h
@@ -27,6 +27,7 @@ void apply_to_attr<attr_type::position>(std::istream &stream, id_t id, UnitConta
 }
 
 const std::tuple<const char*, AttributeSetter> parse_funcs[] = {
+	ApplyToAttr<attr_type::direction>::named_setter,
 	ApplyToAttr<attr_type::hitpoints>::named_setter,
 	ApplyToAttr<attr_type::position>::named_setter,
 };

--- a/libopenage/unit/attribute_spy.h
+++ b/libopenage/unit/attribute_spy.h
@@ -1,0 +1,104 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include "attribute.h"
+#include "attribute_watcher.h"
+
+namespace openage {
+
+template<typename T> class Spied {
+public:
+	Spied(AttributeWatcher &watcher, id_t id, T &value, const char *name)
+		:
+		watcher{watcher},
+		id{id},
+		value(value),
+		name{name} {
+	}
+
+	operator T() const {
+		return this->value;
+	}
+
+	Spied<T>& operator=(T value) {
+		this->watcher.apply(this->id, value, this->name);
+		return *this;
+	}
+
+	template<typename U>
+	Spied<T>& operator+=(U value) {
+		return *this = *this + value;
+	}
+
+	template<typename U>
+	Spied<T>& operator-=(U value) {
+		return *this = *this - value;
+	}
+
+	template<typename U>
+	Spied<T>& operator*=(U value) {
+		return *this = *this * value;
+	}
+
+	template<typename U>
+	Spied<T>& operator/=(U value) {
+		return *this = *this / value;
+	}
+
+	template<typename U>
+	Spied<T>& operator%=(U value) {
+		return *this = *this % value;
+	}
+
+private:
+	AttributeWatcher &watcher;
+	id_t id;
+	T &value;
+	const char *name;
+};
+
+template<attr_type T> class AttributeSpy {
+public:
+	using type = Attribute<T>&;
+
+	static Attribute<T>& create(AttributeWatcher&, id_t, Attribute<T> &attr) {
+		return attr;
+	}
+};
+
+template<> class AttributeSpy<attr_type::hitpoints> {
+public:
+	using type = AttributeSpy<attr_type::hitpoints>;
+
+	static AttributeSpy<attr_type::hitpoints> create(AttributeWatcher &watcher, id_t id, Attribute<attr_type::hitpoints> &attr) {
+		return AttributeSpy<attr_type::hitpoints>{watcher, id, attr};
+	}
+
+	AttributeSpy(AttributeWatcher &watcher, id_t id, Attribute<attr_type::hitpoints> &attr)
+		:
+		current{watcher, id, attr.current, "hitpoints"},
+		max{attr.max},
+		hp_bar_height{attr.hp_bar_height} {
+	}
+
+	Spied<unsigned int> current;
+	unsigned int &max;
+	float &hp_bar_height;
+};
+
+/**
+ * return attribute from a container while spying on it
+ */
+template<attr_type T> typename AttributeSpy<T>::type get_attr(AttributeWatcher &watcher, id_t id, attr_map_t &map) {
+	return AttributeSpy<T>::create(watcher, id, get_attr_ref<T>(map));
+}
+
+/**
+ * return attribute as constant from a container
+ */
+template<attr_type T> const Attribute<T>& get_attr(const attr_map_t &map) {
+	return get_attr_ref<T>(map);
+}
+
+} // namespace openage

--- a/libopenage/unit/attribute_spy.h
+++ b/libopenage/unit/attribute_spy.h
@@ -2,14 +2,19 @@
 
 #pragma once
 
+#include "../terrain/tile_range.h"
+#include "../terrain/tile_range_serialization.h"
 #include "attribute.h"
 #include "attribute_watcher.h"
 
 namespace openage {
 
-template<typename T> class Spied {
+template<typename T>
+class Spied {
 public:
-	Spied(AttributeWatcher &watcher, id_t id, T &value, const char *name)
+	using type = T;
+
+	Spied(curve::CurveRecord &watcher, id_t id, T &value, const char *name)
 		:
 		watcher{watcher},
 		id{id},
@@ -22,7 +27,7 @@ public:
 	}
 
 	Spied<T>& operator=(T value) {
-		this->watcher.apply(this->id, value, this->name);
+		this->watcher.write_out(this->id, value, this->name);
 		return *this;
 	}
 
@@ -52,53 +57,78 @@ public:
 	}
 
 private:
-	AttributeWatcher &watcher;
+	curve::CurveRecord &watcher;
 	id_t id;
 	T &value;
 	const char *name;
 };
 
-template<attr_type T> class AttributeSpy {
+template<attr_type T>
+class AttributeSpy {
 public:
 	using type = Attribute<T>&;
 
-	static Attribute<T>& create(AttributeWatcher&, id_t, Attribute<T> &attr) {
+	static Attribute<T>& create(curve::CurveRecord&, id_t, Attribute<T> &attr) {
 		return attr;
 	}
 };
 
-template<> class AttributeSpy<attr_type::hitpoints> {
+template<>
+class AttributeSpy<attr_type::hitpoints> {
 public:
-	using type = AttributeSpy<attr_type::hitpoints>;
+	static constexpr const char *name = "hitpoints";
+	using type = AttributeSpy;
+	using value_type = unsigned int;
 
-	static AttributeSpy<attr_type::hitpoints> create(AttributeWatcher &watcher, id_t id, Attribute<attr_type::hitpoints> &attr) {
-		return AttributeSpy<attr_type::hitpoints>{watcher, id, attr};
+	static value_type& val_ref(Attribute<attr_type::hitpoints> &attr) {
+		static_assert(std::is_same<value_type, decltype(attr.current)>::value, "spied type mismatch");
+		return attr.current;
 	}
 
-	AttributeSpy(AttributeWatcher &watcher, id_t id, Attribute<attr_type::hitpoints> &attr)
+	static AttributeSpy create(curve::CurveRecord &watcher, id_t id, Attribute<attr_type::hitpoints> &attr) {
+		return AttributeSpy{watcher, id, attr};
+	}
+
+	AttributeSpy(curve::CurveRecord &watcher, id_t id, Attribute<attr_type::hitpoints> &attr)
 		:
-		current{watcher, id, attr.current, "hitpoints"},
+		current{watcher, id, val_ref(attr), AttributeSpy::name},
 		max{attr.max},
 		hp_bar_height{attr.hp_bar_height} {
 	}
 
-	Spied<unsigned int> current;
+	Spied<value_type> current;
 	unsigned int &max;
 	float &hp_bar_height;
+};
+
+template<>
+class AttributeSpy<attr_type::position> {
+public:
+	static constexpr const char *name = "pos";
+	using value_type = tile_range;
 };
 
 /**
  * return attribute from a container while spying on it
  */
-template<attr_type T> typename AttributeSpy<T>::type get_attr(AttributeWatcher &watcher, id_t id, attr_map_t &map) {
+template<attr_type T>
+typename AttributeSpy<T>::type get_attr(curve::CurveRecord &watcher, id_t id, attr_map_t &map) {
 	return AttributeSpy<T>::create(watcher, id, get_attr_ref<T>(map));
 }
 
 /**
  * return attribute as constant from a container
  */
-template<attr_type T> const Attribute<T>& get_attr(const attr_map_t &map) {
+template<attr_type T>
+const Attribute<T>& get_attr(const attr_map_t &map) {
 	return get_attr_ref<T>(map);
+}
+
+template <attr_type T>
+typename AttributeSpy<T>::value_type parse_attr(std::istream &stream) {
+	typename AttributeSpy<T>::value_type val;
+	stream >> val;
+	return val;
 }
 
 } // namespace openage

--- a/libopenage/unit/attribute_watcher.h
+++ b/libopenage/unit/attribute_watcher.h
@@ -6,12 +6,10 @@
 
 namespace openage {
 
-class AttributeWatcher {
-public:
-	template<typename T>
-	void apply(id_t id, T value, const char *name) {
-		std::cout << id << " " << name << " " << value << "\n";
-	}
-};
+inline std::string parse_attr_name(std::istream &stream) {
+	std::string name;
+	stream >> name;
+	return name;
+}
 
 } // namespace openage

--- a/libopenage/unit/attribute_watcher.h
+++ b/libopenage/unit/attribute_watcher.h
@@ -1,0 +1,17 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <iostream>
+
+namespace openage {
+
+class AttributeWatcher {
+public:
+	template<typename T>
+	void apply(id_t id, T value, const char *name) {
+		std::cout << id << " " << name << " " << value << "\n";
+	}
+};
+
+} // namespace openage

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -171,7 +171,7 @@ std::string ObjectProducer::name() const {
 	return this->unit_data.name;
 }
 
-void ObjectProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &player) {
+void ObjectProducer::initialise(curve::CurveRecord &watcher, Unit *unit, Player &player) {
 	ENSURE(this->owner == player, "unit init from a UnitType of a wrong player which breaks tech levels");
 
 	// log attributes
@@ -251,7 +251,7 @@ void ObjectProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &p
 	}
 }
 
-TerrainObject *ObjectProducer::place(AttributeWatcher &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *ObjectProducer::place(curve::CurveRecord &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 
 	// create new object with correct base shape
 	if (this->unit_data.selection_shape > 1) {
@@ -356,7 +356,7 @@ MovableProducer::MovableProducer(const Player &owner, const GameSpec &spec, cons
 
 MovableProducer::~MovableProducer() {}
 
-void MovableProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &player) {
+void MovableProducer::initialise(curve::CurveRecord &watcher, Unit *unit, Player &player) {
 
 	/*
 	 * call base function
@@ -391,7 +391,7 @@ void MovableProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &
 	}
 }
 
-TerrainObject *MovableProducer::place(AttributeWatcher &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *MovableProducer::place(curve::CurveRecord &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	return ObjectProducer::place(watcher, unit, terrain, init_pos);
 }
 
@@ -406,7 +406,7 @@ LivingProducer::LivingProducer(const Player &owner, const GameSpec &spec, const 
 
 LivingProducer::~LivingProducer() {}
 
-void LivingProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &player) {
+void LivingProducer::initialise(curve::CurveRecord &watcher, Unit *unit, Player &player) {
 
 	/*
 	 * call base function
@@ -463,7 +463,7 @@ void LivingProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &p
 	}
 }
 
-TerrainObject *LivingProducer::place(AttributeWatcher &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *LivingProducer::place(curve::CurveRecord &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	return MovableProducer::place(watcher, unit, terrain, init_pos);
 }
 
@@ -530,7 +530,7 @@ std::string BuildingProducer::name() const {
 	return this->unit_data.name;
 }
 
-void BuildingProducer::initialise(AttributeWatcher &watcher, Unit *unit, Player &player) {
+void BuildingProducer::initialise(curve::CurveRecord &watcher, Unit *unit, Player &player) {
 	ENSURE(this->owner == player, "unit init from a UnitType of a wrong player which breaks tech levels");
 
 	// log type
@@ -602,7 +602,7 @@ std::vector<game_resource> BuildingProducer::get_accepted_resources() {
 	return std::vector<game_resource>();
 }
 
-TerrainObject *BuildingProducer::place(AttributeWatcher &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *BuildingProducer::place(curve::CurveRecord &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 
 	// buildings have a square base
 	u->make_location<SquareObject>(this->foundation_size, this->terrain_outline);
@@ -665,7 +665,7 @@ TerrainObject *BuildingProducer::place(AttributeWatcher &watcher, Unit *u, std::
 	return u->location.get();
 }
 
-TerrainObject *BuildingProducer::make_annex(AttributeWatcher &watcher, Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const {
+TerrainObject *BuildingProducer::make_annex(curve::CurveRecord &watcher, Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const {
 
 	// for use in lambda drawing functions
 	auto annex_type = this->owner.get_type(annex_id);
@@ -741,7 +741,7 @@ std::string ProjectileProducer::name() const {
 	return this->unit_data.name;
 }
 
-void ProjectileProducer::initialise(AttributeWatcher &, Unit *unit, Player &player) {
+void ProjectileProducer::initialise(curve::CurveRecord &, Unit *unit, Player &player) {
 	ENSURE(this->owner == player, "unit init from a UnitType of a wrong player which breaks tech levels");
 
 	// initialize graphic set
@@ -759,7 +759,7 @@ void ProjectileProducer::initialise(AttributeWatcher &, Unit *unit, Player &play
 	}
 }
 
-TerrainObject *ProjectileProducer::place(AttributeWatcher &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *ProjectileProducer::place(curve::CurveRecord &watcher, Unit *u, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	/*
 	 * radial base shape without collision checking
 	 */

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -41,7 +41,7 @@ public:
 	int parent_id() const override;
 	std::string name() const override;
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const GameSpec &dataspec;
@@ -72,7 +72,7 @@ public:
 	virtual ~MovableProducer();
 
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const gamedata::unit_movable unit_data;
@@ -95,7 +95,7 @@ public:
 	virtual ~LivingProducer();
 
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_living unit_data;
@@ -115,7 +115,7 @@ public:
 	int parent_id() const override;
 	std::string name() const override;
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const GameSpec &dataspec;
@@ -141,7 +141,7 @@ private:
 	 */
 	bool enable_collisions;
 
-	TerrainObject *make_annex(Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
+	TerrainObject *make_annex(AttributeWatcher &watcher, Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
 };
 
 /**
@@ -157,7 +157,7 @@ public:
 	int parent_id() const override;
 	std::string name() const override;
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_projectile unit_data;

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -40,7 +40,7 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
@@ -71,7 +71,7 @@ public:
 	MovableProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_movable *);
 	virtual ~MovableProducer();
 
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
@@ -94,7 +94,7 @@ public:
 	LivingProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_living *);
 	virtual ~LivingProducer();
 
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
@@ -114,7 +114,7 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
@@ -156,7 +156,7 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -40,8 +40,8 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const GameSpec &dataspec;
@@ -71,8 +71,8 @@ public:
 	MovableProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_movable *);
 	virtual ~MovableProducer();
 
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 protected:
 	const gamedata::unit_movable unit_data;
@@ -94,8 +94,8 @@ public:
 	LivingProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_living *);
 	virtual ~LivingProducer();
 
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_living unit_data;
@@ -114,8 +114,8 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const GameSpec &dataspec;
@@ -141,7 +141,7 @@ private:
 	 */
 	bool enable_collisions;
 
-	TerrainObject *make_annex(AttributeWatcher &watcher, Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
+	TerrainObject *make_annex(curve::CurveRecord &watcher, Unit &u, std::shared_ptr<Terrain> t, int annex_id, coord::phys3 annex_pos, bool c) const;
 };
 
 /**
@@ -156,8 +156,8 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
 	const gamedata::unit_projectile unit_data;

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -49,7 +49,7 @@ bool UnitSelection::on_drawhud() {
 				float percent = static_cast<float>(hp.current) / static_cast<float>(hp.max);
 				int mid = percent * 28.0f - 14.0f;
 
-				coord::phys3 &pos_phys3 = unit_ptr->location->pos.draw;
+				const coord::phys3 &pos_phys3 = unit_ptr->location->pos.draw;
 				coord::camhud pos = pos_phys3.to_camgame().to_window().to_camhud();
 				glColor3f(0.0, 1.0, 0.0);
 				glBegin(GL_LINES); {

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -73,7 +73,7 @@ UnitAction *Unit::before(const UnitAction *action) const {
 	return nullptr;
 }
 
-bool Unit::update(AttributeWatcher &watcher) {
+bool Unit::update(curve::CurveRecord &watcher) {
 
 	// if unit is not on the map then do nothing
 	if (!this->location) {
@@ -118,7 +118,7 @@ bool Unit::update(AttributeWatcher &watcher) {
 	return true;
 }
 
-void Unit::update_secondary(AttributeWatcher &watcher, int64_t time_elapsed) {
+void Unit::update_secondary(curve::CurveRecord &watcher, int64_t time_elapsed) {
 	// update secondary actions and remove when completed
 	auto position_it = std::remove_if(
 		std::begin(this->action_secondary),
@@ -131,7 +131,7 @@ void Unit::update_secondary(AttributeWatcher &watcher, int64_t time_elapsed) {
 }
 
 
-void Unit::apply_all_cmds(AttributeWatcher &watcher) {
+void Unit::apply_all_cmds(curve::CurveRecord &watcher) {
 	std::lock_guard<std::mutex> lock(this->command_queue_lock);
 	while (!this->command_queue.empty()) {
 		auto &action = this->command_queue.front();
@@ -141,7 +141,7 @@ void Unit::apply_all_cmds(AttributeWatcher &watcher) {
 }
 
 
-void Unit::apply_cmd(AttributeWatcher &watcher, std::shared_ptr<UnitAbility> ability, const Command &cmd) {
+void Unit::apply_cmd(curve::CurveRecord &watcher, std::shared_ptr<UnitAbility> ability, const Command &cmd) {
 	bool is_direct = cmd.has_flag(command_flag::direct);
 	if (is_direct) {
 

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -14,6 +14,7 @@
 #include "../handlers.h"
 #include "ability.h"
 #include "attribute.h"
+#include "attribute_spy.h"
 #include "command.h"
 #include "unit_container.h"
 
@@ -120,7 +121,7 @@ public:
 	/**
 	 * update this object using the action currently on top of the stack
 	 */
-	bool update();
+	bool update(AttributeWatcher &watcher);
 
 	/**
 	 * draws this action by taking the graphic type of the top action
@@ -177,11 +178,19 @@ public:
 	bool has_attribute(attr_type type) const;
 
 	/**
-	 * returns attribute based on templated value
+	 * returns attribute based on templated value while spying on it
 	 */
 	template<attr_type T>
-	Attribute<T> &get_attribute() {
-		return *reinterpret_cast<Attribute<T> *>(attribute_map[T].get());
+	typename AttributeSpy<T>::type get_attribute(AttributeWatcher &watcher) {
+		return get_attr<T>(watcher, this->id, this->attribute_map);
+	}
+
+	/**
+	 * returns attribute as constant based on templated value
+	 */
+	template<attr_type T>
+	const Attribute<T>& get_attribute() const {
+		return get_attr<T>(this->attribute_map);
 	}
 
 	/**
@@ -286,18 +295,18 @@ private:
 	/**
 	 * applies new commands as part of the units update process
 	 */
-	void apply_all_cmds();
+	void apply_all_cmds(AttributeWatcher &watcher);
 
 	/**
 	 * applies one command using a chosen ability
 	 * locks the command queue mutex while operating
 	 */
-	void apply_cmd(std::shared_ptr<UnitAbility> ability, const Command &cmd);
+	void apply_cmd(AttributeWatcher &watcher, std::shared_ptr<UnitAbility> ability, const Command &cmd);
 
 	/**
 	 * update all secondary actions
 	 */
-	void update_secondary(int64_t time_elapsed);
+	void update_secondary(AttributeWatcher &watcher, int64_t time_elapsed);
 
 	/**
 	 * erase from action specified by func to the end of the stack

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -121,7 +121,7 @@ public:
 	/**
 	 * update this object using the action currently on top of the stack
 	 */
-	bool update(AttributeWatcher &watcher);
+	bool update(curve::CurveRecord &watcher);
 
 	/**
 	 * draws this action by taking the graphic type of the top action
@@ -181,7 +181,7 @@ public:
 	 * returns attribute based on templated value while spying on it
 	 */
 	template<attr_type T>
-	typename AttributeSpy<T>::type get_attribute(AttributeWatcher &watcher) {
+	typename AttributeSpy<T>::type get_attribute(curve::CurveRecord &watcher) {
 		return get_attr<T>(watcher, this->id, this->attribute_map);
 	}
 
@@ -191,6 +191,14 @@ public:
 	template<attr_type T>
 	const Attribute<T>& get_attribute() const {
 		return get_attr<T>(this->attribute_map);
+	}
+
+	/**
+	 * returns mutable attribute based on templated value
+	 */
+	template<attr_type T>
+	Attribute<T>& get_attribute_unwatched() {
+		return get_attr_ref<T>(this->attribute_map);
 	}
 
 	/**
@@ -295,18 +303,18 @@ private:
 	/**
 	 * applies new commands as part of the units update process
 	 */
-	void apply_all_cmds(AttributeWatcher &watcher);
+	void apply_all_cmds(curve::CurveRecord &watcher);
 
 	/**
 	 * applies one command using a chosen ability
 	 * locks the command queue mutex while operating
 	 */
-	void apply_cmd(AttributeWatcher &watcher, std::shared_ptr<UnitAbility> ability, const Command &cmd);
+	void apply_cmd(curve::CurveRecord &watcher, std::shared_ptr<UnitAbility> ability, const Command &cmd);
 
 	/**
 	 * update all secondary actions
 	 */
-	void update_secondary(AttributeWatcher &watcher, int64_t time_elapsed);
+	void update_secondary(curve::CurveRecord &watcher, int64_t time_elapsed);
 
 	/**
 	 * erase from action specified by func to the end of the stack

--- a/libopenage/unit/unit_container.cpp
+++ b/libopenage/unit/unit_container.cpp
@@ -91,7 +91,7 @@ UnitReference UnitContainer::new_unit() {
 	return this->live_units[id]->get_ref();
 }
 
-UnitReference UnitContainer::new_unit(AttributeWatcher &watcher,
+UnitReference UnitContainer::new_unit(curve::CurveRecord &watcher,
                                       UnitType &type,
                                       Player &owner,
                                       coord::phys3 position) {
@@ -109,7 +109,7 @@ UnitReference UnitContainer::new_unit(AttributeWatcher &watcher,
 	return UnitReference(); // is not valid
 }
 
-UnitReference UnitContainer::new_unit(AttributeWatcher &watcher,
+UnitReference UnitContainer::new_unit(curve::CurveRecord &watcher,
                                       UnitType &type,
                                       Player &owner,
                                       TerrainObject *other) {
@@ -131,7 +131,7 @@ bool dispatch_command(id_t, const Command &) {
 	return true;
 }
 
-bool UnitContainer::update_all(AttributeWatcher &watcher) {
+bool UnitContainer::update_all(curve::CurveRecord &watcher) {
 	// update everything and find objects with no actions
 	std::vector<id_t> to_remove;
 	for (auto &obj : this->live_units) {

--- a/libopenage/unit/unit_container.cpp
+++ b/libopenage/unit/unit_container.cpp
@@ -99,7 +99,7 @@ UnitReference UnitContainer::new_unit(AttributeWatcher &watcher,
 
 	// try placing unit at this location
 	auto terrain_shared = this->get_terrain();
-	auto placed = type.place(newobj.get(), terrain_shared, position);
+	auto placed = type.place(watcher, newobj.get(), terrain_shared, position);
 	if (placed) {
 		type.initialise(watcher, newobj.get(), owner);
 		auto id = newobj->id;
@@ -116,7 +116,7 @@ UnitReference UnitContainer::new_unit(AttributeWatcher &watcher,
 	auto newobj = std::make_unique<Unit>(*this, next_new_id++);
 
 	// try placing unit
-	TerrainObject *placed = type.place_beside(newobj.get(), other);
+	TerrainObject *placed = type.place_beside(watcher, newobj.get(), other);
 	if (placed) {
 		type.initialise(watcher, newobj.get(), owner);
 		auto id = newobj->id;

--- a/libopenage/unit/unit_container.h
+++ b/libopenage/unit/unit_container.h
@@ -17,6 +17,7 @@ class TerrainObject;
 class Unit;
 class UnitContainer;
 class UnitType;
+class AttributeWatcher;
 
 using id_t = unsigned long int;
 
@@ -100,13 +101,13 @@ public:
 	/**
 	 * adds a new unit to the container and initialises using a unit type
 	 */
-	UnitReference new_unit(UnitType &type, Player &owner, coord::phys3 position);
+	UnitReference new_unit(AttributeWatcher &watcher, UnitType &type, Player &owner, coord::phys3 position);
 
 	/**
 	 * adds a new unit to the container and initialises using a unit type
 	 * places outside an existing object using the player of that object
 	 */
-	UnitReference new_unit(UnitType &type, Player &owner, TerrainObject *other);
+	UnitReference new_unit(AttributeWatcher &watcher, UnitType &type, Player &owner, TerrainObject *other);
 
 	/**
 	 * give a command to a unit -- unit creation and deletion should be done as commands
@@ -116,8 +117,9 @@ public:
 	/**
 	 * update dispatched by the game engine
 	 * this will update all game objects
+	 * while spying on their attributes
 	 */
-	bool update_all();
+	bool update_all(AttributeWatcher &watcher);
 
 	/**
 	 * gets a list of all units in the container

--- a/libopenage/unit/unit_container.h
+++ b/libopenage/unit/unit_container.h
@@ -17,7 +17,10 @@ class TerrainObject;
 class Unit;
 class UnitContainer;
 class UnitType;
-class AttributeWatcher;
+
+namespace curve {
+class CurveRecord;
+} // namespace curve
 
 using id_t = unsigned long int;
 
@@ -101,13 +104,13 @@ public:
 	/**
 	 * adds a new unit to the container and initialises using a unit type
 	 */
-	UnitReference new_unit(AttributeWatcher &watcher, UnitType &type, Player &owner, coord::phys3 position);
+	UnitReference new_unit(curve::CurveRecord &watcher, UnitType &type, Player &owner, coord::phys3 position);
 
 	/**
 	 * adds a new unit to the container and initialises using a unit type
 	 * places outside an existing object using the player of that object
 	 */
-	UnitReference new_unit(AttributeWatcher &watcher, UnitType &type, Player &owner, TerrainObject *other);
+	UnitReference new_unit(curve::CurveRecord &watcher, UnitType &type, Player &owner, TerrainObject *other);
 
 	/**
 	 * give a command to a unit -- unit creation and deletion should be done as commands
@@ -119,7 +122,7 @@ public:
 	 * this will update all game objects
 	 * while spying on their attributes
 	 */
-	bool update_all(AttributeWatcher &watcher);
+	bool update_all(curve::CurveRecord &watcher);
 
 	/**
 	 * gets a list of all units in the container

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -41,7 +41,7 @@ UnitTexture *UnitType::default_texture() {
 	return this->graphics[graphic_type::standing].get();
 }
 
-TerrainObject *UnitType::place_beside(Unit *u, TerrainObject const *other) const {
+TerrainObject *UnitType::place_beside(AttributeWatcher &watcher, Unit *u, TerrainObject const *other) const {
 	if (!u || !other) {
 		return nullptr;
 	}
@@ -60,7 +60,7 @@ TerrainObject *UnitType::place_beside(Unit *u, TerrainObject const *other) const
 			continue;
 		}
 
-		auto placed = this->place(u, terrain, temp_pos.to_phys2().to_phys3());
+		auto placed = this->place(watcher, u, terrain, temp_pos.to_phys2().to_phys3());
 		if (placed) {
 			return placed;
 		}
@@ -122,7 +122,7 @@ void NyanType::initialise(AttributeWatcher &, Unit *unit, Player &) {
 	unit->push_action(std::make_unique<IdleAction>(unit), true);
 }
 
-TerrainObject *NyanType::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *NyanType::place(AttributeWatcher &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	// the parsed nyan data gives the rules for terrain placement
 	// which includes valid terrains, base radius and shape
 
@@ -134,7 +134,7 @@ TerrainObject *NyanType::place(Unit *unit, std::shared_ptr<Terrain> terrain, coo
 	};
 
 	// try to place the obj, it knows best whether it will fit.
-	if (unit->location->place(terrain, init_pos, object_state::placed)) {
+	if (unit->location->place(watcher, terrain, init_pos, object_state::placed)) {
 		return unit->location.get();
 	}
 

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -41,7 +41,7 @@ UnitTexture *UnitType::default_texture() {
 	return this->graphics[graphic_type::standing].get();
 }
 
-TerrainObject *UnitType::place_beside(AttributeWatcher &watcher, Unit *u, TerrainObject const *other) const {
+TerrainObject *UnitType::place_beside(curve::CurveRecord &watcher, Unit *u, TerrainObject const *other) const {
 	if (!u || !other) {
 		return nullptr;
 	}
@@ -102,7 +102,7 @@ std::string NyanType::name() const {
 	return "Nyan";
 }
 
-void NyanType::initialise(AttributeWatcher &, Unit *unit, Player &) {
+void NyanType::initialise(curve::CurveRecord &, Unit *unit, Player &) {
 	// reset any existing attributes and type
 	unit->reset();
 
@@ -122,7 +122,7 @@ void NyanType::initialise(AttributeWatcher &, Unit *unit, Player &) {
 	unit->push_action(std::make_unique<IdleAction>(unit), true);
 }
 
-TerrainObject *NyanType::place(AttributeWatcher &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
+TerrainObject *NyanType::place(curve::CurveRecord &watcher, Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
 	// the parsed nyan data gives the rules for terrain placement
 	// which includes valid terrains, base radius and shape
 

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -102,7 +102,7 @@ std::string NyanType::name() const {
 	return "Nyan";
 }
 
-void NyanType::initialise(Unit *unit, Player &) {
+void NyanType::initialise(AttributeWatcher &, Unit *unit, Player &) {
 	// reset any existing attributes and type
 	unit->reset();
 

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -84,7 +84,7 @@ public:
 	 *
 	 * TODO: make const
 	 */
-	virtual void initialise(Unit *, Player &) = 0;
+	virtual void initialise(AttributeWatcher &, Unit *, Player &) = 0;
 
 	/**
 	 * set unit in place -- return if placement was successful
@@ -178,7 +178,7 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(Unit *, Player &) override;
+	void initialise(AttributeWatcher &, Unit *, Player &) override;
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 };

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -93,7 +93,7 @@ public:
 	 * when a unit is ungarrsioned from a building or object
 	 * TODO: make const
 	 */
-	virtual TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
+	virtual TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
 
 	/**
 	 * compare if two types are the same
@@ -109,7 +109,7 @@ public:
 	/**
 	 * similiar to place but places adjacent to an existing object
 	 */
-	TerrainObject *place_beside(Unit *, TerrainObject const *) const;
+	TerrainObject *place_beside(AttributeWatcher &watcher, Unit *, TerrainObject const *) const;
 
 	/**
 	 * copy attributes of this unit type to a new unit instance
@@ -179,7 +179,7 @@ public:
 	int parent_id() const override;
 	std::string name() const override;
 	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 };
 

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -84,7 +84,7 @@ public:
 	 *
 	 * TODO: make const
 	 */
-	virtual void initialise(AttributeWatcher &, Unit *, Player &) = 0;
+	virtual void initialise(curve::CurveRecord &, Unit *, Player &) = 0;
 
 	/**
 	 * set unit in place -- return if placement was successful
@@ -93,7 +93,7 @@ public:
 	 * when a unit is ungarrsioned from a building or object
 	 * TODO: make const
 	 */
-	virtual TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
+	virtual TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const = 0;
 
 	/**
 	 * compare if two types are the same
@@ -109,7 +109,7 @@ public:
 	/**
 	 * similiar to place but places adjacent to an existing object
 	 */
-	TerrainObject *place_beside(AttributeWatcher &watcher, Unit *, TerrainObject const *) const;
+	TerrainObject *place_beside(curve::CurveRecord &watcher, Unit *, TerrainObject const *) const;
 
 	/**
 	 * copy attributes of this unit type to a new unit instance
@@ -178,8 +178,8 @@ public:
 	int id() const override;
 	int parent_id() const override;
 	std::string name() const override;
-	void initialise(AttributeWatcher &, Unit *, Player &) override;
-	TerrainObject *place(AttributeWatcher &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
+	void initialise(curve::CurveRecord &, Unit *, Player &) override;
+	TerrainObject *place(curve::CurveRecord &watcher, Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 };
 

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -95,7 +95,7 @@ def get_string_resources(args):
 
     elif srcdir["language.dll"].is_file():
         from .pefile import PEFile
-        for name in ["language.dll", "language_x1.dll", "language_x1_p1.dll"]:
+        for name in ["language.dll", "language_x1.dll"]:
             pefile = PEFile(srcdir[name].open('rb'))
             stringres.fill_from(pefile.resources().strings)
             count += 1
@@ -126,9 +126,9 @@ def get_blendomatic_data(srcdir):
 def get_gamespec(srcdir, dont_pickle):
     """ reads empires.dat and fixes it """
 
-    cache_file = os.path.join(gettempdir(), "empires2_x1_p1.dat.pickle")
+    cache_file = os.path.join(gettempdir(), "empires2_x1.dat.pickle")
 
-    with srcdir["data/empires2_x1_p1.dat"].open('rb') as empiresdat_file:
+    with srcdir["data/empires2_x1.dat"].open('rb') as empiresdat_file:
         gamespec = load_gamespec(empiresdat_file, cache_file, not dont_pickle)
 
     # modify the read contents of datfile

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -79,7 +79,7 @@ def mount_drs_archives(srcdir, game_versions=None):
         if GameVersion.age2_hd_3x not in game_versions:
             mount_drs("data/gamedata.drs", "gamedata")
         mount_drs("data/gamedata_x1.drs", "gamedata")
-        mount_drs("data/gamedata_x1_p1.drs", "gamedata")
+#        mount_drs("data/gamedata_x1_p1.drs", "gamedata")
         # TODO mount gamedata_x2.drs and _x2_p1 if they exist?
 
     return result

--- a/openage/convert/slp_converter_pool.py
+++ b/openage/convert/slp_converter_pool.py
@@ -99,15 +99,15 @@ class SLPConverterPool:
 
         inqueue, outqueue = self.idle.get()
 
-        with self.job_mutex:
-            inqueue.put((slpdata, custom_cutter))
+        #with self.job_mutex:
+        inqueue.put((slpdata, custom_cutter))
 
         # TODO not sure why this synchronization is needed.
         #      (But it is. otherwise, there are non-deterministic crashes when
         #       depickling some of Texture's numpy internals, especially with
         #       high job counts.).
-        with self.job_mutex:
-            result = outqueue.get()
+        #with self.job_mutex:
+        result = outqueue.get()
 
         self.idle.put((inqueue, outqueue))
 

--- a/openage/testing/testlist.py
+++ b/openage/testing/testlist.py
@@ -67,6 +67,7 @@ def tests_cpp():
     yield "openage::util::tests::matrix"
     yield "openage::util::tests::vector"
     yield "openage::input::tests::parse_event_string", "keybinds parsing"
+    yield "openage::curve::tests::advance_frame", "moving interpolator's frame"
 
 
 def demos_cpp():


### PR DESCRIPTION
The current game logic will be mostly used in the server. Same code will probably be used on the client to predict the outcome of the commands issued by the player.

The outcomes of all commands of all of the players form a history. The history is generated by the server.

This PR starts from an in-memory representation of the history (it's not about network). The goals are:
- [x] modify attributes, so they can record changes
- [x] position is not an `Attribute`, so capture changes inside the constructor and actions
- [x] write out the history while the client is running (currently it has all the server code)
- [ ] write out the history of object creation

*no server-side prediction/correction for the moment

*no special format
- [ ] replay that history on the client
- [ ] output the history with server-side predictions and corrections (move away from recording every change of an attribute)
- [ ] replay the history that contains corrections

Integration is probably going to be via `Unit::action_secondary`, `UnitContainer::new_unit` and `Unit::delete_unit`. The idea is to create one `CurveAction` that will sit forever in the `Unit::action_secondary` and apply all curves on each graphical tick.

To extract changes, the members of `Attribute<T>` can be transformed into "spying" values. It's enough for point-curves, but things like `MoveAction` will eventually need to generate longer curves.

At the end of each logic tick (maybe I should call it a network tick) the history will be resynchronized and a segment from it will be used to show the next tick. Pipelining will be needed. The network frame rate is flexible because in theory it's inversely proportional to the amount of stuff that is coming.

Related - #530.
