### PR TITLE
Log Qt version and bump to Qt 5.5

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -45,7 +45,7 @@ Dependency list:
        S  pycodestyle (or pep8 (deprecated))
     C     pygments
        S  pylint
-    CR    qt5 >=5.4 (Core, Quick, QuickControls modules)
+    CR    qt5 >=5.5 (Core, Quick, QuickControls modules)
 
       A   An installed version of any of the following (wine is your friend).
           Other versions _might_ work; setup disk support will be added soon:

--- a/libopenage/gui/guisys/private/gui_application_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_application_impl.cpp
@@ -1,9 +1,12 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "gui_application_impl.h"
 
 #include <locale>
 #include <cassert>
+
+#include <QtGlobal>
+#include <QtDebug>
 
 namespace qtsdl {
 
@@ -41,6 +44,8 @@ GuiApplicationImpl::GuiApplicationImpl()
 {
 	// Set locale back to POSIX for the decimal point parsing (see qcoreapplication.html#locale-settings).
 	std::locale::global(std::locale().combine<std::numpunct<char>>(std::locale::classic()));
+
+	qInfo() << "Compiled with Qt" << QT_VERSION_STR << "and run with Qt" << qVersion();
 }
 
 } // namespace qtsdl

--- a/libopenage/gui/integration/private/gui_log.cpp
+++ b/libopenage/gui/integration/private/gui_log.cpp
@@ -15,6 +15,9 @@ void gui_log(QtMsgType type, const QMessageLogContext &context, const QString &m
 			case QtDebugMsg:
 			return log::lvl::dbg;
 			break;
+			case QtInfoMsg:
+			return log::lvl::info;
+			break;
 			case QtWarningMsg:
 			return log::lvl::warn;
 			break;


### PR DESCRIPTION
Qt 5.5 has introduced the INFO log level that fits for the version printing.