### PR TITLE
doc: Update required Cython version in Build docs.

### DIFF
--- a/doc/build_instructions/ubuntu_16.04.md
+++ b/doc/build_instructions/ubuntu_16.04.md
@@ -1,4 +1,5 @@
 # Prerequisite steps for Ubuntu users (Ubuntu 16.04)
 
  - `sudo apt-get update`
- - `sudo apt-get install cmake libfreetype6-dev python3-dev cython3 libepoxy-dev libsdl2-dev libsdl2-image-dev libopusfile-dev libfontconfig1-dev libharfbuzz-dev opus-tools python3-pil python3-numpy python3-pygments qtdeclarative5-dev qml-module-qtquick-controls`
+ - `sudo apt-get install cmake libfreetype6-dev python3-dev python3-pip libepoxy-dev libsdl2-dev libsdl2-image-dev libopusfile-dev libfontconfig1-dev libharfbuzz-dev opus-tools python3-pil python3-numpy python3-pygments qtdeclarative5-dev qml-module-qtquick-controls`
+ - `pip3 install cython`

--- a/doc/building.md
+++ b/doc/building.md
@@ -28,7 +28,7 @@ Dependency list:
 
     C     gcc >=4.9 or clang >=3.4 (clang >=3.5 for Mac OS X)
     CRA   python >=3.4
-    C     cython >=0.23
+    C     cython >=0.25
     C     cmake >=3.1.0
       A   numpy
       A   python imaging library (PIL) -> pillow


### PR DESCRIPTION
Master now uses Cython `ctypedef`s nested inside `cppclass`es which is only supported from version 0.25 and up.

Cython 0.25 is not currently in the standard package repositories on Ubuntu 16.04, but is available through pip, so I changed the Ubuntu build doc to account for that.

Ref #772