### PR TITLE
buildsystem: let automoc depend on codegen

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,2 +1,2 @@
 # converted game assets
-/converted
+/converted/

--- a/buildsystem/codegen.cmake
+++ b/buildsystem/codegen.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 the openage authors. See copying.md for legal info.
+# Copyright 2014-2017 the openage authors. See copying.md for legal info.
 
 function(codegen_run)
 	# this function must be called once all required assets have been created, but before the executable is finalized.
@@ -6,7 +6,7 @@ function(codegen_run)
 	# make sure this function gets called only once
 	get_property(codegen_run GLOBAL PROPERTY SFT_CODEGEN_HAS_BEEN_RUN)
 	if(codegen_run)
-		message(FATAL_ERROR codegen has already been run)
+		message(FATAL_ERROR "codegen has already been run")
 	endif()
 	set_property(GLOBAL PROPERTY SFT_CODEGEN_HAS_BEEN_RUN 1)
 

--- a/buildsystem/codegen.cmake
+++ b/buildsystem/codegen.cmake
@@ -29,10 +29,16 @@ function(codegen_run)
 	FILE(READ "${CMAKE_BINARY_DIR}/codegen_depends" CODEGEN_DEPENDS)
 	STRING(REGEX REPLACE "\n" ";" CODEGEN_TARGET_FILES ${CODEGEN_TARGET_FILES})
 	STRING(REGEX REPLACE "\n" ";" CODEGEN_DEPENDS ${CODEGEN_DEPENDS})
+
+	# as the codegen creates all files at once,
+	# let the buildsystem only depend on this single dummy file.
+	# otherwise the codegen invocation would be done for each generated source.
 	set(CODEGEN_TIMEFILE "${CMAKE_BINARY_DIR}/codegen_timefile")
 
+	list(APPEND CODEGEN_TARGET_FILES ${CODEGEN_TIMEFILE})
+
 	add_custom_command(
-		OUTPUT "${CODEGEN_TIMEFILE}"
+		OUTPUT ${CODEGEN_TARGET_FILES}
 		COMMAND ${CODEGEN_INVOCATION} --mode=codegen "--touch-file-on-cache-change=${CMAKE_CURRENT_LIST_FILE}" --force-rerun-on-generated-list-change
 		COMMAND "${CMAKE_COMMAND}" -E touch "${CODEGEN_TIMEFILE}"
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -5,9 +5,8 @@
 # add new sources here, dependencies for linking and including
 # are specified below the source file list.
 
-set(CMAKE_AUTOMOC ON)
-
 declare_binary(libopenage)
+
 
 add_sources(libopenage
 	assetmanager.cpp
@@ -57,7 +56,11 @@ add_sources(libopenage GENERATED ${CODEGEN_TARGET_TUS})
 
 # after this point, no further sources can be added to the executable
 finalize_binary(libopenage openage library allow_no_undefined)
-set_target_properties(libopenage PROPERTIES VERSION 0)
+set_target_properties(libopenage PROPERTIES
+	VERSION 0
+	AUTOMOC ON
+	AUTOGEN_TARGET_DEPENDS "codegen"
+)
 
 # library dependency specification
 


### PR DESCRIPTION
Fixes #907.

Otherwise build may fail because there's
no known recipe to generate the files.

~~We should maybe tune the codegen target to actually have all the generated files as output, not just the timefile. This now was the easier fix, though.~~
The codegen custom command now knows all its output, but the codegen target still depends on the timefile only, so the command isn't run for every generated source.