### PR TITLE
Doxygen improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ include(doxygen)
 # apply those to the project:
 
 # create documentation
-doxygen_configure(libopenage/ openage/)
+doxygen_configure(libopenage/ openage/ doc/ README.md)
 
 add_subdirectory(assets/)
 add_subdirectory(libopenage/)

--- a/buildsystem/doxygen_custom.css
+++ b/buildsystem/doxygen_custom.css
@@ -1,0 +1,270 @@
+/*******************************************************
+ * Make footer black and content white
+ */
+
+body {
+	background-color: #445;
+}
+
+div.contents {
+	background-color: white;
+	padding-top: 10px;
+	padding-left: 12px;
+	padding-right: 8px;
+	padding-bottom: 1em;
+	margin: 0;
+}
+
+
+/*******************************************************
+ * Header
+ */
+
+#titlearea {
+	padding: 1em 0;
+	background-color: white;
+	border-bottom: 2px solid #5373B4;
+}
+
+#projectlogo {
+	padding-left: 1em;
+	text-align: left;
+}
+
+#projectlogo img {
+	height: 6em;
+}
+
+#projectname {
+	visibility: hidden; /* Hide project name, it's already on the logo */
+	text-align: right;
+	padding-right: .3em;
+}
+
+#projectnumber {
+	visibility: visible; /* Show openage version, because this is a children of
+	                        #projectname and I've made that invisible */
+}
+
+#projectalign {
+	width: 100%; /* So I can align the version number to the right */
+}
+
+
+/*******************************************************
+ * Main navbar
+ */
+
+.sm {
+	background-image: none;
+	background-color: black;
+}
+
+.sm a {
+	background-image: none;
+	background-color: black;
+	color: white;
+	text-shadow: 0 1px 1px black;
+	border: none;
+}
+
+.sm a.highlighted,
+.sm a:hover,
+.sm a:active,
+.sm a:focus {
+	background-image: url("tab_a.png");
+	background-repeat: repeat;
+	text-shadow: 0 1px 1px black;
+	border: none;
+}
+
+.sm ul a.highlighted,
+.sm ul a:hover,
+.sm ul a:active,
+.sm ul a:focus {
+	background-image: none;
+	background-color: #ccc;
+	text-shadow: none;
+	border: none;
+	color: inherit;
+}
+
+/*
+ * Those tiny arrows are instead a 0px box with a 4px border, that triangle it's
+ * the one border, the remaining borders are transparent
+ */
+.sm a span.sub-arrow {
+	border-color: white transparent transparent transparent;
+}
+
+.sm ul a span.sub-arrow {
+	border-color: transparent transparent transparent black;
+}
+
+.sm ul a.highlighted span.sub-arrow {
+	border-color: transparent transparent transparent white;
+}
+
+
+/*******************************************************
+ * Hierarchy navbar
+ */
+
+.navpath ul {
+	background-color: #445;
+	background-image: none;
+
+	border: 0;
+}
+
+.navpath ul li.navelem {
+	color: white;
+}
+
+.navpath ul li.navelem a {
+	color: #eee;
+	text-shadow: 0px 1px 1px black;
+}
+
+.navpath ul li.navelem a:hover {
+	color: white;
+	text-decoration: underline;
+}
+
+/*******************************************************
+ * Directory tables
+ */
+
+table.directory tr.even {
+	background-color: #eee;
+}
+
+table.directory td.entry {
+	color: #444;
+}
+
+table.directory td.desc {
+	border-left: 2px solid white;
+}
+
+/* Icons looked off */
+.iconfclosed,
+.iconfopen,
+.icondoc {
+	margin-top: 3px;
+}
+
+
+/*******************************************************
+ * Footer
+ */
+
+hr.footer {
+	display: none;
+}
+
+address.footer {
+	/*background-color: black;*/
+	color: white;
+	padding: 1em;
+	border-top: 2px solid #aac;
+}
+
+div.contents {
+	background-color: white;
+	padding-top: 10px;
+	padding-left: 12px;
+	padding-right: 8px;
+	padding-bottom: 1em;
+	margin: 0;
+}
+
+
+/*******************************************************
+ * Content
+ */
+
+div.textblock {
+	max-width: 900px;
+}
+
+/*
+ * Single-line code blocks
+ */
+pre.fragment {
+	padding: .7em;
+	border: none;
+	background-color: #f2f2f5;
+}
+
+/*
+ * Multiple-line code blocks
+ */
+div.fragment {
+	border: none;
+	background-color: #f2f2f5;
+	padding: .7em;
+}
+
+div.fragment div.line {
+	padding: .5em;
+	text-indent: 0;
+}
+
+div.fragment div.line span.lineno {
+	padding: .5em;
+	text-indent: 0;
+	border-right: 2px solid #aac;
+}
+
+/*
+ * Inline code
+ */
+code {
+	background-color: #eee;
+	padding: 0.3em;
+	margin: 0;
+	font-size: 85%;
+	border-radius: 3px;
+}
+
+/*
+ * Tables
+ */
+table.doxtable {
+	border-bottom: 1px solid #9CAFD4;
+}
+
+table.doxtable th {
+	background-color: #374F7F;
+	color: white;
+	border: none;
+}
+
+table.doxtable tr:nth-child(even) {
+	background-color: #f2f2f5;
+}
+
+table.doxtable tr:nth-child(odd) {
+	background-color: white;
+}
+
+table.doxtable td {
+	border: none;
+}
+
+/* Index letters (those in a black box) */
+div.ah, span.ah {
+	background-color: black;
+	background-image: none;
+	border: none;
+}
+
+/* Index bar */
+div.qindex {
+	border: 1px solid #bac8e4;
+	border-left: 0;
+	border-right: 0;
+	padding: .7em 0;
+	background-color: white;
+}

--- a/buildsystem/templates/Doxyfile.in
+++ b/buildsystem/templates/Doxyfile.in
@@ -34,7 +34,7 @@ PROJECT_NAME           = "@PROJECT_NAME@"
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = "@PROJECT_VERSION@"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer
@@ -47,7 +47,7 @@ PROJECT_BRIEF          =
 # exceed 55 pixels and the maximum width should not exceed 200 pixels.
 # Doxygen will copy the logo to the output directory.
 
-PROJECT_LOGO           =
+PROJECT_LOGO           = "@CMAKE_SOURCE_DIR@/assets/logo/banner.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.
@@ -672,7 +672,9 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          =
+# The default values doesn't include .pyx and .pxd
+
+FILE_PATTERNS          = *.cpp *.h *.py *.pyx *.pxd *.in *.md
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.
@@ -779,7 +781,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = "@CMAKE_SOURCE_DIR@/README.md"
 
 #---------------------------------------------------------------------------
 # configuration options related to source browsing
@@ -917,7 +919,7 @@ HTML_STYLESHEET        =
 # robust against future updates. Doxygen will copy the style sheet file to
 # the output directory.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = "@CMAKE_SOURCE_DIR@/buildsystem/doxygen_custom.css"
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
- [x] Create a nice stylesheet for doxygen
- [X] Include md documentation from `/doc/`
    - [ ] ~Fix problems with md rendering~ Doxygen should fix some things upstream
- [ ] ~Publish everything through gh-pages or something like that~ Not until we fix md rendering

I don't know if the custom css should have only the overrides I want or if I should copy the entire doxygen stylesheet and do modifications there.

Screenshot:
![Preview](http://i.imgur.com/iAaH4ys.jpg)

References: #180