### PR TITLE
Fix OSX Build

### DIFF
--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -87,8 +87,14 @@ find_package(Epoxy REQUIRED)
 find_package(HarfBuzz 1.0.0 REQUIRED)
 
 set(QT_VERSION_REQ "5.4")
-find_package(Qt5Core ${QT_VERSION_REQ} REQUIRED)
-find_package(Qt5Quick ${QT_VERSION_REQ} REQUIRED)
+if(APPLE)
+	# tell CMake to look in the default homebrew installation for Qt5
+	find_package(Qt5Core ${QT_VERSION_REQ} REQUIRED PATHS "/usr/local/Cellar/qt5/*")
+	find_package(Qt5Quick ${QT_VERSION_REQ} REQUIRED PATHS "/usr/local/Cellar/qt5/*")
+else()
+	find_package(Qt5Core ${QT_VERSION_REQ} REQUIRED)
+	find_package(Qt5Quick ${QT_VERSION_REQ} REQUIRED)
+endif()
 
 if(WANT_BACKTRACE)
 	find_package(GCCBacktrace)

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -145,6 +145,11 @@ get_config_option_string()
 configure_file(config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 configure_file(config.cpp.in ${CMAKE_CURRENT_SOURCE_DIR}/config.cpp)
 
+# default homebrew/cellar Qt5 installation
+if(APPLE)
+	find_path(QTPLATFORM_INCLUDE_DIRS QtPlatformHeaders "/usr/local/Cellar/qt5/*/include")
+endif()
+
 # directories for header inclusion
 include_directories(
 	${OPENGL_INCLUDE_DIR}
@@ -154,6 +159,7 @@ include_directories(
 	${SDL2_INCLUDE_DIR}
 	${SDL2IMAGE_INCLUDE_DIRS}
 	${HarfBuzz_INCLUDE_DIRS}
+	${QTPLATFORM_INCLUDE_DIRS}
 )
 
 # link the executable to those libraries

--- a/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
@@ -7,7 +7,13 @@
 #include <QtPlatformHeaders/QGLXNativeContext>
 
 #include "SDL2/SDL_syswm.h"
+// It can't hurt to have this here even though OSX doesn't use X11 by default,
+// you can use it with XQuartz
+#ifndef __APPLE__
 #include "GL/glx.h"
+#else
+#include "OpenGL/glx.h"
+#endif
 
 // DO NOT INCLUDE ANYTHING HERE, X11 HEADERS BREAK STUFF
 

--- a/libopenage/gui/guisys/public/gui_renderer.h
+++ b/libopenage/gui/guisys/public/gui_renderer.h
@@ -4,7 +4,11 @@
 
 #include <memory>
 
+#ifndef __APPLE__
 #include <GL/gl.h>
+#else
+#include <OpenGL/gl.h>
+#endif
 
 struct SDL_Window;
 


### PR DESCRIPTION
I basically just took the fixes @Birch-san found in #643 and made them a bit more portable.

I'm not sure about the 4th problem... I didn't really adapt the fixes too much yet it didn't occur at all for me. It might be that Qt5 is now on 5.7.0, but again I'm not sure.

Also, this just fixes the build, the game still doesn't run sadly. It spams the terminal whith a whole bunch of

```
  File ?, in std::__terminate(void (*)())+0x8 [0x7fffd8869d69]
  File ?, in std::terminate()+0x33 [0x7fffd8869de3]
```

and you can't actually close it except for doing Ctrl-Z and `kill -9 %1`. This might be related to #608.

Closes #643.
