### PR TITLE
Purge engine singleton

### DIFF
--- a/buildsystem/codecompliance/pystyle.py
+++ b/buildsystem/codecompliance/pystyle.py
@@ -5,9 +5,9 @@ Checks PEP8 compliance, with some exceptions.
 """
 
 try:
-    from pep8 import StyleGuide
-except ImportError:
     from pycodestyle import StyleGuide
+except ImportError:
+    from pep8 import StyleGuide
 
 
 # these errors will be ignored by pep8

--- a/libopenage/assetmanager.cpp
+++ b/libopenage/assetmanager.cpp
@@ -47,6 +47,17 @@ void AssetManager::set_data_dir_string(const std::string& data_dir) {
 	}
 }
 
+
+void AssetManager::set_engine(Engine *engine) {
+	this->engine = engine;
+}
+
+
+Engine *AssetManager::get_engine() const {
+	return this->engine;
+}
+
+
 bool AssetManager::can_load(const std::string &name) const {
 	return util::file_size(this->root.join(name)) > 0;
 }

--- a/libopenage/assetmanager.h
+++ b/libopenage/assetmanager.h
@@ -16,6 +16,7 @@ class GuiItemLink;
 
 namespace openage {
 
+class Engine;
 class Texture;
 
 /**
@@ -30,6 +31,17 @@ public:
 
 	std::string get_data_dir_string() const;
 	void set_data_dir_string(const std::string& data_dir);
+
+	/**
+	 * Set the game engine of this asset manager.
+	 * Called from QML.
+	 */
+	void set_engine(Engine *engine);
+
+	/**
+	 * Return the engine responsible for this asset manager.
+	 */
+	Engine *get_engine() const;
 
 	/**
 	 * Test whether a requested asset filename can be loaded.
@@ -65,6 +77,11 @@ protected:
 
 private:
 	void clear();
+
+	/**
+	 * The engine this asset manager is attached to.
+	 */
+	Engine *engine;
 
 	/**
 	 * The root directory for the available assets.

--- a/libopenage/audio/audio_manager.h
+++ b/libopenage/audio/audio_manager.h
@@ -17,35 +17,27 @@
 #include "../gamedata/sound_file.gen.h"
 
 namespace openage {
+
+class Engine;
+
+namespace job {
+class JobManager;
+}
+
+
 namespace audio {
 
-/*
- * This class provides audio functionality.
+/**
+ * This class provides audio functionality for openage.
  */
 class AudioManager {
-private:
-	// the used audio device's name
-	std::string device_name;
-
-	// the audio output format
-	SDL_AudioSpec device_spec;
-	// the used audio device's id
-	SDL_AudioDeviceID device_id;
-
-	std::unique_ptr<int32_t[]> mix_buffer;
-
-	std::unordered_map<std::tuple<category_t,int>,std::shared_ptr<Resource>>
-			resources;
-
-	std::unordered_map<category_t,std::vector<std::shared_ptr<SoundImpl>>>
-			playing_sounds;
-
 public:
-	AudioManager();
+	AudioManager(job::JobManager *job_manager);
 
-	// pass empty device name to indicate, that the default device should be
-	// used
-	AudioManager(const std::string &device_name);
+	/**
+	 * Pass empty device name to indicate, that the default device should be used
+	 */
+	AudioManager(job::JobManager *job_manager, const std::string &device_name);
 
 	~AudioManager();
 
@@ -77,6 +69,11 @@ public:
 	 */
 	SDL_AudioSpec get_device_spec() const;
 
+	/**
+	 * Return the game engine the audio manager is attached to.
+	 */
+	job::JobManager *get_job_manager() const;
+
 private:
 	void add_sound(std::shared_ptr<SoundImpl> sound);
 	void remove_sound(std::shared_ptr<SoundImpl> sound);
@@ -85,8 +82,33 @@ private:
 	// add and remove sound method's
 	friend class Sound;
 
-// static functions
+	/**
+	 * The job manager used in this audio manager for job queuing.
+	 */
+	job::JobManager *job_manager;
 
+	/**
+	 * the used audio device's name
+	 */
+	std::string device_name;
+
+	/**
+	 * the audio output format
+	 */
+	SDL_AudioSpec device_spec;
+
+	/**
+	 * the used audio device's id
+	 */
+	SDL_AudioDeviceID device_id;
+
+	std::unique_ptr<int32_t[]> mix_buffer;
+
+	std::unordered_map<std::tuple<category_t,int>,std::shared_ptr<Resource>> resources;
+
+	std::unordered_map<category_t,std::vector<std::shared_ptr<SoundImpl>>> playing_sounds;
+
+// static functions
 public:
 	/**
 	 * Returns a vector of all available device names.
@@ -102,7 +124,6 @@ public:
 	 * Returns the name of the currently used driver.
 	 */
 	static std::string get_current_driver();
-
 };
 
 }

--- a/libopenage/audio/dynamic_resource.cpp
+++ b/libopenage/audio/dynamic_resource.cpp
@@ -2,7 +2,10 @@
 
 #include "dynamic_resource.h"
 
+
+#include "audio_manager.h"
 #include "../engine.h"
+#include "../job/job_manager.h"
 #include "../log/log.h"
 
 namespace openage {
@@ -13,10 +16,11 @@ chunk_info_t::chunk_info_t(chunk_info_t::state_t state,
 	:
 	state{state},
 	actual_size{0},
-	buffer{new int16_t[buffer_size]} {
-}
+	buffer{std::make_unique<int16_t[]>(buffer_size)} {}
 
-DynamicResource::DynamicResource(category_t category,
+
+DynamicResource::DynamicResource(AudioManager *manager,
+                                 category_t category,
                                  int id,
                                  const std::string &path,
                                  format_t format,
@@ -24,14 +28,13 @@ DynamicResource::DynamicResource(category_t category,
                                  size_t chunk_size,
                                  size_t max_chunks)
 	:
-	Resource{category, id},
+	Resource{manager, category, id},
 	path{path},
 	format{format},
 	preload_threshold{preload_threshold},
 	chunk_size{chunk_size},
 	max_chunks{max_chunks},
-	use_count{0} {
-}
+	use_count{0} {}
 
 void DynamicResource::use() {
 	log::log(MSG(info) << "DYNRES: now in use");
@@ -50,9 +53,8 @@ void DynamicResource::use() {
 			);
 		}
 
-		// get loading job group
-		Engine &e = Engine::get();
-		this->loading_job_group = e.get_job_manager()->create_job_group();
+		// create loading job group
+		this->loading_job_group = this->manager->get_job_manager()->create_job_group();
 	}
 }
 

--- a/libopenage/audio/dynamic_resource.cpp
+++ b/libopenage/audio/dynamic_resource.cpp
@@ -37,8 +37,8 @@ DynamicResource::DynamicResource(AudioManager *manager,
 	use_count{0} {}
 
 void DynamicResource::use() {
-	log::log(MSG(info) << "DYNRES: now in use");
-	log::log(MSG(info) << "CS=" << chunk_size << ", MX=" << max_chunks);
+	log::log(DBG << "DYNRES: now in use");
+	log::log(DBG << "CS=" << chunk_size << ", MX=" << max_chunks);
 
 	// if the resource is new in use
 	if ((this->use_count++) == 0) {
@@ -59,7 +59,7 @@ void DynamicResource::use() {
 }
 
 void DynamicResource::stop_using() {
-	log::log(MSG(info) << "DYNRES: no longer in use");
+	log::log(DBG << "DYNRES: no longer in use");
 
 	// if the resource is not used anymore
 	if ((--this->use_count) == 0) {

--- a/libopenage/audio/in_memory_resource.cpp
+++ b/libopenage/audio/in_memory_resource.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include "in_memory_resource.h"
 
@@ -7,16 +7,24 @@
 namespace openage {
 namespace audio {
 
-InMemoryResource::InMemoryResource(category_t category,
+InMemoryResource::InMemoryResource(AudioManager *manager,
+                                   category_t category,
                                    int id,
                                    const std::string &path,
                                    format_t format)
 	:
-	Resource{category, id} {
+	Resource{manager, category, id} {
 
 	auto loader = InMemoryLoader::create(path, format);
 	buffer = loader->get_resource();
 }
+
+
+void InMemoryResource::use() {}
+
+
+void InMemoryResource::stop_using() {}
+
 
 audio_chunk_t InMemoryResource::get_data(size_t position,
                                          size_t data_length) {

--- a/libopenage/audio/in_memory_resource.h
+++ b/libopenage/audio/in_memory_resource.h
@@ -20,12 +20,13 @@ private:
 	pcm_data_t buffer;
 
 public:
-	InMemoryResource(
-		category_t category, int id,
-		const std::string &path,
-		format_t format=format_t::OPUS
-	);
+	InMemoryResource(AudioManager *manager,
+	                 category_t category, int id, const std::string &path,
+	                 format_t format=format_t::OPUS);
 	virtual ~InMemoryResource() = default;
+
+	void use() override;
+	void stop_using() override;
 
 	audio_chunk_t get_data(size_t position, size_t data_length) override;
 };

--- a/libopenage/audio/opus_dynamic_loader.cpp
+++ b/libopenage/audio/opus_dynamic_loader.cpp
@@ -32,7 +32,7 @@ OpusDynamicLoader::OpusDynamicLoader(const std::string &path)
 	}
 
 	length = static_cast<size_t>(pcm_length) * 2;
-	log::log(MSG(info) << "Create dynamic opus loader: length=" << length << ", channels=" << channels);
+	log::log(DBG << "Create dynamic opus loader: length=" << length << ", channels=" << channels);
 }
 
 size_t OpusDynamicLoader::load_chunk(int16_t *chunk_buffer, size_t offset,

--- a/libopenage/audio/opus_dynamic_loader.cpp
+++ b/libopenage/audio/opus_dynamic_loader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include "opus_dynamic_loader.h"
 

--- a/libopenage/audio/resource.cpp
+++ b/libopenage/audio/resource.cpp
@@ -12,11 +12,11 @@ namespace openage {
 namespace audio {
 
 
-Resource::Resource(category_t category, int id)
-		:
-		category{category},
-		id{id} {
-}
+Resource::Resource(AudioManager *manager, category_t category, int id)
+	:
+	manager{manager},
+	category{category},
+	id{id} {}
 
 
 category_t Resource::get_category() const {
@@ -29,21 +29,16 @@ int Resource::get_id() const {
 }
 
 
-void Resource::use() {}
-
-
-void Resource::stop_using() {}
-
-
-std::shared_ptr<Resource> Resource::create_resource(category_t category, int id,
+std::shared_ptr<Resource> Resource::create_resource(AudioManager *manager,
+                                                    category_t category, int id,
                                                     const std::string &path,
                                                     format_t format,
                                                     loader_policy_t loader_policy) {
 	switch (loader_policy) {
 	case loader_policy_t::IN_MEMORY:
-		return std::make_shared<InMemoryResource>(category, id, path, format);
+		return std::make_shared<InMemoryResource>(manager, category, id, path, format);
 	case loader_policy_t::DYNAMIC:
-		return std::make_shared<DynamicResource>(category, id, path, format);
+		return std::make_shared<DynamicResource>(manager, category, id, path, format);
 	default:
 		throw Error{MSG(err) << "Unsupported loader policy: " << loader_policy};
 	}

--- a/libopenage/audio/resource.cpp
+++ b/libopenage/audio/resource.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include "resource.h"
 

--- a/libopenage/audio/resource.h
+++ b/libopenage/audio/resource.h
@@ -13,6 +13,9 @@
 namespace openage {
 namespace audio {
 
+class AudioManager;
+
+
 /**
  * A Resource contains 16 bit signed integer pcm data, that can be played by
  * sounds. Each Resource has an unique id within it's category. The category
@@ -20,19 +23,8 @@ namespace audio {
  * The id is a unique integer value.
  */
 class Resource {
-private:
-	/**
-	 * The resource's category.
-	 */
-	category_t category;
-
-	/**
-	 * The resource's id.
-	 */
-	int id;
-
 public:
-	Resource(category_t category, int id);
+	Resource(AudioManager *manager, category_t category, int id);
 	virtual ~Resource() = default;
 
 	Resource(const Resource&) = delete;
@@ -48,13 +40,13 @@ public:
 	 * Tells the resource, that it will be used by a sound object, so it can
 	 * preload some pcm samples.
 	 */
-	virtual void use();
+	virtual void use() = 0;
 
 	/**
 	 * Tells the resource, that one sound object does not use this resource any
 	 * longer.
 	 */
-	virtual void stop_using();
+	virtual void stop_using() = 0;
 
 	/**
 	 * Returns a pointer to the sample buffer at the given position and the
@@ -68,10 +60,31 @@ public:
 	 */
 	virtual audio_chunk_t get_data(size_t position, size_t data_length) = 0;
 
-	static std::shared_ptr<Resource> create_resource(category_t category, int id,
+	/**
+	 * create an audio resource, this produces a DynamicResource or a InMemoryResource
+	 */
+	static std::shared_ptr<Resource> create_resource(AudioManager *manager,
+	                                                 category_t category, int id,
 	                                                 const std::string &path,
 	                                                 format_t format,
 	                                                 loader_policy_t loader_policy);
+
+protected:
+	/**
+	 * Audiomanager in charge of this resource.
+	 */
+	AudioManager *manager;
+
+private:
+	/**
+	 * The resource's category.
+	 */
+	category_t category;
+
+	/**
+	 * The resource's id.
+	 */
+	int id;
 };
 
 }

--- a/libopenage/console/buf.cpp
+++ b/libopenage/console/buf.cpp
@@ -1153,4 +1153,9 @@ buf_line *Buf::linedataptr(term_t lineno) {
 	return result;
 }
 
+const coord::term &Buf::get_dims() const {
+	return this->dims;
+}
+
+
 }} // openage::console

--- a/libopenage/console/buf.cpp
+++ b/libopenage/console/buf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include "buf.h"
 

--- a/libopenage/console/buf.cpp
+++ b/libopenage/console/buf.cpp
@@ -141,12 +141,12 @@ public:
 		b->chrdata_size = this->chrdata_size;
 		b->chrdata_end = this->chrdata_end;
 
-		//TODO set the following members of b:
-		//screen_chrdata, screen_linedata
-		//cursorpos, saved_cursorpos,
-		//scrollback_possible, scrollback_pos
-		//TODO call b->clear() with correct
-		//screen buffer part as arguments
+		// TODO set the following members of b:
+		// screen_chrdata, screen_linedata
+		// cursorpos, saved_cursorpos,
+		// scrollback_possible, scrollback_pos
+		// TODO call b->clear() with correct
+		// screen buffer part as arguments
 	}
 
 	void move_ptrs_to_next_line() {
@@ -217,7 +217,7 @@ void Buf::resize(term new_dims) {
 		new_dims.y = 1;
 	}
 
-	//allocate new buffers
+	// allocate new buffers
 	size_t new_linedata_size = new_dims.y + this->scrollback_lines;
 	buf_line *new_linedata = new buf_line[new_linedata_size];
 	buf_line *new_linedata_end = new_linedata + new_linedata_size;
@@ -225,50 +225,50 @@ void Buf::resize(term new_dims) {
 	buf_char *new_chrdata = new buf_char[new_chrdata_size];
 	buf_char *new_chrdata_end = new_chrdata + new_chrdata_size;
 
-	//working positions in new buffers: start at beginning of buffer
+	// working positions in new buffers: start at beginning of buffer
 	buf_line *new_linedata_pos = new_linedata;
 	buf_char *new_chrdata_pos = new_chrdata;
-	//working positions in old buffers: start with oldest line of
-	//scrollback buffer
-	buf_line *old_linedata_scrollbackstart = linedataptr(-scrollback_lines);
-	buf_char *old_chrdata_scrollbackstart = chrdataptr({0, (term_t) -scrollback_lines});
+	// working positions in old buffers: start with oldest line of
+	// scrollback buffer
+	buf_line *old_linedata_scrollbackstart = this->linedataptr(-scrollback_lines);
+	buf_char *old_chrdata_scrollbackstart = this->chrdataptr({0, (term_t) -scrollback_lines});
 	buf_line *old_linedata_pos = old_linedata_scrollbackstart;
 	buf_char *old_chrdata_pos = old_chrdata_scrollbackstart;
 
-	//copy line by line, considering the value stored in
-	//old_linedata_pos->auto_wrapped.
-	//start with the first line of the scrollback buffer, and stop with the
-	//last line of the screen buffer.
-	//do not copy empty characters, unless they are followed by filled
-	//characters in the same line, or a continued wrapped line.
-	//store in term_t variables the locations in the new buffer of
-	//  the first/last line of the old scrollback buffer
-	//  the first/last line of the old screen buffer
-	//these variables need to take into account events where upmost
-	//lines of a buffer are overwritten by new lines.
-	//commented out for now //TODO
+	// copy line by line, considering the value stored in
+	// old_linedata_pos->auto_wrapped.
+	// start with the first line of the scrollback buffer, and stop with the
+	// last line of the screen buffer.
+	// do not copy empty characters, unless they are followed by filled
+	// characters in the same line, or a continued wrapped line.
+	// store in term_t variables the locations in the new buffer of
+	//   the first/last line of the old scrollback buffer
+	//   the first/last line of the old screen buffer
+	// these variables need to take into account events where upmost
+	// lines of a buffer are overwritten by new lines.
+	// commented out for now //TODO
 
-	//term_t scrollback_buf_start;
-	//term_t scrollback_buf_end;
-	//term_t screen_buf_start;
-	//term_t screen_buf_end;
+	// term_t scrollback_buf_start;
+	// term_t scrollback_buf_end;
+	// term_t screen_buf_start;
+	// term_t screen_buf_end;
 
-	//count the number of empty chars that we've found in this line,
-	//and we may or may not still have to copy.
+	// count the number of empty chars that we've found in this line,
+	// and we may or may not still have to copy.
 	size_t empty_chars = 0;
 	while(old_linedata_pos != old_linedata_scrollbackstart) {
-		//should never be >, always ==
-		//also, both checks should always yield identical results
-		//(TODO do an ASSERT to assure this?)
+		// should never be >, always ==
+		// also, both checks should always yield identical results
+		// (TODO do an ASSERT to assure this?)
 		if (old_linedata_pos >= this->linedata_end) {
 			old_linedata_pos = this->linedata;
 		}
 		if (old_chrdata_pos >= this->chrdata_end) {
 			old_chrdata_pos = this->chrdata;
 		}
-		//should never be >, always ==
-		//also, both checks should always yield identical results
-		//(TODO do an ASSERT to assure this?)
+		// should never be >, always ==
+		// also, both checks should always yield identical results
+		// (TODO do an ASSERT to assure this?)
 		if (new_linedata_pos >= new_linedata_end) {
 			new_linedata_pos = new_linedata;
 		}
@@ -281,22 +281,22 @@ void Buf::resize(term new_dims) {
 				empty_chars++;
 			} else {
 				while (empty_chars > 0) {
-					//TODO write the empty chars
+					// TODO write the empty chars
 				}
-				//TODO write the char
+				// TODO write the char
 			}
 
 			old_chrdata_pos++;
 		}
 	}
 
-	//TODO
-	//depending on the variables defined in the previous section,
-	//decide which line is the first line of the screen buffer
-	//int new_chrbuf, and which parts of new_chrbuf must be cleared.
+	// TODO
+	// depending on the variables defined in the previous section,
+	// decide which line is the first line of the screen buffer
+	// int new_chrbuf, and which parts of new_chrbuf must be cleared.
 
-	//TODO
-	//copy
+	// TODO
+	// copy
 
 	this->dims = new_dims;
 }
@@ -316,7 +316,7 @@ void Buf::write(const char *c, ssize_t len) {
 
 void Buf::scroll(term_t lines) {
 	if (lines < 0) {
-		//scroll down
+		// scroll down
 		lines = -lines;
 
 		if ((term_t) this->scrollback_pos < lines) {
@@ -325,7 +325,7 @@ void Buf::scroll(term_t lines) {
 			this->scrollback_pos -= lines;
 		}
 	} else {
-		//scroll up
+		// scroll up
 		this->scrollback_pos += lines;
 		if (this->scrollback_pos > this->scrollback_possible) {
 			this->scrollback_pos = this->scrollback_possible;
@@ -334,7 +334,7 @@ void Buf::scroll(term_t lines) {
 }
 
 void Buf::advance(unsigned linecount) {
-	//sanitize linecount
+	// sanitize linecount
 	if (linecount == 0) {
 		return;
 	}
@@ -342,14 +342,14 @@ void Buf::advance(unsigned linecount) {
 		linecount = this->dims.y + this->scrollback_lines;
 	}
 
-	//update scrollback_possible
+	// update scrollback_possible
 	this->scrollback_possible += linecount;
 	if (this->scrollback_possible > (term_t) this->scrollback_lines) {
 		this->scrollback_possible = this->scrollback_lines;
 	}
 
-	//update scrollback position, to remain at the currently scrolled-to
-	//position
+	// update scrollback position, to remain at the currently scrolled-to
+	// position
 	if (this->scrollback_pos > 0) {
 		this->scrollback_pos += linecount;
 		if (this->scrollback_pos > this->scrollback_possible) {
@@ -358,16 +358,16 @@ void Buf::advance(unsigned linecount) {
 		}
 	}
 
-	//clear the new lines. that's scrollback_buffer[0:linecount]
+	// clear the new lines. that's scrollback_buffer[0:linecount]
 	this->clear({0, (term_t) -this->scrollback_lines}, {0, (term_t) ((term_t) linecount - (term_t) this->scrollback_lines)});
 
-	//move the screen buffer by updating the screen_chrdata pointer
+	// move the screen buffer by updating the screen_chrdata pointer
 	this->screen_chrdata += linecount * this->dims.x;
 	if (this->screen_chrdata >= this->chrdata_end) {
 		this->screen_chrdata -= this->chrdata_size;
 	}
 
-	//also update the screen_linedata pointer
+	// also update the screen_linedata pointer
 	this->screen_linedata += linecount;
 	if (this->screen_linedata >= this->linedata_end) {
 		this->screen_linedata -= this->linedata_size;
@@ -376,7 +376,7 @@ void Buf::advance(unsigned linecount) {
 
 void Buf::write(char c) {
 	if (!this->streamdecoder.feed(c)) {
-		//an error has been detected in the input stream
+		// an error has been detected in the input stream
 		this->process_codepoint(0xFFFD);
 	};
 
@@ -409,8 +409,8 @@ void Buf::pop_last_char() {
 }
 
 void Buf::process_codepoint(int cp) {
-	//if the terminal is currently in escaped state, tread the codepoint as
-	//part of the current escape sequence.
+	// if the terminal is currently in escaped state, tread the codepoint as
+	// part of the current escape sequence.
 	if (this->escaped) {
 		this->escape_sequence.push_back(cp);
 
@@ -421,32 +421,33 @@ void Buf::process_codepoint(int cp) {
 			previous = this->escape_sequence[len - 2];
 		}
 
-		//the first char of the escape sequence determines
-		//its length, terminators and allowed characters.
+		// the first char of the escape sequence determines
+		// its length, terminators and allowed characters.
 		switch (first) {
-		case '[': //CSI
+		case '[':
+			// CSI
 			if (len == 1 or (cp >= 0x20 and cp < 0x40)) {
-				//regular, allowed char
+				// regular, allowed char
 			} else if (cp >= 0x40 and cp < 0x7f) {
-				//terminator
+				// terminator
 				this->process_csi_escape_sequence();
 			} else {
-				//illegal char, abortabortabort
+				// illegal char, abortabortabort
 				this->escape_sequence_aborted();
 			}
 			break;
-		case ']': //OSC
-		case 'P': //DCS
-		case '_': //APC
-		case '^': //PM
-			//terminated by ESC \ or BEL
+		case ']':  // OSC
+		case 'P':  // DCS
+		case '_':  // APC
+		case '^':  // PM
+			// terminated by ESC \ or BEL
 			if ((previous == 0x1b and cp == '\\') or cp == 0x07) {
 				this->process_text_escape_sequence();
 			}
 			break;
-		case '(': //non-utf8-related stuff
-		case ')': //character-set selection etc...
-		case '*': //these are all 2-char sequences
+		case '(':  // non-utf8-related stuff
+		case ')':  // character-set selection etc...
+		case '*':  // these are all 2-char sequences
 		case '+':
 		case '-':
 		case '/':
@@ -454,43 +455,43 @@ void Buf::process_codepoint(int cp) {
 		case '%':
 		case '#':
 		case ' ':
-			//not implemented
+			// not implemented
 			if (len == 2) {
 				this->escape_sequence_aborted();
 			}
 			break;
-		default: //no known multi-cp sequence, treat as single escaped cp
+		default: // no known multi-cp sequence, treat as single escaped cp
 			this->process_escaped_cp(first);
 			break;
 		}
 	} else {
-		//we're not currently escaped, so the char is printed...
-		//at least if it's a printable character.
+		// we're not currently escaped, so the char is printed...
+		// at least if it's a printable character.
 		this->print_codepoint(cp);
 	}
 }
 
 void Buf::print_codepoint(int cp) {
 	switch (cp) {
-	//control characters
-	case 0x00: //NUL: ignore
-	case 0x01: //SOH: ignore
-	case 0x02: //STX: ignore
-	case 0x03: //ETX: ignore
-	case 0x04: //EOT: ignore
-	case 0x05: //ENQ: ignore (empty response)
-	case 0x06: //ACK: ignore
+	// control characters
+	case 0x00: // NUL: ignore
+	case 0x01: // SOH: ignore
+	case 0x02: // STX: ignore
+	case 0x03: // ETX: ignore
+	case 0x04: // EOT: ignore
+	case 0x05: // ENQ: ignore (empty response)
+	case 0x06: // ACK: ignore
 		break;
-	case 0x07: //BEL: set bell flag
+	case 0x07: // BEL: set bell flag
 		this->bell = true;
 		break;
 	case 0x08: // BS: backspace
-		//move cursor 1 left.
-		//if cursor pos is 0, move to end of previous line
-		//if already at (0,0), move to (0,0)
+		// move cursor 1 left.
+		// if cursor pos is 0, move to end of previous line
+		// if already at (0,0), move to (0,0)
 		if (this->cursor_special_lastcol && (this->cursorpos.x == this->dims.x - 1)) {
-			//if we are in the special last-column state, only unset that flag,
-			//but don't move the cursor.
+			// if we are in the special last-column state, only unset that flag,
+			// but don't move the cursor.
 			this->cursor_special_lastcol = false;
 		} else {
 			this->cursorpos.x -= 1;
@@ -504,11 +505,11 @@ void Buf::print_codepoint(int cp) {
 		}
 		break;
 	case 0x09: // HT: horizontal tab
-		//move cursor to next multiple of 8
-		//at least move by 1, at most by 8
-		//if next multiple of 8 is greater than terminal width,
-		//move to end of this line
-		//never move to next line
+		// move cursor to next multiple of 8
+		// at least move by 1, at most by 8
+		// if next multiple of 8 is greater than terminal width,
+		// move to end of this line
+		// never move to next line
 		this->cursorpos.x = ((this->cursorpos.x + 8) / 8) * 8;
 		if (this->cursorpos.x >= this->dims.x) {
 			this->cursorpos.x = this->dims.x - 1;
@@ -533,32 +534,32 @@ void Buf::print_codepoint(int cp) {
 		break;
 	case 0x0e: // SO: ignore
 	case 0x0f: // SI: ignore
-	case 0x10: //DLE: ignore
-	case 0x11: //DC1: ignore
-	case 0x12: //DC2: ignore
-	case 0x13: //DC3: ignore
-	case 0x14: //DC4: ignore
-	case 0x15: //NAK: ignore
-	case 0x16: //SYN: ignore
-	case 0x17: //ETB: ignore
-	case 0x18: //CAN: ignore
+	case 0x10: // DLE: ignore
+	case 0x11: // DC1: ignore
+	case 0x12: // DC2: ignore
+	case 0x13: // DC3: ignore
+	case 0x14: // DC4: ignore
+	case 0x15: // NAK: ignore
+	case 0x16: // SYN: ignore
+	case 0x17: // ETB: ignore
+	case 0x18: // CAN: ignore
 	case 0x19: // EM: ignore
-	case 0x1a: //SUB: ignore
+	case 0x1a: // SUB: ignore
 		break;
-	case 0x1b: //ESC: escape sequence start
+	case 0x1b: // ESC: escape sequence start
 		this->escaped = true;
 		break;
 	case 0x1c: // FS: ignore
 	case 0x1d: // GS: ignore
 	case 0x1e: // RS: ignore
 	case 0x1f: // US: ignore
-	case 0x7f: //DEL: ignore
+	case 0x7f: // DEL: ignore
 		break;
-	default:   //regular, printable character
+	default:   // regular, printable character
 		if (this->cursor_special_lastcol && (this->cursorpos.x == this->dims.x - 1)) {
 			this->cursor_special_lastcol = false;
-			//store the fact that this line was auto-wrapped
-			//and will continue in the next line
+			// store the fact that this line was auto-wrapped
+			// and will continue in the next line
 			this->linedataptr(this->cursorpos.y)->type = LINE_WRAPPED;
 			this->cursorpos.x = 0;
 			if (this->cursorpos.y == this->dims.y - 1) {
@@ -568,18 +569,18 @@ void Buf::print_codepoint(int cp) {
 			}
 		}
 
-		//set char at current cursor pos
+		// set char at current cursor pos
 		buf_char *ptr = this->chrdataptr(this->cursorpos);
 		*ptr = this->current_char_fmt;
 		ptr->cp = cp;
 		buf_line *lineptr = this->linedataptr(this->cursorpos.y);
 
-		//store the fact that this line has been written to
+		// store the fact that this line has been written to
 		if (lineptr->type == LINE_EMPTY) {
 			lineptr->type = LINE_REGULAR;
 		}
 
-		//advance cursor to the right
+		// advance cursor to the right
 		this->cursorpos.x++;
 		if (this->cursorpos.x == this->dims.x) {
 			this->cursorpos.x -= 1;
@@ -672,32 +673,32 @@ void Buf::process_csi_escape_sequence() {
 			currentparam = 10 * currentparam + (cp - '0');
 		} else if (cp == ';') {
 			if (!in_param) {
-				//this ';' did not have a number before it
-				//(ommited)
+				// this ';' did not have a number before it
+				// (ommited)
 				currentparam = -1;
 			}
 
 			params.push_back(currentparam);
 			in_param = false;
 		} else {
-			//unexpected character, we want a nice
-			//semicolon-separated list of decimal numbers.
-			//abortabortabort
+			// unexpected character, we want a nice
+			// semicolon-separated list of decimal numbers.
+			// abortabortabort
 			this->escape_sequence_aborted();
 			return;
 		}
 	}
 
 	if (in_param) {
-		//there's no semicolon at the end, finish the param
+		// there's no semicolon at the end, finish the param
 		params.push_back(currentparam);
 	} else {
-		//there's a semicolon at the end, or we had no params
-		//at all. add param with default value.
+		// there's a semicolon at the end, or we had no params
+		// at all. add param with default value.
 		params.push_back(-1);
 	}
 
-	//default values
+	// default values
 	int defaultval;
 	unsigned minparamcount;
 	switch (type) {
@@ -723,7 +724,7 @@ void Buf::process_csi_escape_sequence() {
 		break;
 	}
 
-	//apply default value requirements
+	// apply default value requirements
 	while (params.size() < minparamcount) {
 		params.push_back(-1);
 	}
@@ -733,54 +734,54 @@ void Buf::process_csi_escape_sequence() {
 		}
 	}
 
-	//execute the escape sequence
+	// execute the escape sequence
 	switch (type) {
-	case '@': //ICH: insert n blank characters
+	case '@': // ICH: insert n blank characters
 		for(int i = 0; i < params[0]; i++) {
 			this->print_codepoint(0x20);
 		}
 		break;
-	case 'A': //CUU: move cursor up
+	case 'A': // CUU: move cursor up
 		this->cursorpos.y -= params[0];
 		if (this->cursorpos.y < 0) {
 			this->cursorpos.y = 0;
 		}
 		break;
-	case 'e': //VPR: vertical position relative
+	case 'e': // VPR: vertical position relative
 		//fall through
-	case 'B': //CUD: move cursor down
+	case 'B': // CUD: move cursor down
 		this->cursorpos.y += params[0];
 		if (this->cursorpos.y >= this->dims.y) {
 			this->cursorpos.y = this->dims.y - 1;
 		}
 		break;
-	case 'C': //CUF: move cursor to the right
+	case 'C': // CUF: move cursor to the right
 		this->cursorpos.x += params[0];
 		if (this->cursorpos.x >= this->dims.x) {
 			this->cursorpos.x = this->dims.x - 1;
 		}
 		break;
-	case 'D': //CUB: move cursor to the left
+	case 'D': // CUB: move cursor to the left
 		this->cursorpos.x -= params[0];
 		if (this->cursorpos.x < 0) {
 			this->cursorpos.x = 0;
 		}
 		break;
-	case 'E': //CNL: move cursor down and to beginning of line
+	case 'E': // CNL: move cursor down and to beginning of line
 		this->cursorpos.x = 0;
 		this->cursorpos.y += params[0];
 		if (this->cursorpos.y >= this->dims.y) {
 			this->cursorpos.y = this->dims.y - 1;
 		}
 		break;
-	case 'F': //CPL: move cursor up and to beginning of line
+	case 'F': // CPL: move cursor up and to beginning of line
 		this->cursorpos.x = 0;
 		this->cursorpos.y -= params[0];
 		if (this->cursorpos.y < 0) {
 			this->cursorpos.y = 0;
 		}
 		break;
-	case 'G': //CHA: set cursorpos.x
+	case 'G': // CHA: set cursorpos.x
 		this->cursorpos.x = params[0] - 1;
 		if (this->cursorpos.x < 0) {
 			this->cursorpos.x = 0;
@@ -789,9 +790,9 @@ void Buf::process_csi_escape_sequence() {
 			this->cursorpos.x = this->dims.x - 1;
 		}
 		break;
-	case 'f': //HVP: set cursorpos
+	case 'f': // HVP: set cursorpos
 		//fall through
-	case 'H': //CUP: set cursorpos
+	case 'H': // CUP: set cursorpos
 		this->cursorpos.y = params[0] - 1;
 		this->cursorpos.x = params[1] - 1;
 		if (this->cursorpos.x < 0) {
@@ -818,80 +819,80 @@ void Buf::process_csi_escape_sequence() {
 		break;
 	case 'J': // ED: erase display
 		switch (params[0]) {
-		case 0: //clear screen buffer from cursor to end
+		case 0: // clear screen buffer from cursor to end
 			this->clear(this->cursorpos, {0, this->dims.y});
 			break;
-		case 1: //clear screen buffer from beginning to cursor
+		case 1: // clear screen buffer from beginning to cursor
 			this->clear({0, 0}, this->cursorpos, true);
 			break;
-		case 2: //clear screen buffer
+		case 2: // clear screen buffer
 			this->clear({0, 0}, {0, this->dims.y});
 			break;
-		default://unknown/unimplemented parameter
+		default: // unknown/unimplemented parameter
 			break;
 		}
 		break;
 	case 'K': // EL: erase line
 		switch (params[0]) {
-		case 0: //clear current line from cursor to end
+		case 0: // clear current line from cursor to end
 			this->clear(this->cursorpos, {0, (term_t) (this->cursorpos.y + 1)});
 			break;
-		case 1: //clear current line from beginning to cursor
+		case 1: // clear current line from beginning to cursor
 			this->clear({0, this->cursorpos.y}, this->cursorpos, true);
 			break;
-		case 2: //clear current line
+		case 2: // clear current line
 			this->clear({0, this->cursorpos.y}, {0, (term_t) (this->cursorpos.y + 1)});
 			break;
-		default://unknown/unimplemented parameter
+		default: // unknown/unimplemented parameter
 			break;
 		}
 		break;
-	case 'm': //SGR: set graphics rendition
+	case 'm': // SGR: set graphics rendition
 		this->process_sgr_code(params);
 		break;
-	case 's': //SCP: save cursor position
+	case 's': // SCP: save cursor position
 		this->saved_cursorpos = this->cursorpos;
 		break;
-	case 'u': //RCP: restore cursor position
+	case 'u': // RCP: restore cursor position
 		this->cursorpos = this->saved_cursorpos;
 		break;
-	case 'l': //set mode
+	case 'l': // set mode
 		if (starts_with_questionmark) {
 			switch(params[0]) {
-			case 25: //cursor invisible
+			case 25: // cursor invisible
 				this->cursor_visible = false;
 				break;
-			case 1049: //switch to alternate screen
-				//TBI
-				//idea: use last dims.y lines of scrollback
-				//buffer to save regular screen data
+			case 1049: // switch to alternate screen
+				// TBI
+				// idea: use last dims.y lines of scrollback
+				// buffer to save regular screen data
 				break;
-			default: //unknown/unimplemented parameter
+			default: // unknown/unimplemented parameter
 				break;
 			}
 		} else {
 			switch(params[0]) {
-			default: //unknown/unimplemented parameter
+			default: // unknown/unimplemented parameter
 				break;
 			}
 			break;
 		}
 		break;
-	case 'h': //reset mode
+	case 'h': // reset mode
 		if (starts_with_questionmark) {
 			switch(params[0]) {
-			case 25: //cursor visible
+			case 25: // cursor visible
 				this->cursor_visible = true;
 				break;
-			case 1049: //restore regular screen
-				//TBI
+			case 1049: // restore regular screen
+				// TBI
 				break;
-			default: //unknown/unimplemented parameter
+			default: // unknown/unimplemented parameter
 				break;
 			}
 		} else {
 			switch(params[0]) {
-			default: //unknown/unimplemented parameter
+			default: // unknown/unimplemented parameter
 				break;
 			}
 			break;
@@ -899,10 +900,10 @@ void Buf::process_csi_escape_sequence() {
 		break;
 	case 'S': // SU
 	case 'T': // SD
-	case 'n': //DSR
-		//not implemented; fall through.
+	case 'n': // DSR
+		// not implemented; fall through.
 	default:
-		//not implemented (or nonexisting)
+		// not implemented (or nonexisting)
 		this->escape_sequence_aborted();
 		return;
 	}
@@ -913,72 +914,72 @@ void Buf::process_sgr_code(const std::vector<int> &params) {
 	for(size_t i = 0; i < params.size(); i++) {
 		int p = params[i];
 		switch (p) {
-		case 0: //reset
+		case 0: // reset
 			this->current_char_fmt = this->default_char_fmt;
 			break;
-		case 1: //bold
+		case 1: // bold
 			this->current_char_fmt.flags |= CHR_BOLD;
 			this->current_char_fmt.flags &= ~CHR_FAINT;
 			break;
-		case 2: //faint
+		case 2: // faint
 			this->current_char_fmt.flags |= CHR_FAINT;
 			this->current_char_fmt.flags &= ~CHR_BOLD;
 			break;
-		case 3: //italic
+		case 3: // italic
 			this->current_char_fmt.flags |= CHR_ITALIC;
 			this->current_char_fmt.flags &= ~CHR_FRAKTUR;
 			break;
-		case 4: //underline
+		case 4: // underline
 			this->current_char_fmt.flags |= CHR_UNDERLINED;
 			break;
-		case 5: //blink slowly
+		case 5: // blink slowly
 			this->current_char_fmt.flags |= CHR_BLINKING;
 			this->current_char_fmt.flags &= ~CHR_BLINKINGFAST;
 			break;
-		case 6: //blink fast
+		case 6: // blink fast
 			this->current_char_fmt.flags |= CHR_BLINKINGFAST;
 			this->current_char_fmt.flags &= ~CHR_BLINKING;
 			break;
-		case 7: //negative
+		case 7: // negative
 			this->current_char_fmt.flags |= CHR_NEGATIVE;
 			break;
-		case 8: //invisible
+		case 8: // invisible
 			this->current_char_fmt.flags |= CHR_INVISIBLE;
 			break;
-		case 9: //struck out
+		case 9: // struck out
 			this->current_char_fmt.flags |= CHR_STRUCKOUT;
 			break;
-		//cases 10-19: font selectors. not implemented.
-		case 20: //fraktur
+		// cases 10-19: font selectors. not implemented.
+		case 20: // fraktur
 			this->current_char_fmt.flags |= CHR_FRAKTUR;
 			this->current_char_fmt.flags &= ~CHR_ITALIC;
 			break;
-		case 21: //bold off
+		case 21: // bold off
 			this->current_char_fmt.flags &= ~CHR_BOLD;
 			break;
-		case 22: //bold and faint off
+		case 22: // bold and faint off
 			this->current_char_fmt.flags &= ~CHR_BOLD;
 			this->current_char_fmt.flags &= ~CHR_FAINT;
 			break;
-		case 23: //italic and fraktur off
+		case 23: // italic and fraktur off
 			this->current_char_fmt.flags &= ~CHR_ITALIC;
 			this->current_char_fmt.flags &= ~CHR_FRAKTUR;
 			break;
-		case 24: //underline off
+		case 24: // underline off
 			this->current_char_fmt.flags &= ~CHR_UNDERLINED;
 			break;
-		case 25: //blinking and blinkingfast off
+		case 25: // blinking and blinkingfast off
 			this->current_char_fmt.flags &= ~CHR_BLINKING;
 			this->current_char_fmt.flags &= ~CHR_BLINKINGFAST;
 			break;
-		//case 26: not yet standardized
-		case 27: //negative off
+		// case 26: not yet standardized
+		case 27: // negative off
 			this->current_char_fmt.flags &= ~CHR_NEGATIVE;
 			break;
-		case 28: //invisible off
+		case 28: // invisible off
 			this->current_char_fmt.flags &= ~CHR_INVISIBLE;
 			break;
-		case 29: //struck out off
+		case 29: // struck out off
 			this->current_char_fmt.flags &= ~CHR_STRUCKOUT;
 			break;
 		case 30:
@@ -988,18 +989,18 @@ void Buf::process_sgr_code(const std::vector<int> &params) {
 		case 34:
 		case 35:
 		case 36:
-		case 37: //foreground color (8 colors)
+		case 37: // foreground color (8 colors)
 			this->current_char_fmt.fgcol = (p - 30);
 			break;
-		case 38: //foreground color (256 colors)
+		case 38: // foreground color (256 colors)
 			i += 2;
 			if (i >= params.size() || params[i] < 0 || params[i] >= 256) {
-				//invalid 256-color SGR code.
+				// invalid 256-color SGR code.
 				return;
 			}
 			this->current_char_fmt.fgcol = params[i];
 			break;
-		case 39: //reset foreground color
+		case 39: // reset foreground color
 			this->current_char_fmt.fgcol = this->default_char_fmt.fgcol;
 			break;
 		case 40:
@@ -1009,67 +1010,67 @@ void Buf::process_sgr_code(const std::vector<int> &params) {
 		case 44:
 		case 45:
 		case 46:
-		case 47: //background color (8 colors)
+		case 47: // background color (8 colors)
 			this->current_char_fmt.bgcol = (p - 40);
 			break;
-		case 48: //background color (256 colors)
+		case 48: // background color (256 colors)
 			i += 2;
 			if (i >= params.size() || params[i] < 0 || params[i] >= 256) {
-				//invalid 256-color SGR code.
-				//abortabortabort
+				// invalid 256-color SGR code.
+				// abortabortabort
 				return;
 			}
 			this->current_char_fmt.bgcol = params[i];
 			break;
-		case 49: //reset background color
+		case 49: // reset background color
 			this->current_char_fmt.bgcol = this->default_char_fmt.bgcol;
 			break;
-		//case 50: not yet standardized
-		case 51: //framed
+		// case 50: not yet standardized
+		case 51: // framed
 			this->current_char_fmt.flags |= CHR_FRAMED;
 			this->current_char_fmt.flags &= ~CHR_ENCIRCLED;
 			break;
-		case 52: //encircled
+		case 52: // encircled
 			this->current_char_fmt.flags |= CHR_ENCIRCLED;
 			this->current_char_fmt.flags &= ~CHR_FRAMED;
 			break;
-		case 53: //overlined
+		case 53: // overlined
 			this->current_char_fmt.flags |= CHR_OVERLINED;
 			break;
-		case 54: //framed and encircled off
+		case 54: // framed and encircled off
 			this->current_char_fmt.flags &= ~CHR_FRAMED;
 			this->current_char_fmt.flags &= ~CHR_ENCIRCLED;
 			break;
-		case 55: //overlined off
+		case 55: // overlined off
 			this->current_char_fmt.flags &= ~CHR_OVERLINED;
 			break;
-		//cases 56-59: not yet standardized
-		case 60: //right side line
+		// cases 56-59: not yet standardized
+		case 60: // right side line
 			this->current_char_fmt.flags |= CHR_RIGHTLINED;
 			break;
-		//case 61: double right side line. not implemented.
-		case 62: //left side line
+		// case 61: double right side line. not implemented.
+		case 62: // left side line
 			this->current_char_fmt.flags |= CHR_LEFTLINED;
 			break;
-		//case 63: double left side line. not implemented.
-		case 64: //stress ideogram
+		// case 63: double left side line. not implemented.
+		case 64: // stress ideogram (whatever that is)
 			this->current_char_fmt.flags |= CHR_STRESS_IDEOGRAM;
 			break;
-		case 65: //disables effects 60-64
+		case 65: // disables effects 60-64
 			this->current_char_fmt.flags &= ~CHR_RIGHTLINED;
 			this->current_char_fmt.flags &= ~CHR_LEFTLINED;
 			break;
-		//cases above 65 are not standardized.
+		// cases above 65 are not standardized.
 		default:
-			//not implemented or not defined.
-			//abortabortabort
+			// not implemented or not defined.
+			// abortabortabort
 			return;
 		}
 	}
 }
 
 void Buf::clear(term start, term end, bool clear_end) {
-	//apply clear_end
+	// apply clear_end
 	if (clear_end) {
 		end.x++;
 		if (end.x > this->dims.x) {
@@ -1082,11 +1083,11 @@ void Buf::clear(term start, term end, bool clear_end) {
 		return;
 	}
 
-	//clear char info
+	// clear char info
 	chrdata_clear(chrdataptr(start), chrdataptr(end));
 
-	//calculate lines to clear
-	//a line is cleared iff all of its characters are cleared
+	// calculate lines to clear
+	// a line is cleared iff all of its characters are cleared
 	term_t line_start = start.y;
 	if (start.x > 0) {
 		line_start++;
@@ -1097,7 +1098,7 @@ void Buf::clear(term start, term end, bool clear_end) {
 		return;
 	}
 
-	//clear line info
+	// clear line info
 	linedata_clear(linedataptr(line_start), linedataptr(line_end));
 }
 

--- a/libopenage/console/console.cpp
+++ b/libopenage/console/console.cpp
@@ -63,8 +63,6 @@ void Console::register_to_engine() {
 	this->engine->register_drawhud_action(this);
 	this->engine->register_resize_action(this);
 
-	// TODO bind any needed input to InputContext
-
 	// Bind the console toggle key globally
 	auto &action = this->engine->get_action_manager();
 	auto &global = this->engine->get_input_manager().get_global_context();
@@ -72,6 +70,9 @@ void Console::register_to_engine() {
 	global.bind(action.get("TOGGLE_CONSOLE"), [this](const input::action_arg_t &) {
 		this->set_visible(!this->visible);
 	});
+
+
+	// TODO: bind any needed input to InputContext
 
 	// toggle console will take highest priority
 	this->input_context.bind(action.get("TOGGLE_CONSOLE"), [this](const input::action_arg_t &) {
@@ -108,7 +109,7 @@ void Console::register_to_engine() {
 
 void Console::set_visible(bool make_visible) {
 	if (make_visible) {
-		this->engine->get_input_manager().register_context(&this->input_context);
+		this->engine->get_input_manager().push_context(&this->input_context);
 		this->visible = true;
 	}
 	else {

--- a/libopenage/console/console.cpp
+++ b/libopenage/console/console.cpp
@@ -22,8 +22,9 @@ namespace console {
  * log console, command console
  */
 
-Console::Console()
+Console::Console(Engine *engine)
 	:
+	engine{engine},
 	bottomleft{0, 0},
 	topright{1, 1},
 	charsize{1, 1},
@@ -40,8 +41,8 @@ Console::Console()
 	log::log(MSG(dbg) << "Console font character size: " << charsize.x << "x" << charsize.y);
 
 	// Adjust the corners of the console based on the default buffer size and char size
-	topright.x = charsize.x * buf.dims.x;
-	topright.y = charsize.y * buf.dims.y;
+	topright.x = charsize.x * this->buf.get_dims().x;
+	topright.y = charsize.y * this->buf.get_dims().y;
 }
 
 Console::~Console () {}
@@ -56,24 +57,24 @@ void Console::load_colors(std::vector<gamedata::palette_color> &colortable) {
 	}
 }
 
-void Console::register_to_engine(Engine *engine) {
-	engine->register_input_action(this);
-	engine->register_tick_action(this);
-	engine->register_drawhud_action(this);
-	engine->register_resize_action(this);
+void Console::register_to_engine() {
+	this->engine->register_input_action(this);
+	this->engine->register_tick_action(this);
+	this->engine->register_drawhud_action(this);
+	this->engine->register_resize_action(this);
 
 	// TODO bind any needed input to InputContext
 
 	// Bind the console toggle key globally
-	auto &action = engine->get().get_action_manager();
-	auto &input = engine->get_input_manager();
-	auto &global = input.get_global_context();
-	global.bind(action.get("TOGGLE_CONSOLE"), [this, &input](const input::action_arg_t &) {
+	auto &action = this->engine->get_action_manager();
+	auto &global = this->engine->get_input_manager().get_global_context();
+
+	global.bind(action.get("TOGGLE_CONSOLE"), [this](const input::action_arg_t &) {
 		this->set_visible(!this->visible);
 	});
 
 	// toggle console will take highest priority
-	this->input_context.bind(action.get("TOGGLE_CONSOLE"), [this, &input](const input::action_arg_t &) {
+	this->input_context.bind(action.get("TOGGLE_CONSOLE"), [this](const input::action_arg_t &) {
 		this->set_visible(false);
 	});
 	this->input_context.bind(input::event_class::UTF8, [this](const input::action_arg_t &arg) {
@@ -93,26 +94,25 @@ void Console::register_to_engine(Engine *engine) {
 				return true;
 
 			case 13: // interpret command
-	 			this->buf.write('\n');
-	 			this->interpret(this->command);
-	 			this->command = "";
-	 			return true;
+				this->buf.write('\n');
+				this->interpret(this->command);
+				this->command = "";
+				return true;
 
 			default:
 				return false;
- 		}
+		}
 	});
 	this->input_context.utf8_mode = true;
 }
 
 void Console::set_visible(bool make_visible) {
-	Engine &e = Engine::get();
 	if (make_visible) {
-		e.get_input_manager().register_context(&this->input_context);
+		this->engine->get_input_manager().register_context(&this->input_context);
 		this->visible = true;
 	}
 	else {
-		e.get_input_manager().remove_context(&this->input_context);
+		this->engine->get_input_manager().remove_context(&this->input_context);
 		this->visible = false;
 	}
 }
@@ -127,8 +127,7 @@ void Console::interpret(const std::string &command) {
 		this->set_visible(false);
 	}
 	else if (command == "list") {
-		Engine &e = Engine::get();
-		for (auto &line : e.list_options()) {
+		for (auto &line : this->engine->list_options()) {
 			this->write(line.c_str());
 		}
 	}
@@ -138,14 +137,14 @@ void Console::interpret(const std::string &command) {
 		if (first_space != std::string::npos && second_space != std::string::npos) {
 			std::string name = command.substr(first_space+1, second_space-first_space-1);
 			std::string value = command.substr(second_space+1, std::string::npos);
-			Engine::get().get_cvar_manager().set(name,value);
+			this->engine->get_cvar_manager().set(name,value);
 		}
 	}
 	else if (command.substr(0,3) == "get") {
 		std::size_t first_space = command.find(" ");
 		if (first_space != std::string::npos) {
 			std::string name = command.substr(first_space+1, std::string::npos);
-			std::string value = Engine::get().get_cvar_manager().get(name);
+			std::string value = this->engine->get_cvar_manager().get(name);
 			this->write(value.c_str());
 		}
 	}
@@ -166,7 +165,7 @@ bool Console::on_drawhud() {
 		return true;
 	}
 
-	draw::to_opengl(this);
+	draw::to_opengl(this->engine, this);
 
 	return true;
 }
@@ -190,8 +189,8 @@ bool Console::on_input(SDL_Event *e) {
 }
 
 bool Console::on_resize(coord::window new_size) {
-	coord::pixel_t w = this->buf.dims.x * this->charsize.x;
-	coord::pixel_t h = this->buf.dims.y * this->charsize.y;
+	coord::pixel_t w = this->buf.get_dims().x * this->charsize.x;
+	coord::pixel_t h = this->buf.get_dims().y * this->charsize.y;
 
 	this->bottomleft = {(new_size.x - w) / 2, (new_size.y - h) / 2};
 	this->topright = {this->bottomleft.x + w, this->bottomleft.y - h};

--- a/libopenage/console/console.h
+++ b/libopenage/console/console.h
@@ -25,24 +25,8 @@ namespace console {
 class Console : InputHandler, TickHandler, HudHandler, ResizeHandler {
 
 public:
-	Console();
+	Console(Engine *engine);
 	~Console();
-
-	coord::camhud bottomleft;
-	coord::camhud topright;
-	coord::camhud charsize;
-
-	std::vector<util::col> termcolors;
-
-	bool visible;
-
-	Buf buf;
-	renderer::Font font;
-
-	input::InputContext input_context;
-
-	// the command state
-	std::string command;
 
 	/**
 	 * load the consoles color table
@@ -53,7 +37,7 @@ public:
 	 * register this console to the engine.
 	 * this leads to the drawing calls, and input handling.
 	 */
-	void register_to_engine(Engine *engine);
+	void register_to_engine();
 
 	void set_visible(bool make_visible);
 
@@ -71,6 +55,26 @@ public:
 	bool on_tick() override;
 	bool on_input(SDL_Event *event) override;
 	bool on_resize(coord::window new_size) override;
+
+protected:
+	Engine *engine;
+
+public:
+	coord::camhud bottomleft;
+	coord::camhud topright;
+	coord::camhud charsize;
+
+	std::vector<util::col> termcolors;
+
+	bool visible;
+
+	Buf buf;
+	renderer::Font font;
+
+	input::InputContext input_context;
+
+	// the command state
+	std::string command;
 };
 
 }} // openage::console

--- a/libopenage/console/draw.cpp
+++ b/libopenage/console/draw.cpp
@@ -21,7 +21,7 @@ namespace openage {
 namespace console {
 namespace draw {
 
-void to_opengl(Console *console) {
+void to_opengl(Engine *engine, Console *console) {
 	coord::camhud topleft = {
 		console->bottomleft.x,
 		// TODO This should probably just be console->topright.y
@@ -30,8 +30,7 @@ void to_opengl(Console *console) {
 	coord::camhud chartopleft;
 	coord::pixel_t ascender = static_cast<coord::pixel_t>(console->font.get_ascender());
 
-	Engine &engine = Engine::get();
-	renderer::TextRenderer *text_renderer = engine.get_text_renderer();
+	renderer::TextRenderer *text_renderer = engine->get_text_renderer();
 	text_renderer->set_font(&console->font);
 
 	int64_t monotime = timing::get_monotonic_time();

--- a/libopenage/console/draw.h
+++ b/libopenage/console/draw.h
@@ -3,6 +3,9 @@
 #pragma once
 
 namespace openage {
+
+class Engine;
+
 namespace util {
 class FD;
 } // openage::util
@@ -17,7 +20,7 @@ namespace draw {
 /**
  * experimental and totally inefficient opengl draw of a terminal buffer.
  */
-void to_opengl(Console *console);
+void to_opengl(Engine *engine, Console *console);
 
 /**
  * very early and inefficient printing of the console to a pty.

--- a/libopenage/console/tests.cpp
+++ b/libopenage/console/tests.cpp
@@ -23,9 +23,13 @@ namespace console {
 namespace tests {
 
 
+// TODO: move to util
 int max(int a, int b) {
 	return (a > b) ? a : b;
 }
+
+
+// TODO: test for console coordinates and resizing
 
 
 void render() {

--- a/libopenage/coord/tests.cpp
+++ b/libopenage/coord/tests.cpp
@@ -5,7 +5,6 @@
 #include "../log/log.h"
 #include "../util/file.h"
 #include "../engine.h"
-#include "../console/console.h"
 #include "../testing/testing.h"
 
 #include "phys2.h"
@@ -549,24 +548,6 @@ void camhud_0() {
 
 	results_w = c.to_window();
 	(results_w == expected_w) or TESTFAIL;
-
-	// Test camhud to term
-
-	// TODO The expected results for this was created by just seeing
-	// What the results acually were. Need to investigate the bottomleft
-	// and top right of console as a toptight that is the camhud type
-	// is negative in its y and thus would be off the screen
-
-	console::Console con;
-
-	window size{80*con.charsize.x, 25*con.charsize.y};
-	con.on_resize(size);
-
-	term expected_t{1, -54};
-	c = {12, 6};
-
-	term results_t = c.to_term(&con);
-	(results_t == expected_t) or TESTFAIL;
 }
 
 /**
@@ -586,17 +567,8 @@ void camhud_delta_0() {
 	(results_wd == expected_wd) or TESTFAIL;
 }
 
-/**
- * This function tests the methods of term
- */
-void term_0() {
-	console::Console con;
-	camhud expected_c{40, 340};
-	term t{5, 5};
+// TODO test the terminal coordinates
 
-	camhud results_c = t.to_camhud(&con);
-	(results_c == expected_c) or TESTFAIL;
-}
 
 /**
  * Top level function for coord testing.
@@ -615,7 +587,6 @@ void coord() {
 	camgame_delta_0();
 	camhud_0();
 	camhud_delta_0();
-	term_0();
 }
 
 }}} // openage::coord::tests

--- a/libopenage/cvar/cvar.cpp
+++ b/libopenage/cvar/cvar.cpp
@@ -1,12 +1,15 @@
 // Copyright 2013-2016 the openage authors. See copying.md for legal info.
 
 #include "cvar.h"
-#include "../engine.h"
+
+#include "../log/log.h"
+
 
 namespace openage {
 namespace cvar {
 
-bool CVarManager::create(const std::string &name,  const std::pair<get_func, set_func> &accessors) {
+bool CVarManager::create(const std::string &name,
+                         const std::pair<get_func, set_func> &accessors) {
 	auto it = this->store.find(name);
 	if (it == this->store.end()) {
 		this->store[name] = accessors;
@@ -14,6 +17,7 @@ bool CVarManager::create(const std::string &name,  const std::pair<get_func, set
 	}
 	return false;
 }
+
 
 std::string CVarManager::get(const std::string &name) const {
 	auto it = this->store.find(name);
@@ -23,6 +27,7 @@ std::string CVarManager::get(const std::string &name) const {
 	return "";
 }
 
+
 void CVarManager::set(const std::string &name, const std::string &value) const {
 	auto it = store.find(name);
 	if (it != store.end()) {
@@ -30,23 +35,25 @@ void CVarManager::set(const std::string &name, const std::string &value) const {
 	}
 }
 
+
 std::string CVarManager::find_main_config() const {
-	return CVarManager::find_main_config_file.call();
+	return find_main_config_file.call();
 }
+
 
 void CVarManager::load_config(const std::string &path) {
-	CVarManager::load_config_file.call(path, this);
+	load_config_file.call(path, this);
 }
+
 
 void CVarManager::load_main_config() {
-	this->load_config(this->find_main_config());
+	auto filename = this->find_main_config();
+	log::log(INFO << "loading configuration files...");
+	this->load_config(filename);
 }
 
-CVarManager &CVarManager::get() {
-	return Engine::get().get_cvar_manager();
-}
 
-pyinterface::PyIfFunc<std::string> CVarManager::find_main_config_file;
-pyinterface::PyIfFunc<void, std::string, CVarManager*> CVarManager::load_config_file;
-}
-}
+pyinterface::PyIfFunc<std::string> find_main_config_file;
+pyinterface::PyIfFunc<void, std::string, CVarManager*> load_config_file;
+
+}} // openage::cvar

--- a/libopenage/cvar/cvar.h
+++ b/libopenage/cvar/cvar.h
@@ -15,38 +15,92 @@
 namespace openage {
 namespace cvar {
 
+/** function type used to get a configuration value */
 using get_func = std::function<std::string()>;
+
+/** function type to set the value of a config entry */
 using set_func = std::function<void(std::string)>;
 
+
 /**
+ * Configuration manager.
+ *
+ * Stores key-value pairs of config data.
+ * Actually it doesn't store data, instead functions
+ * that perform/fetch the configuration at the appropriate place.
+ *
  * pxd:
  *
  * cppclass CVarManager:
  *
  *     string get(string name) except +
  *     void set(string name, string value) except +
- *     void load_config_file(string path) except +
- *     @staticmethod
- *     CVarManager &get() except +
- *     PyIfFunc2[void, string, CVarManager*] load_config_file
- *     PyIfFunc0[string] find_main_config_file
+ *     void load_config(string path) except +
  */
 class CVarManager {
 
-public :
-	bool create(const std::string &name, const std::pair<get_func, set_func> &accessors);
-	std::string get(const std::string &name) const;
-	void set(const std::string &name, const std::string &value) const;
-	std::string find_main_config() const;
-	void load_config(const std::string &path);
-	void load_main_config();
-	static CVarManager &get();
-	static pyinterface::PyIfFunc<std::string> find_main_config_file;
-	static pyinterface::PyIfFunc<void, std::string, CVarManager*> load_config_file;
+public:
+	/**
+	 * Creates a configuration entry
+	 * @returns if the entry name was successful.
+	 *          It won't be if the name was used before.
+	 */
+	bool create(const std::string &name,
+	            const std::pair<get_func, set_func> &accessors);
 
-private :
+	/**
+	 * Gets the value of a config entry.
+	 * Internally calls the stored get function.
+	 */
+	std::string get(const std::string &name) const;
+
+	/**
+	 * Sets the config entry value.
+	 */
+	void set(const std::string &name, const std::string &value) const;
+
+	/**
+	 * Returns the path to the main config file.
+	 */
+	std::string find_main_config() const;
+
+	/**
+	 * Performs the loading of a configuration file
+	 * via the Python implementation.
+	 */
+	void load_config(const std::string &path);
+
+	/**
+	 * Perform the load of the main configuration file.
+	 */
+	void load_main_config();
+
+private:
+	/**
+	 * Store the key-value pair of config options.
+	 * The clue is to store the "what does the config do",
+	 * not the actual value.
+	 * That way the system is universal.
+	 */
 	std::unordered_map<std::string, std::pair<get_func, set_func>> store;
 };
 
-}
-}
+
+/**
+ * Python function to locate the main openage configuration file.
+ * Provides the file name.
+ *
+ * pxd: PyIfFunc0[string] find_main_config_file
+ */
+extern pyinterface::PyIfFunc<std::string> find_main_config_file;
+
+
+/**
+ * Python function to load a configuration file.
+ * The config manager is passed into it.
+ *
+ * pxd: PyIfFunc2[void, string, CVarManager*] load_config_file
+ */
+extern pyinterface::PyIfFunc<void, std::string, CVarManager*> load_config_file;
+
+}} // openage::cvar

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -530,7 +530,6 @@ UnitSelection *Engine::get_unit_selection() {
 }
 
 void Engine::announce_global_binds() {
-
 	emit this->gui_signals.global_binds_changed(
 		this->get_input_manager().get_global_context().active_binds()
 	);

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -38,10 +38,14 @@ signals:
 	/**
 	 * Signal is triggered to anounce a new output mode.
 	 * name: name of the gui mode.
+	 */
+	void announced(const std::string &name);
+
+	/**
+	 * Signal is triggered when the bindings of the mode change.
 	 * binds: list of strings that describe keybindings.
 	 */
-	void announced(const std::string &name,
-	               const std::vector<std::string>& binds);
+	void binds_changed(const std::vector<std::string>& binds);
 };
 
 

--- a/libopenage/game_renderer.h
+++ b/libopenage/game_renderer.h
@@ -39,7 +39,7 @@ public:
  */
 class GameRenderer : DrawHandler {
 public:
-	GameRenderer(openage::Engine *e);
+	GameRenderer(Engine *e);
 	~GameRenderer();
 
 	bool on_draw() override;
@@ -64,7 +64,7 @@ public:
 	RenderOptions settings;
 
 private:
-	openage::Engine *engine;
+	Engine *engine;
 
 };
 

--- a/libopenage/game_singletons_info.h
+++ b/libopenage/game_singletons_info.h
@@ -6,6 +6,7 @@
 
 #include "gui/guisys/public/gui_singleton_items_info.h"
 
+
 namespace openage {
 
 class Engine;
@@ -13,13 +14,25 @@ class Engine;
 namespace gui {
 
 /**
- * Accessible during creation of any singleton QML item.
+ * This container is attached to the QML engine.
+ *
+ * It allows that one can access the members in the qml engine context then.
+ * That also means the members accessible during creation of any singleton QML item.
+ *
+ * This struct is used to link the openage Engine with QML in engine_link.cpp.
  */
 struct GameSingletonsInfo : qtsdl::GuiSingletonItemsInfo {
 	GameSingletonsInfo(Engine *engine, const std::string &data_dir);
 
+	/**
+	 * The openage engine, so it can be "used" in QML as a "QML Singleton".
+	 */
 	Engine *engine;
+
+	/**
+	 * Search path for finding assets n stuff.
+	 */
 	std::string data_dir;
 };
 
-}} // namespace openage::gui
+}} // openage::gui

--- a/libopenage/gamestate/game_main.h
+++ b/libopenage/gamestate/game_main.h
@@ -12,11 +12,15 @@
 #include "team.h"
 #include "../options.h"
 #include "../unit/unit_container.h"
+#include "../util/timing.h"
+
 
 namespace openage {
 
+class Engine;
 class Generator;
 class Terrain;
+
 
 /**
  * Contains information for a single game
@@ -58,7 +62,7 @@ public:
 	/**
 	 * updates the game by one frame
 	 */
-	void update();
+	void update(time_nsec_t lastframe_duration);
 
 	/**
 	 * map information
@@ -112,24 +116,52 @@ signals:
 	void game_running(bool running);
 };
 
+
+/**
+ * Class linked to the QML object "GameMain" via GameMainLink.
+ * Gets instanciated from QML.
+ */
 class GameMainHandle {
 public:
 	explicit GameMainHandle(qtsdl::GuiItemLink *gui_link);
 
 	void set_engine(Engine *engine);
 
+	/**
+	 * End the game and delete the game handle.
+	 */
 	void clear();
 
-	void set_game(std::unique_ptr<GameMain> game);
+	/**
+	 * Pass the given game to the engine and start it.
+	 */
+	void set_game(std::unique_ptr<GameMain> &&game);
+
+	/**
+	 * Return the game.
+	 */
 	GameMain* get_game() const;
 
+	/**
+	 * Test if there is a game running.
+	 */
 	bool is_game_running() const;
 
+	/**
+	 * Emit a qt signal to notify for changes in a running game.
+	 */
 	void announce_running();
 
 private:
+	/**
+	 * The game state as currently owned by the engine,
+	 * just remembered here to access it quickly.
+	 */
 	GameMain *game;
 
+	/**
+	 * The engine the main game handle is attached to.
+	 */
 	Engine *engine;
 
 public:

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -185,9 +185,14 @@ void GameSpec::on_gamedata_loaded(std::vector<gamedata::empiresdat> &gamedata) {
 
 	// playable sound files for the audio manager
 	std::vector<gamedata::sound_file> sound_files;
+
+	// all sounds defined in the game specification
 	for (gamedata::sound &sound : gamedata[0].sounds.data) {
 		std::vector<int> sound_items;
 
+		// each sound may have multiple variation,
+		// processed in this loop
+		// these are the single sound files.
 		for (gamedata::sound_item &item : sound.sound_items.data) {
 			std::string snd_file_location = get_sound_file_location(item.resource_id);
 			if (snd_file_location.empty()) {
@@ -208,9 +213,16 @@ void GameSpec::on_gamedata_loaded(std::vector<gamedata::empiresdat> &gamedata) {
 			};
 			sound_files.push_back(f);
 		}
+
 		// create test sound objects that can be played later
-		this->available_sounds[sound.id] = Sound{sound_items};
+		this->available_sounds[sound.id] = Sound{
+			this,
+			std::move(sound_items)
+		};
 	}
+
+	// TODO: move out the loading of the sound.
+	//       this class only provides the names and locations
 
 	// load the requested sounds.
 	Engine &engine = Engine::get();
@@ -425,8 +437,11 @@ std::shared_ptr<GameSpec> GameSpecHandle::get_spec() {
 
 void GameSpecHandle::start_loading_if_needed() {
 	if (this->active && this->asset_manager && !this->spec) {
+
+		// create the game specification
 		this->spec = std::make_shared<GameSpec>(*this->asset_manager);
 
+		// the load the data
 		this->start_load_job();
 	}
 }
@@ -438,15 +453,22 @@ void GameSpecHandle::start_load_job() {
 	auto spec_and_job = std::make_tuple(this->spec, this->gui_signals, job::Job<bool>{});
 	auto spec_and_job_ptr = std::make_shared<decltype(spec_and_job)>(spec_and_job);
 
-	auto load_job = [spec_and_job_ptr] {
+	// lambda to be executed to actually load the data files.
+	auto perform_load = [spec_and_job_ptr] {
 		return std::get<std::shared_ptr<GameSpec>>(*spec_and_job_ptr)->initialize();
 	};
 
-	Engine &engine = Engine::get();
-	std::get<job::Job<bool>>(*spec_and_job_ptr) = engine.get_job_manager()->enqueue<bool>(load_job, [gui_signals_ptr = this->gui_signals.get()] (job::result_function_t<bool> result) {
-		if (result())
+	auto load_finished = [gui_signals_ptr = this->gui_signals.get()] (job::result_function_t<bool> result) {
+		if (result()) {
+			// send the signal that the load job was finished
 			emit gui_signals_ptr->load_job_finished();
-	});
+		}
+	};
+
+	Engine &engine = Engine::get();
+	std::get<job::Job<bool>>(*spec_and_job_ptr) = engine.get_job_manager()->enqueue<bool>(
+		perform_load, load_finished
+	);
 }
 
 }

--- a/libopenage/gamestate/game_spec.h
+++ b/libopenage/gamestate/game_spec.h
@@ -63,7 +63,8 @@ public:
 	virtual ~GameSpec();
 
 	/**
-	 * begin the main loading job
+	 * perform the main loading job.
+	 * this loads all the data into the storage.
 	 */
 	bool initialize();
 
@@ -216,17 +217,33 @@ namespace openage {
 
 class GameSpecSignals;
 
+/**
+ * Game specification instanciated in QML.
+ * Linked to the "GameSpec" QML type.
+ */
 class GameSpecHandle {
 public:
 	explicit GameSpecHandle(qtsdl::GuiItemLink *gui_link);
 
+	/**
+	 * Control whether this specification can be loaded (=true)
+	 * or will not be loaded (=false).
+	 */
 	void set_active(bool active);
+
+	/**
+	 * invoked from qml when the asset_manager member is set.
+	 */
 	void set_asset_manager(AssetManager *asset_manager);
 
+	/**
+	 * Return if the specification was fully loaded.
+	 */
 	bool is_ready() const;
 
 	/**
-	 * forget everything
+	 * forget everything about the specification and
+	 * reload it with `start_loading_if_needed`.
 	 */
 	void invalidate();
 
@@ -235,17 +252,37 @@ public:
 	 */
 	void announce_spec();
 
+	/**
+	 * Return the contained game specification.
+	 */
 	std::shared_ptr<GameSpec> get_spec();
 
 private:
+	/**
+	 * load the game specification if not already present.
+	 */
 	void start_loading_if_needed();
+
+	/**
+	 * Actually dispatch the loading job to the job manager.
+	 */
 	void start_load_job();
 
+	/**
+	 * called from the job manager when the loading job finished.
+	 */
 	void on_loaded(job::result_function_t<bool> result);
 
+	/**
+	 * The real game specification.
+	 */
 	std::shared_ptr<GameSpec> spec;
 
+	/**
+	 * enables the loading of the game specification.
+	 */
 	bool active;
+
 	AssetManager *asset_manager;
 
 public:

--- a/libopenage/gamestate/game_spec.h
+++ b/libopenage/gamestate/game_spec.h
@@ -2,29 +2,31 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <memory>
-
-#include <QObject>
-
 #include "../job/job.h"
 #include "../gamedata/gamedata.gen.h"
 #include "../gamedata/graphic.gen.h"
 #include "../terrain/terrain.h"
 #include "../unit/unit_texture.h"
-#include "../util/timer.h"
+
+#include <unordered_map>
+#include <memory>
+#include <QObject>
+
 
 namespace openage {
 
 class AssetManager;
+class GameSpec;
 class UnitType;
 class UnitTypeMeta;
 class Player;
+
 
 /**
  * the key type mapped to data objects
  */
 using index_t = int;
+
 
 /**
  * could use unique ptr
@@ -32,16 +34,25 @@ using index_t = int;
 using unit_type_list = std::vector<std::shared_ptr<UnitType>>;
 using unit_meta_list = std::vector<std::shared_ptr<UnitTypeMeta>>;
 
+
 /**
  * simple sound object
  * TODO: move to assetmanager
  */
 class Sound {
 public:
+	Sound(GameSpec *spec, std::vector<int> &&sound_items)
+		:
+		sound_items{sound_items},
+		game_spec{spec} {}
+
 	void play() const;
 
 	std::vector<int> sound_items;
+
+	GameSpec *game_spec;
 };
+
 
 /**
  * GameSpec gives a collection of all game elements
@@ -59,7 +70,7 @@ public:
  */
 class GameSpec {
 public:
-	GameSpec(AssetManager &am);
+	GameSpec(AssetManager *am);
 	virtual ~GameSpec();
 
 	/**
@@ -126,6 +137,12 @@ public:
 	 * makes initial unit types for a particular civ id
 	 */
 	void create_unit_types(unit_meta_list &objects, int civ_id) const;
+
+	/**
+	 * Return the asset manager used for loading resources
+	 * of this game specification.
+	 */
+	AssetManager *get_asset_manager() const;
 
 private:
 	AssetManager *assetmanager;
@@ -204,7 +221,6 @@ private:
 	 */
 	bool gamedata_loaded;
 	void on_gamedata_loaded(std::vector<gamedata::empiresdat> &gamedata);
-	util::Timer load_timer;
 };
 
 } // openage
@@ -220,6 +236,8 @@ class GameSpecSignals;
 /**
  * Game specification instanciated in QML.
  * Linked to the "GameSpec" QML type.
+ *
+ * Wraps the "GameSpec" C++ class from above.
  */
 class GameSpecHandle {
 public:

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -2,7 +2,6 @@
 
 #include "../util/math_constants.h"
 #include "../unit/unit.h"
-#include "../engine.h"
 #include "../rng/rng.h"
 #include "../terrain/terrain_chunk.h"
 #include "game_main.h"
@@ -301,7 +300,7 @@ std::unique_ptr<GameMain> Generator::create(std::shared_ptr<GameSpec> spec) {
 		auto game = std::make_unique<GameMain>(*this);
 		gameio::load(game.get(), this->getv<std::string>("load_filename"));
 
-		return std::move(game);
+		return game;
 	} else {
 		// generation
 		this->create_regions();

--- a/libopenage/gamestate/generator.h
+++ b/libopenage/gamestate/generator.h
@@ -5,8 +5,6 @@
 #include <unordered_set>
 
 #include "../coord/tile.h"
-#include "../assetmanager.h"
-#include "../options.h"
 #include "../gui/guisys/public/gui_property_map.h"
 
 namespace qtsdl {
@@ -18,7 +16,6 @@ namespace openage {
 class GameSpec;
 class Terrain;
 class GameMain;
-class Engine;
 
 namespace rng {
 class RNG;
@@ -121,7 +118,6 @@ private:
 	 * tiles in this region
 	 */
 	tileset_t tiles;
-
 };
 
 
@@ -158,15 +154,22 @@ public:
 	 */
 	void add_units(GameMain &m) const;
 
+	/**
+	 * Create a game from a specification.
+	 */
 	std::unique_ptr<GameMain> create(std::shared_ptr<GameSpec> spec);
 
 private:
 	void create_regions();
 
-	// data version used to create a game
+	/**
+	 * data version used to create a game
+	 */
 	std::shared_ptr<GameSpec> spec;
 
-	// the generated data
+	/**
+	 * the generated data
+	 */
 	std::vector<Region> regions;
 
 public:

--- a/libopenage/gui/assetmanager_link.cpp
+++ b/libopenage/gui/assetmanager_link.cpp
@@ -4,7 +4,12 @@
 
 #include <QtQml>
 
+#include "engine_link.h"
+
 namespace openage {
+
+class Engine;
+
 namespace gui {
 
 namespace {
@@ -31,5 +36,18 @@ void AssetManagerLink::set_data_dir(const QString &data_dir) {
 	};
 	this->s(f, this->data_dir, data_dir);
 }
+
+
+EngineLink *AssetManagerLink::get_engine() const {
+	return this->engine;
+}
+
+void AssetManagerLink::set_engine(EngineLink *engine_link) {
+	static auto f = [] (AssetManager *_this, Engine *engine) {
+		_this->set_engine(engine);
+	};
+	this->s(f, this->engine, engine_link);
+}
+
 
 }} // namespace openage::gui

--- a/libopenage/gui/assetmanager_link.h
+++ b/libopenage/gui/assetmanager_link.h
@@ -9,6 +9,7 @@
 namespace openage {
 namespace gui {
 class AssetManagerLink;
+class EngineLink;
 }} // namespace openage::gui
 
 namespace qtsdl {
@@ -31,6 +32,7 @@ class AssetManagerLink : public qtsdl::GuiItemQObject, public qtsdl::GuiItem<Ass
 	Q_OBJECT
 
 	Q_PROPERTY(QString dataDir READ get_data_dir WRITE set_data_dir)
+	Q_PROPERTY(openage::gui::EngineLink *engine READ get_engine WRITE set_engine)
 
 public:
 	explicit AssetManagerLink(QObject *parent=nullptr);
@@ -39,8 +41,12 @@ public:
 	QString get_data_dir() const;
 	void set_data_dir(const QString &data_dir);
 
+	EngineLink *get_engine() const;
+	void set_engine(EngineLink *engine);
+
 private:
 	QString data_dir;
+	EngineLink *engine;
 };
 
 }} // namespace openage::gui

--- a/libopenage/gui/engine_link.cpp
+++ b/libopenage/gui/engine_link.cpp
@@ -87,8 +87,6 @@ void EngineLink::on_global_binds_changed(const std::vector<std::string>& global_
 		}
 	);
 
-	std::cout << "================= update global binds" << std::endl;
-
 	if (this->global_binds != new_global_binds) {
 		this->global_binds = new_global_binds;
 		emit this->global_binds_changed();

--- a/libopenage/gui/engine_link.h
+++ b/libopenage/gui/engine_link.h
@@ -34,7 +34,13 @@ namespace gui {
 class EngineLink : public qtsdl::GuiSingletonItem {
 	Q_OBJECT
 
-	Q_PROPERTY(QStringList globalBinds READ get_global_binds NOTIFY global_binds_changed)
+	/**
+	 * The text list of global key bindings.
+	 * displayed so one can see what keys are active.
+	 */
+	Q_PROPERTY(QStringList globalBinds
+	           READ get_global_binds
+	           NOTIFY global_binds_changed)
 
 public:
 	explicit EngineLink(QObject *parent, Engine *engine);

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -39,16 +39,27 @@ QStringList OutputModeLink::get_binds() const {
 	return this->binds;
 }
 
-void OutputModeLink::on_announced(const std::string &name, const std::vector<std::string>& binds) {
+void OutputModeLink::on_announced(const std::string &name) {
 	auto new_name = QString::fromStdString(name);
 
 	if (this->name != new_name) {
 		this->name = new_name;
 		emit this->name_changed();
 	}
+}
+
+void OutputModeLink::on_binds_changed(
+	const std::vector<std::string>& binds) {
 
 	QStringList new_binds;
-	std::transform(std::begin(binds), std::end(binds), std::back_inserter(new_binds), [] (const std::string &s) {return QString::fromStdString(s);});
+	std::transform(
+		std::begin(binds),
+		std::end(binds),
+		std::back_inserter(new_binds),
+		[] (const std::string &s) {
+			return QString::fromStdString(s);
+		}
+	);
 
 	if (this->binds != new_binds) {
 		this->binds = new_binds;
@@ -60,7 +71,15 @@ void OutputModeLink::classBegin() {
 }
 
 void OutputModeLink::on_core_adopted() {
-	QObject::connect(&unwrap(this)->gui_signals, &OutputModeSignals::announced, this, &OutputModeLink::on_announced);
+	QObject::connect(&unwrap(this)->gui_signals,
+	                 &OutputModeSignals::announced,
+	                 this,
+	                 &OutputModeLink::on_announced);
+
+	QObject::connect(&unwrap(this)->gui_signals,
+	                 &OutputModeSignals::binds_changed,
+	                 this,
+	                 &OutputModeLink::on_binds_changed);
 }
 
 void OutputModeLink::componentComplete() {

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -51,7 +51,8 @@ signals:
 	void binds_changed();
 
 private slots:
-	void on_announced(const std::string &name, const std::vector<std::string>& binds);
+	void on_announced(const std::string &name);
+	void on_binds_changed(const std::vector<std::string>& binds);
 
 protected:
 	virtual void classBegin() override;

--- a/libopenage/gui/guisys/link/gui_item.h
+++ b/libopenage/gui/guisys/link/gui_item.h
@@ -276,7 +276,15 @@ private:
 			qFatal("Error in QML code: GuiLiveReloader was asked to use same tag '%s' for multiple objects.", qUtf8Printable(tag));
 		} else {
 			if (typeid(decltype(*origin->holder)) != typeid(*holder)) {
-				qFatal("Error in QML code: GuiLiveReloader was asked to restore '%s' into different type '%s' using tag '%s'.", qUtf8Printable(tidier_name(typeid(decltype(*origin->holder)).name())), qUtf8Printable(tidier_name(typeid(*holder).name())), qUtf8Printable(tag));
+				qFatal(
+					"Error in QML code: GuiLiveReloader was asked "
+					"to restore '%s' into different type '%s' "
+					"using tag '%s'.",
+					qUtf8Printable(
+						tidier_name(typeid(decltype(*origin->holder)).name())),
+					qUtf8Printable(tidier_name(typeid(*holder).name())),
+					qUtf8Printable(tag)
+				);
 			} else {
 				origin->holder = checked_static_cast<decltype(origin->holder)>(holder);
 				origin->holder->adopt_shell(origin);

--- a/libopenage/gui/guisys/link/qml_engine_with_singleton_items_info.h
+++ b/libopenage/gui/guisys/link/qml_engine_with_singleton_items_info.h
@@ -12,6 +12,16 @@ namespace qtsdl {
 
 struct GuiSingletonItemsInfo;
 
+/**
+ * The Qml Engine used by openage.
+ *
+ * It's extended to contain the "singleton items info" and a list of image providers.
+ * The singleton item info is just a struct that allows to carry some variables
+ * in the qml-engine, namely the openage-engine.
+ *
+ * That way, the openage-engine and the qml-engine have a 1:1 relation and
+ * qml can access the main engine directly.
+ */
 class QmlEngineWithSingletonItemsInfo : public QQmlEngine {
 	Q_OBJECT
 

--- a/libopenage/gui/guisys/private/gui_renderer_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_renderer_impl.cpp
@@ -14,6 +14,7 @@
 #include "../public/gui_renderer.h"
 #include "platforms/context_extraction.h"
 
+
 namespace qtsdl {
 
 namespace {
@@ -89,11 +90,13 @@ GuiRendererImpl::GuiRendererImpl(SDL_Window *window)
 
 	std::tie(handle, id) = extract_native_context(window);
 
+	// pass the SDL opengl context so qt can use it
 	this->ctx = std::make_unique<QOpenGLContext>();
 	this->ctx->setNativeHandle(handle);
 	this->ctx->create();
 	assert(this->ctx->isValid());
 
+	// reuse the sdl window
 	QWindow *w = QWindow::fromWinId(id);
 	w->setSurfaceType(QSurface::OpenGLSurface);
 
@@ -146,6 +149,13 @@ void GuiRendererImpl::reinit_fbo_if_needed() {
 }
 
 GuiRendererImpl::~GuiRendererImpl() {
+	// TODO: MAYBE:
+	//       the this->ctx member frees the
+	//       gl context even though that's SDL's job.
+	//
+	// the qt doc says that a native context isn't destroyed!
+	// but somehow it is lost or destroyed!
+	// https://doc.qt.io/qt-5/qopenglcontext.html#setNativeHandle
 }
 
 GuiRendererImpl* GuiRendererImpl::impl(GuiRenderer *renderer) {

--- a/libopenage/gui/guisys/private/livereload/recursive_directory_watcher_worker.cpp
+++ b/libopenage/gui/guisys/private/livereload/recursive_directory_watcher_worker.cpp
@@ -55,7 +55,8 @@ void RecursiveDirectoryWatcherWorker::restartWatching() {
 
 void RecursiveDirectoryWatcherWorker::restart_watching(const QStringList &entries_to_watch) {
 	this->watcher.reset();
-	this->watcher = std::move(std::make_unique<QFileSystemWatcher>());
+	this->watcher = std::make_unique<QFileSystemWatcher>();
+
 	QObject::connect(&*this->watcher, &QFileSystemWatcher::directoryChanged, this, &RecursiveDirectoryWatcherWorker::onEntryChanged);
 
 	if (entries_to_watch.empty())

--- a/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
@@ -5,9 +5,8 @@
 #include "context_extraction.h"
 
 #include <QtPlatformHeaders/QGLXNativeContext>
-
-#include "SDL2/SDL_syswm.h"
-#include "GL/glx.h"
+#include <SDL2/SDL_syswm.h>
+#include <GL/glx.h>
 
 // DO NOT INCLUDE ANYTHING HERE, X11 HEADERS BREAK STUFF
 
@@ -19,6 +18,7 @@ std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
 	GLXContext current_context;
 	SDL_SysWMinfo wm_info;
 	SDL_VERSION(&wm_info.version);
+
 	if (SDL_GetWindowWMInfo(window, &wm_info)) {
 		assert(wm_info.info.x11.display);
 
@@ -26,7 +26,13 @@ std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
 		assert(current_context);
 	}
 
-	return std::make_tuple(QVariant::fromValue<QGLXNativeContext>(QGLXNativeContext(current_context, wm_info.info.x11.display, wm_info.info.x11.window)), wm_info.info.x11.window);
+	return std::make_tuple(
+		QVariant::fromValue<QGLXNativeContext>(
+			QGLXNativeContext(current_context,
+			                  wm_info.info.x11.display,
+			                  wm_info.info.x11.window)),
+		wm_info.info.x11.window
+	);
 }
 
 } // namespace qtsdl

--- a/libopenage/gui/qml/main.qml
+++ b/libopenage/gui/qml/main.qml
@@ -44,6 +44,8 @@ Item {
 
 		dataDir: MainArgs.dataDir
 
+		engine: Engine
+
 		LR.tag: "am"
 	}
 

--- a/libopenage/gui_basic.h
+++ b/libopenage/gui_basic.h
@@ -44,7 +44,6 @@ private:
 	virtual bool on_input(SDL_Event *event) override;
 	virtual bool on_drawhud() override;
 
-	std::unique_ptr<shader::Program> textured_screen_quad_shader;
 	GLint tex_loc;
 	GLuint screen_quad_vbo;
 
@@ -58,6 +57,11 @@ private:
 	qtsdl::GuiEngine engine;
 	qtsdl::GuiSubtree subtree;
 	qtsdl::GuiInput input;
+
+	// needs to be deallocated before the GuiRenderer
+	// it accesses opengl api functions which require a
+	// current context:
+	std::unique_ptr<shader::Program> textured_screen_quad_shader;
 };
 
 }} // namespace openage::gui

--- a/libopenage/input/action.h
+++ b/libopenage/input/action.h
@@ -12,11 +12,25 @@ namespace openage {
 
 class Engine;
 
+namespace cvar {
+class CVarManager;
+} // cvar
+
 namespace input {
 
+class InputManager;
+
+/**
+ * Used to identify actions.
+ */
 using action_t = unsigned int;
 
+
+/**
+ * Mapping type from action name to action id.
+ */
 using action_map_t = std::unordered_map<std::string, action_t>;
+
 
 /**
  * The action manager manages all the actions allow creation, access
@@ -24,7 +38,8 @@ using action_map_t = std::unordered_map<std::string, action_t>;
  */
 class ActionManager {
 public:
-	ActionManager(Engine *engine);
+	ActionManager(InputManager *input_manager,
+	              cvar::CVarManager *cvar_manager);
 	bool create(const std::string type);
 	action_t get(const std::string &type);
 	std::string get_name(const action_t action);
@@ -114,8 +129,11 @@ private :
 	};
 
 	action_map_t actions;
-	Engine *engine;
+
+	InputManager *input_manager;
+	cvar::CVarManager *cvar_manager;
 };
+
 
 // TODO: use action_hint_t = std::pair<action_t, int>
 // for example a building command
@@ -140,14 +158,16 @@ struct action_arg_t {
 	std::vector<action_id_t> hints;
 };
 
+
 /**
- * complete the effect of an action
+ * Performs the effect of an action.
  */
 using action_func_t = std::function<void(const action_arg_t &)>;
 
+
 /**
- * for receivers of sets of events a bool is returned
- * to indicate if the event was used
+ * For receivers of sets of events a bool is returned
+ * to indicate if the event was used.
  */
 using action_check_t = std::function<bool(const action_arg_t &)>;
 

--- a/libopenage/input/event.h
+++ b/libopenage/input/event.h
@@ -68,7 +68,7 @@ enum class modifier {
 
 
 struct modifier_hash {
-	int operator()(const modifier &s) const;
+	int operator ()(const modifier &s) const;
 };
 
 
@@ -101,12 +101,14 @@ bool operator ==(ClassCode a, ClassCode b);
 
 
 struct class_code_hash {
-	int operator()(const ClassCode &k) const;
+	int operator ()(const ClassCode &k) const;
 };
 
 
 /**
- * event with a mod
+ * Input event, as triggered by some input device like
+ * mouse, kezb, joystick, tablet, microwave or dildo.
+ * Some modifier keys may also be pressed during the event.
  */
 class Event {
 public:

--- a/libopenage/input/input_context.cpp
+++ b/libopenage/input/input_context.cpp
@@ -52,23 +52,36 @@ InputContext::InputContext()
 	:
 	utf8_mode{false} {}
 
+
 std::vector<std::string> InputContext::active_binds() const {
-	Engine &engine = Engine::get();
-	InputManager &input_manager = engine.get_input_manager();
-	ActionManager &action_manager = engine.get_action_manager();
+	// TODO: this function doesn't belong here.
+	//       go give it a new home in another file.
 
 	std::vector<std::string> result;
 
-	for (auto &action : this->by_type) {
-		std::string action_type_str = action_manager.get_name(action.first);
+	if (this->input_manager == nullptr) {
+		return result;
+	}
 
+	// this is only possible if the action is registered,
+	// then this->input_manager != nullptr.
+	ActionManager &action_manager = this->input_manager->get_engine()->get_action_manager();
+
+	for (auto &action : this->by_type) {
 		std::string keyboard_key;
-		for (auto &key : input_manager.keys) {
+
+		for (auto &key : this->input_manager->keys) {
+			// TODO: this is the wrong check.
+			//       the input manager should have a function
+			//       which returns a list of binds when feeding
+			//       in the InputContext.
 			if (key.first == action.first) {
 				keyboard_key = event_as_string(key.second);
 				break;
 			}
 		}
+
+		std::string action_type_str = action_manager.get_name(action.first);
 
 		result.push_back(keyboard_key + " : " + action_type_str);
 	}
@@ -117,6 +130,17 @@ bool InputContext::execute_if_bound(const action_arg_t &arg) {
 
 	return false;
 }
+
+
+void InputContext::register_to(InputManager *manager) {
+	this->input_manager = manager;
+}
+
+
+void InputContext::unregister() {
+	this->input_manager = nullptr;
+}
+
 
 
 }} // openage::input

--- a/libopenage/input/input_context.cpp
+++ b/libopenage/input/input_context.cpp
@@ -1,92 +1,34 @@
 // Copyright 2015-2016 the openage authors. See copying.md for legal info.
 
-#include <sstream>
 #include "input_context.h"
-#include "../engine.h"
+
+#include "input_manager.h"
+
 
 namespace openage {
 namespace input {
 
-namespace {
-
-std::string mod_set_string(modset_t mod) {
-	if (mod.empty()) {
-		return "";
-	} else {
-		std::stringstream ss;
-		for (auto it = mod.begin(); it != mod.end(); it++) {
-				switch(*it) {
-					case modifier::ALT:
-						ss << "ALT + ";
-						break;
-					case modifier::CTRL:
-						ss << "CTRL + ";
-						break;
-					case modifier::SHIFT:
-						ss << "SHIFT + ";
-						break;
-				}
-		}
-		return ss.str();
-	}
-}
-
-std::string event_as_string(const Event& event) {
-	if (!event.as_utf8().empty()) {
-		return mod_set_string(event.mod) + event.as_utf8();
-	} else {
-		if (event.cc.eclass == event_class::MOUSE_WHEEL) {
-			if(event.cc.code == -1) {
-				return mod_set_string(event.mod) + "Wheel down";
-			} else {
-				return mod_set_string(event.mod) + "Wheel up";
-			}
-		}
-		return mod_set_string(event.mod) + SDL_GetKeyName(event.cc.code);
-	}
-}
-
-} // anonymous ns
 
 InputContext::InputContext()
 	:
-	utf8_mode{false} {}
+	InputContext{nullptr} {}
+
+
+InputContext::InputContext(InputManager *manager)
+	:
+	utf8_mode{false} {
+
+	this->register_to(manager);
+}
 
 
 std::vector<std::string> InputContext::active_binds() const {
-	// TODO: this function doesn't belong here.
-	//       go give it a new home in another file.
-
-	std::vector<std::string> result;
-
 	if (this->input_manager == nullptr) {
-		return result;
+		return {};
 	}
 
-	// this is only possible if the action is registered,
-	// then this->input_manager != nullptr.
-	ActionManager &action_manager = this->input_manager->get_engine()->get_action_manager();
-
-	for (auto &action : this->by_type) {
-		std::string keyboard_key;
-
-		for (auto &key : this->input_manager->keys) {
-			// TODO: this is the wrong check.
-			//       the input manager should have a function
-			//       which returns a list of binds when feeding
-			//       in the InputContext.
-			if (key.first == action.first) {
-				keyboard_key = event_as_string(key.second);
-				break;
-			}
-		}
-
-		std::string action_type_str = action_manager.get_name(action.first);
-
-		result.push_back(keyboard_key + " : " + action_type_str);
-	}
-
-	return result;
+	// TODO: try to purge this backpointer to the input manager.
+	return this->input_manager->active_binds(this->by_type);
 }
 
 void InputContext::bind(action_t type, const action_func_t act) {

--- a/libopenage/input/input_context.h
+++ b/libopenage/input/input_context.h
@@ -13,6 +13,9 @@
 namespace openage {
 namespace input {
 
+class InputManager;
+
+
 /**
  * An input context contains all keybindings and actions
  * active in e.g. the HUD only.
@@ -27,7 +30,10 @@ public:
 	InputContext();
 
 	/**
-	 * a list of all keys which are bound in the current context
+	 * a list of all keys of this context
+	 * which are bound currently in the active context.
+	 *
+	 * TODO: move this method to the input manager.
 	 */
 	std::vector<std::string> active_binds() const;
 
@@ -55,6 +61,17 @@ public:
 	 */
 	bool execute_if_bound(const action_arg_t &e);
 
+	/**
+	 * Called by the InputManager where this context
+	 * shall be registered to.
+	 */
+	void register_to(InputManager *manager);
+
+	/**
+	 * Remove the registration to an input manager.
+	 */
+	void unregister();
+
 
 	/**
 	 * Affects which keyboard events are received:
@@ -64,6 +81,11 @@ public:
 	bool utf8_mode;
 
 private:
+
+	/**
+	 * Input manager this context is bound to.
+	 */
+	InputManager *input_manager;
 
 	/**
 	 * map specific hints

--- a/libopenage/input/input_context.h
+++ b/libopenage/input/input_context.h
@@ -27,7 +27,15 @@ class InputManager;
 class InputContext {
 
 public:
+	/**
+	 * Create an unbound input manager.
+	 */
 	InputContext();
+
+	/**
+	 *
+	 */
+	InputContext(InputManager *manager);
 
 	/**
 	 * a list of all keys of this context
@@ -88,7 +96,7 @@ private:
 	InputManager *input_manager;
 
 	/**
-	 * map specific hints
+	 * Maps an action id to a event execution function.
 	 */
 	std::unordered_map<action_t, action_func_t> by_type;
 

--- a/libopenage/input/input_context.h
+++ b/libopenage/input/input_context.h
@@ -28,12 +28,12 @@ class InputContext {
 
 public:
 	/**
-	 * Create an unbound input manager.
+	 * Create an unbound input context.
 	 */
 	InputContext();
 
 	/**
-	 *
+	 * Create a bound context, assigned to its manager.
 	 */
 	InputContext(InputManager *manager);
 
@@ -42,6 +42,7 @@ public:
 	 * which are bound currently in the active context.
 	 *
 	 * TODO: move this method to the input manager.
+	 *       as InputManager::active_binds(const InputContext &) const;
 	 */
 	std::vector<std::string> active_binds() const;
 

--- a/libopenage/input/input_manager.cpp
+++ b/libopenage/input/input_manager.cpp
@@ -8,15 +8,18 @@
 #include "input_manager.h"
 #include "text_to_event.h"
 
+
 namespace openage {
 namespace input {
 
-InputManager::InputManager()
-	: relative_mode{false} {
-}
+InputManager::InputManager(Engine *engine)
+	:
+	engine{engine},
+	relative_mode{false} {}
+
 
 std::string InputManager::get_bind(const std::string &action_str) {
-	ActionManager &action_manager = Engine::get().get_action_manager();
+	ActionManager &action_manager = this->engine->get_action_manager();
 
 	action_t action = action_manager.get(action_str);
 	if (action_manager.is("UNDEFINED",action)) {
@@ -41,7 +44,7 @@ std::string InputManager::get_bind(const std::string &action_str) {
 
 bool InputManager::set_bind(const std::string &bind_str, const std::string action_str) {
 	try {
-		ActionManager &action_manager = Engine::get().get_action_manager();
+		ActionManager &action_manager = this->engine->get_action_manager();
 
 		action_t action = action_manager.get(action_str);
 		if (action_manager.is("UNDEFINED",action)) {
@@ -109,6 +112,8 @@ InputContext &InputManager::get_top_context() {
 void InputManager::register_context(InputContext *context) {
 	// Create a context list if none exist
 	this->contexts.push_back(context);
+
+	context->register_to(this);
 }
 
 
@@ -120,6 +125,7 @@ void InputManager::remove_context(InputContext *context) {
 	for (auto it = this->contexts.begin(); it != this->contexts.end(); ++it) {
 		if ((*it) == context) {
 			this->contexts.erase(it);
+			context->unregister();
 			return;
 		}
 	}
@@ -304,6 +310,11 @@ bool InputManager::on_input(SDL_Event *e) {
 	} // switch (e->type)
 
 	return true;
+}
+
+
+Engine *InputManager::get_engine() const {
+	return this->engine;
 }
 
 

--- a/libopenage/input/input_manager.h
+++ b/libopenage/input/input_manager.h
@@ -16,8 +16,6 @@
 
 namespace openage {
 
-class Engine;
-
 
 /**
  * The openage input layer.
@@ -25,6 +23,9 @@ class Engine;
  */
 namespace input {
 
+/**
+ * maps actions to events.
+ */
 using binding_map_t = std::unordered_map<action_t, Event>;
 
 
@@ -38,10 +39,10 @@ using binding_map_t = std::unordered_map<action_t, Event>;
  *     bool set_bind(char* bind_char, string action) except +
  *     string get_bind(string action) except +
  */
-class InputManager : public openage::InputHandler {
+class InputManager : public InputHandler {
 
 public:
-	InputManager(Engine *engine);
+	InputManager(ActionManager *action_manager);
 
 	/**
 	 * Return the string representation of the bind assignated to an action.
@@ -93,7 +94,7 @@ public:
 	 * if other contexts are registered afterwards,
 	 * it wanders down the stack, i.e. looses priority.
 	 */
-	void register_context(InputContext *context);
+	void push_context(InputContext *context);
 
 	/**
 	 * removes any matching registered context from the stack.
@@ -166,25 +167,31 @@ public:
 	bool on_input(SDL_Event *e) override;
 
 	/**
-	 * Return the engine where this input manager is bound to.
+	 * Return a string representation of active key bindings
+	 * from the given context.
 	 */
-	Engine *get_engine() const;
+	std::vector<std::string> active_binds(const std::unordered_map<action_t, action_func_t> &ctx_actions) const;
+
+	/**
+	 * Get the action manager attached to this input manager.
+	 */
+	ActionManager *get_action_manager() const;
 
 private:
 	modset_t get_mod() const;
 
 	/**
-	 * Engine where this input manager belongs to.
+	 * The action manager to used for keybind action lookups.
 	 */
-	Engine *engine;
+	ActionManager *action_manager;
 
 	/**
 	 * The global context. Used as fallback.
 	 */
-	InputContext global_hotkeys;
+	InputContext global_context;
 
 	/**
-	 * maps actions to events.
+	 * Maps actions to events.
 	 */
 	binding_map_t keys;
 

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -11,28 +11,38 @@
 #include "game_renderer.h"
 #include "gamestate/generator.h"
 
+#include "shader/shader.h"
+#include "shader/program.h"
+
 namespace openage {
 
 
 int run_game(const main_arguments &args) {
-	log::log(MSG(info) << "launching engine with data directory '" << args.data_directory << "' and fps limit " << args.fps_limit);
+	log::log(MSG(info) << "launching engine with data directory '"
+	                   << args.data_directory
+	                   << "' and fps limit "
+	                   << args.fps_limit);
 
 	util::Timer timer;
 	timer.start();
 
 	util::Dir data_dir{args.data_directory.c_str()};
 
-	Engine::create(&data_dir, args.fps_limit, args.gl_debug, "openage");
-	Engine &engine = Engine::get();
-	engine.get_cvar_manager().load_main_config();
+	Engine engine{&data_dir, args.fps_limit, args.gl_debug, "openage"};
+
+	// read and apply the configuration files
+	auto &cvar_manager = engine.get_cvar_manager();
+	cvar_manager.load_main_config();
 
 	// initialize terminal colors
 	std::vector<gamedata::palette_color> termcolors;
 	util::read_csv_file(data_dir.join("converted/termcolors.docx"), termcolors);
 
-	console::Console console;
+	// TODO: move inside the engine
+	// TODO: support multiple consoles
+	console::Console console{&engine};
 	console.load_colors(termcolors);
-	console.register_to_engine(&engine);
+	console.register_to_engine();
 
 	log::log(MSG(info).fmt("Loading time [engine]: %5.3f s", timer.getval() / 1.0e9));
 
@@ -47,8 +57,6 @@ int run_game(const main_arguments &args) {
 		// run main loop
 		engine.run();
 	}
-
-	Engine::destroy();
 
 	return 0;
 }

--- a/libopenage/pyinterface/pyobject.h
+++ b/libopenage/pyinterface/pyobject.h
@@ -273,9 +273,9 @@ PyObjectRef none();
 } // py
 
 
-// installed by openage.pyinterface.pyobject.setup().
+// installed by openage.cppinterface.pyobject.setup().
 // now follow the various Python callbacks that implement all of the above,
-// and need to be installed by openage.pyinterface.pyobject.setup().
+// and need to be installed by openage.cppinterface.pyobject.setup().
 
 // for use by the reference-counting constructors
 

--- a/libopenage/renderer/text.h
+++ b/libopenage/renderer/text.h
@@ -23,6 +23,9 @@ namespace renderer {
 class TextRenderer {
 
 public:
+	/**
+	 * Requires a working OpenGL context to create buffer objects.
+	 */
 	TextRenderer();
 
 	virtual ~TextRenderer();

--- a/libopenage/terrain/terrain.cpp
+++ b/libopenage/terrain/terrain.cpp
@@ -296,10 +296,11 @@ void Terrain::draw(Engine *engine, RenderOptions *settings) {
 	coord::window wtl, wtr, wbl, wbr;
 
 	// query the window coordinates from the engine first
-	wtl = coord::window{                    0,                     0};
-	wtr = coord::window{engine->engine_coord_data->window_size.x,                     0};
-	wbl = coord::window{                    0, engine->engine_coord_data->window_size.y};
-	wbr = coord::window{engine->engine_coord_data->window_size.x, engine->engine_coord_data->window_size.y};
+	wtl = coord::window{0, 0};
+	wtr = coord::window{engine->get_coord_data()->window_size.x, 0};
+	wbl = coord::window{0, engine->get_coord_data()->window_size.y};
+	wbr = coord::window{engine->get_coord_data()->window_size.x,
+	                    engine->get_coord_data()->window_size.y};
 
 	// then convert them to tile coordinates.
 	tl = wtl.to_camgame().to_phys3(0).to_phys2().to_tile();

--- a/libopenage/texture.cpp
+++ b/libopenage/texture.cpp
@@ -109,8 +109,6 @@ void Texture::load() {
 		strncpy(meta_filename, filename.c_str(), m_len - 5);
 		strncpy(meta_filename + m_len - 5, "docx", 5);
 
-		log::log(MSG(info) << "Loading meta file: " << meta_filename);
-
 		// get subtexture information by meta file exported by script
 		util::read_csv_file(meta_filename, this->subtextures);
 

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -471,7 +471,6 @@ TerrainObject *LivingProducer::place(Unit *unit, std::shared_ptr<Terrain> terrai
 BuildingProducer::BuildingProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_building *ud)
 	:
 	UnitType(owner),
-	dataspec(spec),
 	unit_data{*ud},
 	texture{spec.get_unit_texture(ud->graphic_standing0)},
 	destroyed{spec.get_unit_texture(ud->graphic_dying0)},

--- a/libopenage/unit/producer.h
+++ b/libopenage/unit/producer.h
@@ -108,7 +108,9 @@ private:
  */
 class BuildingProducer: public UnitType {
 public:
-	BuildingProducer(const Player &owner, const GameSpec &spec, const gamedata::unit_building *ud);
+	BuildingProducer(const Player &owner,
+	                 const GameSpec &spec,
+	                 const gamedata::unit_building *ud);
 	virtual ~BuildingProducer();
 
 	int id() const override;
@@ -118,7 +120,6 @@ public:
 	TerrainObject *place(Unit *, std::shared_ptr<Terrain>, coord::phys3) const override;
 
 private:
-	const GameSpec &dataspec;
 	const gamedata::unit_building unit_data;
 
 	/**

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -15,11 +15,12 @@
 
 namespace openage {
 
-UnitSelection::UnitSelection()
+UnitSelection::UnitSelection(Engine *engine)
 	:
 	selection_type{selection_type_t::nothing},
 	drag_active{false},
-	font_size{12} {
+	font_size{12},
+	engine{engine} {
 }
 
 bool UnitSelection::on_drawhud() {
@@ -296,12 +297,11 @@ void UnitSelection::show_attributes(Unit *u) {
 	}
 
 	// render text
-	Engine &engine = Engine::get();
 	int vpos = 160;
-	engine.render_text({0, vpos}, 20, "%s", u->unit_type->name().c_str());
+	this->engine->render_text({0, vpos}, 20, "%s", u->unit_type->name().c_str());
 	for (auto &s : lines) {
 		vpos -= this->font_size;
-		engine.render_text({0, vpos}, this->font_size, "%s", s.c_str());
+		engine->render_text({0, vpos}, this->font_size, "%s", s.c_str());
 	}
 }
 

--- a/libopenage/unit/selection.h
+++ b/libopenage/unit/selection.h
@@ -11,6 +11,7 @@
 
 namespace openage {
 
+class Engine;
 class Terrain;
 
 std::vector<coord::tile> tiles_in_range(coord::camgame p1, coord::camgame p2);
@@ -36,7 +37,7 @@ enum class selection_type_t {
  */
 class UnitSelection: public HudHandler {
 public:
-	UnitSelection();
+	UnitSelection(Engine *engine);
 
 	bool on_drawhud() override;
 	void drag_begin(coord::camgame pos);
@@ -104,6 +105,11 @@ private:
 	bool drag_active;
 	coord::camgame start, end;
 	int font_size;
+
+	/**
+	 * Engine where this selection is attached to.
+	 */
+	Engine *engine;
 };
 
 } // namespace openage

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -16,7 +16,7 @@
 
 namespace openage {
 
-Unit::Unit(UnitContainer &c, id_t id)
+Unit::Unit(UnitContainer *c, id_t id)
 	:
 	id{id},
 	unit_type{nullptr},
@@ -74,7 +74,7 @@ UnitAction *Unit::before(const UnitAction *action) const {
 	return nullptr;
 }
 
-bool Unit::update() {
+bool Unit::update(time_nsec_t lastframe_duration) {
 
 	// if unit is not on the map then do nothing
 	if (!this->location) {
@@ -92,11 +92,12 @@ bool Unit::update() {
 	 * the active action is on top
 	 */
 	if (this->has_action()) {
-		Engine &engine = Engine::get();
+		// TODO: change the entire unit action timing
+		//       to a higher resolution like nsecs or usecs.
 
-		// TODO: change the entire unit action timing to a higher resolution like
-		// nsecs or usecs.
-		auto time_elapsed = engine.lastframe_duration_nsec() / 1e6;
+		// time as float, in milliseconds.
+		auto time_elapsed = lastframe_duration / 1e6;
+
 		this->top()->update(time_elapsed);
 
 		// the top primary action specifies whether
@@ -291,16 +292,11 @@ void Unit::stop_actions() {
 }
 
 UnitReference Unit::get_ref() {
-	return UnitReference(&container, id, this);
+	return UnitReference(this->container, id, this);
 }
 
 UnitContainer *Unit::get_container() const {
-	return &container;
-}
-
-std::vector<UnitAction *> Unit::current_actions() const {
-	std::vector<UnitAction *> result;
-	return result;
+	return this->container;
 }
 
 std::string Unit::logsource_name() {

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -12,6 +12,7 @@
 #include "../coord/phys3.h"
 #include "../terrain/terrain_object.h"
 #include "../handlers.h"
+#include "../util/timing.h"
 #include "ability.h"
 #include "attribute.h"
 #include "command.h"
@@ -32,7 +33,7 @@ class UnitAction;
  */
 class Unit : public log::LogSource {
 public:
-	Unit(UnitContainer &c, id_t id);
+	Unit(UnitContainer *c, id_t id);
 
 	/**
 	 * unit cleanup will delete terrain object
@@ -120,7 +121,7 @@ public:
 	/**
 	 * update this object using the action currently on top of the stack
 	 */
-	bool update();
+	bool update(time_nsec_t lastframe_duration);
 
 	/**
 	 * draws this action by taking the graphic type of the top action
@@ -225,11 +226,6 @@ public:
 	UnitContainer *get_container() const;
 
 	/**
-	 *
-	 */
-	std::vector<UnitAction *> current_actions() const;
-
-	/**
 	 * Returns the unit's name as the LogSource name.
 	 */
 	std::string logsource_name() override;
@@ -281,7 +277,7 @@ private:
 	/**
 	 * the container that updates this unit
 	 */
-	UnitContainer &container;
+	UnitContainer *container;
 
 	/**
 	 * applies new commands as part of the units update process

--- a/libopenage/unit/unit_container.cpp
+++ b/libopenage/unit/unit_container.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 the openage authors. See copying.md for legal info.
+// Copyright 2014-2016 the openage authors. See copying.md for legal info.
 
 #include <memory>
 

--- a/libopenage/unit/unit_container.h
+++ b/libopenage/unit/unit_container.h
@@ -7,6 +7,8 @@
 
 #include "../coord/tile.h"
 #include "../handlers.h"
+#include "../util/timing.h"
+
 
 namespace openage {
 
@@ -18,7 +20,12 @@ class Unit;
 class UnitContainer;
 class UnitType;
 
+
+/**
+ * Type used to identify each single unit in the game.
+ */
 using id_t = unsigned long int;
+
 
 /**
  * immutable reference data
@@ -58,7 +65,6 @@ private:
 	 * will just copy the shared pointer
 	 */
 	std::shared_ptr<reference_data> data;
-
 };
 
 /**
@@ -114,10 +120,10 @@ public:
 	bool dispatch_command(id_t to_id, const Command &cmd);
 
 	/**
-	 * update dispatched by the game engine
-	 * this will update all game objects
+	 * update dispatched by the game engine on each physics tick.
+	 * this will update all game objects.
 	 */
-	bool update_all();
+	bool update_all(time_nsec_t lastframe_duration);
 
 	/**
 	 * gets a list of all units in the container
@@ -136,7 +142,6 @@ private:
 	 * Terrain for initialising new units
 	 */
 	std::weak_ptr<Terrain> terrain;
-
 };
 
 } // namespace openage

--- a/libopenage/util/fps.cpp
+++ b/libopenage/util/fps.cpp
@@ -19,8 +19,6 @@ FrameCounter::FrameCounter()
 	frame_timer{false} {
 }
 
-FrameCounter::~FrameCounter() {}
-
 
 void FrameCounter::frame() {
 	this->nsec_lastframe = this->frame_timer.getandresetval();

--- a/libopenage/util/fps.h
+++ b/libopenage/util/fps.h
@@ -10,7 +10,7 @@ namespace util {
 class FrameCounter {
 public:
 	FrameCounter();
-	~FrameCounter();
+	~FrameCounter() = default;
 
 	/** to be called each time a frame has been completed */
 	void frame();
@@ -19,10 +19,10 @@ public:
 	float fps;
 
 	/** contains the number of completed frames */
-	unsigned count;
+	uint64_t count;
 
 	/** nanoseconds used for the last frame */
-	int64_t nsec_lastframe;
+	time_nsec_t nsec_lastframe;
 
 private:
 	float frame_count_weighted;

--- a/libopenage/util/profiler.cpp
+++ b/libopenage/util/profiler.cpp
@@ -11,6 +11,11 @@
 namespace openage {
 namespace util {
 
+Profiler::Profiler(Engine *engine)
+	:
+	engine{engine} {}
+
+
 Profiler::~Profiler() {
 	this->unregister_all();
 }
@@ -168,7 +173,7 @@ void Profiler::draw_legend() {
 		coord::window position = coord::window();
 		position.x = box_x + PROFILER_COM_BOX_WIDTH + 2;
 		position.y = box_y + 2;
-		Engine::get().render_text(position, 12, "%s", com.second.display_name.c_str());
+		this->engine->render_text(position, 12, "%s", com.second.display_name.c_str());
 
 		offset += PROFILER_COM_BOX_HEIGHT + 2;
 	}
@@ -189,8 +194,7 @@ void Profiler::append_to_history(std::string com, double percentage) {
 }
 
 bool Profiler::engine_in_debug_mode() {
-	Engine &engine = Engine::get();
-	if (engine.drawing_debug_overlay.value) {
+	if (this->engine->drawing_debug_overlay.value) {
 		return true;
 	} else {
 		return false;

--- a/libopenage/util/profiler.h
+++ b/libopenage/util/profiler.h
@@ -18,6 +18,10 @@ constexpr int PROFILER_COM_BOX_WIDTH = 30;
 constexpr int PROFILER_COM_BOX_HEIGHT = 15;
 
 namespace openage {
+
+class Engine;
+
+
 namespace util {
 
 struct color {
@@ -34,7 +38,7 @@ struct component_time_data {
 
 class Profiler {
 public:
-	Profiler() = default;
+	Profiler(Engine *engine);
 	~Profiler();
 
 	/**
@@ -107,17 +111,19 @@ public:
 	void end_frame_measure();
 
 private:
-	std::chrono::high_resolution_clock::time_point frame_start;
-	std::chrono::high_resolution_clock::duration frame_duration;
-	std::unordered_map<std::string, component_time_data> components;
-	int insert_pos = 0;
-
 	void draw_canvas();
 	void draw_legend();
 	void draw_component_performance(std::string com);
 	double duration_to_percentage(std::chrono::high_resolution_clock::duration duration);
 	void append_to_history(std::string com, double percentage);
 	bool engine_in_debug_mode();
+
+	std::chrono::high_resolution_clock::time_point frame_start;
+	std::chrono::high_resolution_clock::duration frame_duration;
+	std::unordered_map<std::string, component_time_data> components;
+	int insert_pos = 0;
+
+	Engine *engine;
 };
 
 }} // openage::util

--- a/libopenage/util/timer.cpp
+++ b/libopenage/util/timer.cpp
@@ -2,62 +2,64 @@
 
 #include "timer.h"
 
-#include "../util/timing.h"
+#include "timing.h"
 
 namespace openage {
 namespace util {
 
 Timer::Timer(bool stopped) {
-	reset(stopped);
+	this->reset(stopped);
 }
 
 void Timer::reset(bool stopped) {
 	this->stopped = stopped;
-	if(stopped) {
-		stoppedat = 0;
+	if (this->stopped) {
+		this->stoppedat = 0;
 	} else {
-		starttime = timing::get_monotonic_time();
+		this->starttime = timing::get_monotonic_time();
 	}
 }
 
 void Timer::stop() {
-	if(!stopped) {
-		stopped = true;
-		stoppedat = timing::get_monotonic_time() - starttime;
+	if (not stopped) {
+		this->stopped = true;
+		this->stoppedat = timing::get_monotonic_time() - this->starttime;
 	}
 }
 
 void Timer::start() {
-	if(stopped) {
-		stopped = false;
-		starttime = timing::get_monotonic_time() - stoppedat;
+	if (not this->stopped) {
+		this->stopped = false;
+		this->starttime = timing::get_monotonic_time() - this->stoppedat;
 	}
 }
 
-int64_t Timer::getval() const {
-	if(stopped) {
-		return stoppedat;
+time_nsec_t Timer::getval() const {
+	if (this->stopped) {
+		return this->stoppedat;
 	} else {
-		return timing::get_monotonic_time() - starttime;
+		return timing::get_monotonic_time() - this->starttime;
 	}
 }
 
-int64_t Timer::getandresetval() {
-	int64_t result;
-	if(stopped) {
-		result = stoppedat;
-		stoppedat = 0;
-	} else {
-		int64_t now = timing::get_monotonic_time();
-		result = now - starttime;
-		starttime = now;
+time_nsec_t Timer::getandresetval() {
+	time_nsec_t result;
+
+	if (this->stopped) {
+		result    = this->stoppedat;
+		this->stoppedat = 0;
+	}
+	else {
+		time_nsec_t now = timing::get_monotonic_time();
+		result = now - this->starttime;
+		this->starttime = now;
 	}
 
 	return result;
 }
 
 bool Timer::isstopped() const {
-	return stopped;
+	return this->stopped;
 }
 
-}} // openage::util
+}}  // openage::util

--- a/libopenage/util/timer.h
+++ b/libopenage/util/timer.h
@@ -2,7 +2,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+
+#include "timing.h"
+
 
 namespace openage {
 namespace util {
@@ -16,24 +19,24 @@ class Timer {
 		/**
 		 * while paused, stores the current timer value
 		 */
-		int64_t stoppedat;
+		time_nsec_t stoppedat;
 
 		/**
 		 * while running, stores the time the timer is counting from
 		 */
-		int64_t starttime;
+		time_nsec_t starttime;
 	};
 
 public:
 	/**
 	 * creates the timer, in either stopped or running state.
 	 */
-	Timer(bool stopped = true);
+	Timer(bool stopped=true);
 
 	/**
 	 * resets the timer, in either stopped or running state.
 	 */
-	void reset(bool stopped = true);
+	void reset(bool stopped=true);
 
 	/**
 	 * stops/pauses the timer.
@@ -48,13 +51,13 @@ public:
 	/**
 	 * reads the current timer value, in nanoseconds.
 	 */
-	int64_t getval() const;
+	time_nsec_t getval() const;
 
 	/**
 	 * reads the current timer value, in nanoseconds,
 	 * and resets the timer to zero (preserving started/stopped state).
 	 */
-	int64_t getandresetval();
+	time_nsec_t getandresetval();
 
 	/**
 	 * returns whether the timer is currently running.

--- a/libopenage/util/timing.cpp
+++ b/libopenage/util/timing.cpp
@@ -10,18 +10,18 @@
 namespace openage {
 namespace timing {
 
-int64_t get_real_time() {
-    std::chrono::system_clock::time_point t;
-    t = std::chrono::system_clock::now();
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
-    return (int64_t) ns;
+time_nsec_t get_real_time() {
+	std::chrono::system_clock::time_point t;
+	t = std::chrono::system_clock::now();
+	auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
+	return static_cast<time_nsec_t>(ns);
 }
 
-int64_t get_monotonic_time() {
-    std::chrono::steady_clock::time_point t;
-    t = std::chrono::steady_clock::now();
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
-    return (int64_t) ns;
+time_nsec_t get_monotonic_time() {
+	std::chrono::steady_clock::time_point t;
+	t = std::chrono::steady_clock::now();
+	auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count();
+	return static_cast<time_nsec_t>(ns);
 }
 
 }} // namespace openage::timing

--- a/libopenage/util/timing.h
+++ b/libopenage/util/timing.h
@@ -5,6 +5,13 @@
 #include <cstdint>
 
 namespace openage {
+
+/**
+ * Type to store time in nanoseconds.
+ */
+using time_nsec_t = uint64_t;
+
+
 namespace timing {
 
 /**
@@ -13,11 +20,11 @@ namespace timing {
  *
  * not influenced by system time changes.
  */
-int64_t get_monotonic_time();
+time_nsec_t get_monotonic_time();
 
 /**
  * returns the number of nanoseconds since the UNIX epoch.
  */
-int64_t get_real_time();
+time_nsec_t get_real_time();
 
 }} // namespace openage::timing

--- a/openage/cvar/config_file.py
+++ b/openage/cvar/config_file.py
@@ -4,17 +4,27 @@
 Load and save the configuration : file <-> console var system
 """
 
+from ..log import info
 
-def load_config_file(path, set_cvar, loaded=None):
+
+def load_config_file(path, set_cvar, loaded_files=None):
     """
     Load a config file, with possible subfile, into the cvar system.
+
+    set_cvar is a function that accepts (key, value) to actually
+    add the data.
     """
-    if not loaded:
-        loaded = {}
-    if not path.is_file() or path in loaded:
+
+    if not loaded_files:
+        loaded_files = set()
+
+    if not path.is_file() or path in loaded_files:
         return
 
-    loaded[path] = True
+    info("loading config file %s..." % path)
+
+    loaded_files.add(path)
+
     with path.open() as config:
         for line in config:
             lstrip = line.lstrip()
@@ -26,7 +36,8 @@ def load_config_file(path, set_cvar, loaded=None):
 
             if split[0] == "set" and len(split) >= 3:
                 set_cvar(split[1], " ".join(split[2:]))
+
             elif split[0] == "load" and len(split) >= 2:
                 for sub_path in split[1:]:
                     new_path = path.parent / sub_path
-                    load_config_file(new_path, set_cvar, loaded)
+                    load_config_file(new_path, set_cvar, loaded_files)

--- a/openage/cvar/cvar.pyx
+++ b/openage/cvar/cvar.pyx
@@ -1,23 +1,45 @@
 # Copyright 2016-2016 the openage authors. See copying.md for legal info.
 
+import platform
+
 from libcpp.string cimport string
 
-from libopenage.cvar.cvar cimport CVarManager
+from libopenage.cvar.cvar cimport (
+    CVarManager,
+    load_config_file as load_config_file_cpp,
+    find_main_config_file as find_main_config_file_cpp)
 
-from .config_file import load_config_file as load_config
+from .config_file import load_config_file as load_config_py
 
 from os.path import expanduser, expandvars
 from pathlib import Path
-import platform
 
-cdef void load_config_file(string path, CVarManager *manager) except * with gil:
-    load_config(Path(path.decode('UTF-8')), lambda x,y : manager[0].set(x.encode('UTF-8'),y.encode('UTF-8')))
+
+cdef void load_config_file(string path,
+                           CVarManager *manager) except * with gil:
+    """
+    Relay the call to load values from a config file
+    into the configuration manager.
+
+    Effectively glues together the call from C++ to Python.
+    """
+
+    load_config_py(Path(path.decode('UTF-8')),
+                   lambda x, y: manager.set(x.encode('UTF-8'),
+                                            y.encode('UTF-8')))
+
 
 cdef string find_main_config_file() except * with gil:
+    """
+    Locates the main configuration file by name in some searchpaths.
+    """
+
     cfg_file = "keybinds.oac"
     system = platform.system()
 
     if system == "Windows":
+        # TODO: verify that windows users really store data there
+        #       and not just in C:\openage\
         home_expandable = "%APPDATA%"
         global_expandable = "%ALLUSERSPROFILE%"
     else:
@@ -25,16 +47,18 @@ cdef string find_main_config_file() except * with gil:
         global_expandable = "/etc"
 
     home_cfg = Path(expanduser(home_expandable))/cfg_file
-
     if home_cfg.is_file():
         return str(home_cfg.resolve()).encode("UTF-8")
 
-    global_cfg = Path(expandvars(global_expandable)) / cfg_file
+    global_cfg = Path(expandvars(global_expandable))/cfg_file
     if global_cfg.is_file():
         return str(global_cfg.resolve()).encode("UTF-8")
 
+    # the default config file is in the development repository.
+    # TODO: default for some installed version if in non-dev mode.
     return str(Path.cwd()/"cfg"/cfg_file).encode("UTF-8")
 
+
 def setup():
-    CVarManager.get().load_config_file.bind0(load_config_file)
-    CVarManager.get().find_main_config_file.bind0(find_main_config_file)
+    load_config_file_cpp.bind0(load_config_file)
+    find_main_config_file_cpp.bind0(find_main_config_file)


### PR DESCRIPTION
Fixes #329.

The decision to have a global engine object was really really bad. It lead to wrong design in some subsystems as the engine could just be reached directly.

TODOs:
* [x] Fix in-game crashes