### PR TITLE
Surrounded Engine::run with try catch

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -95,6 +95,7 @@ _the openage authors_ are:
 | Marco Savelli               | Piruzzolo                   | svlmrc@gmail.com                      |
 | Yvan Burrie                 | yvan-burrie                 | yvan.burrie@hotmail.com               |
 | Martin Bernardi             | martinber                   | martinbernardi@openmailbox.org        |
+| Erik Griese                 | citron0xa9                  | erik.griese@yahoo.de                  |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -305,10 +305,15 @@ bool Engine::draw_debug_overlay() {
 }
 
 void Engine::run() {
-	this->job_manager.start();
-	this->running = true;
-	this->loop();
-	this->running = false;
+	try {
+		this->job_manager.start();
+		this->running = true;
+		this->loop();
+		this->running = false;
+	} catch (...) {
+		this->job_manager.stop();
+		throw;
+	}
 }
 
 void Engine::stop() {


### PR DESCRIPTION
 - This allows to stop all workers
 - after that is done the exception is rethrown

fixes #766 