### PR TITLE
Fix Age2HD string resources search

### DIFF
--- a/openage/convert/hdlanguagefile.py
+++ b/openage/convert/hdlanguagefile.py
@@ -26,8 +26,12 @@ def read_age2_hd_fe_stringresources(stringres, path):
         try:
             if lang == b'_common':
                 continue
+            if lang == b'_packages':
+                continue
+            if lang.lower() == b'.ds_store'.lower():
+                continue
 
-            langfilename = ["resources", lang.decode(),
+            langfilename = [lang.decode(),
                             "strings", "key-value",
                             "key-value-strings-utf8.txt"]
 


### PR DESCRIPTION
I did `make run` for the first time, and found that the search for string resources looks in the wrong path. It looks in `resources/resources/`. As a result: no string resources are found, and `driver.py` reaches [this statement](https://github.com/SFTtech/openage/blob/6488818ff0412f5e7f1df7a1af724b79decf657f/openage/convert/driver.py#L54):

```python
    if not count:
        raise FileNotFoundError("could not find any language files")
```

I assume this is because [`driver.py` sets `path` to `srcdir["resources"]`](https://github.com/SFTtech/openage/blob/6488818ff0412f5e7f1df7a1af724b79decf657f/openage/convert/driver.py#L41), so when `hdlanguagefile.py` adds another `"resources"` into the search path: it fails (there's no such directory as `resources/resources`).

Maybe the better place to make this fix is inside `driver.py`, but IIRC I briefly tried that and it didn't help.

If someone feels strongly about making the fix in `driver.py` instead: I can double-check whether that change would work. but I would need to know what to delete to ensure that `make run` will attempt again the search for string resources.

My assets come from Age2HD (I used `steamcmd.sh` to install the Windows game to my Mac. it was hard because `steamcmd.sh` is a travesty):

```
INFO [py] Game version(s) detected:
INFO [py]  * Age of Empires 2: HD + African Kingdoms (Version 4.7+)
INFO [py]  * Age of Empires 2: HD + Forgotten Empires (Version 4.0+)
…
INFO [py] asset conversion complete; asset version: 6
```

Also I made the asset search skip some files (`_packages`, and macOS's `.ds_store`) that are known to not be string resource languages.