### PR TITLE
GUI: Start game after assets have loaded

### DIFF
--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -291,7 +291,7 @@ public:
 
 	void set_modes(const std::vector<OutputMode*> &modes);
 
-	void set_mode(int mode);
+	void set_mode(int mode, bool signal_if_unchanged=false);
 	void announce_mode();
 	void announce_current_player_name();
 

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -198,7 +198,7 @@ GameControlLink::GameControlLink(QObject *parent)
 	GuiItem{this},
 	mode{},
 	effective_mode_index{-1},
-	mode_index{},
+	mode_index{-1},
 	engine{},
 	game{},
 	current_civ_index{} {
@@ -241,7 +241,7 @@ int GameControlLink::get_mode_index() const {
 
 void GameControlLink::set_mode_index(int mode) {
 	static auto f = [] (GameControl *_this, int mode) {
-		_this->set_mode(mode);
+		_this->set_mode(mode, true);
 	};
 
 	this->sf(f, this->mode_index, mode);
@@ -312,6 +312,7 @@ void GameControlLink::on_modes_changed(OutputMode *mode, int mode_index) {
 	this->i(f, this->mode_index);
 
 	this->on_mode_changed(mode, mode_index);
+	emit this->modes_changed();
 }
 
 void GameControlLink::on_current_player_name_changed(const std::string &current_player_name) {

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -231,7 +231,7 @@ class GameControlLink : public qtsdl::GuiItemQObject, public QQmlParserStatus, p
 	Q_PROPERTY(openage::gui::OutputModeLink* mode READ get_mode NOTIFY mode_changed)
 	Q_PROPERTY(int effectiveModeIndex READ get_effective_mode_index NOTIFY mode_changed)
 	Q_PROPERTY(int modeIndex READ get_mode_index WRITE set_mode_index)
-	Q_PROPERTY(QVariantList modes READ get_modes WRITE set_modes)
+	Q_PROPERTY(QVariantList modes READ get_modes WRITE set_modes NOTIFY modes_changed)
 	Q_PROPERTY(openage::gui::EngineLink* engine READ get_engine WRITE set_engine)
 	Q_PROPERTY(openage::gui::GameMainLink* game READ get_game WRITE set_game)
 	Q_PROPERTY(QString currentPlayerName READ get_current_player_name NOTIFY current_player_name_changed)
@@ -261,6 +261,7 @@ public:
 
 signals:
 	void mode_changed();
+	void modes_changed();
 	void current_player_name_changed();
 	void current_civ_index_changed();
 

--- a/libopenage/gui/qml/CreateGameWhenReady.qml
+++ b/libopenage/gui/qml/CreateGameWhenReady.qml
@@ -1,0 +1,28 @@
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+import QtQuick 2.4
+import yay.sfttech.openage 1.0
+
+GameCreator {
+	id: root
+
+	property bool enabled: false
+	property GameControl gameControl
+	property int gameControlTargetModeIndex
+
+	property int specState: gameSpec ? gameSpec.state : GameSpec.Null
+	property int gameState: game ? game.state : GameMain.Null
+
+	onSpecStateChanged: {
+		if (enabled && specState == GameSpec.Ready)
+			activate()
+	}
+
+	onGameStateChanged: {
+		if (enabled && gameState == GameMain.Running)
+			if (gameControl.modeIndex != -1)
+				gameControl.modeIndex = gameControlTargetModeIndex
+			else
+				console.error("CreateGameWhenReady: could not find the desired mode to switch to")
+	}
+}

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -124,6 +124,17 @@ Item {
 			LR.tag: "editorMode"
 		}
 
+		CreateGameWhenReady {
+			enabled: createWhenReady.checked
+
+			game: gameObj
+			gameSpec: specObj
+			generatorParameters: genParamsObj
+			gameControl: gameControlObj
+
+			gameControlTargetModeIndex: gameControlObj.modes.indexOf(actionModeObj)
+		}
+
 		states: [
 			State {
 				id: creationMode
@@ -140,6 +151,11 @@ Item {
 						generatorParameters: genParamsObj
 						gameSpec: specObj
 						game: gameObj
+					},
+					CheckBoxFlat {
+						id: createWhenReady
+						text: "create_when_ready"
+						visible: specObj.state == GameSpec.Loading
 					}
 				]
 

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -65,7 +65,13 @@ Item {
 		engine: Engine
 		game: gameObj
 
-		modes: [createModeObj, editorModeObj, actionModeObj]
+		/**
+		 * must be run after the engine is attached
+		 */
+		Component.onCompleted: {
+			modes = [createModeObj, editorModeObj, actionModeObj]
+			modeIndex = 0
+		}
 
 		LR.tag: "gamecontrol"
 	}


### PR DESCRIPTION
Checkbox to generate the game and enter the ActionMode as soon as the assets are loaded.

Related to #551: click on the checkbox once instead of clicking the generate_game until it loads.

For more specific stuff it's probably useful to figure out how to write demos (like a demo to record replay and a demo to play it). But the autolaunch feature looks generic enough to be added to the generator's menu.