### PR TITLE
Buildsystem: Added Benchmarking

### DIFF
--- a/libopenage/testing/CMakeLists.txt
+++ b/libopenage/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_sources(libopenage
 	testing.cpp
+	benchmark_test.cpp
 )
 
 pxdgen(

--- a/libopenage/testing/benchmark_test.cpp
+++ b/libopenage/testing/benchmark_test.cpp
@@ -1,0 +1,12 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#include <unistd.h>
+
+namespace openage {
+namespace test {
+
+void benchmark() {
+	usleep(1000);
+}
+
+}} // openage::test

--- a/openage/codegen/cpp_testlist.py
+++ b/openage/codegen/cpp_testlist.py
@@ -68,9 +68,9 @@ def generate_testlist(projectdir):
     """
     root_namespace = Namespace()
 
-    from ..testing.list_processor import tests_and_demos_cpp
+    from ..testing.list_processor import list_targets_cpp
 
-    for testname, _, _, _ in tests_and_demos_cpp():
+    for testname, _, _, _ in list_targets_cpp():
         root_namespace.add_functionname(testname.split('::'))
 
     func_prototypes = list(root_namespace.gen_prototypes())

--- a/openage/testing/CMakeLists.txt
+++ b/openage/testing/CMakeLists.txt
@@ -10,4 +10,5 @@ add_py_modules(
 	main.py
 	testing.py
 	testlist.py
+	benchmark.py
 )

--- a/openage/testing/benchmark.py
+++ b/openage/testing/benchmark.py
@@ -1,0 +1,48 @@
+# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+""" Benchmarking tools for the tests. """
+
+from timeit import timeit
+from sys import stdout
+from time import sleep
+
+
+def benchmark_test_function():
+    """ Simple function to call in for benchmarking. """
+    sleep(0.1)
+
+
+def benchmark(func):
+    """
+    Benchmark the given function. Repeated execution helps to give a maximum to
+    the consumed time, until one iteration takes more than 5s, summed up 10s.
+    """
+
+    result = [(0, 1)]
+    number = 1
+    total = [0, 0]
+    str_row_format = "{:10} {:12}  {:11}"
+    row_format1 = "{:10} "
+    row_format2 = "{:11.8f}s  {:10.8f}s"
+    row_format = row_format1 + row_format2
+
+    print(str_row_format.format("Iterations", "Total time", "Average time per execution"))
+    while number < 4 or result[-1][0] < 5 and number < 65537:
+        print(row_format1.format(number), end="")
+        stdout.flush()
+
+        time = timeit(stmt=func, number=number)
+        result.append((time, number))
+        print(row_format2.format(time, time / number))
+        total[0] += number
+        total[1] += time
+        stdout.flush()
+        number *= 2
+
+    del result[0]
+
+    print()
+    print("Benchmark Results: ")
+    print("------------------")
+    print(str_row_format.format("Iterations", "Total time", "Average time per execution"))
+    print(row_format.format(total[0], total[1], total[1] / total[0]))

--- a/openage/testing/main.py
+++ b/openage/testing/main.py
@@ -6,8 +6,9 @@ import argparse
 
 from ..util.strings import format_progress
 
+from .benchmark import benchmark
 from .testing import TestError
-from .list_processor import get_all_tests_and_demos
+from .list_processor import get_all_targets
 
 
 def print_test_list(test_list):
@@ -16,7 +17,7 @@ def print_test_list(test_list):
     """
     namelen = max(len(name) for name, _ in test_list.keys())
 
-    for current_type in ['test', 'demo']:
+    for current_type in ['test', 'demo', 'benchmark']:
         for (name, type_), (_, lang, desc, _) in test_list.items():
             if type_ == current_type:
                 print("[%s %3s] %-*s  %s" % (type_, lang, namelen, name, desc))
@@ -42,29 +43,32 @@ def init_subparser(cli):
     cli.add_argument("--demo", "-d", nargs=argparse.REMAINDER,
                      help=("run the given demo; the remaining arguments "
                            "are passed to the demo."))
+    cli.add_argument("--benchmark", "-b", nargs=argparse.REMAINDER,
+                     help=("run the given benchmark"))
     cli.add_argument("test", nargs='*', help="run this test")
 
 
 def process_args(args, error):
     """ Processes the given args, detecting errors. """
-    if not args.run_all_tests and not args.demo and not args.test:
+    if not (args.run_all_tests or args.demo or args.test or args.benchmark):
         args.list = True
 
     if args.have_assets and not args.run_all_tests:
         error("you have to run all tests, "
               "otherwise I don't care if you have assets")
 
-    if args.run_all_tests and (args.test or args.demo):
-        error("can't run individual test or demo when running all tests")
+    if args.run_all_tests and (args.test or args.demo or args.benchmark):
+        error("can't run individual test or demo or benchmark when running "
+              "all tests")
 
-    if args.test and args.demo:
-        error("can't run a demo _and_ tests")
+    if bool(args.test) ^ bool(args.demo) ^ bool(args.benchmark):
+        error("can only run one of demo, benchmarks tests")
 
     # link python and c++ so it hopefully works when testing
     from openage.cppinterface.setup import setup
     setup()
 
-    test_list = get_all_tests_and_demos()
+    test_list = get_all_targets()
 
     # the current test environment can have influence on the tests itself.
     test_environment = {
@@ -88,14 +92,17 @@ def process_args(args, error):
             matched = [elem[0] for elem in test_list
                        if elem[0].startswith(test) and elem[1] == "test"]
 
-            if not matched:
-                error("no such test: " + test)
-            else:
+            if matched:
                 args.test.extend(matched)
+            else:
+                error("no such test: " + test)
             args.test.remove(test)
-    if args.demo:
-        if (args.demo[0], 'demo') not in test_list:
-            error("no such demo: " + args.demo[0])
+
+    if args.demo and (args.demo[0], 'demo') not in test_list:
+        error("no such demo: " + args.demo[0])
+
+    if args.benchmark and (args.benchmark[0], 'benchmark') not in test_list:
+        error("no such benchmark: " + args.benchmark[0])
 
     return test_list
 
@@ -138,3 +145,7 @@ def main(args, error):
     if args.demo:
         _, _, _, demofun = test_list[args.demo[0], 'demo']
         exit(demofun(args.demo[1:]))
+
+    if args.benchmark:
+        _, _, _, benchmarktest = test_list[args.benchmark[0], 'benchmark']
+        benchmark(benchmarktest)

--- a/openage/testing/testlist.py
+++ b/openage/testing/testlist.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2017 the openage authors. See copying.md for legal info.
 
 """ Lists of all possible tests; enter your tests here. """
 
@@ -48,6 +48,17 @@ def demos_py():
            "demonstrates the translation of Python log messages")
 
 
+def benchmark_py():
+    """
+    Yields tuples of (name, description) for python benchmark
+    methods.
+    """
+
+    # TODO Add a real benchmark here, and remove this one
+    yield ("openage.testing.benchmark.benchmark_test_function",
+           "Benchmark yourself")
+
+
 def tests_cpp():
     """
     Yields tuples of (name, description, condition_function)
@@ -94,3 +105,13 @@ def demos_cpp():
            "translates a Python exception to C++")
     yield ("openage::pyinterface::tests::pyobject_demo",
            "a tiny interactive interpreter using PyObjectRef")
+
+
+def benchmark_cpp():
+    """
+    Yields tuples of (name, description) for C++ benchmark
+    methods.
+    """
+
+    # TODO Add a real benchmark here!
+    yield ("openage::test::benchmark", "Test the benchmark")


### PR DESCRIPTION
fixes #167

added ```./run test -b BENCHMARK ``` for benchmarking the code. 

It runs the benchmark until the whole block takes longer than 5 seconds, totalling in 10 seconds for the whole process. Minimum of 7 Iterations in total.

This enables us, to benchmark also more complex systems that take a longer while, and still keep the same logic for high-performance tests.

It will produce Output like: 

```
$ ./run test -b testing.benchmark.benchmark
Iterations Total time    Average time per execution
         1  0.10013296s  0.10013296s
         2  0.20025852s  0.10012926s
         4  0.40048001s  0.10012000s
         8  0.80094380s  0.10011798s
        16  1.60193363s  0.10012085s
        32  3.20378083s  0.10011815s
        64  6.40750377s  0.10011725s

Benchmark Results:
------------------
Iterations Total time    Average time per execution
       127 12.71503352s  0.10011837s
```