### PR TITLE
run ci with 24 cores

### DIFF
--- a/.kevin
+++ b/.kevin
@@ -12,7 +12,7 @@ configure:
 	./configure --mode=debug
 
 build: configure
-	CLICOLOR_FORCE=1 make -j4 build
+	CLICOLOR_FORCE=1 make -j$(nproc) build
 
 test: build
 	make tests


### PR DESCRIPTION
We have a new server with a lot of processing power. CI can now run with 24 cores instead of 4. Timers are now down to 13 sec for codestyle and 50 sec for build. :tada: :fireworks: 