### PR TITLE
Repair action & resource bundle

### DIFF
--- a/doc/reverse_engineering/repair.md
+++ b/doc/reverse_engineering/repair.md
@@ -21,3 +21,9 @@ For each hp repaired, resources equal to the half of corresponding build cost ar
 ## Exceptions
 
 * Town center repair costs no stone.
+
+## Math
+
+```
+750 hp/min = 750/60000 hp/msec = 0.0125 hp/msec => 80 msec/hp
+```

--- a/doc/reverse_engineering/repair.md
+++ b/doc/reverse_engineering/repair.md
@@ -1,14 +1,14 @@
-### Repair
+# Repair
 
 Buildings, siege weapons and ships can be repaired by villagers.
 
 ## Speed
 
-Buildings are repaired at the base repairing speed of *750 hp/min* which is not affected by the total hp of the building/unit.
+Buildings are repaired at the base repairing speed of **750 hp/min** which is not affected by the total hp of the building/unit.
 
-Siege weapons and ships are repaired at *25%* of the base speed (188 hp/min).
+Siege weapons and ships are repaired at **25%** of the base speed (188 hp/min).
 
-After the first villager, each villager repairs at *50%* of the base speed (375 hp/min for building and 188 hp/min for siege weapons and ships).
+After the first villager, each villager repairs at **50%** of the base speed (375 hp/min for building and 188 hp/min for siege weapons and ships).
 
 ## Cost
 

--- a/doc/reverse_engineering/repair.md
+++ b/doc/reverse_engineering/repair.md
@@ -1,0 +1,23 @@
+### Repair
+
+Buildings, siege weapons and ships can be repaired by villagers.
+
+## Speed
+
+Buildings are repaired at the base repairing speed of *750 hp/min* which is not affected by the total hp of the building/unit.
+
+Siege weapons and ships are repaired at *25%* of the base speed (188 hp/min).
+
+After the first villager, each villager repairs at *50%* of the base speed (375 hp/min for building and 188 hp/min for siege weapons and ships).
+
+## Cost
+
+For each hp repaired, resources equal to the half of corresponding build cost are deducted.
+
+```
+(repair 1 hp cost) = 0.5 * (build cost) / (build max hp)
+```
+
+## Exceptions
+
+* Town center repair costs no stone.

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -105,6 +105,11 @@ ActionMode::ActionMode(qtsdl::GuiItemLink *gui_link)
 		this->ability = ability_type::garrison;
 		emit this->gui_signals.ability_changed(std::to_string(this->ability));
 	});
+	this->bind(action.get("SET_ABILITY_REPAIR"), [this](const input::action_arg_t &) {
+		this->use_set_ability = true;
+		this->ability = ability_type::repair;
+		emit this->gui_signals.ability_changed(std::to_string(this->ability));
+	});
 	this->bind(action.get("SPAWN_VILLAGER"), [this](const input::action_arg_t &) {
 		Engine &engine = Engine::get();
 		auto player = this->game_control->get_current_player();

--- a/libopenage/gamestate/CMakeLists.txt
+++ b/libopenage/gamestate/CMakeLists.txt
@@ -6,5 +6,5 @@ add_sources(libopenage
 	generator.cpp
 	player.cpp
 	team.cpp
-	resource.h
+	resource.cpp
 )

--- a/libopenage/gamestate/CMakeLists.txt
+++ b/libopenage/gamestate/CMakeLists.txt
@@ -6,4 +6,5 @@ add_sources(libopenage
 	generator.cpp
 	player.cpp
 	team.cpp
+	resource.h
 )

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -142,7 +142,8 @@ std::shared_ptr<GameSpec> Generator::get_spec() const {
 std::vector<std::string> Generator::player_names() const {
 	auto result = this->get_csv("player_names");
 
-	result.push_back("gaia");
+	// gaia is player 0
+	result.insert(result.begin(), "gaia");
 
 	return result;
 }

--- a/libopenage/gamestate/player.cpp
+++ b/libopenage/gamestate/player.cpp
@@ -14,6 +14,11 @@ Player::Player(Civilisation *civ, unsigned int number, std::string name)
 	civ{civ},
 	name{name},
 	team{nullptr} {
+	// starting resources
+	this->resources[game_resource::food] = 1000;
+	this->resources[game_resource::wood] = 1000;
+	this->resources[game_resource::stone] = 1000;
+	this->resources[game_resource::gold] = 1000;
 }
 
 bool Player::operator ==(const Player &other) const {

--- a/libopenage/gamestate/player.cpp
+++ b/libopenage/gamestate/player.cpp
@@ -46,22 +46,20 @@ bool Player::owns(Unit &unit) const {
 	return false;
 }
 
+void Player::receive(const ResourceBundle& amount) {
+	this->resources += amount;
+}
+
 void Player::receive(const game_resource resource, double amount) {
-	auto r = this->resources.find(resource);
-	if (r == this->resources.end()) {
-		this->resources[resource] = amount;
-	}
-	else {
-		this->resources[resource] += amount;
-	}
+	this->resources[resource] += amount;
+}
+
+bool Player::deduct(const ResourceBundle& amount) {
+	return this->resources.deduct(amount);
 }
 
 bool Player::deduct(const game_resource resource, double amount) {
-	auto r = this->resources.find(resource);
-	if (r == this->resources.end()) {
-		return false;
-	}
-	else if (this->resources[resource] >= amount) {
+	if (this->resources[resource] >= amount) {
 		this->resources[resource] -= amount;
 		return true;
 	}
@@ -69,13 +67,7 @@ bool Player::deduct(const game_resource resource, double amount) {
 }
 
 double Player::amount(const game_resource resource) const {
-	auto r = this->resources.find(resource);
-	if (r == this->resources.end()) {
-		return 0.0;
-	}
-	else {
-		return this->resources.at(resource);
-	}
+	return this->resources.get(resource);
 }
 
 size_t Player::type_count() {

--- a/libopenage/gamestate/player.h
+++ b/libopenage/gamestate/player.h
@@ -68,12 +68,13 @@ public:
 	/**
 	 * add to stockpile
 	 */
+	void receive(const ResourceBundle& amount);
 	void receive(const game_resource resource, double amount);
 
 	/**
 	 * remove from stockpile if available
-	 * TODO parameter uses set of resources
 	 */
+	bool deduct(const ResourceBundle& amount);
 	bool deduct(const game_resource resource, double amount);
 
 	/**
@@ -107,7 +108,7 @@ private:
 	/**
 	 * resources this player currently has
 	 */
-	std::unordered_map<game_resource, double> resources;
+	ResourceBundle resources;
 
 	/**
 	 * unit types which can be produced by this player.

--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -1,0 +1,12 @@
+// Copyright 2016 the openage authors. See copying.md for legal info.
+
+#include "resource.h"
+
+namespace openage {
+
+ResourceBoundle::ResourceBoundle()
+	:
+	value{0} {
+}
+
+} // openage

--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
 #include "resource.h"
 
@@ -7,6 +7,57 @@ namespace openage {
 ResourceBoundle::ResourceBoundle()
 	:
 	value{0} {
+}
+
+bool ResourceBoundle::operator> (const ResourceBoundle& other) const {
+	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+		if (!(this->get(i) > other.get(i))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool ResourceBoundle::operator>= (const ResourceBoundle& other) const {
+	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+		if (!(this->get(i) >= other.get(i))) {
+			return false;
+		}
+	}
+	return true;
+}
+
+ResourceBoundle& ResourceBoundle::operator+= (const ResourceBoundle& other) {
+	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+		(*this)[i] += other.get(i);
+	}
+	return *this;
+}
+
+ResourceBoundle& ResourceBoundle::operator-= (const ResourceBoundle& other) {
+	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+		(*this)[i] -= other.get(i);
+	}
+	return *this;
+}
+
+ResourceBoundle& ResourceBoundle::operator*= (float a) {
+	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+		(*this)[i] *= a;
+	}
+	return *this;
+}
+
+bool ResourceBoundle::has(const ResourceBoundle& amount) const {
+	return *this >= amount;
+}
+
+bool ResourceBoundle::deduct(const ResourceBoundle& amount) {
+	if(*this >= amount) {
+		*this -= amount;
+		return true;
+	}
+	return false;
 }
 
 } // openage

--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -4,12 +4,12 @@
 
 namespace openage {
 
-ResourceBoundle::ResourceBoundle()
+ResourceBundle::ResourceBundle()
 	:
 	value{0} {
 }
 
-bool ResourceBoundle::operator> (const ResourceBoundle& other) const {
+bool ResourceBundle::operator> (const ResourceBundle& other) const {
 	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
 		if (!(this->get(i) > other.get(i))) {
 			return false;
@@ -18,7 +18,7 @@ bool ResourceBoundle::operator> (const ResourceBoundle& other) const {
 	return true;
 }
 
-bool ResourceBoundle::operator>= (const ResourceBoundle& other) const {
+bool ResourceBundle::operator>= (const ResourceBundle& other) const {
 	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
 		if (!(this->get(i) >= other.get(i))) {
 			return false;
@@ -27,32 +27,32 @@ bool ResourceBoundle::operator>= (const ResourceBoundle& other) const {
 	return true;
 }
 
-ResourceBoundle& ResourceBoundle::operator+= (const ResourceBoundle& other) {
+ResourceBundle& ResourceBundle::operator+= (const ResourceBundle& other) {
 	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
 		(*this)[i] += other.get(i);
 	}
 	return *this;
 }
 
-ResourceBoundle& ResourceBoundle::operator-= (const ResourceBoundle& other) {
+ResourceBundle& ResourceBundle::operator-= (const ResourceBundle& other) {
 	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
 		(*this)[i] -= other.get(i);
 	}
 	return *this;
 }
 
-ResourceBoundle& ResourceBoundle::operator*= (float a) {
+ResourceBundle& ResourceBundle::operator*= (double a) {
 	for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
 		(*this)[i] *= a;
 	}
 	return *this;
 }
 
-bool ResourceBoundle::has(const ResourceBoundle& amount) const {
+bool ResourceBundle::has(const ResourceBundle& amount) const {
 	return *this >= amount;
 }
 
-bool ResourceBoundle::deduct(const ResourceBoundle& amount) {
+bool ResourceBundle::deduct(const ResourceBundle& amount) {
 	if(*this >= amount) {
 		*this -= amount;
 		return true;

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -17,6 +17,66 @@ enum class game_resource {
 	RESOURCE_TYPE_COUNT
 };
 
+class ResourceBoundle {
+public:
+
+	ResourceBoundle();
+
+	float& operator[] (game_resource res) { return value[(int) res]; }
+	float& operator[] (int index) { return value[index]; }
+
+	float get(game_resource res) const { return value[(int) res]; }
+	float get(int index) const { return value[index]; }
+
+	bool operator> (const ResourceBoundle& other) const {
+		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+			if (!(this->get(i) > other.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+	bool operator>= (const ResourceBoundle& other) const {
+		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+			if (!(this->get(i) >= other.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	ResourceBoundle& operator+= (const ResourceBoundle& other) {
+		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+			(*this)[i] += other.get(i);
+		}
+		return *this;
+	}
+	ResourceBoundle& operator-= (const ResourceBoundle& other) {
+		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+			(*this)[i] -= other.get(i);
+		}
+		return *this;
+	}
+	
+	ResourceBoundle& operator*= (float a) {
+		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
+			(*this)[i] *= a;
+		}
+		return *this;
+	}
+	
+	bool deduct(const ResourceBoundle& amount) {
+		if(*this >= amount) {
+			*this -= amount;
+			return true;
+		}
+		return false;
+	}
+
+private:
+	float value[(int) game_resource::RESOURCE_TYPE_COUNT];
+};
+
 } // namespace openage
 
 namespace std {

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -17,6 +17,9 @@ enum class game_resource {
 	RESOURCE_TYPE_COUNT
 };
 
+/**
+ *
+ */
 class ResourceBoundle {
 public:
 
@@ -28,50 +31,17 @@ public:
 	float get(game_resource res) const { return value[(int) res]; }
 	float get(int index) const { return value[index]; }
 
-	bool operator> (const ResourceBoundle& other) const {
-		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
-			if (!(this->get(i) > other.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
-	bool operator>= (const ResourceBoundle& other) const {
-		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
-			if (!(this->get(i) >= other.get(i))) {
-				return false;
-			}
-		}
-		return true;
-	}
+	bool operator> (const ResourceBoundle& other) const;
+	bool operator>= (const ResourceBoundle& other) const;
 
-	ResourceBoundle& operator+= (const ResourceBoundle& other) {
-		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
-			(*this)[i] += other.get(i);
-		}
-		return *this;
-	}
-	ResourceBoundle& operator-= (const ResourceBoundle& other) {
-		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
-			(*this)[i] -= other.get(i);
-		}
-		return *this;
-	}
-	
-	ResourceBoundle& operator*= (float a) {
-		for (int i=0; i<(int) game_resource::RESOURCE_TYPE_COUNT; i++) {
-			(*this)[i] *= a;
-		}
-		return *this;
-	}
-	
-	bool deduct(const ResourceBoundle& amount) {
-		if(*this >= amount) {
-			*this -= amount;
-			return true;
-		}
-		return false;
-	}
+	ResourceBoundle& operator+= (const ResourceBoundle& other);
+	ResourceBoundle& operator-= (const ResourceBoundle& other);
+
+	ResourceBoundle& operator*= (float a);
+
+	bool has(const ResourceBoundle& amount) const;
+
+	bool deduct(const ResourceBoundle& amount);
 
 private:
 	float value[(int) game_resource::RESOURCE_TYPE_COUNT];

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -18,33 +18,35 @@ enum class game_resource {
 };
 
 /**
- *
+ * a set of amounts of game resources
  */
-class ResourceBoundle {
+class ResourceBundle {
 public:
 
-	ResourceBoundle();
+	ResourceBundle();
 
-	float& operator[] (game_resource res) { return value[(int) res]; }
-	float& operator[] (int index) { return value[index]; }
+	bool operator> (const ResourceBundle& other) const;
+	bool operator>= (const ResourceBundle& other) const;
 
-	float get(game_resource res) const { return value[(int) res]; }
-	float get(int index) const { return value[index]; }
+	ResourceBundle& operator+= (const ResourceBundle& other);
+	ResourceBundle& operator-= (const ResourceBundle& other);
 
-	bool operator> (const ResourceBoundle& other) const;
-	bool operator>= (const ResourceBoundle& other) const;
+	ResourceBundle& operator*= (double a);
 
-	ResourceBoundle& operator+= (const ResourceBoundle& other);
-	ResourceBoundle& operator-= (const ResourceBoundle& other);
+	bool has(const ResourceBundle& amount) const;
 
-	ResourceBoundle& operator*= (float a);
+	bool deduct(const ResourceBundle& amount);
 
-	bool has(const ResourceBoundle& amount) const;
+	double& operator[] (game_resource res) { return value[(int) res]; }
+	double& operator[] (int index) { return value[index]; }
 
-	bool deduct(const ResourceBoundle& amount);
+	// Getters
+
+	double get(game_resource res) const { return value[(int) res]; }
+	double get(int index) const { return value[index]; }
 
 private:
-	float value[(int) game_resource::RESOURCE_TYPE_COUNT];
+	double value[(int) game_resource::RESOURCE_TYPE_COUNT];
 };
 
 } // namespace openage

--- a/libopenage/gui/actions_list_model.cpp
+++ b/libopenage/gui/actions_list_model.cpp
@@ -62,7 +62,7 @@ void ActionsListModel::set_active_buttons(const ActionButtonsType &active_button
 		this->beginResetModel();
 		this->add_button(30, -1, static_cast<int>(GroupIDs::NoGroup), "BUILD_MENU");
 		this->add_button(31, -1, static_cast<int>(GroupIDs::NoGroup), "BUILD_MENU_MIL");
-		this->add_button(28, -1, static_cast<int>(GroupIDs::NoGroup), "REPAIR");
+		this->add_button(28, -1, static_cast<int>(GroupIDs::NoGroup), "SET_ABILITY_REPAIR");
 		this->add_button(59, -1, static_cast<int>(GroupIDs::NoGroup), "KILL_UNIT");
 		this->add_button(2,  -1, static_cast<int>(GroupIDs::NoGroup), "SET_ABILITY_GARRISON");
 

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -322,7 +322,7 @@ bool HealAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 }
 
 void HealAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
-	to_modify.log(MSG(dbg) << "invoke repair action");
+	to_modify.log(MSG(dbg) << "invoke heal action");
 	if (play_sound && this->sound) {
 		this->sound->play();
 	}

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -385,7 +385,7 @@ bool ConvertAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 }
 
 void ConvertAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
-	to_modify.log(MSG(dbg) << "invoke repair action");
+	to_modify.log(MSG(dbg) << "invoke convert action");
 	if (play_sound && this->sound) {
 		this->sound->play();
 	}

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -150,8 +150,8 @@ UngarrisonAbility::UngarrisonAbility(const Sound *s)
 
 bool UngarrisonAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 	if (to_modify.has_attribute(attr_type::garrison)) {
-		auto &garison_attr = to_modify.get_attribute<attr_type::garrison>();
-		return cmd.has_position() && !garison_attr.content.empty();
+		auto &garrison_attr = to_modify.get_attribute<attr_type::garrison>();
+		return cmd.has_position() && !garrison_attr.content.empty();
 	}
 	return false;
 }
@@ -301,6 +301,97 @@ void RepairAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound)
 
 	Unit *target = cmd.unit();
 	to_modify.push_action(std::make_unique<RepairAction>(&to_modify, target->get_ref()));
+}
+
+HealAbility::HealAbility(const Sound *s)
+	:
+	sound{s} {
+}
+
+bool HealAbility::can_invoke(Unit &to_modify, const Command &cmd) {
+	if (cmd.has_unit()) {
+		Unit &target = *cmd.unit();
+		return &to_modify != &target &&
+		       to_modify.location &&
+		       target.location &&
+		       target.location->is_placed() &&
+		       is_damaged(target) &&
+		       is_ally(to_modify, target);
+	}
+	return false;
+}
+
+void HealAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+	to_modify.log(MSG(dbg) << "invoke repair action");
+	if (play_sound && this->sound) {
+		this->sound->play();
+	}
+
+	Unit *target = cmd.unit();
+	to_modify.push_action(std::make_unique<HealAction>(&to_modify, target->get_ref()));
+}
+
+ResearchAbility::ResearchAbility(const Sound *s)
+	:
+	sound{s} {
+}
+
+bool ResearchAbility::can_invoke(Unit &/*to_modify*/, const Command &/*cmd*/) {
+	// TODO implement
+	return false;
+}
+
+void ResearchAbility::invoke(Unit &to_modify, const Command &/*cmd*/, bool play_sound) {
+	to_modify.log(MSG(dbg) << "not implemented");
+	if (play_sound && this->sound) {
+		this->sound->play();
+	}
+	// TODO implement
+}
+
+PatrolAbility::PatrolAbility(const Sound *s)
+	:
+	sound{s} {
+}
+
+bool PatrolAbility::can_invoke(Unit &/*to_modify*/, const Command &/*cmd*/) {
+	// TODO implement
+	return false;
+}
+
+void PatrolAbility::invoke(Unit &to_modify, const Command &/*cmd*/, bool play_sound) {
+	to_modify.log(MSG(dbg) << "not implemented");
+	if (play_sound && this->sound) {
+		this->sound->play();
+	}
+	// TODO implement
+}
+
+ConvertAbility::ConvertAbility(const Sound *s)
+	:
+	sound{s} {
+}
+
+bool ConvertAbility::can_invoke(Unit &to_modify, const Command &cmd) {
+	if (cmd.has_unit()) {
+		Unit &target = *cmd.unit();
+		return &to_modify != &target &&
+		       to_modify.location &&
+		       target.location &&
+		       target.location->is_placed() &&
+		       is_enemy(to_modify, target);
+	}
+	return false;
+}
+
+void ConvertAbility::invoke(Unit &to_modify, const Command &cmd, bool play_sound) {
+	to_modify.log(MSG(dbg) << "invoke repair action");
+	if (play_sound && this->sound) {
+		this->sound->play();
+	}
+
+	Unit *target = cmd.unit();
+	to_modify.push_action(std::make_unique<ConvertAction>(&to_modify, target->get_ref()));
 }
 
 ability_set UnitAbility::set_from_list(const std::vector<ability_type> &items) {

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -115,7 +115,7 @@ public:
 
 };
 
-/*
+/**
  * initiates a move action when given a valid target
  */
 class MoveAbility: public UnitAbility {
@@ -134,7 +134,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * sets the gather point on buildings
  */
 class SetPointAbility: public UnitAbility {
@@ -151,7 +151,7 @@ public:
 };
 
 
-/*
+/**
  * ability to garrision inside a building
  */
 class GarrisonAbility: public UnitAbility {
@@ -170,7 +170,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * ability to ungarrision a building
  */
 class UngarrisonAbility: public UnitAbility {
@@ -189,7 +189,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * buildings train new objects
  */
 class TrainAbility: public UnitAbility {
@@ -208,7 +208,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * villagers build new buildings
  */
 class BuildAbility: public UnitAbility {
@@ -227,7 +227,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates an gather resource action when given a valid target
  */
 class GatherAbility: public UnitAbility {
@@ -246,7 +246,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates an attack action when given a valid target
  */
 class AttackAbility: public UnitAbility {
@@ -265,7 +265,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates a repair action when given a valid target
  */
 class RepairAbility: public UnitAbility {
@@ -284,7 +284,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates a heal action when given a valid target
  */
 class HealAbility: public UnitAbility {
@@ -303,7 +303,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates a research
  * TODO implement
  */
@@ -323,7 +323,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates a patrol action when given a valid target
  * TODO implement
  */
@@ -343,7 +343,7 @@ private:
 	const Sound *sound;
 };
 
-/*
+/**
  * initiates a convert action when given a valid target
  */
 class ConvertAbility: public UnitAbility {

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -101,8 +101,8 @@ public:
  	 * some common functions
 	 */
 	bool has_hitpoints(Unit &target);
-	bool has_hitpoints(Unit &target);
 	bool is_damaged(Unit &target);
+	bool has_resource(Unit &target);
 	bool is_same_player(Unit &to_modify, Unit &target);
 	bool is_ally(Unit &to_modify, Unit &target);
 	bool is_enemy(Unit &to_modify, Unit &target);
@@ -274,6 +274,84 @@ public:
 
 	ability_type type() override {
 		return ability_type::repair;
+	}
+
+	bool can_invoke(Unit &to_modify, const Command &cmd) override;
+
+	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+
+private:
+	const Sound *sound;
+};
+
+/*
+ * initiates a heal action when given a valid target
+ */
+class HealAbility: public UnitAbility {
+public:
+	HealAbility(const Sound *s=nullptr);
+
+	ability_type type() override {
+		return ability_type::heal;
+	}
+
+	bool can_invoke(Unit &to_modify, const Command &cmd) override;
+
+	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+
+private:
+	const Sound *sound;
+};
+
+/*
+ * initiates a research
+ * TODO implement
+ */
+class ResearchAbility: public UnitAbility {
+public:
+	ResearchAbility(const Sound *s=nullptr);
+
+	ability_type type() override {
+		return ability_type::research;
+	}
+
+	bool can_invoke(Unit &to_modify, const Command &cmd) override;
+
+	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+
+private:
+	const Sound *sound;
+};
+
+/*
+ * initiates a patrol action when given a valid target
+ * TODO implement
+ */
+class PatrolAbility: public UnitAbility {
+public:
+	PatrolAbility(const Sound *s=nullptr);
+
+	ability_type type() override {
+		return ability_type::patrol;
+	}
+
+	bool can_invoke(Unit &to_modify, const Command &cmd) override;
+
+	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+
+private:
+	const Sound *sound;
+};
+
+/*
+ * initiates a convert action when given a valid target
+ */
+class ConvertAbility: public UnitAbility {
+public:
+	ConvertAbility(const Sound *s=nullptr);
+
+	ability_type type() override {
+		return ability_type::convert;
 	}
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -101,7 +101,8 @@ public:
  	 * some common functions
 	 */
 	bool has_hitpoints(Unit &target);
-	bool has_resource(Unit &target);
+	bool has_hitpoints(Unit &target);
+	bool is_damaged(Unit &target);
 	bool is_same_player(Unit &to_modify, Unit &target);
 	bool is_ally(Unit &to_modify, Unit &target);
 	bool is_enemy(Unit &to_modify, Unit &target);
@@ -254,6 +255,25 @@ public:
 
 	ability_type type() override {
 		return ability_type::attack;
+	}
+
+	bool can_invoke(Unit &to_modify, const Command &cmd) override;
+
+	void invoke(Unit &to_modify, const Command &cmd, bool play_sound=false) override;
+
+private:
+	const Sound *sound;
+};
+
+/*
+ * initiates a repair action when given a valid target
+ */
+class RepairAbility: public UnitAbility {
+public:
+	RepairAbility(const Sound *s=nullptr);
+
+	ability_type type() override {
+		return ability_type::repair;
 	}
 
 	bool can_invoke(Unit &to_modify, const Command &cmd) override;

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -101,10 +101,10 @@ void UnitAction::damage_object(Unit &target, unsigned dmg) {
 	if (target.has_attribute(attr_type::hitpoints)) {
 		auto &hp = target.get_attribute<attr_type::hitpoints>();
 		if (hp.current > dmg) {
-						hp.current -= dmg;
+			hp.current -= dmg;
 		}
 		else {
-						hp.current = 0;
+			hp.current = 0;
 		}
 	}
 }
@@ -229,8 +229,8 @@ void TargetAction::on_completion() {
 		new_target = find_near(*this->entity->location,
 			[this](const TerrainObject &obj) {
 				return obj.unit.unit_type->id() == this->target_type_id &&
-											obj.unit.has_attribute(attr_type::resource) &&
-											obj.unit.get_attribute<attr_type::resource>().amount > 0.0f;
+				       obj.unit.has_attribute(attr_type::resource) &&
+				       obj.unit.get_attribute<attr_type::resource>().amount > 0.0f;
 			});
 	}
 
@@ -244,8 +244,8 @@ void TargetAction::on_completion() {
 
 bool TargetAction::completed() const {
 	if (this->end_action ||
-					!this->target.is_valid() ||
-					!this->target.get()->location) {
+	    !this->target.is_valid() ||
+	    !this->target.get()->location) {
 		return true;
 	}
 	return this->completed_in_range(this->target.get());
@@ -375,8 +375,8 @@ void FoundationAction::on_completion() {
 
 bool FoundationAction::completed() const {
 	return this->cancel ||
-								(this->entity->has_attribute(attr_type::building) &&
-								(this->entity->get_attribute<attr_type::building>().completed >= 1.0f));
+	       (this->entity->has_attribute(attr_type::building) &&
+	       (this->entity->get_attribute<attr_type::building>().completed >= 1.0f));
 }
 
 IdleAction::IdleAction(Unit *e)
@@ -602,8 +602,8 @@ bool MoveAction::completed() const {
 
 	// no more waypoints to a static location
 	if (this->end_action ||
-					(!this->unit_target.is_valid() &&
-					this->path.waypoints.empty())) {
+	    (!this->unit_target.is_valid() &&
+	    this->path.waypoints.empty())) {
 		return true;
 	}
 
@@ -836,7 +836,7 @@ const graphic_set &BuildAction::current_graphics() const {
 		auto &gatherer_attr = this->entity->get_attribute<attr_type::gatherer>();
 
 		if (this->get_target().is_valid() &&
-						this->get_target().get()->has_attribute(attr_type::building)) {
+		    this->get_target().get()->has_attribute(attr_type::building)) {
 
 			// set builder graphics if available
 			if (gatherer_attr.graphics.count(gamedata::unit_classes::BUILDING) > 0) {
@@ -872,7 +872,7 @@ RepairAction::RepairAction(Unit *e, UnitReference tar)
 
 void RepairAction::update_in_range(unsigned int time, Unit *target_unit) {
 
-	auto &hp = target_ptr->get_attribute<attr_type::hitpoints>();
+	auto &hp = target_unit->get_attribute<attr_type::hitpoints>();
 	auto &owner = this->entity->get_attribute<attr_type::owner>();
 
 	if (hp.current >= hp.max) {
@@ -949,7 +949,7 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 
 		// attack objects which have hitpoints (trees, hunt, sheep)
 		if (this->entity->has_attribute(attr_type::owner) &&
-						targeted_resource->has_attribute(attr_type::hitpoints)) {
+		    targeted_resource->has_attribute(attr_type::hitpoints)) {
 			auto &pl_attr = this->entity->get_attribute<attr_type::owner>();
 			auto &hp_attr = targeted_resource->get_attribute<attr_type::hitpoints>();
 
@@ -1002,7 +1002,7 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 
 		// make sure the resource stil exists
 		if (this->target.is_valid() &&
-						this->target.get()->get_attribute<attr_type::resource>().amount > 0.0f) {
+		    this->target.get()->get_attribute<attr_type::resource>().amount > 0.0f) {
 
 			// return to resouce collection
 			this->target_resource = true;
@@ -1030,10 +1030,10 @@ UnitReference GatherAction::nearest_dropsite(game_resource res_type) {
 			}
 
 			return obj.unit.get_attribute<attr_type::building>().completed >= 1.0f &&
-										obj.unit.has_attribute(attr_type::owner) &&
-										obj.unit.get_attribute<attr_type::owner>().player.owns(*this->entity) &&
-										obj.unit.has_attribute(attr_type::dropsite) &&
-										obj.unit.get_attribute<attr_type::dropsite>().accepting_resource(res_type);
+			       obj.unit.has_attribute(attr_type::owner) &&
+			       obj.unit.get_attribute<attr_type::owner>().player.owns(*this->entity) &&
+			       obj.unit.has_attribute(attr_type::dropsite) &&
+			       obj.unit.get_attribute<attr_type::dropsite>().accepting_resource(res_type);
 	});
 
 	if (ds) {
@@ -1057,7 +1057,7 @@ AttackAction::AttackAction(Unit *e, UnitReference tar)
 
 	// switch graphic type for villagers not collecting resources
 	if (this->entity->has_attribute(attr_type::gatherer) &&
-					!tar.get()->has_attribute(attr_type::resource)) {
+	    !tar.get()->has_attribute(attr_type::resource)) {
 		auto &att_attr = this->entity->get_attribute<attr_type::attack>();
 		auto &pl_attr = this->entity->get_attribute<attr_type::owner>();
 		att_attr.attack_type->initialise(this->entity, pl_attr.player);
@@ -1231,7 +1231,7 @@ void ProjectileAction::update(unsigned int time) {
 		if (tc && !tc->obj.empty()) {
 			for (auto obj_location : tc->obj) {
 				if (this->entity->location.get() != obj_location &&
-								obj_location->check_collisions()) {
+				    obj_location->check_collisions()) {
 					this->damage_object(obj_location->unit, 1);
 					break;
 				}

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -866,7 +866,14 @@ RepairAction::RepairAction(Unit *e, UnitReference tar)
 			this->time *= 4;
 		}
 
-		this->cost = 1; // TODO change to 0.5f * (target cost) / (target max hp)
+		// cost formula: 0.5 * (target cost) / (target max hp)
+		auto &hp = target->get_attribute<attr_type::hitpoints>();
+
+		// TODO get the target unit's cost
+		//this->cost += get target cost;
+		this->cost[game_resource::wood] = 100; // temp
+
+		this->cost *= 0.5 / hp.max;
 	}
 }
 
@@ -892,7 +899,7 @@ void RepairAction::update_in_range(unsigned int time, Unit *target_unit) {
 	}
 
 	if (this->time_left <= 0 && !this->complete) {
-		if (owner.player.deduct(game_resource::wood, this->cost)) { // TODO create and use game_resource_boundle
+		if (owner.player.deduct(this->cost)) {
 			this->time_left += this->time;
 		}
 		else {

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -394,9 +394,9 @@ void IdleAction::update(unsigned int time) {
 
 	// auto task searching
 	if (this->entity->location &&
-					this->entity->has_attribute(attr_type::owner) &&
-					this->entity->has_attribute(attr_type::attack) &&
-					this->entity->get_attribute<attr_type::attack>().stance != attack_stance::do_nothing) {
+	    this->entity->has_attribute(attr_type::owner) &&
+	    this->entity->has_attribute(attr_type::attack) &&
+	    this->entity->get_attribute<attr_type::attack>().stance != attack_stance::do_nothing) {
 
 		// restart search from new tile when moved
 		auto terrain = this->entity->location->get_terrain();

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -909,7 +909,7 @@ void RepairAction::update_in_range(unsigned int time, Unit *target_unit) {
 	}
 
 	// inc frame
-	this->frame += time * this->current_graphics().at(graphic)->frame_count;
+	this->frame += time * this->frame_rate / 2.5f;
 }
 
 GatherAction::GatherAction(Unit *e, UnitReference tar)

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -423,7 +423,10 @@ private:
 	float time;
 	float time_left;
 
-	ResourceBundle cost; // calculate and store the cost in the constructor
+	/**
+	 * stores the cost of the repair for 1hp
+	 */
+	ResourceBundle cost;
 
 };
 

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../pathfinding/path.h"
+#include "../gamestate/resource.h"
 #include "attribute.h"
 #include "unit.h"
 #include "unit_container.h"
@@ -406,7 +407,6 @@ private:
 
 /**
  * repairs a unit
- * TODO: implement cost, at the moment all repairs cost 1 wood
  */
 class RepairAction: public TargetAction {
 public:
@@ -422,8 +422,8 @@ private:
 
 	float time;
 	float time_left;
-	// TODO create and use game_resource_boundle
-	int cost; // calculate and store the cost in the constructor
+
+	ResourceBundle cost; // calculate and store the cost in the constructor
 
 };
 

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -405,7 +405,8 @@ private:
 };
 
 /**
- * repairs an object
+ * repairs a unit
+ * TODO: implement cost, at the moment all repairs cost 1 wood
  */
 class RepairAction: public TargetAction {
 public:
@@ -418,11 +419,12 @@ public:
 
 private:
 	bool complete;
-	
+
 	float time;
 	float time_left;
-	int cost; // TODO create and use game_resource_boundle
-	
+	// TODO create and use game_resource_boundle
+	int cost; // calculate and store the cost in the constructor
+
 };
 
 /**

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -418,7 +418,11 @@ public:
 
 private:
 	bool complete;
-
+	
+	float time;
+	float time_left;
+	int cost; // TODO create and use game_resource_boundle
+	
 };
 
 /**

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -448,6 +448,7 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 		}
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 		unit->give_ability(std::make_shared<BuildAbility>(this->on_attack));
+		unit->give_ability(std::make_shared<RepairAbility>(this->on_attack));
 	}
 	else if (this->unit_data.unit_class == gamedata::unit_classes::FISHING_BOAT) {
 		unit->add_attribute(std::make_shared<Attribute<attr_type::gatherer>>());


### PR DESCRIPTION
Repair of units based on the [doc/reverse_engineering/repair.md](doc/reverse_engineering/repair.md) (file in pull request).

In order to continue:
* ~~A data structure for multiple resource costs should be implemented (game_resource_bundle ?)~~
* The cost of the unit should be stored somewhere (inside unt_type ?)

~~Can I implement these? or just leave as it is and revisit after the nyan revolution?~~

EDIT: Also game_resource_bundle should replace the `game_resource type, int value` couples all over the place.