### PR TITLE
datastructure: add concurrent double buffer

### DIFF
--- a/libopenage/datastructure/concurrent_double_buffer.h
+++ b/libopenage/datastructure/concurrent_double_buffer.h
@@ -1,0 +1,101 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <atomic>
+
+
+namespace openage {
+namespace datastructure {
+
+template<typename T>
+class ConcurrentDoubleBuffer;
+
+/// A lock that allows access to the data in the back buffer.
+template<typename T>
+class ConcurrentDoubleBufferLock {
+public:
+	/// Returns a reference to the back buffer data.
+	T& get() {
+		return *this->data;
+	}
+
+private:
+	friend class ConcurrentDoubleBuffer<T>;
+	ConcurrentDoubleBufferLock(std::unique_lock<std::mutex> &&lock, T* data)
+		: lock(std::move(lock))
+		, data(data) {}
+
+	/// A lock on writing to the back and swapping the buffers.
+	std::unique_lock<std::mutex> lock;
+
+	/// The data in the back buffer.
+	T* data;
+};
+
+/**
+ * A single-reader multiple-writer double buffer structure. It has a front and back
+ * buffer. The back is meant for writing, while the front should be read from.
+ * The intended usage if for writers to store new information in the back
+ * while the front is being read. After the reader is done, it locks the back
+ * buffer (same as the writers do) and swaps the front with the back. If the data
+ * doesn't differ by much, that might also involve copying the new front into
+ * the new back to have resume writing from the most recent state.
+ */
+template<typename T>
+class ConcurrentDoubleBuffer {
+public:
+	/// Tries to default-construct the buffers.
+	ConcurrentDoubleBuffer() {}
+
+	/// Copy-constructs the buffers.
+	ConcurrentDoubleBuffer(const T &front, const T &back)
+		: one(front)
+		, two(back) {}
+
+	/// Move-constructs the buffers.
+	ConcurrentDoubleBuffer(T &&front, T &&back)
+		: one(std::move(front))
+		, two(std::move(back)) {}
+
+	/// Returns a reference to the data in the front buffer.
+	T& get_front() {
+		if (one_is_front) {
+			return this->one;
+		}
+		else {
+			return this->two;
+		}
+	}
+
+	/// Returns a writer lock on the back buffer.
+	ConcurrentDoubleBufferLock<T> lock_back() {
+		if (one_is_front) {
+			return ConcurrentDoubleBufferLock<T>(std::unique_lock<std::mutex>(lock), &two);
+		}
+		else {
+			return ConcurrentDoubleBufferLock<T>(std::unique_lock<std::mutex>(lock), &one);
+		}
+	}
+
+	/// Swaps the buffers. It must be ensured that no concurrent readers are working.
+	void swap() {
+		std::unique_lock<std::mutex> lk(this->lock);
+		this->one_is_front = !this->one_is_front;
+	}
+
+private:
+	/// A lock on writing to the back and swapping the buffers.
+	std::mutex lock;
+
+	/// Which buffer is the front. If true, one is the front, else two is the front.
+	bool one_is_front = true;
+
+	/// The buffer data.
+	T one, two;
+};
+
+}} // openage::datastructure

--- a/libopenage/datastructure/tests.h
+++ b/libopenage/datastructure/tests.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,9 +24,7 @@ struct heap_elem {
 	}
 };
 
-} // namespace tests
-} // namespace datastructure
-} // namespace openage
+}}} // openage::datastructure::tests
 
 namespace std {
 
@@ -39,4 +37,5 @@ struct hash<openage::datastructure::tests::heap_elem> {
 		return elem.data;
 	}
 };
-} // namespace std
+
+} // std

--- a/openage/testing/testlist.py
+++ b/openage/testing/testlist.py
@@ -70,6 +70,7 @@ def tests_cpp():
     yield "openage::coord::tests::coord"
     yield "openage::datastructure::tests::constexpr_map"
     yield "openage::datastructure::tests::pairing_heap"
+    yield "openage::datastructure::tests::concurrent_double_buffer"
     yield "openage::job::tests::test_job_manager"
     yield "openage::path::tests::path_node", "pathfinding"
     yield "openage::pyinterface::tests::pyobject"


### PR DESCRIPTION
This structure supports intercomponent communication between the event loop and the Presenter in the new architecture.