### PR TITLE
renderer: fix font glyph memory allocations

### DIFF
--- a/libopenage/renderer/font/font.h
+++ b/libopenage/renderer/font/font.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -166,7 +166,7 @@ public:
 	 * @param glyph: The glyph's info is loaded in to this object.
 	 * @returns The glyph's bitmap data.
 	 */
-	std::unique_ptr<unsigned char> load_glyph(codepoint_t codepoint, Glyph &glyph) const;
+	std::unique_ptr<unsigned char[]> load_glyph(codepoint_t codepoint, Glyph &glyph) const;
 
 private:
 	/**

--- a/libopenage/renderer/font/glyph_atlas.cpp
+++ b/libopenage/renderer/font/glyph_atlas.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include "glyph_atlas.h"
 
@@ -85,7 +85,7 @@ GlyphAtlas::Entry GlyphAtlas::get(Font *font, codepoint_t codepoint) {
 	}
 
 	Glyph glyph;
-	std::unique_ptr<unsigned char> image = font->load_glyph(codepoint, glyph);
+	std::unique_ptr<unsigned char[]> image = font->load_glyph(codepoint, glyph);
 	return this->set(key, glyph, image.get());
 }
 


### PR DESCRIPTION
Fixes the memtype mismatch crash of #884. 