### PR TITLE
units can get removed before on_complete runs

### DIFF
--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -236,7 +236,7 @@ void TargetAction::on_completion() {
 	// retask units on nearby objects
 	// such as gathers targeting a new resource
 	// when the current target expires
-	this->on_completion_in_range(this->target.get());
+	this->on_completion_in_range(this->target_type_id);
 }
 
 bool TargetAction::completed() const {
@@ -1036,13 +1036,13 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 	this->frame += time * this->frame_rate / 3.0f;
 }
 
-void GatherAction::on_completion_in_range(Unit *) {
+void GatherAction::on_completion_in_range(int target_type) {
 
 	// find a different target with same type
 	TerrainObject *new_target = nullptr;
 	new_target = find_near(*this->entity->location,
-		[this](const TerrainObject &obj) {
-			return obj.unit.unit_type->id() == this->get_target_type_id() &&
+		[this, target_type](const TerrainObject &obj) {
+			return obj.unit.unit_type->id() == target_type &&
 				   !obj.unit.has_attribute(attr_type::worker) &&
 				   obj.unit.has_attribute(attr_type::resource) &&
 				   obj.unit.get_attribute<attr_type::resource>().amount > 0.0;

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -1041,7 +1041,7 @@ void GatherAction::on_completion_in_range(int target_type) {
 	// find a different target with same type
 	TerrainObject *new_target = nullptr;
 	new_target = find_near(*this->entity->location,
-		[this, target_type](const TerrainObject &obj) {
+		[target_type](const TerrainObject &obj) {
 			return obj.unit.unit_type->id() == target_type &&
 				   !obj.unit.has_attribute(attr_type::worker) &&
 				   obj.unit.has_attribute(attr_type::resource) &&

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -177,12 +177,11 @@ public:
 	 * Control units action when in range of the target
 	 */
 	virtual void update_in_range(unsigned int, Unit *) = 0;
-	virtual void on_completion_in_range(Unit *) = 0;
+	virtual void on_completion_in_range(int target_type) = 0;
 	virtual bool completed_in_range(Unit *) const = 0;
 
 	coord::phys_t distance_to_target();
 	Unit *update_distance();
-
 
 	UnitReference get_target() const;
 	int get_target_type_id() const;
@@ -347,7 +346,7 @@ public:
 	virtual ~GarrisonAction() {}
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "garrison"; }
 
@@ -406,7 +405,7 @@ public:
 	virtual ~BuildAction() {}
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	void on_completion() override;
 	std::string name() const override { return "build"; }
@@ -426,7 +425,7 @@ public:
 	virtual ~RepairAction() {}
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "repair"; }
 
@@ -452,7 +451,7 @@ public:
 	virtual ~GatherAction();
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override;
+	void on_completion_in_range(int target_type) override;
 	bool completed_in_range(Unit *) const override { return this->complete; }
 	std::string name() const override { return "gather"; }
 
@@ -472,7 +471,7 @@ public:
 	virtual ~AttackAction();
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "attack"; }
 
@@ -499,7 +498,7 @@ public:
 	virtual ~HealAction();
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override;
 	std::string name() const override { return "heal"; }
 
@@ -521,7 +520,7 @@ public:
 	virtual ~ConvertAction() {}
 
 	void update_in_range(unsigned int time, Unit *target_unit) override;
-	void on_completion_in_range(Unit *) override {}
+	void on_completion_in_range(int) override {}
 	bool completed_in_range(Unit *) const override { return this->complete >= 1.0f; }
 	std::string name() const override { return "convert"; }
 


### PR DESCRIPTION
Minor correction to last pr. Using the pointer to target unit in on_completion() is not a good idea, they may already be removed. Instead pass id of the type.