### PR TITLE
Attributes system improvements

### DIFF
--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -70,3 +70,22 @@ bool ResourceBundle::deduct(const ResourceBundle& amount) {
 }
 
 } // openage
+
+namespace std {
+
+string to_string(const openage::game_resource &res) {
+	switch (res) {
+	case openage::game_resource::wood:
+		return "wood";
+	case openage::game_resource::food:
+		return "food";
+	case openage::game_resource::gold:
+		return "gold";
+	case openage::game_resource::stone:
+		return "stone";
+	default:
+		return "unknown";
+	}
+}
+
+} // namespace std

--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -62,7 +62,7 @@ bool ResourceBundle::has(const ResourceBundle& amount) const {
 }
 
 bool ResourceBundle::deduct(const ResourceBundle& amount) {
-	if (*this >= amount) {
+	if (this->has(amount)) {
 		*this -= amount;
 		return true;
 	}

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -41,6 +41,10 @@ public:
 
 	bool has(const ResourceBundle& amount) const;
 
+	/**
+	 * If amount can't be deducted return false, else deduct the given amount
+	 * and return true.
+	 */
 	bool deduct(const ResourceBundle& amount);
 
 	double& operator[] (const game_resource res) { return value[(int) res]; }
@@ -49,7 +53,7 @@ public:
 	// Getters
 
 	double get(const game_resource res) const { return value[(int) res]; }
-	double get(int index) const { return value[index]; }
+	double get(const int index) const { return value[index]; }
 
 private:
 	double value[(int) game_resource::RESOURCE_TYPE_COUNT];

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -59,6 +59,8 @@ private:
 
 namespace std {
 
+std::string to_string(const openage::game_resource &res);
+
 /**
  * hasher for game resource
  */

--- a/libopenage/unit/CMakeLists.txt
+++ b/libopenage/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_sources(libopenage
 	ability.cpp
 	action.cpp
+	attribute.cpp
 	command.cpp
 	producer.cpp
 	selection.cpp

--- a/libopenage/unit/CMakeLists.txt
+++ b/libopenage/unit/CMakeLists.txt
@@ -2,6 +2,7 @@ add_sources(libopenage
 	ability.cpp
 	action.cpp
 	attribute.cpp
+	attributes.cpp
 	command.cpp
 	producer.cpp
 	selection.cpp

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -22,7 +22,7 @@ bool UnitAbility::is_damaged(Unit &target) {
 }
 
 bool UnitAbility::has_resource(Unit &target) {
-	return target.has_attribute(attr_type::resource) &&
+	return target.has_attribute(attr_type::resource) && !target.has_attribute(attr_type::worker) &&
 	       target.get_attribute<attr_type::resource>().amount > 0;
 }
 

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -12,8 +12,8 @@
 namespace openage {
 
 bool UnitAbility::has_hitpoints(Unit &target) {
-	return target.has_attribute(attr_type::hitpoints) &&
-	       target.get_attribute<attr_type::hitpoints>().current > 0;
+	return target.has_attribute(attr_type::damaged) &&
+	       target.get_attribute<attr_type::damaged>().hp > 0;
 }
 
 bool UnitAbility::is_damaged(Unit &target) {

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -224,7 +224,7 @@ bool GatherAbility::can_invoke(Unit &to_modify, const Command &cmd) {
 		Unit &target = *cmd.unit();
 		return &to_modify != &target &&
 		       to_modify.location &&
-		       to_modify.has_attribute(attr_type::gatherer) &&
+		       to_modify.has_attribute(attr_type::worker) &&
 		       has_resource(target);
 	}
 	return false;

--- a/libopenage/unit/ability.cpp
+++ b/libopenage/unit/ability.cpp
@@ -17,8 +17,8 @@ bool UnitAbility::has_hitpoints(Unit &target) {
 }
 
 bool UnitAbility::is_damaged(Unit &target) {
-	return target.has_attribute(attr_type::hitpoints) &&
-	       target.get_attribute<attr_type::hitpoints>().current < target.get_attribute<attr_type::hitpoints>().max;
+	return target.has_attribute(attr_type::damaged) && target.has_attribute(attr_type::hitpoints) &&
+	       target.get_attribute<attr_type::damaged>().hp < target.get_attribute<attr_type::hitpoints>().hp;
 }
 
 bool UnitAbility::has_resource(Unit &target) {

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -924,7 +924,6 @@ GatherAction::GatherAction(Unit *e, UnitReference tar)
 	Unit *target = this->target.get();
 	this->resource_class = target->unit_type->unit_class;
 	auto &worker = this->entity->get_attribute<attr_type::worker>();
-	auto &worker_resource = this->entity->get_attribute<attr_type::resource>();
 
 	// handle unit type changes based on resource class
 	if (worker.graphics.count(this->resource_class) > 0) {
@@ -934,6 +933,7 @@ GatherAction::GatherAction(Unit *e, UnitReference tar)
 	}
 
 	// set the type of gatherer
+	auto &worker_resource = this->entity->get_attribute<attr_type::resource>();
 	if (target->has_attribute(attr_type::resource)) {
 		auto &resource_attr = target->get_attribute<attr_type::resource>();
 		if (worker_resource.resource_type != resource_attr.resource_type) {
@@ -998,7 +998,7 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 			else {
 
 				// transfer using gather rate
-				double amount = worker.gather_rate * time;
+				double amount = worker.gather_rate[worker_resource.resource_type] * time;
 				worker_resource.amount += amount;
 				resource_attr.amount -= amount;
 			}

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -397,7 +397,8 @@ void IdleAction::update(unsigned int time) {
 	if (this->entity->location &&
 	    this->entity->has_attribute(attr_type::owner) &&
 	    this->entity->has_attribute(attr_type::attack) &&
-	    this->entity->get_attribute<attr_type::attack>().stance != attack_stance::do_nothing) {
+	    this->entity->has_attribute(attr_type::formation) &&
+	    this->entity->get_attribute<attr_type::formation>().stance != attack_stance::do_nothing) {
 
 		// restart search from new tile when moved
 		auto terrain = this->entity->location->get_terrain();

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -873,16 +873,17 @@ RepairAction::RepairAction(Unit *e, UnitReference tar)
 		//this->cost += get target cost;
 		this->cost[game_resource::wood] = 100; // temp
 
-		this->cost *= 0.5 / hp.max;
+		this->cost *= 0.5 / hp.hp;
 	}
 }
 
 void RepairAction::update_in_range(unsigned int time, Unit *target_unit) {
 
 	auto &hp = target_unit->get_attribute<attr_type::hitpoints>();
+	auto &dm = target_unit->get_attribute<attr_type::damaged>();
 	auto &owner = this->entity->get_attribute<attr_type::owner>();
 
-	if (hp.current >= hp.max) {
+	if (dm.hp >= hp.hp) {
 		// repaired by something else
 		this->complete = true;
 	}
@@ -890,9 +891,9 @@ void RepairAction::update_in_range(unsigned int time, Unit *target_unit) {
 		this->time_left -= time;
 
 		if (this->time_left <= 0) {
-			hp.current += 1;
+			dm.hp += 1;
 
-			if (hp.current >= hp.max) {
+			if (dm.hp >= hp.hp) {
 				this->complete = true;
 			}
 		}

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -807,7 +807,8 @@ void BuildAction::on_completion() {
 	}
 	this->entity->log(MSG(dbg) << "Done building, searching for new building");
 	auto valid = [this](const TerrainObject &obj) {
-		if (!obj.unit.has_attribute(attr_type::building) ||
+		if (!this->entity->get_attribute<attr_type::owner>().player.owns(obj.unit) ||
+		    !obj.unit.has_attribute(attr_type::building) ||
 		    obj.unit.get_attribute<attr_type::building>().completed >= 1.0f) {
 			return false;
 		}
@@ -982,7 +983,7 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 
 		// dropsite has been reached
 		// add value to player stockpile
-		Player &player = this->entity->get_attribute<attr_type::owner>().player;
+		auto &player = this->entity->get_attribute<attr_type::owner>().player;
 		player.receive(worker_resource.resource_type, worker_resource.amount);
 		worker_resource.amount = 0.0;
 
@@ -1087,7 +1088,7 @@ void AttackAction::fire_projectile(const Attribute<attr_type::attack> &att, cons
 	current_pos.up = att.init_height;
 
 	// create using the producer
-	auto player = this->entity->get_attribute<attr_type::owner>().player;
+	auto &player = this->entity->get_attribute<attr_type::owner>().player;
 	auto projectile_ref = container->new_unit(*att.ptype, player, current_pos);
 
 	// send towards target using a projectile ability (creates projectile motion action)

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -397,7 +397,6 @@ public:
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	void on_completion() override;
 	std::string name() const override { return "build"; }
-	const graphic_set &current_graphics() const override;
 
 private:
 	float complete, build_rate;
@@ -441,7 +440,6 @@ public:
 	void update_in_range(unsigned int time, Unit *target_unit) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "gather"; }
-	const graphic_set &current_graphics() const override;
 
 private:
 	bool complete, target_resource;

--- a/libopenage/unit/attribute.cpp
+++ b/libopenage/unit/attribute.cpp
@@ -6,48 +6,6 @@
 
 namespace openage {
 
-void Attributes::add(const std::shared_ptr<AttributeContainer> attr) {
-	this->attrs[attr->type] = attr;
-}
-
-void Attributes::add_copies(const Attributes &other) {
-	this->add_copies(other, true, true);
-}
-
-void Attributes::add_copies(const Attributes &other, bool shared, bool unshared) {
-	for (auto &i : other.attrs) {
-		auto &attr = *i.second.get();
-
-		if (attr.shared()) {
-			if (shared) {
-				// pass self
-				this->add(i.second);
-			}
-		}
-		else if (unshared) {
-			// create copy
-			this->add(attr.copy());
-		}
-	}
-}
-
-bool Attributes::remove(const attr_type type) {
-	return this->attrs.erase(type) > 0;
-}
-
-bool Attributes::has(const attr_type type) const {
-	return this->attrs.find(type) != this->attrs.end();
-}
-
-std::shared_ptr<AttributeContainer> Attributes::get(const attr_type type) const {
-	return this->attrs.at(type);
-}
-
-template<attr_type T>
-Attribute<T> &Attributes::get() const {
-	return *reinterpret_cast<Attribute<T> *>(this->attrs.at(T).get());
-}
-
 bool Attribute<attr_type::dropsite>::accepting_resource(game_resource res) const {
 	return std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end();
 }
@@ -60,4 +18,4 @@ void Attribute<attr_type::multitype>::switchType(const gamedata::unit_classes cl
 	}
 }
 
-} /* namespace openage */
+} // namespace openage

--- a/libopenage/unit/attribute.cpp
+++ b/libopenage/unit/attribute.cpp
@@ -24,7 +24,7 @@ void Attributes::add_copies(const Attributes &other, bool shared, bool unshared)
 				this->add(i.second);
 			}
 		}
-		else if(unshared) {
+		else if (unshared) {
 			// create copy
 			this->add(attr.copy());
 		}

--- a/libopenage/unit/attribute.cpp
+++ b/libopenage/unit/attribute.cpp
@@ -10,11 +10,11 @@ void Attributes::add(const std::shared_ptr<AttributeContainer> attr) {
 	this->attrs[attr->type] = attr;
 }
 
-void Attributes::addCopies(const Attributes &other) {
-	this->addCopies(other, true, true);
+void Attributes::add_copies(const Attributes &other) {
+	this->add_copies(other, true, true);
 }
 
-void Attributes::addCopies(const Attributes &other, bool shared, bool unshared) {
+void Attributes::add_copies(const Attributes &other, bool shared, bool unshared) {
 	for (auto &i : other.attrs) {
 		auto &attr = *i.second.get();
 
@@ -46,6 +46,10 @@ std::shared_ptr<AttributeContainer> Attributes::get(const attr_type type) const 
 template<attr_type T>
 Attribute<T> &Attributes::get() const {
 	return *reinterpret_cast<Attribute<T> *>(this->attrs.at(T).get());
+}
+
+bool Attribute<attr_type::dropsite>::accepting_resource(game_resource res) const {
+	return std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end();
 }
 
 void Attribute<attr_type::multitype>::switchType(const gamedata::unit_classes cls, Unit *unit) const {

--- a/libopenage/unit/attribute.cpp
+++ b/libopenage/unit/attribute.cpp
@@ -1,0 +1,43 @@
+// Copyright 2016-2017 the openage authors. See copying.md for legal info.
+
+#include "attribute.h"
+
+namespace openage {
+
+void Attributes::add(std::shared_ptr<AttributeContainer> attr) {
+	this->attrs[attr->type] = attr;
+}
+
+void Attributes::addCopies(Attributes & other) {
+	for (const auto &i : other.attrs) {
+		const auto &attr = *i.second.get();
+
+		if (attr.shared()) {
+			// pass self
+			this->add(i.second);
+		}
+		else {
+			// create copy
+			this->add(attr.copy());
+		}
+	}
+}
+
+bool Attributes::remove(attr_type type) {
+	return this->attrs.erase(type) > 0;
+}
+
+bool Attributes::has(attr_type type) const {
+	return this->attrs.find(type) != this->attrs.end();
+}
+
+std::shared_ptr<AttributeContainer> Attributes::get(attr_type type) const {
+	return this->attrs.at(type);
+}
+
+template<attr_type T>
+Attribute<T> Attributes::get() const {
+	return *reinterpret_cast<Attribute<T> *>(this->attrs.at(T).get());
+}
+
+} /* namespace openage */

--- a/libopenage/unit/attribute.cpp
+++ b/libopenage/unit/attribute.cpp
@@ -1,14 +1,14 @@
-// Copyright 2016-2017 the openage authors. See copying.md for legal info.
+// Copyright 2016-2016 the openage authors. See copying.md for legal info.
 
 #include "attribute.h"
 
 namespace openage {
 
-void Attributes::add(std::shared_ptr<AttributeContainer> attr) {
+void Attributes::add(const std::shared_ptr<AttributeContainer> attr) {
 	this->attrs[attr->type] = attr;
 }
 
-void Attributes::addCopies(Attributes & other) {
+void Attributes::addCopies(const Attributes & other) {
 	for (const auto &i : other.attrs) {
 		const auto &attr = *i.second.get();
 
@@ -23,20 +23,20 @@ void Attributes::addCopies(Attributes & other) {
 	}
 }
 
-bool Attributes::remove(attr_type type) {
+bool Attributes::remove(const attr_type type) {
 	return this->attrs.erase(type) > 0;
 }
 
-bool Attributes::has(attr_type type) const {
+bool Attributes::has(const attr_type type) const {
 	return this->attrs.find(type) != this->attrs.end();
 }
 
-std::shared_ptr<AttributeContainer> Attributes::get(attr_type type) const {
+std::shared_ptr<AttributeContainer> Attributes::get(const attr_type type) const {
 	return this->attrs.at(type);
 }
 
 template<attr_type T>
-Attribute<T> Attributes::get() const {
+Attribute<T> &Attributes::get() const {
 	return *reinterpret_cast<Attribute<T> *>(this->attrs.at(T).get());
 }
 

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -128,22 +128,56 @@ template<attr_type T> Attribute<T> get_attr(attr_map_t &map) {
 	return *reinterpret_cast<Attribute<T> *>(map[T]);
 }
 
+/**
+ * Wraps a templated shared attribute
+ *
+ * Shared attributes are common across all units of
+ * one type
+ */
+class SharedAttributeContainer: public AttributeContainer {
+public:
+
+	SharedAttributeContainer(attr_type t)
+		:
+		AttributeContainer{t} {}
+
+	bool shared() const override {
+		return true;
+	}
+
+};
+
+/**
+ * Wraps a templated unshared attribute
+ *
+ * Shared attributes are copied for each unit of
+ * one type
+ */
+class UnsharedAttributeContainer: public AttributeContainer {
+public:
+
+	UnsharedAttributeContainer(attr_type t)
+		:
+		AttributeContainer{t} {}
+
+	bool shared() const override {
+		return false;
+	}
+
+};
+
 // -----------------------------
 // attribute definitions go here
 // -----------------------------
 
 class Player;
 
-template<> class Attribute<attr_type::owner>: public AttributeContainer {
+template<> class Attribute<attr_type::owner>: public SharedAttributeContainer {
 public:
 	Attribute(Player &p)
 		:
-		AttributeContainer{attr_type::owner},
+		SharedAttributeContainer{attr_type::owner},
 		player(p) {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::owner>>(*this);
@@ -152,17 +186,13 @@ public:
 	Player &player;
 };
 
-template<> class Attribute<attr_type::hitpoints>: public AttributeContainer {
+template<> class Attribute<attr_type::hitpoints>: public UnsharedAttributeContainer {
 public:
 	Attribute(unsigned int i)
 		:
-		AttributeContainer{attr_type::hitpoints},
+		UnsharedAttributeContainer{attr_type::hitpoints},
 		current{i},
 		max{i} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::hitpoints>>(*this);
@@ -173,16 +203,12 @@ public:
 	float hp_bar_height;
 };
 
-template<> class Attribute<attr_type::armor>: public AttributeContainer {
+template<> class Attribute<attr_type::armor>: public SharedAttributeContainer {
 public:
 	Attribute(typeamount_map a)
 		:
-		AttributeContainer{attr_type::armor},
+		SharedAttributeContainer{attr_type::armor},
 		armor{a} {}
-
-	bool shared() const override {
-		return true;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::armor>>(*this);
@@ -191,7 +217,7 @@ public:
 	typeamount_map armor;
 };
 
-template<> class Attribute<attr_type::attack>: public AttributeContainer {
+template<> class Attribute<attr_type::attack>: public UnsharedAttributeContainer {
 public:
 	// TODO remove (keep for testing)
 	// 4 = gamedata::hit_class::UNITS_MELEE (not exported at the moment)
@@ -201,17 +227,13 @@ public:
 
 	Attribute(UnitType *type, coord::phys_t r, coord::phys_t h, typeamount_map d, UnitType *reset_type)
 		:
-		AttributeContainer{attr_type::attack},
+		UnsharedAttributeContainer{attr_type::attack},
 		ptype{type},
 		range{r},
 		init_height{h},
 		damage{d},
 		stance{attack_stance::do_nothing},
 		attack_type{reset_type} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::attack>>(*this);
@@ -231,19 +253,15 @@ public:
 	UnitType *attack_type;
 };
 
-template<> class Attribute<attr_type::heal>: public AttributeContainer {
+template<> class Attribute<attr_type::heal>: public SharedAttributeContainer {
 public:
 	Attribute(coord::phys_t r, coord::phys_t h, unsigned int l, float ra)
 		:
-		AttributeContainer{attr_type::heal},
+		SharedAttributeContainer{attr_type::heal},
 		range{r},
 		init_height{h},
 		life{l},
 		rate{ra} {}
-
-	bool shared() const override {
-		return true;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::heal>>(*this);
@@ -255,17 +273,12 @@ public:
 	float rate;
 };
 
-
-template<> class Attribute<attr_type::speed>: public AttributeContainer {
+template<> class Attribute<attr_type::speed>: public SharedAttributeContainer {
 public:
 	Attribute(coord::phys_t sp)
 		:
-		AttributeContainer{attr_type::speed},
+		SharedAttributeContainer{attr_type::speed},
 		unit_speed{sp} {}
-
-	bool shared() const override {
-		return true;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::speed>>(*this);
@@ -274,16 +287,12 @@ public:
 	coord::phys_t unit_speed; // possibly use a pointer to account for tech upgrades
 };
 
-template<> class Attribute<attr_type::direction>: public AttributeContainer {
+template<> class Attribute<attr_type::direction>: public UnsharedAttributeContainer {
 public:
 	Attribute(coord::phys3_delta dir)
 		:
-		AttributeContainer{attr_type::direction},
+		UnsharedAttributeContainer{attr_type::direction},
 		unit_dir(dir) {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::direction>>(*this);
@@ -292,17 +301,13 @@ public:
 	coord::phys3_delta unit_dir;
 };
 
-template<> class Attribute<attr_type::projectile>: public AttributeContainer {
+template<> class Attribute<attr_type::projectile>: public UnsharedAttributeContainer {
 public:
 	Attribute(float arc)
 		:
-		AttributeContainer{attr_type::projectile},
+		UnsharedAttributeContainer{attr_type::projectile},
 		projectile_arc{arc},
 		launched{false} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::projectile>>(*this);
@@ -313,11 +318,11 @@ public:
 	bool launched;
 };
 
-template<> class Attribute<attr_type::building>: public AttributeContainer {
+template<> class Attribute<attr_type::building>: public UnsharedAttributeContainer {
 public:
 	Attribute()
 		:
-		AttributeContainer{attr_type::building},
+		UnsharedAttributeContainer{attr_type::building},
 		completed{.0f},
 		is_dropsite{true},
 		foundation_terrain{0} {}
@@ -346,17 +351,13 @@ public:
 	coord::phys3 gather_point;
 };
 
-template<> class Attribute<attr_type::dropsite>: public AttributeContainer {
+template<> class Attribute<attr_type::dropsite>: public SharedAttributeContainer {
 public:
 
 	Attribute(std::vector<game_resource> types)
 		:
-		AttributeContainer{attr_type::dropsite},
+		SharedAttributeContainer{attr_type::dropsite},
 		resource_types{types} {}
-
-	bool shared() const override {
-		return true;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::dropsite>>(*this);
@@ -377,17 +378,13 @@ private:
 /**
  * resource capacity of an object, trees, mines, villagers etc.
  */
-template<> class Attribute<attr_type::resource>: public AttributeContainer {
+template<> class Attribute<attr_type::resource>: public UnsharedAttributeContainer {
 public:
 	Attribute(game_resource type, float init_amount)
 		:
-		AttributeContainer{attr_type::resource},
+		UnsharedAttributeContainer{attr_type::resource},
 		resource_type{type},
 		amount{init_amount} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::resource>>(*this);
@@ -402,16 +399,12 @@ class UnitTexture;
 /**
  * TODO: rename to worker
  */
-template<> class Attribute<attr_type::gatherer>: public AttributeContainer {
+template<> class Attribute<attr_type::gatherer>: public UnsharedAttributeContainer {
 public:
 	Attribute()
 		:
-		AttributeContainer{attr_type::gatherer},
+		UnsharedAttributeContainer{attr_type::gatherer},
 		amount{.0f} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::gatherer>>(*this);
@@ -426,15 +419,11 @@ public:
 	std::unordered_map<gamedata::unit_classes, UnitType *> graphics;
 };
 
-template<> class Attribute<attr_type::garrison>: public AttributeContainer {
+template<> class Attribute<attr_type::garrison>: public UnsharedAttributeContainer {
 public:
 	Attribute()
 		:
-		AttributeContainer{attr_type::garrison} {}
-
-	bool shared() const override {
-		return false;
-	}
+		UnsharedAttributeContainer{attr_type::garrison} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::garrison>>(*this);

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -112,14 +112,9 @@ public:
 	virtual std::shared_ptr<AttributeContainer> copy() const = 0;
 };
 
-// TODO be replaced by Attributes
-using attr_map_t = std::map<attr_type, std::shared_ptr<AttributeContainer>>;
-
 /**
  * Contains a group of attributes.
  * Can contain only one attribute of each type.
- *
- * TODO replace attr_map_t
  */
 class Attributes {
 public:
@@ -128,33 +123,33 @@ public:
 	/**
 	 * Add an attribute or replace any attribute of the same type.
 	 */
-	void add(std::shared_ptr<AttributeContainer> attr);
+	void add(const std::shared_ptr<AttributeContainer> attr);
 
 	/**
 	 * Add copies of all the attributes from the given Attributes.
 	 */
-	void addCopies(Attributes & attrs);
+	void addCopies(const Attributes &attrs);
 
 	/**
 	 * Remove an attribute based on the type.
 	 */
-	bool remove(attr_type type);
+	bool remove(const attr_type type);
 
 	/**
 	 * Check if the attribute of the given type exists.
 	 */
-	bool has(attr_type type) const;
+	bool has(const attr_type type) const;
 
 	/**
 	 * Get the attribute based on the type.
 	 */
-	std::shared_ptr<AttributeContainer> get(attr_type type) const;
+	std::shared_ptr<AttributeContainer> get(const attr_type type) const;
 
 	/**
 	 * Get the attribute
 	 */
 	template<attr_type T>
-	Attribute<T> get() const;
+	Attribute<T> &get() const;
 
 private:
 
@@ -166,14 +161,6 @@ private:
  * and a unsigned int value used as the amount
  */
 using typeamount_map = std::unordered_map<int, unsigned int>;
-
-/**
- * return attribute from a container
- * TODO be replaced by Attributes::get
- */
-template<attr_type T> Attribute<T> get_attr(attr_map_t &map) {
-	return *reinterpret_cast<Attribute<T> *>(map[T]);
-}
 
 /**
  * Wraps a templated shared attribute

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -107,8 +107,7 @@ public:
 	virtual bool shared() const = 0;
 
 	/**
-	 * produces an copy of the attribute for non-shared attributes
-	 * shared attributes will return themselves
+	 * Produces an copy of the attribute.
 	 */
 	virtual std::shared_ptr<AttributeContainer> copy() const = 0;
 };
@@ -122,19 +121,19 @@ using attr_map_t = std::map<attr_type, std::shared_ptr<AttributeContainer>>;
  *
  * TODO replace attr_map_t
  */
-class Attributes{
+class Attributes {
 public:
 	Attributes() {}
 
 	/**
 	 * Add an attribute or replace any attribute of the same type.
 	 */
-	bool add(std::shared_ptr<AttributeContainer> attr);
+	void add(std::shared_ptr<AttributeContainer> attr);
 
 	/**
 	 * Add copies of all the attributes from the given Attributes.
 	 */
-	bool addCopies(Attributes & attrs);
+	void addCopies(Attributes & attrs);
 
 	/**
 	 * Remove an attribute based on the type.

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -31,7 +31,7 @@ template<> struct hash<gamedata::unit_classes> {
 namespace openage {
 
 /**
- * types of action graphics
+ * Types of action graphics
  */
 enum class graphic_type {
 	construct,
@@ -49,12 +49,12 @@ enum class graphic_type {
 class UnitTexture;
 
 /**
- * collection of graphics attached to each unit
+ * Collection of graphics attached to each unit.
  */
 using graphic_set = std::map<graphic_type, std::shared_ptr<UnitTexture>>;
 
 /**
- * list of attribute types
+ * List of unit's attribute types.
  */
 enum class attr_type {
 	owner,
@@ -75,6 +75,10 @@ enum class attr_type {
 	garrison
 };
 
+/**
+ * List of unit's attack stance.
+ * Can be used for buildings also.
+ */
 enum class attack_stance {
 	aggresive,
 	devensive,
@@ -82,6 +86,10 @@ enum class attack_stance {
 	do_nothing
 };
 
+/**
+ * List of unit's formation.
+ * Effect applys on a group of units.
+ */
 enum class attack_formation {
 	line,
 	staggered,
@@ -96,7 +104,7 @@ enum class attack_formation {
 template<attr_type T> class Attribute;
 
 /**
- * wraps a templated attribute
+ * Wraps a templated attribute
  */
 class AttributeContainer {
 public:
@@ -293,6 +301,10 @@ public:
 	typeamount_map armor;
 };
 
+/**
+ * TODO implement min range
+ * TODO can a unit have multiple attacks such as villagers hunting map target classes onto attacks
+ */
 template<> class Attribute<attr_type::attack>: public SharedAttributeContainer {
 public:
 	// TODO remove (keep for testing)
@@ -313,15 +325,28 @@ public:
 		return std::make_shared<Attribute<attr_type::attack>>(*this);
 	}
 
-	// TODO: can a unit have multiple attacks such as villagers hunting
-	// map target classes onto attacks
+	/**
+	 * The projectile's unit type
+	 */
+	UnitType *ptype;
 
-	UnitType *ptype; // projectile type
+	/**
+	 * The max range of the attack
+	 */
 	coord::phys_t range;
+
+	/**
+	 * The height from which the projectile starts
+	 */
 	coord::phys_t init_height;
+
 	typeamount_map damage;
 };
 
+/**
+ * The attack stance and formation
+ * TODO store patrol and follow command information
+ */
 template<> class Attribute<attr_type::formation>: public UnsharedAttributeContainer {
 public:
 
@@ -386,7 +411,6 @@ public:
 		return std::make_shared<Attribute<attr_type::speed>>(*this);
 	}
 
-	// TODO possibly use a pointer to account for tech upgrades
 	// TODO rename to default or normal
 	coord::phys_t unit_speed;
 };
@@ -422,6 +446,9 @@ public:
 	bool launched;
 };
 
+/**
+ * TODO revisit after unit training is improved
+ */
 template<> class Attribute<attr_type::building>: public UnsharedAttributeContainer {
 public:
 	Attribute()
@@ -455,7 +482,6 @@ public:
  */
 template<> class Attribute<attr_type::dropsite>: public SharedAttributeContainer {
 public:
-
 	Attribute(std::vector<game_resource> types)
 		:
 		SharedAttributeContainer{attr_type::dropsite},
@@ -472,6 +498,7 @@ public:
 
 /**
  * Resource capacity of a trees, mines, animal, worker etc.
+ * TODO add a way to define slower and faster resource gathering time needed
  */
 template<> class Attribute<attr_type::resource>: public UnsharedAttributeContainer {
 public:

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -225,11 +225,11 @@ public:
  * The max hitpoints and health bar information.
  * TODO change bar information stucture
  */
-template<> class Attribute<attr_type::hitpoints>: public UnsharedAttributeContainer {
+template<> class Attribute<attr_type::hitpoints>: public SharedAttributeContainer {
 public:
 	Attribute(unsigned int i)
 		:
-		UnsharedAttributeContainer{attr_type::hitpoints},
+		SharedAttributeContainer{attr_type::hitpoints},
 		hp{i} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
@@ -385,33 +385,31 @@ public:
 		:
 		UnsharedAttributeContainer{attr_type::building},
 		completed{.0f},
-		is_dropsite{true},
 		foundation_terrain{0} {}
-
-	bool shared() const override {
-		return false;
-	}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::building>>(*this);
 	}
 
 	float completed;
-	bool is_dropsite;
 	int foundation_terrain;
 
 	// set the TerrainObject to this state
 	// once building has been completed
 	object_state completion_state;
 
-	// TODO: use unit class, fish and forage have different dropsites
-	game_resource resource_type;
-
 	// TODO: list allowed trainable producers
 	UnitType *pp;
+
+	/**
+	 * The go to point after a unit is created.
+	 */
 	coord::phys3 gather_point;
 };
 
+/**
+ * The resources that are accepted.
+ */
 template<> class Attribute<attr_type::dropsite>: public SharedAttributeContainer {
 public:
 
@@ -425,14 +423,9 @@ public:
 	}
 
 	bool accepting_resource(game_resource res) {
-		if (std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end()) {
-			return true;
-		} else {
-			return false;
-		}
+		return std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end();
 	}
 
-private:
 	std::vector<game_resource> resource_types;
 };
 
@@ -441,7 +434,7 @@ private:
  */
 template<> class Attribute<attr_type::resource>: public UnsharedAttributeContainer {
 public:
-	Attribute(game_resource type, float init_amount)
+	Attribute(game_resource type, double init_amount)
 		:
 		UnsharedAttributeContainer{attr_type::resource},
 		resource_type{type},
@@ -452,7 +445,7 @@ public:
 	}
 
 	game_resource resource_type;
-	float amount;
+	double amount;
 };
 
 class UnitTexture;
@@ -465,21 +458,25 @@ public:
 	Attribute()
 		:
 		UnsharedAttributeContainer{attr_type::gatherer},
-		amount{.0f} {}
+		amount{.0} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::gatherer>>(*this);
 	}
 
 	game_resource current_type;
-	float amount;
-	float capacity;
-	float gather_rate;
+	double amount;
+	double capacity;
+	double gather_rate;
 
 	// texture sets available for each resource
 	std::unordered_map<gamedata::unit_classes, UnitType *> graphics;
 };
 
+/**
+ * Units put inside a building.
+ * TODO add capacity per type of unit
+ */
 template<> class Attribute<attr_type::garrison>: public UnsharedAttributeContainer {
 public:
 	Attribute()

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -130,14 +130,14 @@ public:
 	/**
 	 * Add copies of all the attributes from the given Attributes.
 	 */
-	void addCopies(const Attributes &attrs);
+	void add_copies(const Attributes &attrs);
 
 	/**
 	 * Add copies of all the attributes from the given Attributes.
 	 * If shared is false, shared attributes are ignored.
 	 * If unshared is false, unshared attributes are ignored.
 	 */
-	void addCopies(const Attributes &attrs, bool shared, bool unshared);
+	void add_copies(const Attributes &attrs, bool shared, bool unshared);
 
 	/**
 	 * Remove an attribute based on the type.
@@ -187,7 +187,6 @@ public:
 	bool shared() const override {
 		return true;
 	}
-
 };
 
 /**
@@ -206,7 +205,6 @@ public:
 	bool shared() const override {
 		return false;
 	}
-
 };
 
 // -----------------------------
@@ -441,9 +439,7 @@ public:
 		return std::make_shared<Attribute<attr_type::dropsite>>(*this);
 	}
 
-	bool accepting_resource(game_resource res) {
-		return std::find(resource_types.begin(), resource_types.end(), res) != resource_types.end();
-	}
+	bool accepting_resource(game_resource res) const;
 
 	std::vector<game_resource> resource_types;
 };

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -58,6 +58,7 @@ using graphic_set = std::map<graphic_type, std::shared_ptr<UnitTexture>>;
  */
 enum class attr_type {
 	owner,
+	damaged,
 	hitpoints,
 	armor,
 	attack,
@@ -220,21 +221,47 @@ public:
 	Player &player;
 };
 
+/**
+ * The max hitpoints and health bar information.
+ * TODO change bar information stucture
+ */
 template<> class Attribute<attr_type::hitpoints>: public UnsharedAttributeContainer {
 public:
 	Attribute(unsigned int i)
 		:
 		UnsharedAttributeContainer{attr_type::hitpoints},
-		current{i},
-		max{i} {}
+		hp{i} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::hitpoints>>(*this);
 	}
 
-	unsigned int current;
-	unsigned int max;
+	/**
+	 * The max hitpoints
+	 */
+	unsigned int hp;
 	float hp_bar_height;
+};
+
+/**
+ * The current hitpoints.
+ * TODO add last damage taken timestamp
+ */
+template<> class Attribute<attr_type::damaged>: public UnsharedAttributeContainer {
+public:
+	Attribute(unsigned int i)
+		:
+		UnsharedAttributeContainer{attr_type::damaged},
+		hp{i} {}
+
+	std::shared_ptr<AttributeContainer> copy() const override {
+		return std::make_shared<Attribute<attr_type::damaged>>(*this);
+	}
+
+	/**
+	 * The current hitpoint
+	 */
+	unsigned int hp;
 };
 
 template<> class Attribute<attr_type::armor>: public SharedAttributeContainer {

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -62,6 +62,7 @@ enum class attr_type {
 	hitpoints,
 	armor,
 	attack,
+	formation,
 	heal,
 	speed,
 	direction,
@@ -80,6 +81,14 @@ enum class attack_stance {
 	stand_ground,
 	do_nothing
 };
+
+enum class attack_formation {
+	line,
+	staggered,
+	box,
+	flank
+};
+
 
 /**
  * this type gets specialized for each attribute
@@ -284,7 +293,7 @@ public:
 	typeamount_map armor;
 };
 
-template<> class Attribute<attr_type::attack>: public UnsharedAttributeContainer {
+template<> class Attribute<attr_type::attack>: public SharedAttributeContainer {
 public:
 	// TODO remove (keep for testing)
 	// 4 = gamedata::hit_class::UNITS_MELEE (not exported at the moment)
@@ -294,12 +303,11 @@ public:
 
 	Attribute(UnitType *type, coord::phys_t r, coord::phys_t h, typeamount_map d)
 		:
-		UnsharedAttributeContainer{attr_type::attack},
+		SharedAttributeContainer{attr_type::attack},
 		ptype{type},
 		range{r},
 		init_height{h},
-		damage{d},
-		stance{attack_stance::do_nothing} {}
+		damage{d} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
 		return std::make_shared<Attribute<attr_type::attack>>(*this);
@@ -312,9 +320,27 @@ public:
 	coord::phys_t range;
 	coord::phys_t init_height;
 	typeamount_map damage;
+};
 
-	// TODO move elsewhere in order to become shared attribute
+template<> class Attribute<attr_type::formation>: public UnsharedAttributeContainer {
+public:
+
+	Attribute()
+		:
+		Attribute{attack_stance::do_nothing} {}
+
+	Attribute(attack_stance stance)
+		:
+		UnsharedAttributeContainer{attr_type::formation},
+		stance{stance},
+		formation{attack_formation::line} {}
+
+	std::shared_ptr<AttributeContainer> copy() const override {
+		return std::make_shared<Attribute<attr_type::formation>>(*this);
+	}
+
 	attack_stance stance;
+	attack_formation formation;
 };
 
 /**

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -69,7 +69,7 @@ enum class attr_type {
 	building,
 	dropsite,
 	resource,
-	gatherer,
+	worker,
 	garrison
 };
 
@@ -434,6 +434,10 @@ public:
  */
 template<> class Attribute<attr_type::resource>: public UnsharedAttributeContainer {
 public:
+	Attribute()
+		:
+		Attribute{game_resource::food, 0} {}
+
 	Attribute(game_resource type, double init_amount)
 		:
 		UnsharedAttributeContainer{attr_type::resource},
@@ -451,21 +455,18 @@ public:
 class UnitTexture;
 
 /**
- * TODO: rename to worker
+ * The worker's capacity and gather rates.
  */
-template<> class Attribute<attr_type::gatherer>: public UnsharedAttributeContainer {
+template<> class Attribute<attr_type::worker>: public UnsharedAttributeContainer {
 public:
 	Attribute()
 		:
-		UnsharedAttributeContainer{attr_type::gatherer},
-		amount{.0} {}
+		UnsharedAttributeContainer{attr_type::worker} {}
 
 	std::shared_ptr<AttributeContainer> copy() const override {
-		return std::make_shared<Attribute<attr_type::gatherer>>(*this);
+		return std::make_shared<Attribute<attr_type::worker>>(*this);
 	}
 
-	game_resource current_type;
-	double amount;
 	double capacity;
 	double gather_rate;
 

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -132,57 +132,6 @@ public:
 };
 
 /**
- * Contains a group of attributes.
- * Can contain only one attribute of each type.
- */
-class Attributes {
-public:
-	Attributes() {}
-
-	/**
-	 * Add an attribute or replace any attribute of the same type.
-	 */
-	void add(const std::shared_ptr<AttributeContainer> attr);
-
-	/**
-	 * Add copies of all the attributes from the given Attributes.
-	 */
-	void add_copies(const Attributes &attrs);
-
-	/**
-	 * Add copies of all the attributes from the given Attributes.
-	 * If shared is false, shared attributes are ignored.
-	 * If unshared is false, unshared attributes are ignored.
-	 */
-	void add_copies(const Attributes &attrs, bool shared, bool unshared);
-
-	/**
-	 * Remove an attribute based on the type.
-	 */
-	bool remove(const attr_type type);
-
-	/**
-	 * Check if the attribute of the given type exists.
-	 */
-	bool has(const attr_type type) const;
-
-	/**
-	 * Get the attribute based on the type.
-	 */
-	std::shared_ptr<AttributeContainer> get(const attr_type type) const;
-
-	/**
-	 * Get the attribute
-	 */
-	template<attr_type T>
-	Attribute<T> &get() const;
-
-private:
-
-	std::map<attr_type, std::shared_ptr<AttributeContainer>> attrs;
-};
-
-/**
  * An unordered_map with a int key used as a type id
  * and a unsigned int value used as the amount
  */

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -307,6 +307,8 @@ public:
 	coord::phys_t range;
 	coord::phys_t init_height;
 	typeamount_map damage;
+
+	// TODO move elsewhere in order to become shared attribute
 	attack_stance stance;
 
 	// TODO move elsewhere in order to become shared attribute
@@ -314,13 +316,15 @@ public:
 	UnitType *attack_type;
 };
 
+/**
+ * Healing capabilities.
+ */
 template<> class Attribute<attr_type::heal>: public SharedAttributeContainer {
 public:
-	Attribute(coord::phys_t r, coord::phys_t h, unsigned int l, float ra)
+	Attribute(coord::phys_t r, unsigned int l, float ra)
 		:
 		SharedAttributeContainer{attr_type::heal},
 		range{r},
-		init_height{h},
 		life{l},
 		rate{ra} {}
 
@@ -328,9 +332,19 @@ public:
 		return std::make_shared<Attribute<attr_type::heal>>(*this);
 	}
 
+	/**
+	 * The max range of the healing.
+	 */
 	coord::phys_t range;
-	coord::phys_t init_height; // TODO remove?
+
+	/**
+	 * Life healed in each cycle
+	 */
 	unsigned int life;
+
+	/**
+	 * The rate of each heal cycle
+	 */
 	float rate;
 };
 
@@ -345,7 +359,9 @@ public:
 		return std::make_shared<Attribute<attr_type::speed>>(*this);
 	}
 
-	coord::phys_t unit_speed; // possibly use a pointer to account for tech upgrades
+	// TODO possibly use a pointer to account for tech upgrades
+	// TODO rename to default or normal
+	coord::phys_t unit_speed;
 };
 
 template<> class Attribute<attr_type::direction>: public UnsharedAttributeContainer {
@@ -408,7 +424,7 @@ public:
 };
 
 /**
- * The resources that are accepted.
+ * The resources that are accepted to be dropped.
  */
 template<> class Attribute<attr_type::dropsite>: public SharedAttributeContainer {
 public:
@@ -430,7 +446,7 @@ public:
 };
 
 /**
- * resource capacity of an object, trees, mines, villagers etc.
+ * Resource capacity of a trees, mines, animal, worker etc.
  */
 template<> class Attribute<attr_type::resource>: public UnsharedAttributeContainer {
 public:
@@ -467,10 +483,19 @@ public:
 		return std::make_shared<Attribute<attr_type::worker>>(*this);
 	}
 
+	/**
+	 * The max number of resources that can be carried.
+	 */
 	double capacity;
-	double gather_rate;
+
+	/**
+	 * The gather rate for each resource.
+	 * The ResourceBundle class is used but instead of amounts it stores gather rates.
+	 */
+	ResourceBundle gather_rate;
 
 	// texture sets available for each resource
+	// TODO move elsewhere
 	std::unordered_map<gamedata::unit_classes, UnitType *> graphics;
 };
 
@@ -488,6 +513,9 @@ public:
 		return std::make_shared<Attribute<attr_type::garrison>>(*this);
 	}
 
+	/**
+	 * The units that are garrisoned.
+	 */
 	std::vector<UnitReference> content;
 };
 

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -113,7 +113,54 @@ public:
 	virtual std::shared_ptr<AttributeContainer> copy() const = 0;
 };
 
+// TODO be replaced by Attributes
 using attr_map_t = std::map<attr_type, std::shared_ptr<AttributeContainer>>;
+
+/**
+ * Contains a group of attributes.
+ * Can contain only one attribute of each type.
+ *
+ * TODO replace attr_map_t
+ */
+class Attributes{
+public:
+	Attributes() {}
+
+	/**
+	 * Add an attribute or replace any attribute of the same type.
+	 */
+	bool add(std::shared_ptr<AttributeContainer> attr);
+
+	/**
+	 * Add copies of all the attributes from the given Attributes.
+	 */
+	bool addCopies(Attributes & attrs);
+
+	/**
+	 * Remove an attribute based on the type.
+	 */
+	bool remove(attr_type type);
+
+	/**
+	 * Check if the attribute of the given type exists.
+	 */
+	bool has(attr_type type) const;
+
+	/**
+	 * Get the attribute based on the type.
+	 */
+	std::shared_ptr<AttributeContainer> get(attr_type type) const;
+
+	/**
+	 * Get the attribute
+	 */
+	template<attr_type T>
+	Attribute<T> get() const;
+
+private:
+
+	std::map<attr_type, std::shared_ptr<AttributeContainer>> attrs;
+};
 
 /**
  * An unordered_map with a int key used as a type id
@@ -123,6 +170,7 @@ using typeamount_map = std::unordered_map<int, unsigned int>;
 
 /**
  * return attribute from a container
+ * TODO be replaced by Attributes::get
  */
 template<attr_type T> Attribute<T> get_attr(attr_map_t &map) {
 	return *reinterpret_cast<Attribute<T> *>(map[T]);

--- a/libopenage/unit/attributes.cpp
+++ b/libopenage/unit/attributes.cpp
@@ -1,0 +1,49 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#include "attributes.h"
+
+namespace openage {
+
+void Attributes::add(const std::shared_ptr<AttributeContainer> attr) {
+	this->attrs[attr->type] = attr;
+}
+
+void Attributes::add_copies(const Attributes &other) {
+	this->add_copies(other, true, true);
+}
+
+void Attributes::add_copies(const Attributes &other, bool shared, bool unshared) {
+	for (auto &i : other.attrs) {
+		auto &attr = *i.second.get();
+
+		if (attr.shared()) {
+			if (shared) {
+				// pass self
+				this->add(i.second);
+			}
+		}
+		else if (unshared) {
+			// create copy
+			this->add(attr.copy());
+		}
+	}
+}
+
+bool Attributes::remove(const attr_type type) {
+	return this->attrs.erase(type) > 0;
+}
+
+bool Attributes::has(const attr_type type) const {
+	return this->attrs.find(type) != this->attrs.end();
+}
+
+std::shared_ptr<AttributeContainer> Attributes::get(const attr_type type) const {
+	return this->attrs.at(type);
+}
+
+template<attr_type T>
+Attribute<T> &Attributes::get() const {
+	return *reinterpret_cast<Attribute<T> *>(this->attrs.at(T).get());
+}
+
+} // namespace openage

--- a/libopenage/unit/attributes.h
+++ b/libopenage/unit/attributes.h
@@ -1,0 +1,62 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <map>
+
+#include "attribute.h"
+
+namespace openage {
+
+/**
+ * Contains a group of attributes.
+ * Can contain only one attribute of each type.
+ */
+class Attributes {
+public:
+	Attributes() {}
+
+	/**
+	 * Add an attribute or replace any attribute of the same type.
+	 */
+	void add(const std::shared_ptr<AttributeContainer> attr);
+
+	/**
+	 * Add copies of all the attributes from the given Attributes.
+	 */
+	void add_copies(const Attributes &attrs);
+
+	/**
+	 * Add copies of all the attributes from the given Attributes.
+	 * If shared is false, shared attributes are ignored.
+	 * If unshared is false, unshared attributes are ignored.
+	 */
+	void add_copies(const Attributes &attrs, bool shared, bool unshared);
+
+	/**
+	 * Remove an attribute based on the type.
+	 */
+	bool remove(const attr_type type);
+
+	/**
+	 * Check if the attribute of the given type exists.
+	 */
+	bool has(const attr_type type) const;
+
+	/**
+	 * Get the attribute based on the type.
+	 */
+	std::shared_ptr<AttributeContainer> get(const attr_type type) const;
+
+	/**
+	 * Get the attribute
+	 */
+	template<attr_type T>
+	Attribute<T> &get() const;
+
+private:
+
+	std::map<attr_type, std::shared_ptr<AttributeContainer>> attrs;
+};
+
+} // namespace openage

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -380,15 +380,14 @@ void MovableProducer::initialise(Unit *unit, Player &player) {
 
 	// projectile of melee attacks
 	UnitType *proj_type = this->owner.get_type(this->projectile);
-	UnitType *reset_type = this->parent_type();
 	if (this->unit_data.projectile_unit_id > 0 && proj_type) {
 
 		// calculate requirements for ranged attacks
 		coord::phys_t range_phys = coord::settings::phys_per_tile * this->unit_data.max_range;
-		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(proj_type, range_phys, 48000, 1, reset_type));
+		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(proj_type, range_phys, 48000, 1));
 	}
 	else {
-		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(nullptr, 0, 0, 1, reset_type));
+		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(nullptr, 0, 0, 1));
 	}
 }
 
@@ -418,6 +417,7 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 	if (this->unit_data.unit_class == gamedata::unit_classes::CIVILIAN) {
 		unit->add_attribute(std::make_shared<Attribute<attr_type::worker>>());
 		unit->add_attribute(std::make_shared<Attribute<attr_type::resource>>());
+		unit->add_attribute(std::make_shared<Attribute<attr_type::multitype>>());
 
 		// add graphic ids for resource actions
 		auto &worker_attr = unit->get_attribute<attr_type::worker>();
@@ -427,28 +427,31 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 		worker_attr.gather_rate[game_resource::gold] = 0.002;
 		worker_attr.gather_rate[game_resource::stone] = 0.002;
 
+		auto &multitype_attr = unit->get_attribute<attr_type::multitype>();
 		// currently not sure where the game data keeps these values
 		// todo PREY_ANIMAL SEA_FISH
 		if (this->parent_id() == 83) {
 
 			// male graphics
-			worker_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(156); // builder 118
-			worker_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(120); // forager
-			worker_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(592); // sheperd
-			worker_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(123); // woodcutter
-			worker_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(579); // gold miner
-			worker_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(124); // stone miner
+			multitype_attr.types[gamedata::unit_classes::CIVILIAN] = this->parent_type(); // get default villager
+			multitype_attr.types[gamedata::unit_classes::BUILDING] = this->owner.get_type(156); // builder 118
+			multitype_attr.types[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(120); // forager
+			multitype_attr.types[gamedata::unit_classes::SHEEP] = this->owner.get_type(592); // sheperd
+			multitype_attr.types[gamedata::unit_classes::TREES] = this->owner.get_type(123); // woodcutter
+			multitype_attr.types[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(579); // gold miner
+			multitype_attr.types[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(124); // stone miner
 
 		}
 		else {
 
 			// female graphics
-			worker_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(222); // builder 212
-			worker_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(354); // forager
-			worker_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(590); // sheperd
-			worker_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(218); // woodcutter
-			worker_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(581); // gold miner
-			worker_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(220); // stone miner
+			multitype_attr.types[gamedata::unit_classes::CIVILIAN] = this->parent_type(); // get default villager
+			multitype_attr.types[gamedata::unit_classes::BUILDING] = this->owner.get_type(222); // builder 212
+			multitype_attr.types[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(354); // forager
+			multitype_attr.types[gamedata::unit_classes::SHEEP] = this->owner.get_type(590); // sheperd
+			multitype_attr.types[gamedata::unit_classes::TREES] = this->owner.get_type(218); // woodcutter
+			multitype_attr.types[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(581); // gold miner
+			multitype_attr.types[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(220); // stone miner
 		}
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 		unit->give_ability(std::make_shared<BuildAbility>(this->on_attack));
@@ -462,7 +465,6 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 		auto &worker_attr = unit->get_attribute<attr_type::worker>();
 		worker_attr.capacity = 15.0;
 		worker_attr.gather_rate[game_resource::food] = 0.002;
-		worker_attr.graphics[gamedata::unit_classes::SEA_FISH] = this;
 
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 	}
@@ -567,7 +569,7 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 	UnitType *proj_type = this->owner.get_type(this->projectile);
 	if (this->unit_data.projectile_unit_id > 0 && proj_type) {
 		coord::phys_t range_phys = coord::settings::phys_per_tile * this->unit_data.max_range;
-		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(proj_type, range_phys, 350000, 1, this));
+		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(proj_type, range_phys, 350000, 1));
 		unit->give_ability(std::make_shared<AttackAbility>());
 	}
 

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -191,6 +191,7 @@ void ObjectProducer::initialise(Unit *unit, Player &player) {
 	// hitpoints if available
 	if (this->unit_data.hit_points > 0) {
 		unit->add_attribute(std::make_shared<Attribute<attr_type::hitpoints>>(this->unit_data.hit_points));
+		unit->add_attribute(std::make_shared<Attribute<attr_type::damaged>>(this->unit_data.hit_points));
 	}
 
 	// collectable resources
@@ -555,6 +556,7 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 	// garrison and hp for all buildings
 	unit->add_attribute(std::make_shared<Attribute<attr_type::garrison>>());
 	unit->add_attribute(std::make_shared<Attribute<attr_type::hitpoints>>(this->unit_data.hit_points));
+	unit->add_attribute(std::make_shared<Attribute<attr_type::damaged>>(this->unit_data.hit_points));
 
 	bool has_destruct_graphic = this->destroyed != nullptr;
 	unit->push_action(std::make_unique<FoundationAction>(unit, has_destruct_graphic), true);

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -421,8 +421,11 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 
 		// add graphic ids for resource actions
 		auto &worker_attr = unit->get_attribute<attr_type::worker>();
-		worker_attr.capacity = 10.0f;
-		worker_attr.gather_rate = 0.002f;
+		worker_attr.capacity = 10.0;
+		worker_attr.gather_rate[game_resource::wood] = 0.002;
+		worker_attr.gather_rate[game_resource::food] = 0.002;
+		worker_attr.gather_rate[game_resource::gold] = 0.002;
+		worker_attr.gather_rate[game_resource::stone] = 0.002;
 
 		// currently not sure where the game data keeps these values
 		// todo PREY_ANIMAL SEA_FISH
@@ -457,8 +460,8 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 
 		// add fishing abilites
 		auto &worker_attr = unit->get_attribute<attr_type::worker>();
-		worker_attr.capacity = 15.0f;
-		worker_attr.gather_rate = 0.002f;
+		worker_attr.capacity = 15.0;
+		worker_attr.gather_rate[game_resource::food] = 0.002;
 		worker_attr.graphics[gamedata::unit_classes::SEA_FISH] = this;
 
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -389,6 +389,7 @@ void MovableProducer::initialise(Unit *unit, Player &player) {
 	else {
 		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(nullptr, 0, 0, 1));
 	}
+	unit->add_attribute(std::make_shared<Attribute<attr_type::formation>>());
 }
 
 TerrainObject *MovableProducer::place(Unit *unit, std::shared_ptr<Terrain> terrain, coord::phys3 init_pos) const {
@@ -570,6 +571,8 @@ void BuildingProducer::initialise(Unit *unit, Player &player) {
 	if (this->unit_data.projectile_unit_id > 0 && proj_type) {
 		coord::phys_t range_phys = coord::settings::phys_per_tile * this->unit_data.max_range;
 		unit->add_attribute(std::make_shared<Attribute<attr_type::attack>>(proj_type, range_phys, 350000, 1));
+		// formation is used only for the attack_stance
+		unit->add_attribute(std::make_shared<Attribute<attr_type::formation>>(attack_stance::aggresive));
 		unit->give_ability(std::make_shared<AttackAbility>());
 	}
 

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -416,50 +416,50 @@ void LivingProducer::initialise(Unit *unit, Player &player) {
 
 	// add worker attributes
 	if (this->unit_data.unit_class == gamedata::unit_classes::CIVILIAN) {
-		unit->add_attribute(std::make_shared<Attribute<attr_type::gatherer>>());
+		unit->add_attribute(std::make_shared<Attribute<attr_type::worker>>());
+		unit->add_attribute(std::make_shared<Attribute<attr_type::resource>>());
 
 		// add graphic ids for resource actions
-		auto &gather_attr = unit->get_attribute<attr_type::gatherer>();
-		gather_attr.current_type = game_resource::wood;
-		gather_attr.capacity = 10.0f;
-		gather_attr.gather_rate = 0.002f;
+		auto &worker_attr = unit->get_attribute<attr_type::worker>();
+		worker_attr.capacity = 10.0f;
+		worker_attr.gather_rate = 0.002f;
 
 		// currently not sure where the game data keeps these values
 		// todo PREY_ANIMAL SEA_FISH
 		if (this->parent_id() == 83) {
 
 			// male graphics
-			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(156); // builder 118
-			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(120); // forager
-			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(592); // sheperd
-			gather_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(123); // woodcutter
-			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(579); // gold miner
-			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(124); // stone miner
+			worker_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(156); // builder 118
+			worker_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(120); // forager
+			worker_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(592); // sheperd
+			worker_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(123); // woodcutter
+			worker_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(579); // gold miner
+			worker_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(124); // stone miner
 
 		}
 		else {
 
 			// female graphics
-			gather_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(222); // builder 212
-			gather_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(354); // forager
-			gather_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(590); // sheperd
-			gather_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(218); // woodcutter
-			gather_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(581); // gold miner
-			gather_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(220); // stone miner
+			worker_attr.graphics[gamedata::unit_classes::BUILDING] = this->owner.get_type(222); // builder 212
+			worker_attr.graphics[gamedata::unit_classes::BERRY_BUSH] = this->owner.get_type(354); // forager
+			worker_attr.graphics[gamedata::unit_classes::SHEEP] = this->owner.get_type(590); // sheperd
+			worker_attr.graphics[gamedata::unit_classes::TREES] = this->owner.get_type(218); // woodcutter
+			worker_attr.graphics[gamedata::unit_classes::GOLD_MINE] = this->owner.get_type(581); // gold miner
+			worker_attr.graphics[gamedata::unit_classes::STONE_MINE] = this->owner.get_type(220); // stone miner
 		}
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 		unit->give_ability(std::make_shared<BuildAbility>(this->on_attack));
 		unit->give_ability(std::make_shared<RepairAbility>(this->on_attack));
 	}
 	else if (this->unit_data.unit_class == gamedata::unit_classes::FISHING_BOAT) {
-		unit->add_attribute(std::make_shared<Attribute<attr_type::gatherer>>());
+		unit->add_attribute(std::make_shared<Attribute<attr_type::worker>>());
+		unit->add_attribute(std::make_shared<Attribute<attr_type::resource>>());
 
 		// add fishing abilites
-		auto &gather_attr = unit->get_attribute<attr_type::gatherer>();
-		gather_attr.current_type = game_resource::food;
-		gather_attr.capacity = 15.0f;
-		gather_attr.gather_rate = 0.002f;
-		gather_attr.graphics[gamedata::unit_classes::SEA_FISH] = this;
+		auto &worker_attr = unit->get_attribute<attr_type::worker>();
+		worker_attr.capacity = 15.0f;
+		worker_attr.gather_rate = 0.002f;
+		worker_attr.graphics[gamedata::unit_classes::SEA_FISH] = this;
 
 		unit->give_ability(std::make_shared<GatherAbility>(this->on_attack));
 	}

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -312,7 +312,8 @@ void UnitSelection::show_attributes(Unit *u) {
 selection_type_t UnitSelection::get_unit_selection_type(const Player &player, Unit *u) {
 	bool is_building = u->has_attribute(attr_type::building);
 
-	// Check color
+	// Check owner
+	// TODO implement allied units
 	if (u->is_own_unit(player)) {
 		return is_building ? selection_type_t::own_buildings : selection_type_t::own_units;
 	} else {

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -284,12 +284,12 @@ void UnitSelection::show_attributes(Unit *u) {
 	}
 	if (u->has_attribute(attr_type::hitpoints) && u->has_attribute(attr_type::damaged)) {
 		auto &hp = u->get_attribute<attr_type::hitpoints>();
-		auto &dm = u->get_attribute<attr_type::hitpoints>();
+		auto &dm = u->get_attribute<attr_type::damaged>();
 		lines.push_back("hitpoints: "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
 	}
 	if (u->has_attribute(attr_type::resource)) {
 		auto &res_attr = u->get_attribute<attr_type::resource>();
-		lines.push_back("resource: "+std::to_string(res_attr.amount));
+		lines.push_back("resource: "+std::to_string(res_attr.amount)+" "+std::to_string(res_attr.resource_type));
 	}
 	if (u->has_attribute(attr_type::building)) {
 		auto &build_attr = u->get_attribute<attr_type::building>();

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -47,9 +47,10 @@ bool UnitSelection::on_drawhud() {
 	for (auto u : this->units) {
 		if (u.second.is_valid()) {
 			Unit *unit_ptr = u.second.get();
-			if (unit_ptr->location && unit_ptr->has_attribute(attr_type::hitpoints)) {
+			if (unit_ptr->location && unit_ptr->has_attribute(attr_type::hitpoints) && unit_ptr->has_attribute(attr_type::damaged)) {
 				auto &hp = unit_ptr->get_attribute<attr_type::hitpoints>();
-				float percent = static_cast<float>(hp.current) / static_cast<float>(hp.max);
+				auto &dm = unit_ptr->get_attribute<attr_type::damaged>();
+				float percent = static_cast<float>(dm.hp) / static_cast<float>(hp.hp);
 				int mid = percent * 28.0f - 14.0f;
 
 				coord::phys3 &pos_phys3 = unit_ptr->location->pos.draw;
@@ -127,7 +128,7 @@ void UnitSelection::toggle_unit(const Player &player, Unit *u, bool append) {
 void UnitSelection::add_unit(const Player &player, Unit *u, bool append) {
 	// Only select resources and units with hitpoints > 0
 	if (u->has_attribute(attr_type::resource) ||
-	   (u->has_attribute(attr_type::hitpoints) && u->get_attribute<attr_type::hitpoints>().current > 0)) {
+	   (u->has_attribute(attr_type::damaged) && u->get_attribute<attr_type::damaged>().hp > 0)) {
 
 		selection_type_t unit_type = get_unit_selection_type(player, u);
 		int unit_type_i = static_cast<int>(unit_type);
@@ -281,9 +282,10 @@ void UnitSelection::show_attributes(Unit *u) {
 		auto &own_attr = u->get_attribute<attr_type::owner>();
 		lines.push_back(own_attr.player.name);
 	}
-	if (u->has_attribute(attr_type::hitpoints)) {
-		auto &hp_attr = u->get_attribute<attr_type::hitpoints>();
-		lines.push_back("hitpoints: "+std::to_string(hp_attr.current)+"/"+std::to_string(hp_attr.max));
+	if (u->has_attribute(attr_type::hitpoints) && u->has_attribute(attr_type::damaged)) {
+		auto &hp = u->get_attribute<attr_type::hitpoints>();
+		auto &dm = u->get_attribute<attr_type::hitpoints>();
+		lines.push_back("hitpoints: "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
 	}
 	if (u->has_attribute(attr_type::resource)) {
 		auto &res_attr = u->get_attribute<attr_type::resource>();

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #include <algorithm>
 #include <cmath>
@@ -248,6 +248,10 @@ void Unit::add_attribute(std::shared_ptr<AttributeContainer> attr) {
 
 void Unit::add_attributes(const Attributes &attr) {
 	this->attributes.addCopies(attr);
+}
+
+void Unit::add_attributes(const Attributes &attr, bool shared, bool unshared) {
+	this->attributes.addCopies(attr, shared, unshared);
 }
 
 bool Unit::has_attribute(attr_type type) const {

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -283,8 +283,8 @@ void Unit::stop_gather() {
 
 void Unit::stop_actions() {
 
-	// work around for gatherers continuing to work after retasking
-	if (this->has_attribute(attr_type::gatherer)) {
+	// work around for workers continuing to work after retasking
+	if (this->has_attribute(attr_type::worker)) {
 		this->stop_gather();
 	}
 

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -243,11 +243,15 @@ void Unit::secondary_action(std::unique_ptr<UnitAction> action) {
 }
 
 void Unit::add_attribute(std::shared_ptr<AttributeContainer> attr) {
-	this->attribute_map.emplace(attr_map_t::value_type(attr->type, attr));
+	this->attributes.add(attr);
+}
+
+void Unit::add_attributes(const Attributes &attr) {
+	this->attributes.addCopies(attr);
 }
 
 bool Unit::has_attribute(attr_type type) const {
-	return (this->attribute_map.count(type) > 0);
+	return this->attributes.has(type);
 }
 
 std::shared_ptr<UnitAbility> Unit::queue_cmd(const Command &cmd) {

--- a/libopenage/unit/unit.cpp
+++ b/libopenage/unit/unit.cpp
@@ -247,11 +247,11 @@ void Unit::add_attribute(std::shared_ptr<AttributeContainer> attr) {
 }
 
 void Unit::add_attributes(const Attributes &attr) {
-	this->attributes.addCopies(attr);
+	this->attributes.add_copies(attr);
 }
 
 void Unit::add_attributes(const Attributes &attr, bool shared, bool unshared) {
-	this->attributes.addCopies(attr, shared, unshared);
+	this->attributes.add_copies(attr, shared, unshared);
 }
 
 bool Unit::has_attribute(attr_type type) const {

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -174,10 +174,17 @@ public:
 	void add_attribute(std::shared_ptr<AttributeContainer> attr);
 
 	/**
-	 * give a new attributes this this unit
-	 * this is used to add the default attributes
+	 * Give new attributes to this unit.
+	 * This is used to add the default attributes
 	 */
 	void add_attributes(const Attributes &attr);
+
+	/**
+	 * Give new attributes to this unit.
+	 * If shared is false, shared attributes are ignored.
+	 * If unshared is false, unshared attributes are ignored.
+	 */
+	void add_attributes(const Attributes &attr, bool shared, bool unshared);
 
 	/**
 	 * returns whether attribute is available

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -246,6 +246,12 @@ public:
 	 */
 	std::string logsource_name() override;
 
+	/**
+	 * Unit attributes include color, hitpoints, speed, objects garrisoned etc
+	 * contains 0 or 1 values for each type
+	 */
+	Attributes attributes;
+
 private:
 	/**
 	 * ability available -- actions that this entity
@@ -275,13 +281,6 @@ private:
 	 * mutex controlling updates to the command queue
 	 */
 	std::mutex command_queue_lock;
-
-
-	/**
-	 * Unit attributes include color, hitpoints, speed, objects garrisoned etc
-	 * contains 0 or 1 values for each type
-	 */
-	Attributes attributes;
 
 
 	/**

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -15,6 +15,7 @@
 #include "../util/timing.h"
 #include "ability.h"
 #include "attribute.h"
+#include "attributes.h"
 #include "command.h"
 #include "unit_container.h"
 

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -174,6 +174,12 @@ public:
 	void add_attribute(std::shared_ptr<AttributeContainer> attr);
 
 	/**
+	 * give a new attributes this this unit
+	 * this is used to add the default attributes
+	 */
+	void add_attributes(const Attributes &attr);
+
+	/**
 	 * returns whether attribute is available
 	 */
 	bool has_attribute(attr_type type) const;
@@ -183,7 +189,9 @@ public:
 	 */
 	template<attr_type T>
 	Attribute<T> &get_attribute() {
-		return *reinterpret_cast<Attribute<T> *>(attribute_map[T].get());
+		return *reinterpret_cast<Attribute<T> *>(attributes.get(T).get());
+		// TODO change to (templates errors)
+		//return attributes.get<T>();
 	}
 
 	/**
@@ -266,7 +274,7 @@ private:
 	 * Unit attributes include color, hitpoints, speed, objects garrisoned etc
 	 * contains 0 or 1 values for each type
 	 */
-	attr_map_t attribute_map;
+	Attributes attributes;
 
 
 	/**

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -30,8 +30,15 @@ UnitType::UnitType(const Player &owner)
 }
 
 void UnitType::reinitialise(Unit *unit, Player &player) {
-	// TODO implement it
+	// In case reinitialise is not implemented separately
+
+	Attributes tmp;
+	// copy only unshared
+	tmp.addCopies(unit->attributes, false, true);
+	// initialise the new unit
 	this->initialise(unit, player);
+	// replace new unshared attributes with the old
+	unit->attributes.addCopies(tmp);
 }
 
 bool UnitType::operator==(const UnitType &other) const {

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -34,11 +34,11 @@ void UnitType::reinitialise(Unit *unit, Player &player) {
 
 	Attributes tmp;
 	// copy only unshared
-	tmp.addCopies(unit->attributes, false, true);
+	tmp.add_copies(unit->attributes, false, true);
 	// initialise the new unit
 	this->initialise(unit, player);
 	// replace new unshared attributes with the old
-	unit->attributes.addCopies(tmp);
+	unit->attributes.add_copies(tmp);
 }
 
 bool UnitType::operator==(const UnitType &other) const {

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -69,6 +69,7 @@ TerrainObject *UnitType::place_beside(Unit *u, TerrainObject const *other) const
 }
 
 void UnitType::copy_attributes(Unit *unit) const {
+	// TODO be replaced by Attributes::addCopies
 	for (auto &attr : this->default_attributes) {
 		unit->add_attribute(attr.second->copy());
 	}

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -29,6 +29,11 @@ UnitType::UnitType(const Player &owner)
 	owner{owner} {
 }
 
+void UnitType::reinitialise(Unit *unit, Player &player) {
+	// TODO implement it
+	this->initialise(unit, player);
+}
+
 bool UnitType::operator==(const UnitType &other) const {
 	return this->type_abilities == other.type_abilities;
 }
@@ -101,7 +106,7 @@ std::string NyanType::name() const {
 }
 
 void NyanType::initialise(Unit *unit, Player &) {
-	// reset any existing attributes and type
+	// removes all actions and abilities
 	unit->reset();
 
 	// initialise unit

--- a/libopenage/unit/unit_type.cpp
+++ b/libopenage/unit/unit_type.cpp
@@ -69,14 +69,11 @@ TerrainObject *UnitType::place_beside(Unit *u, TerrainObject const *other) const
 }
 
 void UnitType::copy_attributes(Unit *unit) const {
-	// TODO be replaced by Attributes::addCopies
-	for (auto &attr : this->default_attributes) {
-		unit->add_attribute(attr.second->copy());
-	}
+	unit->add_attributes(this->default_attributes);
 }
 
-void UnitType::upgrade(const AttributeContainer &attr) {
-	*this->default_attributes[attr.type] = attr;
+void UnitType::upgrade(const std::shared_ptr<AttributeContainer> &attr) {
+	this->default_attributes.add(attr);
 }
 
 UnitType *UnitType::parent_type() const {

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -85,6 +85,16 @@ public:
 	 * TODO: make const
 	 */
 	virtual void initialise(Unit *, Player &) = 0;
+
+	/**
+	 * Initialize units shared attributes only to this type spec
+	 *
+	 * This can be called using existing units to modify type if the type
+	 * Ensure that the unit has been placed before seting the units type
+	 *
+	 * TODO define if pure vitrual or not / should be in nyan?
+	 */
+	virtual void reinitialise(Unit *, Player &);
 
 	/**
 	 * set unit in place -- return if placement was successful

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -119,7 +119,7 @@ public:
 	/**
 	 * upgrades one attribute of this unit type
 	 */
-	void upgrade(const AttributeContainer &attr);
+	void upgrade(const std::shared_ptr<AttributeContainer> &attr);
 
 	/**
 	 * returns type matching parent_id()
@@ -145,7 +145,7 @@ public:
 	/**
 	 * default attributes which get copied to new units
 	 */
-	attr_map_t default_attributes;
+	Attributes default_attributes;
 
 	/**
 	 * The set of graphics used for this type

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "../coord/phys3.h"
-#include "attribute.h"
+#include "attributes.h"
 
 namespace openage {
 


### PR DESCRIPTION
### Attributes system improvements goals:

- [x] Abstract shared and ushared attributes
  - [x] share method
  - [x] ~~copy method (???)~~
- [x] Convert `attr_map_t` into a proper class (`Attributes`?)
  - [x] implement
    - [x] add `attributes.cpp` (?)
  - [x] refactor
- [x] Split attributes and refactor changes
  - [x] hitpoints -> hitpoints + current hitpoints (issue #651)
  - [x] building -> building + dropsite (semi-implemented)
  - [x] attack: move attack stance elsewher
- [x] Change the worker atrribute
  - [x] rename
  - [x] split into unshared and shared
    - [x] carrying resources
    - [x] move worker action graphics to somewhere else ($1)
  - [x] gather rate per resource
  - [x] move attack type (used only for villagers) from attack ($2)
- [x] Multitype attribute (for unit with subtypes: villages, trebuchets)
  - [x] implement
  - [x] refactor producers and fix $1 and $2
- [x] Change type bugs
  - [x] use `reinitialise` instead of `reinitialise` in order to keep the unshared attributes (eg. life)
- [x] ~~Actions attribute calls optimize~~
  - [x] ~~move has/get attribute in constructor (call once and store) (?)~~
  - [x] ~~move basic operations inside attributes~~
- [x] Add doc


### Notes

- All files including `attributes.h`: `unit_type.h`, `unit.h`, `action.h`
- `Attributes` methods:
  - bool add/has/removeAttribute (hide all map methods)
  - Attribute get<attr_type>

### Bugs found (and solved) on the way

- Health reset every time villager changes resources (eg. from wood to stone) (wait... no)
- One gather rate for all resources
- Search for new building to build includes enemy's building
- Towers auto attack
- ...