### PR TITLE
Bug fix: Ownerless projectiles

### DIFF
--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -334,8 +334,10 @@ void DeadAction::update(unsigned int time) {
 }
 
 void DeadAction::on_completion() {
-	auto &owner = this->entity->get_attribute<attr_type::owner>().player;
-	owner.active_unit_removed(this->entity); // TODO move before the start of dead action
+	if (this->entity->has_attribute(attr_type::owner)) {
+		auto &owner = this->entity->get_attribute<attr_type::owner>().player;
+		owner.active_unit_removed(this->entity); // TODO move before the start of dead action
+	}
 
 	this->on_complete_func();
 }
@@ -370,8 +372,10 @@ void FoundationAction::on_completion() {
 		return;
 	}
 
-	auto &owner = this->entity->get_attribute<attr_type::owner>().player;
-	owner.active_unit_added(this->entity);
+	if (this->entity->has_attribute(attr_type::owner)) {
+		auto &owner = this->entity->get_attribute<attr_type::owner>().player;
+		owner.active_unit_added(this->entity);
+	}
 
 	// add destruction effect when available
 	if (this->add_destruct_effect) {


### PR DESCRIPTION
Fix to #760. Some projectile do not have owners, added checks for that.

In the future (when the friendly fire and accuracy is (re)implemented) this should be revisited.

EDIT: the `active_unit_removed` and `active_unit_added` are reworked in #758.
EDIT2: also now the kill cannot be credited to a player