### PR TITLE
force colored cmake output in kevin builds

### DIFF
--- a/.kevin
+++ b/.kevin
@@ -12,7 +12,7 @@ configure:
 	./configure --mode=debug
 
 build: configure
-	make -j4 build
+	CLICOLOR_FORCE=1 make -j4 build
 
 test: build
 	make tests


### PR DESCRIPTION
SFTtech/kevin#14. For the time being, this should be an acceptable workaround.