### PR TITLE
audio: fix broken log message

### DIFF
--- a/libopenage/audio/audio_manager.cpp
+++ b/libopenage/audio/audio_manager.cpp
@@ -80,7 +80,7 @@ AudioManager::AudioManager(job::JobManager *job_manager,
 	         << (device_name.empty() ? "default" : device_name)
 	         << " [freq=" << device_spec.freq
 	         << ", format=" << device_spec.format
-	         << ", channels=" << device_spec.channels
+	         << ", channels=" << static_cast<uint16_t>(device_spec.channels)
 	         << ", samples=" << device_spec.samples
 	         << "]");
 


### PR DESCRIPTION
C++ is awesome. `device_spec.channels` is a `uint8_t` and therefore printed as `char`.