### PR TITLE
use multiprocessing with pylint

### DIFF
--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -77,7 +77,7 @@ def process_args(args, error):
         args.test_git_change_years = True
 
     if not any((args.headerguards, args.legal, args.authors, args.pystyle, args.cppstyle,
-                args.test_git_change_years, args.pylint, args.filemodes)):
+                args.test_git_change_years, args.pylint, args.filemodes, args.textfiles)):
         error("no checks were specified")
 
     has_git = bool(shutil.which('git'))

--- a/buildsystem/codecompliance/pylint.py
+++ b/buildsystem/codecompliance/pylint.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 """
 Checks the Python modules with pylint.
@@ -20,6 +20,13 @@ def find_issues(check_files, dirnames):
     """ Invokes the external utility. """
 
     invocation = ['--rcfile=etc/pylintrc', '--reports=n']
+
+    # pylint crashes with multiprocessing when cython modules are present
+    if any(findfiles(dirnames, [".so"])):
+        print("Cython modules found, using single process linting.")
+    else:
+        from multiprocessing import cpu_count
+        invocation.append("--jobs={:d}".format(cpu_count()))
 
     ignored_modules = list(find_pyx_modules(dirnames))
     ignored_modules.append('numpy')


### PR DESCRIPTION
pylint crashes in multiprocessing mode when there are compiled cython modules in the tree (despite explicitly ignoring those modules). We have to fall back to single-process mode in this case.
Otherwise, this speeds up the style checker by about 10 seconds. Would be pretty nice for kevin builds.
Also fixed a bug where you could not run the codecompliance module in textfile only mode.