### PR TITLE
show timestamp in build output for easier VM troubleshooting

### DIFF
--- a/.kevin
+++ b/.kevin
@@ -5,6 +5,7 @@
 
 
 sanity_check:
+	date -Iseconds
 	make checkall
 
 configure:


### PR DESCRIPTION
#649 had a CI error because of a missing pep8 module. It would have been nice to see a timestamp in the build output.