### PR TITLE
Doc - Civilization and unit statistics for AoE I

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -100,6 +100,7 @@ _the openage authors_ are:
 | Michal Jarzabek             | stiopa                      | stiopa à gmail dawt com                           |
 | Christopher Wilson          | cdw33                       | cdw33 à zips dawt uakron dawt edu                 |
 | Wojciech Nawrocki           | Vtec234                     | wjnawrocki à protonmail dawt com                  |
+| Folkert van Verseveld       | methos, medicijnman         | folkert dawt van dawt verseveld à gmail dawt com  |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/reverse_engineering/civilizations.md
+++ b/doc/reverse_engineering/civilizations.md
@@ -1,0 +1,115 @@
+# Civilization attributes
+
+## Age of Empires I
+
+### Civilization specials
+
+Civilization | Bonus
+-------------|------
+Assyrian     | +40% Archery Range unit fire rate; Villagers 30% faster.
+Babylonian   | Double wall and tower hit points; +30% Priest rejuvenation rate; +30% stone mining.
+Choson       | +80 Long Swordsman and Legion hit points, +2 tower range, -30% Priest cost.
+Egyptian     | +20% gold mining; +33% Chariot and Chariot Archer hit points; +3 Priest range.
+Greek        | Hoplite, Phalanx and Centurion 30% faster; War ships 30% faster.
+Hittite      | Double Stone Thrower, Catapult, Heavy Catapult hit points; +1 Archery Range unit attack; +4 war ship range.
+Minoan       | -30% ship cost; +2 Composite Bowman range; +25% Farm production.
+Persian      | +30% hunting; -30% Farm production; War Elephant and Elephant Archer 50% faster; +50% Trireme fire rate.
+Phoenician   | -25% War Elephant and Elephant Archer cost; +65% Catapult Trireme and Juggernaught fire rate.
+Shang        | -30% Villager cost; Double wall hit points.
+Sumerian     | +15 villager hit points; +50% Stone Thrower, Catapult, Heavy Catapult fire rate; Double Farm production.
+Yamato       | -25% Horse Archers, Scout, Cavalry, Heavy Cavalry, Cataphract cost; Villagers 30% faster; +30% ship hit points.
+
+### Unit/Building creation table
+
+If a unit or building is listed in the following table, that particular
+civilization can produce that particular unit/building:
+
+Infantry:
+
+Unit/Build.     | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+----------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Broad Swordsman | III |    x |     x |    x |        |       |    x |    x |    x |     x |     x |    x |
+Long Swordsman  |  IV |    x |     x |    x |        |       |      |    x |    x |     x |       |    x |
+Legion          |  IV |    x |     x |    x |        |       |      |      |    x |     x |       |      |
+Hoplite         | III |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Phalanx         |  IV |      |       |      |        |     x |    x |    x |      |     x |       |    x |    x
+Centurion       |  IV |      |       |      |        |     x |    x |    x |      |     x |       |    x |    x
+
+Archers:
+
+Unit/Build.        | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+-------------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Chariot Archer     | III |    x |     x |      |      x |       |    x |      |      |     x |     x |    x |
+Improved Bowman    | III |      |     x |    x |      x |       |      |    x |    x |     x |     x |      |    x
+Composite Bowman   |  IV |      |     x |      |      x |       |      |    x |    x |     x |     x |      |    x
+Elephant Archer    |  IV |      |       |      |      x |       |    x |      |    x |     x |       |      |
+Horse Archer       |  IV |    x |     x |    x |        |       |    x |      |    x |       |     x |    x |    x
+Heavy Horse Archer |  IV |      |       |      |        |       |    x |      |    x |       |     x |    x |    x
+
+Cavalry:
+
+Unit/Build.   | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+--------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Chariot       | III |    x |     x |      |      x |       |    x |      |      |     x |     x |    x |
+Cavalry       | III |    x |     x |    x |        |     x |    x |    x |    x |     x |     x |      |    x
+Heavy Cavalry |  IV |    x |       |    x |        |     x |      |      |    x |       |     x |      |    x
+Cataphract    |  IV |    x |       |    x |        |       |      |      |    x |       |     x |      |    x
+War Elephant  |  IV |      |       |      |      x |       |    x |      |    x |     x |       |    x |
+
+Siege Weapons:
+
+Unit/Build.    | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+---------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Ballista       |  IV |    x |       |    x |        |     x |      |    x |      |       |     x |      |
+Catapult       |  IV |    x |     x |      |        |     x |    x |    x |    x |       |     x |    x |
+Helepolis      |  IV |    x |       |    x |        |     x |      |    x |      |       |     x |      |
+Heavy Catapult |  IV |    x |     x |      |        |     x |    x |    x |      |       |       |    x |
+
+Boats:
+
+Unit/Build.      | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+-----------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Fishing Ship     | III |    x |     x |    x |      x |     x |      |    x |    x |     x |     x |    x |    x
+Merchant Ship    | III |    x |     x |    x |      x |     x |    x |    x |    x |     x |     x |      |    x
+Trireme          |  IV |    x |       |    x |      x |     x |      |    x |    x |     x |       |    x |    x
+Catapult Trireme |  IV |      |       |      |      x |     x |      |    x |    x |     x |       |      |    x
+Heavy Transport  |  IV |      |       |      |      x |     x |      |    x |    x |     x |       |      |    x
+Juggernaught     |  IV |      |       |      |      x |     x |      |    x |    x |     x |       |      |    x
+
+Buildings:
+
+Unit/Build.    | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+---------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Academy        | III |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Fortification  | IV  |    x |     x |    x |      x |     x |    x |      |    x |     x |     x |    x |
+Guard Tower    | IV  |    x |     x |    x |      x |     x |    x |      |    x |     x |     x |    x |
+Ballista Tower | IV  |    x |     x |    x |      x |     x |    x |      |      |     x |       |    x |
+
+Technologies
+
+Unit/Build.   | Age | Ass. | Baby. | Cho. | Egypt. | Greek | Hit. | Min. | Per. | Phoe. | Shang | Sum. | Yama.
+--------------|-----|------|-------|------|--------|-------|------|------|------|-------|-------|------|------
+Architecture  | III |      |     x |    x |      x |     x |    x |    x |    x |       |     x |    x |    x
+Artisanship   | III |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Astrology     | III |    x |     x |    x |      x |     x |    x |      |    x |     x |     x |      |
+Bronze Shield | III |      |     x |    x |        |     x |    x |    x |    x |     x |     x |    x |    x
+Mysticism     | III |    x |     x |    x |      x |     x |      |      |    x |     x |     x |    x |
+Nobility      | III |      |     x |      |      x |     x |    x |    x |    x |     x |     x |    x |    x
+Plow          | III |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Polytheism    | III |    x |     x |    x |      x |     x |      |    x |    x |     x |     x |    x |    x
+Wheel         | III |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Afterlife     |  IV |    x |     x |    x |      x |     x |      |      |    x |     x |     x |      |    x
+Alchemy       |  IV |      |     x |      |      x |     x |    x |    x |    x |     x |       |    x |    x
+Aristocracy   |  IV |      |     x |      |      x |     x |    x |    x |      |     x |       |    x |    x
+Ballistics    |  IV |    x |     x |    x |      x |     x |    x |    x |      |     x |       |    x |    x
+Chain mail    |  IV |      |       |      |      x |     x |    x |    x |    x |       |     x |    x |    x
+Coinage       |  IV |    x |     x |    x |        |     x |    x |    x |      |     x |       |      |    x
+Craftsmanship |  IV |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |      |    x
+Engineering   |  IV |      |     x |      |      x |     x |    x |    x |    x |     x |       |    x |    x
+Fanaticism    |  IV |    x |     x |    x |      x |     x |      |      |    x |     x |     x |      |
+Irrigation    |  IV |    x |     x |    x |      x |     x |    x |    x |      |     x |     x |    x |    x
+Iron Shield   |  IV |      |       |      |        |     x |    x |    x |    x |     x |     x |      |    x
+Jihad         |  IV |    x |     x |    x |      x |       |      |      |    x |     x |     x |      |
+Metallurgy    |  IV |    x |       |    x |      x |       |    x |    x |    x |       |     x |      |    x
+Monotheism    |  IV |    x |     x |    x |      x |       |      |      |    x |     x |     x |      |
+Siegecraft    |  IV |    x |     x |    x |        |     x |    x |    x |      |       |       |    x |    x

--- a/doc/reverse_engineering/scoring.md
+++ b/doc/reverse_engineering/scoring.md
@@ -1,0 +1,53 @@
+# Score system
+
+## Age of Empires I
+
+The score is based on 5 categories: military, economy, religion, technology and
+survival/wonders.
+
+### Military
+
+Task                           | Score
+-------------------------------|-----------------------------------------------------------------
+Kills                          | 0.5 points per unit
+Buildings destroyed            | 1 point per building
+Generalship                    | number of kills minus number of losses (value must be positive)
+Most military units and towers | 25 point bonus
+
+### Economy
+
+Task                        | Score           | Notes
+----------------------------|-----------------|---------
+Gold from mining and trade  | 1/100 of value  |
+Net resources tributed      | 1/60 of value   |
+Villager population         | 1 per villager  | includes trade, transport, and fishing vessels
+Largest villager population | 25 point bonus  | includes trade, transport, and fishing vessels
+Exploration                 | 1 per 3% of map |
+Largest area explored       | 25 point bonus  |
+
+### Religion
+
+Task                              | Score
+----------------------------------|-------------------------
+Conversion                        | 2 points per conversion
+Most conversions                  | 25 point bonus
+Temples built                     | 3 points per temple
+Ruins controlled                  | 10 points per ruin
+Artifacts controlled              | 10 points per artifact
+Control of all Ruins or Artifacts | 50 point bonus
+
+### Technology
+
+Task                             | Score
+---------------------------------|-------------------------
+Technologies researched          | 2 points per technology
+Most techonologies researched    | 50 point bonus
+First civilization to Bronze Age | 25 point bonus
+First civilization to Iron Age   | 25 point bonus
+
+### Survival/Wonders
+
+Task                         | Score
+-----------------------------|-----------------------
+Still alive before game ends | 100 points
+Wonders held                 | 100 points per wonder

--- a/doc/reverse_engineering/scoring.md
+++ b/doc/reverse_engineering/scoring.md
@@ -5,6 +5,16 @@
 The score is based on 5 categories: military, economy, religion, technology and
 survival/wonders.
 
+In case of equality there should not be any player that gets a bonus for the
+largest number. However, the game engine does pick one player that gets the
+bonus. The player that gets the bonus is defined by a couple of factors:
+
+* If player X gets the largest number before player Y does, X gets the bonus
+  before Y does and keeps the bonus.
+* If both players get the largest number at the same gametick the player with
+  the lowest index (i.e. the game engine's internal assigned identifier) gets
+  the bonus.
+
 ### Military
 
 Task                           | Score

--- a/doc/reverse_engineering/unit_stats/unit_stats_aoe.csv
+++ b/doc/reverse_engineering/unit_stats/unit_stats_aoe.csv
@@ -1,0 +1,41 @@
+Icon,Name,Age,HP,Att.,Att. Type,Reload Time,M. Arm,P. Arm,LOS,R,Acc.,Speed,Tr. Time,Food,Wood,Stone,Gold,Special
+,Villager,I,25,3,M,?,?,?,?,0,?,M,?,50,0,0,0,
+,Priest,III,25,0,?,?,?,?,?,10,?,S,?,0,0,0,125,
+,Clubman,I,40,3,M,?,?,?,?,0,?,M,?,50,0,0,0,
+,Axeman,II,50,5,M,?,?,?,?,0,?,M,?,50,0,0,0,
+,Short Swordsman,III,60,7,M,?,?,?,?,0,?,M,?,35,0,0,15,
+,Broad Swordsman,III,70,9,M,?,?,?,?,0,?,M,?,35,0,0,15,
+,Long Swordsman,IV,80,11,M,?,?,?,?,0,?,M,?,35,0,0,15,
+,Legion,IV,160,13,M,?,?,?,?,0,?,M,?,35,0,0,15,
+,Hoplite,III,120,17,M,?,?,?,?,0,?,S,?,60,0,0,40,
+,Phalanx,IV,120,20,M,?,?,?,?,0,?,S,?,60,0,0,40,
+,Centurion,IV,160,30,M,?,?,?,?,0,?,S,?,60,0,0,40,
+,Bowman,II,35,3,P,?,?,?,?,5,?,M,?,40,20,0,0,
+,Improved Bowman,III,40,4,P,?,?,?,?,6,?,M,?,40,0,0,20,
+,Composite Bowman,III,45,5,P,?,?,?,?,7,?,M,?,40,0,0,20,
+,Chariot Archer,III,70,4,P,?,?,?,?,7,?,F,?,40,0,0,70,High resistance to conversion; triple attack vs. Priest.
+,Elephant Archer,IV,600,5,P,?,?,?,?,7,?,S,?,180,0,0,60,
+,Horse Archer,IV,60,7,P,?,?,?,?,7,?,F,?,50,0,0,70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
+,Heavy Horse Archer,IV,90,8,P,?,?,?,?,7,?,F,?,50,0,0,70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
+,Scout,II,60,3,M,?,?,?,?,0,?,F,?,100,0,0,0,
+,Chariot,III,100,7,M,?,?,?,?,0,?,F,?,40,60,0,0,High resistance to conversion; double attack vs. Priest.
+,Cavalry,III,150,8,M,?,?,?,?,0,?,F,?,70,80,0,0,+5 attack vs. infantry.
+,Heavy Cavalry,IV,150,10,M,?,?,?,?,0,?,F,?,70,80,0,0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
+,Cataphract,IV,180,12,M,?,?,?,?,0,?,F,?,70,80,0,0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
+,War Elephant,IV,600,15,M,?,?,?,?,0,?,S,?,170,0,0,40,Trample damage to adjacent units; attack strength not upgradable.
+,Stone Thrower,III,75,50,M,?,?,?,?,10,?,S,?,0,180,0,80,Fire rate once/5 sec; small damage area; minimum range 2.
+,Catapult,IV,75,60,M,?,?,?,?,12,?,S,?,0,180,0,80,Fire rate once/5 sec; medium damage area; minimum range 2.
+,Heavy Catapult,IV,150,60,M,?,?,?,?,13,?,S,?,0,180,0,80,Fire rate once/5 sec; large damage area; minimum range 2.
+,Ballista,IV,55,40,M,?,?,?,?,9,?,S,?,0,100,0,80,Fire rate once/3 sec; minimum range 3.
+,Helepolis,IV,55,40,M,?,?,?,?,10,?,S,?,0,100,0,80,Fire rate once/1.5 sec; minimum range 3.
+,Fishing Boat,I,45,0,,?,?,?,?,0,?,M,?,0,50,0,0,
+,Fishing Ship,III,75,0,,?,?,?,?,0,?,F,?,0,50,0,0,
+,Trade Boat,I,200,0,,?,?,?,?,0,?,F,?,0,100,0,0,
+,Merchant Ship,III,250,0,,?,?,?,?,0,?,F,?,0,100,0,0,
+,Light Transport,II,150,0,,?,?,?,?,0,?,M,?,0,150,0,0,
+,Heavy Transport,IV,200,0,,?,?,?,?,0,?,F,?,0,150,0,0,
+,Scout Ship,II,120,5,P,?,?,?,?,5,?,F,?,0,135,0,0,
+,War Galley,III,160,8,P,?,?,?,?,6,?,F,?,0,135,0,0,
+,Trireme,IV,200,12,P,?,?,?,?,7,?,F,?,0,135,0,0,Fire rate once/2 sec.
+,Catapult Trireme,IV,120,35,P,?,?,?,?,9,?,F,?,0,135,0,75,Fire rate once/5 sec; small damage area.
+,Juggernaught,IV,200,35,P,?,?,?,?,10,?,F,?,0,135,0,75,Fire rate once/5 sec; medium damage area.

--- a/doc/reverse_engineering/unit_stats/unit_stats_aoe.csv
+++ b/doc/reverse_engineering/unit_stats/unit_stats_aoe.csv
@@ -1,41 +1,41 @@
-Icon,Name,Age,HP,Att.,Att. Type,Reload Time,M. Arm,P. Arm,LOS,R,Acc.,Speed,Tr. Time,Food,Wood,Stone,Gold,Special
-,Villager,I,25,3,M,?,?,?,?,0,?,M,?,50,0,0,0,
-,Priest,III,25,0,?,?,?,?,?,10,?,S,?,0,0,0,125,
-,Clubman,I,40,3,M,?,?,?,?,0,?,M,?,50,0,0,0,
-,Axeman,II,50,5,M,?,?,?,?,0,?,M,?,50,0,0,0,
-,Short Swordsman,III,60,7,M,?,?,?,?,0,?,M,?,35,0,0,15,
-,Broad Swordsman,III,70,9,M,?,?,?,?,0,?,M,?,35,0,0,15,
-,Long Swordsman,IV,80,11,M,?,?,?,?,0,?,M,?,35,0,0,15,
-,Legion,IV,160,13,M,?,?,?,?,0,?,M,?,35,0,0,15,
-,Hoplite,III,120,17,M,?,?,?,?,0,?,S,?,60,0,0,40,
-,Phalanx,IV,120,20,M,?,?,?,?,0,?,S,?,60,0,0,40,
-,Centurion,IV,160,30,M,?,?,?,?,0,?,S,?,60,0,0,40,
-,Bowman,II,35,3,P,?,?,?,?,5,?,M,?,40,20,0,0,
-,Improved Bowman,III,40,4,P,?,?,?,?,6,?,M,?,40,0,0,20,
-,Composite Bowman,III,45,5,P,?,?,?,?,7,?,M,?,40,0,0,20,
-,Chariot Archer,III,70,4,P,?,?,?,?,7,?,F,?,40,0,0,70,High resistance to conversion; triple attack vs. Priest.
-,Elephant Archer,IV,600,5,P,?,?,?,?,7,?,S,?,180,0,0,60,
-,Horse Archer,IV,60,7,P,?,?,?,?,7,?,F,?,50,0,0,70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
-,Heavy Horse Archer,IV,90,8,P,?,?,?,?,7,?,F,?,50,0,0,70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
-,Scout,II,60,3,M,?,?,?,?,0,?,F,?,100,0,0,0,
-,Chariot,III,100,7,M,?,?,?,?,0,?,F,?,40,60,0,0,High resistance to conversion; double attack vs. Priest.
-,Cavalry,III,150,8,M,?,?,?,?,0,?,F,?,70,80,0,0,+5 attack vs. infantry.
-,Heavy Cavalry,IV,150,10,M,?,?,?,?,0,?,F,?,70,80,0,0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
-,Cataphract,IV,180,12,M,?,?,?,?,0,?,F,?,70,80,0,0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
-,War Elephant,IV,600,15,M,?,?,?,?,0,?,S,?,170,0,0,40,Trample damage to adjacent units; attack strength not upgradable.
-,Stone Thrower,III,75,50,M,?,?,?,?,10,?,S,?,0,180,0,80,Fire rate once/5 sec; small damage area; minimum range 2.
-,Catapult,IV,75,60,M,?,?,?,?,12,?,S,?,0,180,0,80,Fire rate once/5 sec; medium damage area; minimum range 2.
-,Heavy Catapult,IV,150,60,M,?,?,?,?,13,?,S,?,0,180,0,80,Fire rate once/5 sec; large damage area; minimum range 2.
-,Ballista,IV,55,40,M,?,?,?,?,9,?,S,?,0,100,0,80,Fire rate once/3 sec; minimum range 3.
-,Helepolis,IV,55,40,M,?,?,?,?,10,?,S,?,0,100,0,80,Fire rate once/1.5 sec; minimum range 3.
-,Fishing Boat,I,45,0,,?,?,?,?,0,?,M,?,0,50,0,0,
-,Fishing Ship,III,75,0,,?,?,?,?,0,?,F,?,0,50,0,0,
-,Trade Boat,I,200,0,,?,?,?,?,0,?,F,?,0,100,0,0,
-,Merchant Ship,III,250,0,,?,?,?,?,0,?,F,?,0,100,0,0,
-,Light Transport,II,150,0,,?,?,?,?,0,?,M,?,0,150,0,0,
-,Heavy Transport,IV,200,0,,?,?,?,?,0,?,F,?,0,150,0,0,
-,Scout Ship,II,120,5,P,?,?,?,?,5,?,F,?,0,135,0,0,
-,War Galley,III,160,8,P,?,?,?,?,6,?,F,?,0,135,0,0,
-,Trireme,IV,200,12,P,?,?,?,?,7,?,F,?,0,135,0,0,Fire rate once/2 sec.
-,Catapult Trireme,IV,120,35,P,?,?,?,?,9,?,F,?,0,135,0,75,Fire rate once/5 sec; small damage area.
-,Juggernaught,IV,200,35,P,?,?,?,?,10,?,F,?,0,135,0,75,Fire rate once/5 sec; medium damage area.
+Name              ,Age, HP,Att.,Att. Type,Reload Time,M. Arm,P. Arm,LOS, R,Acc.,Speed,Tr. Time,Food,Wood,Stone,Gold,Special
+Villager          ,I  , 25,   3,        M,        1.5,     0,     0,  4, 0,   0,    M,      20,  50,   0,    0,   0,
+Priest            ,III, 25,   0,        P,          0,     0,     0, 15,10,  10,    S,      50,   0,   0,    0, 125,
+Clubman           ,I  , 40,   3,        M,        1.5,     0,     0,  4, 0,   0,    M,      27,  50,   0,    0,   0,
+Axeman            ,II , 50,   5,        M,        1.5,     0,     0,  4, 0,   0,    M,      27,  50,   0,    0,   0,
+Short Swordsman   ,III, 60,   7,        M,        1.5,     1,     0,  4, 0,   0,    M,      27,  35,   0,    0,  15,
+Broad Swordsman   ,III, 70,   9,        M,        1.5,     1,     0,  4, 0,   0,    M,      27,  35,   0,    0,  15,
+Long Swordsman    ,IV , 80,  11,        M,        1.5,     2,     0,  4, 0,   0,    M,      27,  35,   0,    0,  15,
+Legion            ,IV ,160,  13,        M,        1.5,     2,     0,  4, 0,   0,    M,      27,  35,   0,    0,  15,
+Hoplite           ,III,120,  17,        M,        1.5,     5,     0,  4, 0,   0,    S,      36,  60,   0,    0,  40,
+Phalanx           ,IV ,120,  20,        M,        1.5,     7,     0,  4, 0,   0,    S,      36,  60,   0,    0,  40,
+Centurion         ,IV ,160,  30,        M,        1.5,     8,     0,  4, 0,   0,    S,      36,  60,   0,    0,  40,
+Bowman            ,II , 35,   3,        P,        1.4,     0,     0,  7, 5,   5,    M,      30,  40,  20,    0,   0,
+Improved Bowman   ,III, 40,   4,        P,        1.4,     0,     0,  8, 6,   6,    M,      30,  40,   0,    0,  20,
+Composite Bowman  ,III, 45,   5,        P,        1.4,     0,     0,  9, 7,   7,    M,      30,  40,   0,    0,  20,
+Chariot Archer    ,III, 70,   4,        P,        1.5,     0,     0,  9, 7,   7,    F,      40,  40,   0,    0,  70,High resistance to conversion; triple attack vs. Priest.
+Elephant Archer   ,IV ,600,   5,        P,        1.5,     0,     0,  8, 7,   7,    S,      50, 180,   0,    0,  60,
+Horse Archer      ,IV , 60,   7,        P,        1.5,     0,     2,  9, 7,   7,    F,      40,  50,   0,    0,  70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
+Heavy Horse Archer,IV , 90,   8,        P,        1.5,     0,     2,  9, 7,   7,    F,      40,  50,   0,    0,  70,"+2 armor vs. missile weapons*, Ballista, Helepolis"
+Scout             ,II , 60,   3,        M,        0.9,     0,     0,  8, 0,   0,    F,      30, 100,   0,    0,   0,
+Chariot           ,III,100,   7,        M,        1.4,     0,     0,  4, 0,   0,    F,      40,  40,  60,    0,   0,High resistance to conversion; double attack vs. Priest.
+Cavalry           ,III,150,   8,        M,        1.3,     0,     0,  4, 0,   0,    F,      40,  70,  80,    0,   0,+5 attack vs. infantry.
+Heavy Cavalry     ,IV ,150,  10,        M,        1.3,     1,     1,  4, 0,   0,    F,      40,  70,  80,    0,   0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
+Cataphract        ,IV ,180,  12,        M,        1.3,     3,     1,  4, 0,   0,    F,      40,  70,  80,    0,   0,"+5 attack vs. infantry; +1 armor vs. missile weapons*, Ballista, Helepolis."
+War Elephant      ,IV ,600,  15,        M,          1,     0,     0,  4, 0,   0,    S,      50, 170,   0,    0,  40,Trample damage to adjacent units; attack strength not upgradable.
+Stone Thrower     ,III, 75,  50,        M,          5,     0,     0, 13,10,  10,    S,      60,   0, 180,    0,  80,Fire rate once/5 sec; small damage area; minimum range 2.
+Catapult          ,IV , 75,  60,        M,          5,     0,     0, 15,12,  12,    S,      60,   0, 180,    0,  80,Fire rate once/5 sec; medium damage area; minimum range 2.
+Heavy Catapult    ,IV ,150,  60,        M,          5,     0,     0, 16,13,  13,    S,      60,   0, 180,    0,  80,Fire rate once/5 sec; large damage area; minimum range 2.
+Ballista          ,IV , 55,  40,        M,          3,     0,     0, 11, 9,   9,    S,      50,   0, 100,    0,  80,Fire rate once/3 sec; minimum range 3.
+Helepolis         ,IV , 55,  40,        M,        1.5,     0,     0, 12,10,  10,    S,      50,   0, 100,    0,  80,Fire rate once/1.5 sec; minimum range 3.
+Fishing Boat      ,I  , 45,   0,         ,          0,     0,     0,  6, 0,   0,    M,      20,   0,  50,    0,   0,
+Fishing Ship      ,III, 75,   0,         ,          0,     0,     0,  6, 0,   0,    F,      20,   0,  50,    0,   0,
+Trade Boat        ,I  ,200,   0,         ,          0,     0,     0,  4, 0,   0,    F,      25,   0, 100,    0,   0,
+Merchant Ship     ,III,250,   0,         ,          0,     0,     0,  5, 0,   0,    F,      25,   0, 100,    0,   0,
+Light Transport   ,II ,150,   0,         ,          0,     0,     0,  5, 0,   0,    M,      38,   0, 150,    0,   0,
+Heavy Transport   ,IV ,200,   0,         ,          0,     0,     0,  5, 0,   0,    F,      38,   0, 150,    0,   0,
+Scout Ship        ,II ,120,   5,        P,        1.4,     0,     0,  7, 5,   5,    F,      30,   0, 135,    0,   0,
+War Galley        ,III,160,   8,        P,        1.5,     0,     0,  9, 6,   6,    F,      30,   0, 135,    0,   0,
+Trireme           ,IV ,200,  12,        P,          2,     0,     0, 10, 7,   7,    F,      30,   0, 135,    0,   0,Fire rate once/2 sec.
+Catapult Trireme  ,IV ,120,  35,        P,          5,     0,     0, 12, 9,   9,    F,      45,   0, 135,    0,  75,Fire rate once/5 sec; small damage area.
+Juggernaught      ,IV ,200,  35,        P,          5,     0,     0, 13,10,  10,    F,      45,   0, 135,    0,  75,Fire rate once/5 sec; medium damage area.

--- a/doc/reverse_engineering/unit_stats/unit_stats_aoe.txt
+++ b/doc/reverse_engineering/unit_stats/unit_stats_aoe.txt
@@ -1,0 +1,3 @@
+Notes:
+This unit attributes table is copied from the original game manual of Age of Empires I for MacOS 9
+Missile weapons: Archery Range units, towers, Scout Ship, War Galley, Trireme


### PR DESCRIPTION
This PR includes documentation regarding the original Age of Empires I
(not Rise of Rome). Rise of Rome will probably be implemented in another
PR.

The scoring system and civilization specials and unit/building creation
table are completely documented.

- [x] Scoring system
- [x] Civilization specials
- [x] Civilization unit/building creation table
- [x] Unit statistics
  - [x] Name
  - [x] Age
  - [x] Hit points
  - [x] Attack
  - [x] Attack Type
  - [x] Reload time
  - [x] Melee and Pierce Armor
  - [x] LOS
  - [x] Ranged accuracy
  - [x] Speed
  - [x] Training time
  - [x] Resource cost
  - [x] Special attributes

Feedback is appreciated regarding the formatting; I am not sure if this
is sufficient or if the documentation should be located elsewhere.