### PR TITLE
buildsystem: add convenience options for using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,23 @@ if(NOT DEFINED GLOBAL_CONFIG_DIR)
 	set(GLOBAL_CONFIG_DIR "/etc/openage")
 endif()
 
+
+# build the project with ccache
+# distros can also do this but they don't use this mechanism
+option(ENABLE_CCACHE "prefix each compile command with ccache")
+
+if(ENABLE_CCACHE)
+	find_program(CCACHE_FOUND "ccache")
+
+	if(CCACHE_FOUND)
+		set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+		set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+	else()
+		message(FATAL_ERROR "ccache not found, but you requested it")
+	endif(CCACHE_FOUND)
+endif()
+
+
 # option processing is now done.
 
 

--- a/configure
+++ b/configure
@@ -252,6 +252,9 @@ def invoke_cmake(args, bindir, defines, options):
     if args.ninja:
         invocation.extend(['-G', 'Ninja'])
 
+    if args.ccache:
+        invocation.extend(['-DENABLE_CCACHE=ON'])
+
     cxx_options = dict()
     cxx_options["CXX_OPTIMIZATION_LEVEL"] = args.optimize
     cxx_options["CXX_SANITIZE_MODE"] = args.sanitize
@@ -381,6 +384,8 @@ def parse_args():
                      help="all following args are passed directly to cmake")
     cli.add_argument("--ninja", action="store_true",
                      help="use ninja instead of GNU make")
+    cli.add_argument("--ccache", action="store_true",
+                     help="activate using the ccache compiler cache")
 
     args = cli.parse_args()
 


### PR DESCRIPTION
Speeds up some compilations if used.

The cache will be in `~/.cache/ccache` by default.

`ccache -s` will show you statistics. which you can `watch -n1` during builds :)