### PR TITLE
Support and document debugging with gdbgui

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -105,6 +105,7 @@ _the openage authors_ are:
 | David Carlier               | devnexen                    | devnexen à gmail dawt com                         |
 | Tushar Maheshwari           | tusharpm                    | tushar27192 à gmail dawt com                      |
 | Piotr Szpetkowski           | piotr-szpetkowski           | piotr dawt szpetkowski à pyquest dawt space       |
+| Julian Guillotel            | arialwhite                  | julian dawt gullotel à gmail dawt com             |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,0 +1,39 @@
+# How to debug openage?
+## Qt Creator IDE
+See [ide.md](/doc/ide.md)
+## GDB
+GDB can be used to debug C++ code in a terminal.
+
+To being able to debug with GDB use `./configure` script such as:
+```
+./configure --mode=debug --compiler=gcc
+```
+build the game
+```
+make
+```
+Then
+```
+gdb -ex 'set breakpoint pending on' -ex 'b openage::run_game' -ex run --args run game
+```
+The game will be paused at the start of the function run_game() located in `libopenage/main.cpp`
+
+#### Note:
+The `run` executable is a compiled version of `run.py` that also embeds the interpreter.
+The game is intended to be run by `run.py` but it is much easier to debug the `./run` file
+
+### GDBGUI
+
+[gdbgui](https://github.com/cs01/gdbgui) is a browser-based frontend for GDB.
+
+To install gdbgui in Ubuntu:
+
+```
+sudo pip3 install gdbgui --upgrade
+```
+Then
+```
+gdbgui ./run
+```
+The gdbgui web page will be at `http://127.0.0.1:5000`
+Use the command `run` in the GDB prompt to start debugging


### PR DESCRIPTION
I figured out how to debug libopenage with gdbgui. It is a browser-based frontend to gdb built with Python and JavaScript.

gdbgui: https://github.com/cs01/gdbgui

This PR:
- Add a .gdbinit (gdb commands) to debug openage and break at main.cpp
- Document how to debug openage and how to do this with gdbgui

![gdbgui3](https://user-images.githubusercontent.com/7106652/29496931-e0b5dc7c-85dd-11e7-9327-fd8ccf2682e2.png)

