### PR TITLE
undo final change of gui-gl-context pull request, to prevent SIGSEGV

### DIFF
--- a/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
@@ -50,7 +50,9 @@ std::tuple<QVariant, std::function<void()>> extract_native_context_and_switchbac
 		current_context = glXGetCurrentContext();
 		assert(current_context);
 
-		return std::make_tuple(QVariant::fromValue<QGLXNativeContext>(QGLXNativeContext(current_context, wm_info.info.x11.display, wm_info.info.x11.window)), std::bind(SDL_GL_MakeCurrent, window, SDL_GL_GetCurrentContext()));
+		return std::make_tuple(QVariant::fromValue<QGLXNativeContext>(QGLXNativeContext(current_context, wm_info.info.x11.display, wm_info.info.x11.window)), [wm_info, current_context] {
+			glXMakeCurrent(wm_info.info.x11.display, wm_info.info.x11.window, current_context);
+		});
 	}
 
 	return std::tuple<QVariant, std::function<void()>>{};


### PR DESCRIPTION
By reverting the final change to gui-gl-context, Mac runtime gets a little further.

We need to mention the magic commit (d577f5681bf61e09cd7d8175661be2df389b9b4d):

```bash
git cherry-pick --no-commit d577f5681bf61e09cd7d8175661be2df389b9b4d
```

master = launches successfully with fully black window; never renders anything
master + magic commit = launches grey window, finishes loading, encounters SIGSEGV
master + this pull request + magic commit = launches window, proceeds to the graph view. successfully presents game if you click generate_game.