### PR TITLE
GUI: Warn about possible missing includes

### DIFF
--- a/libopenage/gui/guisys/link/gui_item.h
+++ b/libopenage/gui/guisys/link/gui_item.h
@@ -181,6 +181,7 @@ public:
 		GuiItemBase *base = checked_static_cast<GuiItemBase*>(checked_static_cast<T*>(this));
 
 		emit base->game_logic_caller.in_game_logic_thread([=] {
+			static_assert_about_unwrapping<F, decltype(unwrap(checked_static_cast<T*>(this))), decltype(unwrap_if_can(args))...>();
 			f(unwrap(checked_static_cast<T*>(this)), unwrap_if_can(args)...);
 		});
 	}
@@ -213,6 +214,8 @@ private:
 	template<typename F, typename A>
 	void assign_while_catching_constant_properies_inits(F f, A &&arg) {
 		GuiItemBase *base = checked_static_cast<GuiItemBase*>(checked_static_cast<T*>(this));
+
+		static_assert_about_unwrapping<F, decltype(unwrap(checked_static_cast<T*>(this))), decltype(unwrap_if_can(arg))>();
 
 		if (base->init_over)
 			emit base->game_logic_caller.in_game_logic_thread([=] {f(unwrap(checked_static_cast<T*>(this)), unwrap_if_can(arg));});

--- a/libopenage/gui/guisys/link/gui_item_link.h
+++ b/libopenage/gui/guisys/link/gui_item_link.h
@@ -83,4 +83,39 @@ typename Unwrap<T>::Type* unwrap_if_can(T *t) {
 	return unwrap(t);
 }
 
+/**
+ * Checking that callable can be called with given argument types.
+ */
+struct can_call_test {
+	template<typename F, typename ... Args>
+	static decltype(std::declval<F>()(std::declval<Args>()...), std::true_type()) f(int);
+
+	template<typename F, typename ... Args>
+	static std::false_type f(...);
+};
+
+/**
+ * Evaluates to true if callable can be called with given argument types.
+ *
+ * @tparam F callable
+ * @tparam A arguments to test against the callable
+ */
+template<typename F, typename ... Args>
+struct can_call : decltype(can_call_test::f<F, Args...>(0)) {
+};
+
+/**
+ * To print our own error message that warns about possible cause of the argument mismatch.
+ *
+ * Unwrapping uses type trait "Unwrap" that is defined in the header with corresponding type.
+ * If the header is not included, then compiler considers it as a basic type and tries to pass it wrapped to a function that expects an unwrapped type.
+ *
+ * @tparam F callable
+ * @tparam A arguments to test against the callable
+ */
+template<typename F, typename ... Args>
+constexpr void static_assert_about_unwrapping() {
+	static_assert(can_call<F, Args...>{}, "One of possible causes: if you're passing SomethingLink*, then don't forget to #include \"something_link.h\".");
+}
+
 } // namespace qtsdl


### PR DESCRIPTION
Unwrapping of the GUI binding classes like `SomeClassLink` into `SomeClass` uses type trait `Unwrap` that is defined in the header with corresponding type. If the header is not included, then compiler considers it as a basic type and tries to pass it wrapped to a function that expects an unwrapped type. To warn about that possibility, PR adds a compile-time error message if the arguments don't match for any reason.