### PR TITLE
fix build with libbacktrace, clean up log includes

### DIFF
--- a/buildsystem/modules/FindGCCBacktrace.cmake
+++ b/buildsystem/modules/FindGCCBacktrace.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 # This module defines:
 #
@@ -18,8 +18,8 @@ find_library(GCCBacktrace_LIBRARY
 )
 
 include(CheckCXXSourceCompiles)
-list(APPEND CMAKE_REQUIRED_INCLUDES GCCBacktrace_INCLUDE_DIR)
-list(APPEND CMAKE_REQUIRED_LIBRARIES GCCBacktrace_LIBRARY)
+list(APPEND CMAKE_REQUIRED_INCLUDES ${GCCBacktrace_INCLUDE_DIR})
+list(APPEND CMAKE_REQUIRED_LIBRARIES ${GCCBacktrace_LIBRARY})
 set(CMAKE_REQUIRED_QUIET TRUE)
 CHECK_CXX_SOURCE_COMPILES("
 #include <iostream>
@@ -52,6 +52,6 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
 	GCCBacktrace
 	FOUND_VAR GCCBacktrace_FOUND
-	REQUIRED_VARS GCCBacktrace_LIBRARY GCCBacktrace_INCLUDE_DIR)
+	REQUIRED_VARS GCCBacktrace_LIBRARIES GCCBacktrace_INCLUDE_DIRS)
 
-mark_as_advanced(GCCBacktrace_LIBRARY GCCBacktrace_INCLUDE_DIR)
+mark_as_advanced(GCCBacktrace_LIBRARIES GCCBacktrace_INCLUDE_DIRS)

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -157,7 +157,7 @@ include_directories(
 	${SDL2_INCLUDE_DIR}
 	${SDL2IMAGE_INCLUDE_DIRS}
 	${HarfBuzz_INCLUDE_DIRS}
-        ${QTPLATFORM_INCLUDE_DIRS}
+	${QTPLATFORM_INCLUDE_DIRS}
 )
 
 # link the executable to those libraries

--- a/libopenage/error/demo.cpp
+++ b/libopenage/error/demo.cpp
@@ -1,10 +1,12 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include <vector>
 #include <string>
 
+#include "../log/log.h"
 #include "backtrace.h"
 #include "error.h"
+
 
 namespace openage {
 namespace error {

--- a/libopenage/error/error.h
+++ b/libopenage/error/error.h
@@ -9,7 +9,6 @@
 #include <string>
 
 // pxd: from libopenage.log.message cimport message
-#include "../log/log.h"
 #include "../log/message.h"
 
 // pxd: from libopenage.error.backtrace cimport Backtrace

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -1,11 +1,14 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+
+#include "game_control.h"
 
 #include "engine.h"
 #include "error/error.h"
 #include "gamestate/game_spec.h"
-#include "util/strings.h"
+#include "log/log.h"
 #include "terrain/terrain_chunk.h"
-#include "game_control.h"
+#include "util/strings.h"
+
 
 namespace openage {
 

--- a/libopenage/gamestate/civilisation.cpp
+++ b/libopenage/gamestate/civilisation.cpp
@@ -1,7 +1,10 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
-#include "../unit/unit_type.h"
 #include "civilisation.h"
+
+#include "../log/log.h"
+#include "../unit/unit_type.h"
+
 
 namespace openage {
 

--- a/libopenage/gamestate/game_main.cpp
+++ b/libopenage/gamestate/game_main.cpp
@@ -1,11 +1,14 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+
+#include "game_main.h"
 
 #include "../engine.h"
+#include "../log/log.h"
 #include "../terrain/terrain.h"
 #include "../unit/unit_type.h"
-#include "game_main.h"
 #include "game_spec.h"
 #include "generator.h"
+
 
 namespace openage {
 

--- a/libopenage/gamestate/game_spec.cpp
+++ b/libopenage/gamestate/game_spec.cpp
@@ -1,18 +1,21 @@
 // Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
+#include "game_spec.h"
+
+#include <tuple>
+
 #include "../assetmanager.h"
 #include "../engine.h"
 #include "../gamedata/blending_mode.gen.h"
 #include "../gamedata/string_resource.gen.h"
 #include "../gamedata/terrain.gen.h"
+#include "../log/log.h"
 #include "../rng/global_rng.h"
 #include "../unit/producer.h"
 #include "../util/strings.h"
 #include "../util/timer.h"
 #include "civilisation.h"
-#include "game_spec.h"
 
-#include <tuple>
 
 namespace openage {
 

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -1,13 +1,16 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
-#include "../util/math_constants.h"
-#include "../unit/unit.h"
+#include "generator.h"
+
+#include "../log/log.h"
 #include "../rng/rng.h"
 #include "../terrain/terrain_chunk.h"
+#include "../unit/unit.h"
+#include "../util/math_constants.h"
 #include "game_main.h"
 #include "game_save.h"
 #include "game_spec.h"
-#include "generator.h"
+
 
 namespace openage {
 

--- a/libopenage/gamestate/player.cpp
+++ b/libopenage/gamestate/player.cpp
@@ -1,9 +1,12 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
+#include "player.h"
+
+#include "../log/log.h"
 #include "../unit/unit.h"
 #include "../unit/unit_type.h"
-#include "player.h"
 #include "team.h"
+
 
 namespace openage {
 

--- a/libopenage/gui/actions_list_model.cpp
+++ b/libopenage/gui/actions_list_model.cpp
@@ -1,10 +1,11 @@
-// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+// Copyright 2016-2017 the openage authors. See copying.md for legal info.
 
 #include "actions_list_model.h"
 
-#include <QtQml>
-
+#include "../log/log.h"
 #include "game_control_link.h"
+
+#include <QtQml>
 
 namespace openage {
 namespace gui {

--- a/libopenage/gui/integration/private/gui_log.cpp
+++ b/libopenage/gui/integration/private/gui_log.cpp
@@ -1,11 +1,10 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "../../integration/private/gui_log.h"
 
 #include <QString>
 
 #include "../../../log/log.h"
-#include "../../../log/message.h"
 
 namespace openage {
 namespace gui {

--- a/libopenage/input/text_to_event.cpp
+++ b/libopenage/input/text_to_event.cpp
@@ -1,14 +1,15 @@
-// Copyright 2016-2016 the openage authors. See copying.md for legal info.
+// Copyright 2016-2017 the openage authors. See copying.md for legal info.
 
 #include "text_to_event.h"
 
 #include <regex>
 #include <stdexcept>
-
 #include <SDL2/SDL.h>
 
 #include "../error/error.h"
+#include "../log/log.h"
 #include "../testing/testing.h"
+
 
 namespace openage {
 namespace input {

--- a/libopenage/log/log.h
+++ b/libopenage/log/log.h
@@ -1,9 +1,10 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 // pxd: from libopenage.log.level cimport level
 #include "level.h"
+#include "message.h"
 
 namespace openage {
 namespace log {

--- a/libopenage/log/named_logsource.h
+++ b/libopenage/log/named_logsource.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -7,6 +7,7 @@
 
 // pxd: from libopenage.log.logsource cimport LogSource
 #include "logsource.h"
+
 
 namespace openage {
 namespace log {

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -3,16 +3,16 @@
 #include "main.h"
 
 #include "console/console.h"
-#include "gamedata/color.gen.h"
-#include "util/file.h"
-
 #include "engine.h"
 #include "game_control.h"
 #include "game_renderer.h"
+#include "gamedata/color.gen.h"
 #include "gamestate/generator.h"
-
-#include "shader/shader.h"
+#include "log/log.h"
 #include "shader/program.h"
+#include "shader/shader.h"
+#include "util/file.h"
+
 
 namespace openage {
 

--- a/libopenage/pyinterface/exctranslate_tests.cpp
+++ b/libopenage/pyinterface/exctranslate_tests.cpp
@@ -1,12 +1,13 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "exctranslate_tests.h"
 
 #include <vector>
 
+#include "../log/log.h"
 #include "../testing/testing.h"
-
 #include "pyexception.h"
+
 
 namespace openage {
 namespace pyinterface {

--- a/libopenage/renderer/font/font_manager.cpp
+++ b/libopenage/renderer/font/font_manager.cpp
@@ -1,10 +1,11 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "font_manager.h"
 
-#include "font.h"
-
 #include <fontconfig/fontconfig.h>
+
+#include "../../log/log.h"
+#include "font.h"
 
 namespace openage {
 namespace renderer {

--- a/libopenage/screenshot.cpp
+++ b/libopenage/screenshot.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #include "screenshot.h"
 #include "util/strings.h"
@@ -12,7 +12,6 @@
 
 #include "coord/window.h"
 #include "log/log.h"
-#include "log/message.h"
 #include <ctime>
 
 namespace openage {

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -1,17 +1,19 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+
+#include "selection.h"
 
 #include <cmath>
 
 #include "../coord/tile.h"
 #include "../coord/tile3.h"
 #include "../engine.h"
+#include "../log/log.h"
 #include "../terrain/terrain.h"
-
 #include "action.h"
 #include "command.h"
 #include "producer.h"
-#include "selection.h"
 #include "unit.h"
+
 
 namespace openage {
 

--- a/libopenage/unit/unit.h
+++ b/libopenage/unit/unit.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,15 +8,16 @@
 #include <vector>
 #include <queue>
 
-#include "../log/logsource.h"
 #include "../coord/phys3.h"
-#include "../terrain/terrain_object.h"
 #include "../handlers.h"
+#include "../log/logsource.h"
+#include "../terrain/terrain_object.h"
 #include "../util/timing.h"
 #include "ability.h"
 #include "attribute.h"
 #include "command.h"
 #include "unit_container.h"
+
 
 namespace openage {
 

--- a/libopenage/unit/unit_container.cpp
+++ b/libopenage/unit/unit_container.cpp
@@ -1,12 +1,14 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+
+#include "unit_container.h"
 
 #include <memory>
 
+#include "../log/log.h"
 #include "../terrain/terrain_object.h"
-
 #include "producer.h"
 #include "unit.h"
-#include "unit_container.h"
+
 
 namespace openage {
 

--- a/libopenage/unit/unit_container.h
+++ b/libopenage/unit/unit_container.h
@@ -1,9 +1,10 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "../coord/tile.h"
 #include "../handlers.h"

--- a/libopenage/unit/unit_texture.cpp
+++ b/libopenage/unit/unit_texture.cpp
@@ -1,14 +1,17 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+
+#include "unit_texture.h"
 
 #include <cmath>
 #include <iostream>
 
 #include "../coord/phys3.h"
 #include "../coord/window.h"
-#include "../util/math_constants.h"
 #include "../gamestate/game_spec.h"
+#include "../log/log.h"
 #include "../texture.h"
-#include "unit_texture.h"
+#include "../util/math_constants.h"
+
 
 namespace openage {
 

--- a/libopenage/util/externalprofiler.cpp
+++ b/libopenage/util/externalprofiler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #include "externalprofiler.h"
 
@@ -13,7 +13,6 @@
 #include "subprocess.h"
 #include "os.h"
 #include "../log/log.h"
-#include "../log/message.h"
 
 
 namespace openage {

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -10,6 +10,8 @@
 #include <string.h>
 
 #include "../error/error.h"
+#include "../log/log.h"
+
 
 namespace openage {
 namespace util {

--- a/libopenage/util/os.cpp
+++ b/libopenage/util/os.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #include "os.h"
 
@@ -15,7 +15,6 @@
 #endif
 
 #include "../log/log.h"
-#include "../log/message.h"
 #include "subprocess.h"
 
 namespace openage {

--- a/libopenage/util/subprocess.cpp
+++ b/libopenage/util/subprocess.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #include "subprocess.h"
 
@@ -17,7 +17,6 @@
 #endif
 
 #include "../log/log.h"
-#include "../log/message.h"
 #include "strings.h"
 
 namespace openage {


### PR DESCRIPTION
* Fixed linker error when building with libbacktrace.
* `log/log.h` was implicitly imported by `error/error.h`.
* Reordered some includes to match "associated - global - local" structure.
