### PR TITLE
Load data 34 times faster!

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,5 +1,2 @@
 # converted game assets
 /converted
-
-# cache files
-cache.docx

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,2 +1,5 @@
 # converted game assets
 /converted
+
+# cache files
+cache.docx

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "../assetmanager.h"
 #include "../engine.h"

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -38,7 +38,9 @@ bool GameSpec::initialize() {
 	util::Dir gamedata_dir = this->assetmanager->get_data_dir()->append(this->data_path);
 
 	log::log(MSG(info) << "Loading game specification files...");
-	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx");
+	util::csv_file_map_t *tmp = load_multi_csv_file(gamedata_dir, "gamedata.docx");
+	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx", tmp);
+	delete tmp;
 
 	this->on_gamedata_loaded(this->gamedata);
 	this->gamedata_loaded = true;

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -36,7 +36,6 @@ bool GameSpec::initialize() {
 	util::Dir gamedata_dir = this->assetmanager->get_data_dir()->append(this->data_path);
 
 	util::csv_file_map_t *meta_file_map = load_multi_csv_file(gamedata_dir, "gamedata.docx");
-	util::csv_file_map = meta_file_map;
 
 	this->load_terrain(*this->assetmanager, meta_file_map);
 

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -33,14 +33,13 @@ bool GameSpec::initialize() {
 	util::Timer load_timer;
 	load_timer.start();
 
+	util::load_csv_file_cache(*this->assetmanager->get_data_dir());
+
 	this->load_terrain(*this->assetmanager);
 
 	util::Dir gamedata_dir = this->assetmanager->get_data_dir()->append(this->data_path);
 
-	log::log(MSG(info)
-	         << "loading game specification files... "
-	         << "will be faster once we use nyan, so please help!");
-
+	log::log(MSG(info) << "Loading game specification files... (will take a while only the first time)");
 	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx");
 
 	this->on_gamedata_loaded(this->gamedata);

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -38,7 +38,7 @@ bool GameSpec::initialize() {
 	util::csv_file_map_t *meta_file_map = load_multi_csv_file(gamedata_dir, "gamedata.docx");
 	util::csv_file_map = meta_file_map;
 
-	this->load_terrain(*this->assetmanager);
+	this->load_terrain(*this->assetmanager, meta_file_map);
 
 	log::log(MSG(info) << "Loading game specification files...");
 	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx", meta_file_map);
@@ -307,7 +307,7 @@ void GameSpec::load_projectile(const gamedata::unit_projectile &proj, unit_meta_
 	}
 }
 
-void GameSpec::load_terrain(AssetManager &am) {
+void GameSpec::load_terrain(AssetManager &am, util::csv_file_map_t *file_map) {
 
 	// Terrain data files
 	util::Dir *data_dir = am.get_data_dir();
@@ -315,7 +315,7 @@ void GameSpec::load_terrain(AssetManager &am) {
 	std::vector<gamedata::string_resource> string_resources;
 	util::read_csv_file(asset_dir.join("string_resources.docx"), string_resources);
 	std::vector<gamedata::terrain_type> terrain_meta;
-	util::read_csv_file(asset_dir.join("gamedata/gamedata-empiresdat/0000-terrains.docx"), terrain_meta);
+	util::read_csv_file(asset_dir.join("gamedata/gamedata-empiresdat/0000-terrains.docx"), terrain_meta, file_map);
 	std::vector<gamedata::blending_mode> blending_meta;
 	util::read_csv_file(asset_dir.join("blending_modes.docx"), blending_meta);
 

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -33,14 +33,15 @@ bool GameSpec::initialize() {
 	util::Timer load_timer;
 	load_timer.start();
 
-	this->load_terrain(*this->assetmanager);
-
 	util::Dir gamedata_dir = this->assetmanager->get_data_dir()->append(this->data_path);
 
+	util::csv_file_map_t *meta_file_map = load_multi_csv_file(gamedata_dir, "gamedata.docx");
+	util::csv_file_map = meta_file_map;
+
+	this->load_terrain(*this->assetmanager);
+
 	log::log(MSG(info) << "Loading game specification files...");
-	util::csv_file_map_t *tmp = load_multi_csv_file(gamedata_dir, "gamedata.docx");
-	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx", tmp);
-	delete tmp;
+	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx", meta_file_map);
 
 	this->on_gamedata_loaded(this->gamedata);
 	this->gamedata_loaded = true;

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -33,13 +33,11 @@ bool GameSpec::initialize() {
 	util::Timer load_timer;
 	load_timer.start();
 
-	util::load_csv_file_cache(*this->assetmanager->get_data_dir());
-
 	this->load_terrain(*this->assetmanager);
 
 	util::Dir gamedata_dir = this->assetmanager->get_data_dir()->append(this->data_path);
 
-	log::log(MSG(info) << "Loading game specification files... (will take a while only the first time)");
+	log::log(MSG(info) << "Loading game specification files...");
 	this->gamedata = util::recurse_data_files<gamedata::empiresdat>(gamedata_dir, "gamedata-empiresdat.docx");
 
 	this->on_gamedata_loaded(this->gamedata);

--- a/libopenage/gamestate/game_spec.h
+++ b/libopenage/gamestate/game_spec.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -7,6 +7,7 @@
 #include "../gamedata/graphic.gen.h"
 #include "../terrain/terrain.h"
 #include "../unit/unit_texture.h"
+#include "../util/file.h"
 
 #include <unordered_map>
 #include <memory>
@@ -214,7 +215,7 @@ private:
 	/**
 	 * fill in the terrain_data attribute of this
 	 */
-	void load_terrain(AssetManager &am);
+	void load_terrain(AssetManager &am, util::csv_file_map_t *file_map);
 
 	/**
 	 * has game data been load yet

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "main.h"
 
@@ -34,7 +34,7 @@ int run_game(const main_arguments &args) {
 	auto &cvar_manager = engine.get_cvar_manager();
 	cvar_manager.load_main_config();
 
-	util::load_csv_files(data_dir);
+	util::load_csv_files(data_dir.join("converted/meta.docx"));
 
 	// initialize terminal colors
 	std::vector<gamedata::palette_color> termcolors;

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -34,8 +34,6 @@ int run_game(const main_arguments &args) {
 	auto &cvar_manager = engine.get_cvar_manager();
 	cvar_manager.load_main_config();
 
-	util::load_csv_files(data_dir.join("converted/meta.docx"));
-
 	// initialize terminal colors
 	std::vector<gamedata::palette_color> termcolors;
 	util::read_csv_file(data_dir.join("converted/termcolors.docx"), termcolors);

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -34,6 +34,8 @@ int run_game(const main_arguments &args) {
 	auto &cvar_manager = engine.get_cvar_manager();
 	cvar_manager.load_main_config();
 
+	util::load_csv_files(data_dir);
+
 	// initialize terminal colors
 	std::vector<gamedata::palette_color> termcolors;
 	util::read_csv_file(data_dir.join("converted/termcolors.docx"), termcolors);

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -92,32 +92,31 @@ std::vector<std::string> file_get_lines(const std::string &file_name) {
 	return result;
 }
 
-std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
+csv_file_map_t *csv_file_map = nullptr;
 
-void load_csv_files(std::string path) {
+csv_file_map_t *load_multi_csv_file(Dir basedir, const std::string &fname) {
+	std::string path = basedir.join(fname);
 
-	log::log(MSG(info) << "Loading csv files");
-	if (file_size(path) == -1) {
-		log::log(MSG(info) << "Cannot find csv file at " << path);
-		return;
-	}
-
+	log::log(MSG(info) << "Loading multi csv file: " << fname);
 	std::vector<std::string> lines = file_get_lines(path);
+
+	csv_file_map_t *map = new csv_file_map_t();
 
 	std::string current_file = "";
 	for (auto& line : lines) {
 		if (line[0] == '#' && line[1] == '#' && line[2] == ' ') {
-			current_file = "./assets/converted" + line.erase(0, 3);
-			csv_file_map.emplace(current_file, std::vector<std::string>());
+			current_file = basedir.join(line.erase(0, 3));
+			map->emplace(current_file, std::vector<std::string>());
 		}
 		else {
 			if (line.empty() || line[0] == '#') {
 				continue;
 			}
-			csv_file_map.at(current_file).push_back(line);
+			map->at(current_file).push_back(line);
 		}
 	}
-	log::log(MSG(info) << "Loaded csv files: " << csv_file_map.size());
+	log::log(MSG(info) << "Loaded csv files: " << map->size());
+	return map;
 }
 
 }} // openage::util

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -92,56 +92,33 @@ std::vector<std::string> file_get_lines(const std::string &file_name) {
 	return result;
 }
 
-std::unordered_map<std::string, std::vector<std::string>> csv_file_cache_map;
-std::string csv_file_cache_map_path;
-bool csv_file_cache_active = false;
+std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
 
-void load_csv_file_cache(Dir basedir) {
-	csv_file_cache_map_path = basedir.join("cache.docx");
-	csv_file_cache_active = true;
+void load_csv_files(Dir basedir) {
+	std::string path = basedir.join("converted/meta.docx");
 
-	log::log(MSG(info) << "Loading csv file cache");
-	if (file_size(csv_file_cache_map_path) == -1) {
-		log::log(MSG(info) << "Cannot find csv file cache at " << csv_file_cache_map_path);
+	log::log(MSG(info) << "Loading csv files");
+	if (file_size(path) == -1) {
+		log::log(MSG(info) << "Cannot find csv file at " << path);
 		return;
 	}
 
-	std::vector<std::string> lines = file_get_lines(csv_file_cache_map_path);
-	log::log(MSG(info) << "Loaded lines from csv file cache: " << lines.size());
+	std::vector<std::string> lines = file_get_lines(path);
 
 	std::string current_file = "";
 	for (auto& line : lines) {
 		if (line[0] == '#' && line[1] == '#' && line[2] == ' ') {
-			current_file = line.erase(0, 3);
-			csv_file_cache_map.emplace(current_file, std::vector<std::string>());
+			current_file = "./assets/converted" + line.erase(0, 3);
+			csv_file_map.emplace(current_file, std::vector<std::string>());
 		}
 		else {
-			csv_file_cache_map.at(current_file).push_back(line);
+			if (line.empty() || line[0] == '#') {
+				continue;
+			}
+			csv_file_map.at(current_file).push_back(line);
 		}
 	}
-	log::log(MSG(info) << "Loaded files from csv file cache: " << csv_file_cache_map.size());
-}
-
-void add_to_csv_file_cache(const std::string &fname) {
-	if (!csv_file_cache_active) {
-		return;
-	}
-	// add file to cache file and also load it
-	std::ofstream cachefile{csv_file_cache_map_path, std::ios_base::app};
-	cachefile << "## " << fname << "\n";
-	csv_file_cache_map.emplace(fname, std::vector<std::string>());
-	std::vector<std::string> lines = file_get_lines(fname);
-	for (auto& line : lines) {
-		if (line.empty() || line[0] == '#') {
-			continue;
-		}
-		cachefile << line << "\n";
-		csv_file_cache_map.at(fname).push_back(line);
-	}
-}
-
-void deactivate_csv_file_cache() {
-	csv_file_cache_active = false;
+	log::log(MSG(info) << "Loaded csv files: " << csv_file_map.size());
 }
 
 }} // openage::util

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -94,8 +94,7 @@ std::vector<std::string> file_get_lines(const std::string &file_name) {
 
 std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
 
-void load_csv_files(Dir basedir) {
-	std::string path = basedir.join("converted/meta.docx");
+void load_csv_files(std::string path) {
 
 	log::log(MSG(info) << "Loading csv files");
 	if (file_size(path) == -1) {

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -105,7 +105,7 @@ csv_file_map_t *load_multi_csv_file(Dir basedir, const std::string &fname) {
 	std::string current_file = "";
 	for (auto& line : lines) {
 		if (line[0] == '#' && line[1] == '#' && line[2] == ' ') {
-			current_file = basedir.join(line.erase(0, 3));
+			current_file = basedir.join(line.erase(0, 3)) + ".docx";
 			map->emplace(current_file, std::vector<std::string>());
 		}
 		else {

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -30,11 +30,9 @@ ssize_t read_whole_file(char **result, const std::string &filename);
  */
 std::vector<std::string> file_get_lines(const std::string &file_name);
 
-extern std::unordered_map<std::string, std::vector<std::string>> csv_file_cache_map;
+extern std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
 
-void load_csv_file_cache(Dir basedir);
-void add_to_csv_file_cache(const std::string &fname);
-void deactivate_csv_file_cache();
+void load_csv_files(Dir basedir);
 
 /**
  * read a single csv file.
@@ -46,12 +44,8 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out) {
 	lineformat current_line_data;
 	std::vector<char> strbuf;
 
-	if (!csv_file_cache_map.count(fname)) {
-		add_to_csv_file_cache(fname);
-	}
-
-	if (csv_file_cache_map.count(fname)) {
-		std::vector<std::string> lines = csv_file_cache_map.at(fname);
+	if (csv_file_map.count(fname)) {
+		std::vector<std::string> lines = csv_file_map.at(fname);
 
 		for (auto &line : lines) {
 			line_count += 1;

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -32,7 +32,7 @@ std::vector<std::string> file_get_lines(const std::string &file_name);
 
 extern std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
 
-void load_csv_files(Dir basedir);
+void load_csv_files(std::string path);
 
 /**
  * read a single csv file.

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -33,7 +33,7 @@ std::vector<std::string> file_get_lines(const std::string &file_name);
 using csv_file_map_t = std::unordered_map<std::string, std::vector<std::string>>;
 
 /**
- *
+ * Load a multi csv file into a csv_file_map_t
  */
 csv_file_map_t *load_multi_csv_file(Dir basedir, const std::string &fname);
 
@@ -45,13 +45,18 @@ extern csv_file_map_t *csv_file_map;
  * call the destination struct .fill() method for actually storing line data
  */
 template<typename lineformat>
-void read_csv_file(const std::string &fname, std::vector<lineformat> &out) {
+void read_csv_file(const std::string &fname, std::vector<lineformat> &out, csv_file_map_t *file_map = nullptr) {
 	size_t line_count = 0;
 	lineformat current_line_data;
 	std::vector<char> strbuf;
 
-	if (csv_file_map && csv_file_map->count(fname)) {
-		std::vector<std::string> lines = csv_file_map->at(fname);
+	// TODO chnage the auto gen files in order to remove this
+	if (!file_map) {
+		file_map = csv_file_map;
+	}
+
+	if (file_map && file_map->count(fname)) {
+		std::vector<std::string> lines = file_map->at(fname);
 
 		for (auto &line : lines) {
 			line_count += 1;
@@ -113,28 +118,17 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out) {
 	}
 }
 
-/**
- * reads data files recursively.
- * should be called from the .recurse() method of the struct.
- */
-template<class lineformat>
-std::vector<lineformat> recurse_data_files(Dir basedir, const std::string &fname, csv_file_map_t *file_map) {
-
-	csv_file_map = file_map;
-
-	return recurse_data_files<lineformat>(basedir, fname);
-}
 
 /**
  * reads data files recursively.
  * should be called from the .recurse() method of the struct.
  */
 template<class lineformat>
-std::vector<lineformat> recurse_data_files(Dir basedir, const std::string &fname) {
+std::vector<lineformat> recurse_data_files(Dir basedir, const std::string &fname, csv_file_map_t *file_map = nullptr) {
 	std::vector<lineformat> result;
 	std::string merged_filename = basedir.join(fname);
 
-	read_csv_file<lineformat>(merged_filename, result);
+	read_csv_file<lineformat>(merged_filename, result, file_map);
 
 	//the new basedir is the old basedir
 	// + the directory part of the current relative file name

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -52,6 +52,7 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out, csv_f
 
 	// TODO chnage the auto gen files in order to remove this
 	if (!file_map) {
+		log::log(MSG(info) << "Loading without passing the map: " << fname);
 		file_map = csv_file_map;
 	}
 
@@ -137,7 +138,7 @@ std::vector<lineformat> recurse_data_files(Dir basedir, const std::string &fname
 	size_t line_count = 0;
 	for (auto &entry : result) {
 		line_count += 1;
-		if (not entry.recurse(new_basedir)) {
+		if (not entry.recurse(new_basedir, file_map)) {
 			throw Error(MSG(err) <<
 				"Failed to read follow-up files for " <<
 				merged_filename << ":" << line_count);
@@ -159,8 +160,8 @@ struct subdata {
 	std::string filename;
 	std::vector<cls> data;
 
-	bool read(Dir basedir) {
-		this->data = recurse_data_files<cls>(basedir, this->filename);
+	bool read(Dir basedir, csv_file_map_t *file_map = nullptr) {
+		this->data = recurse_data_files<cls>(basedir, this->filename, file_map);
 		return true;
 	}
 

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -6,8 +6,8 @@
 #include <cstring>
 #include <fstream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "../error/error.h"
 
@@ -30,9 +30,15 @@ ssize_t read_whole_file(char **result, const std::string &filename);
  */
 std::vector<std::string> file_get_lines(const std::string &file_name);
 
-extern std::unordered_map<std::string, std::vector<std::string>> csv_file_map;
+using csv_file_map_t = std::unordered_map<std::string, std::vector<std::string>>;
 
-void load_csv_files(std::string path);
+/**
+ *
+ */
+csv_file_map_t *load_multi_csv_file(Dir basedir, const std::string &fname);
+
+// TODO chnage the auto gen files in order to remove this
+extern csv_file_map_t *csv_file_map;
 
 /**
  * read a single csv file.
@@ -44,8 +50,8 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out) {
 	lineformat current_line_data;
 	std::vector<char> strbuf;
 
-	if (csv_file_map.count(fname)) {
-		std::vector<std::string> lines = csv_file_map.at(fname);
+	if (csv_file_map && csv_file_map->count(fname)) {
+		std::vector<std::string> lines = csv_file_map->at(fname);
 
 		for (auto &line : lines) {
 			line_count += 1;
@@ -105,6 +111,18 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out) {
 				"Empty or missing.");
 		}
 	}
+}
+
+/**
+ * reads data files recursively.
+ * should be called from the .recurse() method of the struct.
+ */
+template<class lineformat>
+std::vector<lineformat> recurse_data_files(Dir basedir, const std::string &fname, csv_file_map_t *file_map) {
+
+	csv_file_map = file_map;
+
+	return recurse_data_files<lineformat>(basedir, fname);
 }
 
 /**

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -37,9 +37,6 @@ using csv_file_map_t = std::unordered_map<std::string, std::vector<std::string>>
  */
 csv_file_map_t *load_multi_csv_file(Dir basedir, const std::string &fname);
 
-// TODO chnage the auto gen files in order to remove this
-extern csv_file_map_t *csv_file_map;
-
 /**
  * read a single csv file.
  * call the destination struct .fill() method for actually storing line data
@@ -49,12 +46,6 @@ void read_csv_file(const std::string &fname, std::vector<lineformat> &out, csv_f
 	size_t line_count = 0;
 	lineformat current_line_data;
 	std::vector<char> strbuf;
-
-	// TODO chnage the auto gen files in order to remove this
-	if (!file_map) {
-		log::log(MSG(info) << "Loading without passing the map: " << fname);
-		file_map = csv_file_map;
-	}
 
 	if (file_map && file_map->count(fname)) {
 		std::vector<std::string> lines = file_map->at(fname);

--- a/libopenage/util/timer.cpp
+++ b/libopenage/util/timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2016 the openage authors. See copying.md for legal info.
+// Copyright 2013-2017 the openage authors. See copying.md for legal info.
 
 #include "timer.h"
 

--- a/libopenage/util/timer.cpp
+++ b/libopenage/util/timer.cpp
@@ -28,7 +28,7 @@ void Timer::stop() {
 }
 
 void Timer::start() {
-	if (not this->stopped) {
+	if (this->stopped) {
 		this->stopped = false;
 		this->starttime = timing::get_monotonic_time() - this->stoppedat;
 	}
@@ -46,7 +46,7 @@ time_nsec_t Timer::getandresetval() {
 	time_nsec_t result;
 
 	if (this->stopped) {
-		result    = this->stoppedat;
+		result = this->stoppedat;
 		this->stoppedat = 0;
 	}
 	else {

--- a/openage/convert/changelog.py
+++ b/openage/convert/changelog.py
@@ -35,7 +35,7 @@ CHANGES = (
     {"graphics"},
     {"interface"},
     {"interface"},
-    {"gamedata", "metadata"},
+    {"metadata"},
 )
 
 # the current version number equals the number of changes

--- a/openage/convert/changelog.py
+++ b/openage/convert/changelog.py
@@ -35,7 +35,7 @@ CHANGES = (
     {"graphics"},
     {"interface"},
     {"interface"},
-    {"gamedata"},
+    {"gamedata", "metadata"},
 )
 
 # the current version number equals the number of changes

--- a/openage/convert/changelog.py
+++ b/openage/convert/changelog.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 """
 Asset version change log
@@ -35,6 +35,7 @@ CHANGES = (
     {"graphics"},
     {"interface"},
     {"interface"},
+    {"gamedata"},
 )
 
 # the current version number equals the number of changes

--- a/openage/convert/dataformat/data_definition.py
+++ b/openage/convert/dataformat/data_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 
@@ -38,13 +38,19 @@ class DataDefinition(StructDefinition):
             csv_column_types.append(repr(c_type))
 
         # the resulting csv content
-        # begin with the csv information comment header
-        txt = [
+        txt = []
+
+        # create the file meta comment for sigle file packed csv files
+        if self.single_output:
+            txt.extend(["## ", self.name_data_file, "\n"])
+
+        # create the csv information comment header
+        txt.extend([
             "# struct ", self.name_struct, "\n",
             commentify_lines("# ", self.struct_description),
             "# ", genfile.DELIMITER.join(csv_column_types), "\n",
             "# ", genfile.DELIMITER.join(self.members.keys()), "\n",
-        ]
+        ])
 
         from .multisubtype_base import MultisubtypeBaseFile
 
@@ -91,10 +97,13 @@ class DataDefinition(StructDefinition):
             # create one csv line, separated by DELIMITER (probably a ,)
             txt.extend((genfile.DELIMITER.join(row_entries), "\n"))
 
-        if self.prefix:
-            snippet_file_name = self.prefix + self.name_data_file
+        if self.single_output:
+            snippet_file_name = self.single_output
         else:
             snippet_file_name = self.name_data_file
+
+        if self.prefix:
+            snippet_file_name = self.prefix + snippet_file_name
 
         return [ContentSnippet(
             "".join(txt),

--- a/openage/convert/dataformat/data_formatter.py
+++ b/openage/convert/dataformat/data_formatter.py
@@ -80,7 +80,7 @@ $parsers
         # collection of all type definitions
         self.typedefs = dict()
 
-    def add_data(self, data_set_pile, prefix=None):
+    def add_data(self, data_set_pile, prefix=None, single_output=None):
         """
         add a given StructDefinition to the storage, so it can be exported later.
 
@@ -97,6 +97,9 @@ $parsers
             # (missing: struct, structimpl)
             if prefix:
                 data_set.prefix = prefix
+
+            if single_output:
+                data_set.single_output = single_output
 
             # collect column type specifications
             for member_name, member_type in data_set.members.items():
@@ -184,10 +187,5 @@ $parsers
         # we now invoke the content generation for each generated file
         for gen_file in generate_files:
             file_name, content = gen_file.generate()
-            if gen_file.format_ in {"csv"}:
-                with open('assets/converted/meta.docx', 'ab') as outfile:
-                    outfile.write(('## ' + file_name + '\n').encode('utf-8'))
-                    outfile.write(content.encode('utf-8'))
-            else:
-                with projectdir[file_name].open('wb') as outfile:
-                    outfile.write(content.encode('utf-8'))
+            with projectdir[file_name].open('wb') as outfile:
+                outfile.write(content.encode('utf-8'))

--- a/openage/convert/dataformat/data_formatter.py
+++ b/openage/convert/dataformat/data_formatter.py
@@ -58,13 +58,13 @@ $parsers
             func_name = "recurse",
             templates = {
                 0: entry_parser.ParserTemplate(
-                    signature    = "int %srecurse(openage::util::Dir /*basedir*/)",
+                    signature    = "int %srecurse(openage::util::Dir /*basedir*/, openage::util::csv_file_map_t */*file_map*/)",
                     headers      = util.determine_header("engine_dir"),
                     impl_headers = set(),
                     template     = "$signature {\n\treturn -1;\n}\n"
                 ),
                 None: entry_parser.ParserTemplate(
-                    signature = "int %srecurse(openage::util::Dir basedir)",
+                    signature = "int %srecurse(openage::util::Dir basedir, openage::util::csv_file_map_t *file_map)",
                     headers   = util.determine_header("engine_dir"),
                     impl_headers = set(),
                     template  = "$signature {\n$parsers\n\n\treturn -1;\n}\n"

--- a/openage/convert/dataformat/data_formatter.py
+++ b/openage/convert/dataformat/data_formatter.py
@@ -184,5 +184,10 @@ $parsers
         # we now invoke the content generation for each generated file
         for gen_file in generate_files:
             file_name, content = gen_file.generate()
-            with projectdir[file_name].open('wb') as outfile:
-                outfile.write(content.encode('utf-8'))
+            if file_name.endswith('.docx'):
+                with open('assets/converted/meta.docx', 'ab') as file:
+                    file.write(('## ' + file_name + '\n').encode('utf-8'))
+                    file.write(content.encode('utf-8'))
+            else:
+                with projectdir[file_name].open('wb') as outfile:
+                    outfile.write(content.encode('utf-8'))

--- a/openage/convert/dataformat/data_formatter.py
+++ b/openage/convert/dataformat/data_formatter.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 
@@ -184,10 +184,10 @@ $parsers
         # we now invoke the content generation for each generated file
         for gen_file in generate_files:
             file_name, content = gen_file.generate()
-            if file_name.endswith('.docx'):
-                with open('assets/converted/meta.docx', 'ab') as file:
-                    file.write(('## ' + file_name + '\n').encode('utf-8'))
-                    file.write(content.encode('utf-8'))
+            if gen_file.format_ in {"csv"}:
+                with open('assets/converted/meta.docx', 'ab') as outfile:
+                    outfile.write(('## ' + file_name + '\n').encode('utf-8'))
+                    outfile.write(content.encode('utf-8'))
             else:
                 with projectdir[file_name].open('wb') as outfile:
                     outfile.write(content.encode('utf-8'))

--- a/openage/convert/dataformat/generated_file.py
+++ b/openage/convert/dataformat/generated_file.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 
@@ -25,6 +25,7 @@ class GeneratedFile:
     default_preferences = {
         "folder":         "",
         "file_suffix":    "",
+        "process":        True,
         "content_prefix": Template(""),
         "content_suffix": Template(""),
     }
@@ -35,6 +36,7 @@ class GeneratedFile:
         "csv": {
             "folder":      "",
             "file_suffix": ".docx",
+            "process":     False,
         },
         "struct": {
             "file_suffix": ".gen.h",
@@ -143,6 +145,12 @@ namespace ${namespace} {
         # apply preference overrides
         prefs = self.default_preferences.copy()
         prefs.update(self.output_preferences[self.format_])
+
+        # if there is no need for sorting and resolving dependencies, just return the snippets
+        # as they have been added
+        if not prefs["process"]:
+            file_data = "\n".join(snippet.get_data() for snippet in self.snippets)
+            return prefs["folder"] + '/' + self.file_name + prefs["file_suffix"], file_data
 
         snippets_header = {s for s in self.snippets if s.section == SectionType.section_header}
         snippets_body   = self.snippets - snippets_header

--- a/openage/convert/dataformat/members.py
+++ b/openage/convert/dataformat/members.py
@@ -672,7 +672,7 @@ class MultisubtypeMember(RefMember, DynLengthMember):
             # function to recursively read the referenced files
             txt.extend((
                 "int %s::recurse(openage::util::Dir basedir, openage::util::csv_file_map_t *file_map) {\n" % (self.type_name),
-                "\tthis->index_file.read(basedir); //read ref-file entries\n",
+                "\tthis->index_file.read(basedir, file_map); //read ref-file entries\n",
                 "\tint subtype_count = this->index_file.data.size();\n"
                 "\tif (subtype_count != %s) {\n" % len(self.class_lookup),
                 "\t\tthrow openage::error::Error(MSG(err) << \"multisubtype index file entry count mismatched! \" << subtype_count << \" != %d\");\n" % (len(self.class_lookup)),
@@ -697,7 +697,7 @@ class MultisubtypeMember(RefMember, DynLengthMember):
                     "\t\tthrow openage::error::Error(MSG(err) << \"multisubtype index file contains no entry for %s!\");\n" % (entry_name),
                     "\t}\n",
                     "\tthis->%s.filename = this->index_file.data[idx].filename;\n" % (entry_name),
-                    "\tthis->%s.read(new_basedir);\n" % (entry_name),
+                    "\tthis->%s.read(new_basedir, file_map);\n" % (entry_name),
                     "\tidx = -1;\n\n"
                 ))
             txt.append("\treturn -1;\n}\n")

--- a/openage/convert/dataformat/members.py
+++ b/openage/convert/dataformat/members.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,abstract-method
 
@@ -615,7 +615,7 @@ class MultisubtypeMember(RefMember, DynLengthMember):
                 destination = "fill",
             ),
             EntryParser(
-                ["this->%s.recurse(basedir);" % (member)],
+                ["this->%s.recurse(basedir, file_map);" % (member)],
                 headers     = set(),
                 typerefs    = set(),
                 destination = "recurse",
@@ -671,7 +671,7 @@ class MultisubtypeMember(RefMember, DynLengthMember):
 
             # function to recursively read the referenced files
             txt.extend((
-                "int %s::recurse(openage::util::Dir basedir) {\n" % (self.type_name),
+                "int %s::recurse(openage::util::Dir basedir, openage::util::csv_file_map_t *file_map) {\n" % (self.type_name),
                 "\tthis->index_file.read(basedir); //read ref-file entries\n",
                 "\tint subtype_count = this->index_file.data.size();\n"
                 "\tif (subtype_count != %s) {\n" % len(self.class_lookup),
@@ -768,7 +768,7 @@ class SubdataMember(MultisubtypeMember):
                 destination = "fill",
             ),
             EntryParser(
-                ["this->%s.read(basedir);" % (member)],
+                ["this->%s.read(basedir, file_map);" % (member)],
                 headers     = set(),
                 typerefs    = set(),
                 destination = "recurse",

--- a/openage/convert/dataformat/struct_definition.py
+++ b/openage/convert/dataformat/struct_definition.py
@@ -34,8 +34,8 @@ class StructDefinition:
         self.name_struct_file   = target.name_struct_file    # !< name of file where generated struct will be placed
         self.name_struct        = target.name_struct         # !< name of generated C struct
         self.struct_description = target.struct_description  # !< comment placed above generated C struct
-        self.prefix             = None
-        self.single_output      = None
+        self.prefix             = None                       # !< if not None, a prefix will be added to the final path
+        self.single_output      = None                       # !< if not None, will be packed with other files into a single one
         self.target             = target                     # !< target Exportable class that defines the data format
 
         # create ordered dict of member type objects from structure definition

--- a/openage/convert/dataformat/struct_definition.py
+++ b/openage/convert/dataformat/struct_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 
@@ -35,6 +35,7 @@ class StructDefinition:
         self.name_struct        = target.name_struct         # !< name of generated C struct
         self.struct_description = target.struct_description  # !< comment placed above generated C struct
         self.prefix             = None
+        self.single_output      = None
         self.target             = target                     # !< target Exportable class that defines the data format
 
         # create ordered dict of member type objects from structure definition

--- a/openage/convert/dataformat/util.py
+++ b/openage/convert/dataformat/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C
 
@@ -106,7 +106,7 @@ def determine_header(for_type):
         "int":             set(),
         "read_csv_file":   {util_file_h},
         "subdata":         {util_file_h},
-        "engine_dir":      {util_dir_h},
+        "engine_dir":      {util_dir_h, util_file_h},
         "engine_error":    {error_error_h},
         "engine_log":      {log_h},
     }

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 # pylint: disable=R0912
 """
 Receives cleaned-up srcdir and targetdir objects from .main, and drives the
@@ -194,7 +194,7 @@ def convert_metadata(args):
     yield "empires.dat"
     gamespec = get_gamespec(args.srcdir, args.game_versions, args.flag("no_pickle_cache"))
     data_dump = gamespec.dump("gamedata")
-    data_formatter.add_data(data_dump[0], prefix="gamedata/")
+    data_formatter.add_data(data_dump[0], prefix="gamedata/", single_output="gamedata")
 
     yield "blendomatic.dat"
     blend_data = get_blendomatic_data(args.srcdir)

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -191,6 +191,10 @@ def convert_metadata(args):
     if args.flag("no_metadata"):
         return
 
+    gamedata_path = args.targetdir.joinpath('gamedata')
+    if gamedata_path.exists():
+        gamedata_path.removerecursive()
+
     yield "empires.dat"
     gamespec = get_gamespec(args.srcdir, args.game_versions, args.flag("no_pickle_cache"))
     data_dump = gamespec.dump("gamedata")

--- a/openage/convert/slp_converter_pool.py
+++ b/openage/convert/slp_converter_pool.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 """
 Multiprocessing-based SLP-to-texture converter service.
@@ -91,7 +91,9 @@ class SLPConverterPool:
             return Texture(SLP(slpdata), self.palette, custom_cutter)
 
         if free_memory() < 2**30:
+            # TODO print the warn only once
             warn("Low on memory; disabling parallel SLP conversion")
+
             # acquire job_mutex in order to block any concurrent activity until
             # this job is done.
             with self.job_mutex:


### PR DESCRIPTION
From
![screenshot from 2017-01-02 15-24-56](https://cloud.githubusercontent.com/assets/6997990/21591957/d6f9f0aa-d111-11e6-9601-7307b88866f7.png)
to
![screenshot from 2017-01-02 16-06-28](https://cloud.githubusercontent.com/assets/6997990/21591962/df66af94-d111-11e6-990e-98592fecc160.png)
(after the first time)

### How
I create a `cache.docx` file which contains all the other `*.docx`. Every time the read csv function is called the the file is added to the cache file. The first time (before the creation of the cache) the load time is like the old days and from the second time and after all the loading is happening from the cache structure much faster (= 34 times faster).

### Notes
- The cache file is only around 13 MB
- Fixed the timers wrong logic
- Comments are not cached