### PR TITLE
Exceptions: break into debugger on throwing an exception

### DIFF
--- a/libopenage/error/error.cpp
+++ b/libopenage/error/error.cpp
@@ -12,11 +12,19 @@ namespace error {
 
 constexpr const char *runtime_error_message = "polymorphic openage Error object; catch by reference!";
 
+static bool enable_break_on_create = false;
+void Error::debug_break_on_create(bool state) {
+	enable_break_on_create = state;
+}
 
 Error::Error(const log::message &msg, bool generate_backtrace, bool store_cause)
 	:
 	std::runtime_error{runtime_error_message},
 	msg(msg) {
+
+	if (unlikely(enable_break_on_create)) {
+		BREAKPOINT;
+	}
 
 	if (generate_backtrace) {
 		auto backtrace = std::make_shared<StackAnalyzer>();

--- a/libopenage/error/error.h
+++ b/libopenage/error/error.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+// pxd: from libcpp cimport bool
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -34,6 +35,7 @@ namespace error {
  * log::log().
  *
  * pxd:
+ * void debug_break_on_error "::openage::error::Error::debug_break_on_create"(bool state) except +
  *
  * cppclass Error:
  *     message msg
@@ -116,6 +118,10 @@ public:
 	 */
 	const char *what() const noexcept override;
 
+	/**
+	 * Turn on debug breaks in the constructor
+	 */
+	static void debug_break_on_create(bool state);
 
 private:
 	friend pyinterface::PyException;

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -50,6 +50,10 @@ def main(argv=None):
                             help="force-enable development mode")
     global_cli.add_argument("--no-devmode", action="store_true",
                             help="force-disable devlopment mode")
+    global_cli.add_argument("--trap-exceptions", action="store_true",
+                            help=("upon throwing an exception a debug break is "
+                                  "triggered. this will crash openage if no "
+                                  "debugger is present"))
 
     # shared directory arguments for most subcommands
     cfg_cli = argparse.ArgumentParser(add_help=False)

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -589,7 +589,7 @@ def main(args, error):
 
     # initialize libopenage
     from ..cppinterface.setup import setup
-    setup()
+    setup(args)
 
     # conversion source
     if args.source_dir is not None:

--- a/openage/cppinterface/exctranslate.pyx
+++ b/openage/cppinterface/exctranslate.pyx
@@ -23,7 +23,7 @@ from libcpp cimport bool as cppbool
 
 from libopenage.log.level cimport level, err as lvl_err
 from libopenage.log.message cimport message
-from libopenage.error.error cimport Error
+from libopenage.error.error cimport Error, debug_break_on_error
 from libopenage.error.backtrace cimport Backtrace, backtrace_symbol
 from libopenage.pyinterface.functional cimport Func1
 from libopenage.pyinterface.pyexception cimport (
@@ -38,7 +38,7 @@ from libopenage.pyinterface.exctranslate cimport (
 
 import importlib
 from ..testing.testing import TestError
-
+from ..log import err, info
 
 cdef extern from "Python.h":
     cdef cppclass PyCodeObject:
@@ -302,7 +302,7 @@ cdef void pyexception_bt_get_symbols_impl(
         frame = frame.tb_next
 
 
-def setup():
+def setup(args):
     """
     Installs the functions defined here in their PyFunc pointers.
     """
@@ -311,5 +311,12 @@ def setup():
         raise_cpp_pyexception,
         check_exception,
         describe_exception)
+
+
+    if args.trap_exceptions:
+        info("Throwing errors will break into an attached debugger")
+        debug_break_on_error(True)
+    else:
+        debug_break_on_error(False)
 
     pyexception_bt_get_symbols.bind0(pyexception_bt_get_symbols_impl)

--- a/openage/cppinterface/setup.py
+++ b/openage/cppinterface/setup.py
@@ -12,7 +12,7 @@ from ..log.log_cpp import enable_log_translation
 
 
 @run_once
-def setup():
+def setup(args):
     """
     After a call to setup(), the C++ interface is in a usable state.
 
@@ -30,7 +30,7 @@ def setup():
 
     # this is where calls to the setup methods of all other modules belong.
     from .exctranslate import setup as exctranslate_setup
-    exctranslate_setup()
+    exctranslate_setup(args)
 
     from .exctranslate_tests import setup as exctranslate_tests_setup
     exctranslate_tests_setup()

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -38,7 +38,7 @@ def main(args, error):
     from ..util.fslike.union import Union
 
     # initialize libopenage
-    cpp_interface_setup()
+    cpp_interface_setup(args)
 
     info("launching openage {}".format(config.VERSION))
     info("compiled by {}".format(config.COMPILER))

--- a/openage/testing/main.py
+++ b/openage/testing/main.py
@@ -66,7 +66,7 @@ def process_args(args, error):
 
     # link python and c++ so it hopefully works when testing
     from openage.cppinterface.setup import setup
-    setup()
+    setup(args)
 
     test_list = get_all_targets()
 


### PR DESCRIPTION
Implements #570  

Test this with: 

`./run test -a` will run successfully without changes

`./run test --trap-exceptions -a` will trap wit: 

```
[ 3/27]  py cppinterface.exctranslate_tests.cpp_to_py
[1]    23108 trace trap (core dumped)  ./run test --trap-exceptions -a
```