### PR TITLE
[WIP] Add Travis CI build & testing for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+os:
+  - osx
+before_install:
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -showsdks
+install:
+  - brew update
+  - brew install caskroom/cask/brew-cask
+  - brew tap caskroom/fonts
+  - brew tap homebrew/versions
+  - brew tap homebrew/python
+  - brew update
+  - brew cask install font-dejavu-sans
+  - brew install python3 libepoxy freetype fontconfig harfbuzz sdl2 sdl2_image opus opus-tools opusfile
+  - brew install qt5
+  - pip3.5 install pygments cython numpy Pillow
+script:
+  - CMAKE_PREFIX_PATH=/usr/local/opt/qt5 ./configure --compiler=clang++ --prefix=/usr
+  - make -j4
+  - make tests

--- a/copying.md
+++ b/copying.md
@@ -89,6 +89,7 @@ _the openage authors_ are:
 | Johannes Walcher            | tomatower                   | johannes.walcher@stusta.de            |
 | Akritas Akritidis           | MaanooAk                    | akritasak@gmail.com                   |
 | Edgard Mota                 | edgardmota                  | edgardmota@gmail.com                  |
+| Boris Dušek                 | dusek                       | me@dusek.me                           |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -6,6 +6,9 @@
 # are specified below the source file list.
 
 set(CMAKE_AUTOMOC ON)
+if(APPLE)
+        list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/qt5)
+endif()
 
 declare_binary(libopenage)
 
@@ -139,6 +142,10 @@ get_config_option_string()
 configure_file(config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 configure_file(config.cpp.in ${CMAKE_CURRENT_SOURCE_DIR}/config.cpp)
 
+if(APPLE)
+	find_path(QTPLATFORM_INCLUDE_DIRS QtPlatformHeaders "/usr/local/opt/qt5/include")
+endif()
+
 # directories for header inclusion
 include_directories(
 	${OPENGL_INCLUDE_DIR}
@@ -148,6 +155,7 @@ include_directories(
 	${SDL2_INCLUDE_DIR}
 	${SDL2IMAGE_INCLUDE_DIRS}
 	${HarfBuzz_INCLUDE_DIRS}
+        ${QTPLATFORM_INCLUDE_DIRS}
 )
 
 # link the executable to those libraries

--- a/libopenage/gui/guisys/public/gui_renderer.h
+++ b/libopenage/gui/guisys/public/gui_renderer.h
@@ -4,7 +4,11 @@
 
 #include <memory>
 
+#ifndef __APPLE__
 #include <GL/gl.h>
+#else
+#include <OpenGL/gl.h>
+#endif
 
 struct SDL_Window;
 


### PR DESCRIPTION
This adds CI testing of the macOS build on Travis. It builds the project (basically `./configure && make`) and then runs the tests (`make tests`)

This is a WIP as it contains an adjusted form of fixes from #648 (all in second commit) in order to be able to demonstrate a [successful build](https://travis-ci.org/dusek/openage/builds/171836562). After #648 is merged, this PR will be updated (finished) to take into account the final form of fixes (basically drop the second commit, and adjust the first commit if necessary).
