### PR TITLE
convert: enhance filter options

### DIFF
--- a/doc/media/drs-files.md
+++ b/doc/media/drs-files.md
@@ -99,10 +99,11 @@ DRS files that come with the base AoK game.
 
 ### gamedata.drs
 
-Contains random map scripts (RMS), as well as AI scripts.
+Contains random map scripts (RMS), as well as AI scripts and some graphic files.
 Random Map scripts describe how the builtin maps should be generated.
 AI scripts tell the computer what to do, such as build units, gather resources,
 and generally make it "smart". These are all `bin` files.
+The graphic files (`slp`) are described below.
 
 ### graphics.drs
 

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -241,14 +241,8 @@ def convert_media(args):
     """ Converts the media part """
 
     # set of (drsname, suffix) to ignore
-    # if drsname is None, it matches to any naoe
-    ignored = set()
-    if args.flag("no_sounds"):
-        ignored.add((None, '.wav'))
-    if args.flag("no_graphics"):
-        ignored.add((frozenset({'graphics', 'terrain', 'gamedata'}), '.slp'))
-    if args.flag("no_interface"):
-        ignored.add((frozenset({'interface'}), '.slp'))
+    # if dirname is None, it matches to any name
+    ignored = get_filter(args)
 
     files_to_convert = []
     for dirname in ['sounds', 'graphics', 'terrain',
@@ -279,7 +273,7 @@ def convert_media(args):
             # do the dir "renaming"
             if dirname == "gamedata" and filepath.suffix == ".slp":
                 output_dir = "graphics"
-            elif dirname == "gamedata" and filepath.suffix == ".wav":
+            elif dirname in {"gamedata", "interface"} and filepath.suffix == ".wav":
                 output_dir = "sounds"
 
             files_to_convert.append((filepath, output_dir))
@@ -309,6 +303,27 @@ def convert_media(args):
             ) for (fpath, dirname) in files_to_convert),
             jobs
         )
+
+
+def get_filter(args):
+    """
+    Return a set containing tuples (DIRNAMES, SUFFIX), where DIRNAMES
+    is a set of strings. Files in directory D with D in DIRNAMES and with
+    suffix SUFFIX shall not be converted.
+    If DIRNAMES is None, it matches all directories.
+    """
+    ignored = set()
+    if args.flag("no_sounds"):
+        ignored.add((None, '.wav'))
+    if args.flag("no_graphics"):
+        ignored.add((frozenset({'graphics', 'terrain', 'gamedata'}), '.slp'))
+    if args.flag("no_interface"):
+        ignored.add((frozenset({'interface'}), '.slp'))
+        ignored.add((frozenset({'interface'}), '.bin'))
+    if args.flag("no_scripts"):
+        ignored.add((frozenset({'gamedata'}), '.bin'))
+
+    return ignored
 
 
 def change_dir(path_parts, dirname):

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -564,6 +564,10 @@ def init_subparser(cli):
         help="do not convert interface graphics")
 
     cli.add_argument(
+        "--no-scripts", action='store_true',
+        help="do not convert scripts (AI and Random Maps)")
+
+    cli.add_argument(
         "--no-pickle-cache", action='store_true',
         help="don't use a pickle file to skip the dat file reading.")
 


### PR DESCRIPTION
This adds an option to ignore AI and Random Map scripts.

Interface files where not filtered correctly. I found this by running
`$ python3 -m openage convert --no-graphics --no-interface --no-metadata  -v  --force`
There are some `bin` files belonging to animations in `interface.drs`. This documented in `doc/media/drs-file.md`.

There was no option to ignore the random map scripts. There is now.

