### PR TITLE
pep8 module renaming support

### DIFF
--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -97,15 +97,14 @@ def process_args(args, error):
             error("--test-git-change-years requires git")
 
     if args.pystyle:
-        try:
-            importlib.import_module('pep8')
-        except ImportError:
-            error("pep8 python module required for style checking")
+        if not importlib.util.find_spec('pep8') and \
+           not importlib.util.find_spec('pycodestyle'):
+
+            error("pep8 or pycodestyle python module "
+                  "required for style checking")
 
     if args.pylint:
-        try:
-            importlib.import_module('pylint')
-        except ImportError:
+        if not importlib.util.find_spec('pylint'):
             error("pylint python module required for linting")
 
 

--- a/buildsystem/codecompliance/pystyle.py
+++ b/buildsystem/codecompliance/pystyle.py
@@ -1,10 +1,14 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 """
 Checks PEP8 compliance, with some exceptions.
 """
 
-from pep8 import StyleGuide
+try:
+    from pep8 import StyleGuide
+except ImportError:
+    from pycodestyle import StyleGuide
+
 
 # these errors will be ignored by pep8
 IGNORE_ERRORS = (

--- a/doc/building.md
+++ b/doc/building.md
@@ -23,6 +23,7 @@ Dependencies are needed for:
 * C = compiling
 * R = running
 * A = asset conversion
+* S = sanity checks (make checkall)
 
 Dependency list:
 
@@ -42,7 +43,9 @@ Dependency list:
     CR    sdl2_image
     CR    opusfile
       A   opus-tools
+       S  pycodestyle (or pep8 (deprecated))
     C     pygments
+       S  pylint
     CR    qt5 >=5.4 (Core, Quick, QuickControls modules)
 
       A   An installed version of any of the following (wine is your friend).
@@ -52,9 +55,12 @@ Dependency list:
      - Age of Empires II: Forgotten Empires
      - Age of Empires II HD
 
-### Specific Prerequisite steps per Platform
 
-There are some prerequisite steps that need to be performed so *openage* can be built successfully. Those steps vary from platform to platform, and are described bellow for some of the most common ones:
+### Dependency installation
+
+There are some prerequisite steps that need to be performed so *openage* can be
+built successfully. Those steps vary from platform to platform, and are
+described below for some of the most common ones:
 
 - [Ubuntu (>= 15.04)](build_instructions/ubuntu_15.04.md)
 - [Fedora 20, 21](build_instructions/fedora_20_21.md)
@@ -63,6 +69,7 @@ There are some prerequisite steps that need to be performed so *openage* can be 
 - [openSUSE Tumbleweed](build_instructions/opensuse_tumbleweed.md)
 - [Mac OS X 10.10 Yosemite](build_instructions/os_x_10.10_yosemite.md)
 - [Arch Linux](build_instructions/arch_linux.md)
+
 
 ## Build procedure
 

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -51,6 +51,9 @@ def main(argv=None):
 
     subparsers = cli.add_subparsers(dest="subcommand")
 
+    # enable reimports for "init_subparser"
+    # pylint: disable=reimported
+
     from .game.main import init_subparser
     game_cli = subparsers.add_parser(
         "game",


### PR DESCRIPTION
The pep8 module was renamed to pycodestyle:

https://github.com/PyCQA/pycodestyle
https://github.com/PyCQA/pycodestyle/issues/466