### PR TITLE
Player teams

### DIFF
--- a/libopenage/gamestate/CMakeLists.txt
+++ b/libopenage/gamestate/CMakeLists.txt
@@ -5,4 +5,5 @@ add_sources(libopenage
 	game_spec.cpp
 	generator.cpp
 	player.cpp
+	team.cpp
 )

--- a/libopenage/gamestate/game_main.cpp
+++ b/libopenage/gamestate/game_main.cpp
@@ -44,6 +44,14 @@ Player *GameMain::get_player(unsigned int player_id) {
 	return &this->players.at(player_id);
 }
 
+unsigned int GameMain::team_count() const {
+	return this->teams.size();
+}
+
+Team *GameMain::get_team(unsigned int team_id) {
+	return &this->teams.at(team_id);
+}
+
 GameSpec *GameMain::get_spec() {
 	return this->spec.get();
 }

--- a/libopenage/gamestate/game_main.h
+++ b/libopenage/gamestate/game_main.h
@@ -9,6 +9,7 @@
 #include <QObject>
 
 #include "player.h"
+#include "team.h"
 #include "../options.h"
 #include "../unit/unit_container.h"
 
@@ -40,6 +41,16 @@ public:
 	Player *get_player(unsigned int player_id);
 
 	/**
+	 * the number of teams
+	 */
+	unsigned int team_count() const;
+
+	/**
+	 * team by id
+	 */
+	Team *get_team(unsigned int team_id);
+
+	/**
 	 * the spec in this games settings
 	 */
 	GameSpec *get_spec();
@@ -59,6 +70,11 @@ public:
 	 * no objects should be added of removed once populated
 	 */
 	std::vector<Player> players;
+
+	/**
+	 * all teams in the game
+	 */
+	std::vector<Team> teams;
 
 	/**
 	 * all the objects that have been placed.

--- a/libopenage/gamestate/player.cpp
+++ b/libopenage/gamestate/player.cpp
@@ -3,6 +3,7 @@
 #include "../unit/unit.h"
 #include "../unit/unit_type.h"
 #include "player.h"
+#include "team.h"
 
 namespace openage {
 
@@ -11,7 +12,8 @@ Player::Player(Civilisation *civ, unsigned int number, std::string name)
 	player_number{number},
 	color{number},
 	civ{civ},
-	name{name} {
+	name{name},
+	team{nullptr} {
 }
 
 bool Player::operator ==(const Player &other) const {
@@ -20,14 +22,21 @@ bool Player::operator ==(const Player &other) const {
 
 bool Player::is_enemy(const Player &other) const {
 
-	// everyone else is enemy
-	return player_number != other.player_number;
+	return !this->is_ally(other);
 }
 
 bool Player::is_ally(const Player &other) const {
 
+	if (this->player_number == other.player_number) {
+		return true; // same player
+	}
+
+	if (this->team && this->team->is_member(other)) {
+		return true; // same team
+	}
+
 	// everyone else is enemy
-	return player_number == other.player_number;
+	return false;
 }
 
 bool Player::owns(Unit &unit) const {

--- a/libopenage/gamestate/player.h
+++ b/libopenage/gamestate/player.h
@@ -12,6 +12,7 @@
 namespace openage {
 
 class Unit;
+class Team;
 
 class Player {
 public:
@@ -37,6 +38,12 @@ public:
 	 * visible name of this player
 	 */
 	const std::string name;
+
+	/**
+	 * the team of this player
+	 * nullptr if member of no team
+	 */
+	Team *team;
 
 	/**
 	 * checks if two players are the same

--- a/libopenage/gamestate/team.cpp
+++ b/libopenage/gamestate/team.cpp
@@ -1,0 +1,64 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#include "team.h"
+#include "player.h"
+
+namespace openage {
+
+Team::Team(unsigned int id)
+	:
+	Team{id, "Anonymous Team", nullptr} {}
+
+Team::Team(unsigned int id, std::string name)
+	:
+	Team{id, name, nullptr} {}
+
+Team::Team(unsigned int id, std::string name, Player *leader)
+	:
+	id{id},
+	name{name} {
+
+	if (leader) {
+		this->members[leader] = member_type::leader;
+	}
+}
+
+bool Team::operator ==(const Team &other) const {
+	return this->id == other.id;
+}
+
+void Team::add_member(Player &player, const member_type type) {
+	// if already exists, replace member type
+	this->members[&player] = type;
+	// change player team pointer
+	player.team = this;
+}
+
+void Team::change_member_type(Player &player, const member_type type) {
+	auto p = this->members.find(&player);
+	if (p != this->members.end()) {
+		this->members[&player] = type;
+	}
+}
+
+bool Team::is_member(const Player &player) const {
+	auto p = this->members.find(&player);
+	return (p != this->members.end());
+}
+
+void Team::remove_member(Player &player) {
+	this->members.erase(&player);
+	// change player team pointer
+	player.team = nullptr;
+}
+
+member_type Team::get_member_type(Player &player) {
+	auto p = this->members.find(&player);
+	if (p != this->members.end()) {
+		return this->members[&player];
+	}
+	// return pseudo member type for completion
+	return member_type::none;
+}
+
+} // openage

--- a/libopenage/gamestate/team.cpp
+++ b/libopenage/gamestate/team.cpp
@@ -19,7 +19,7 @@ Team::Team(unsigned int id, std::string name, Player *leader)
 	name{name} {
 
 	if (leader) {
-		this->members[leader] = member_type::leader;
+		this->add_member(*leader, member_type::leader);
 	}
 }
 

--- a/libopenage/gamestate/team.h
+++ b/libopenage/gamestate/team.h
@@ -1,0 +1,60 @@
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace openage {
+
+class Player;
+
+/**
+ * Types of membership
+ */
+enum class member_type {
+	leader,
+	member,
+	recruit,
+	none // pseudo type
+};
+
+/**
+ * A team of players
+ */
+class Team {
+public:
+	Team(unsigned int id);
+	Team(unsigned int id, std::string name);
+	Team(unsigned int id, std::string name, Player *leader);
+
+	/**
+	 * unique id of the team
+	 */
+	const unsigned int id;
+
+	/**
+	 * visible name of this team
+	 */
+	const std::string name;
+
+	bool operator ==(const Team &other) const;
+
+
+	void add_member(Player &player, const member_type type);
+
+	void change_member_type(Player &player, const member_type type);
+
+	bool is_member(const Player &player) const;
+
+	void remove_member(Player &player);
+
+	member_type get_member_type(Player &player);
+
+private:
+
+	std::unordered_map<const Player*, member_type> members;
+
+};
+
+} // openage


### PR DESCRIPTION
Added teams of players. Member types are also supported, currently we have:
- leader: creator and master of the team
- member: member before the start of the game
- recruit: player that became member at some point during the game

I cant understand what that means (need help):

```
.../openage$ make checkall
python3 -m buildsystem.codecompliance --all
************* Module openage.__main__
W: 60, 4: Reimport 'init_subparser' (imported line 54) (reimported)
W: 65, 4: Reimport 'init_subparser' (imported line 54) (reimported)
W: 70, 4: Reimport 'init_subparser' (imported line 54) (reimported)
W: 75, 4: Reimport 'init_subparser' (imported line 54) (reimported)
WARNING linting issue: python code is noncompliant: 4
Makefile:126: recipe for target 'checkall' failed
make: *** [checkall] Error 1
```
