### PR TITLE
[Windows] Change path separator in generated pxd files

### DIFF
--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -273,7 +273,7 @@ class PXDGenerator:
                 if namespace != previous_namespace:
                     yield (
                         "cdef extern "
-                        "from r\"" + self.filename + "\" "
+                        "from r\"" + self.filename.replace('\\', '/') + "\" "
                         "namespace \"" + namespace + "\" "
                         "nogil"
                         ":"


### PR DESCRIPTION
A workaround until cython/cython#1912 is addressed and a fix is available.

Summary of the changes
- Both `\` and `/` are valid path separators on Windows. The first one is native and default in python (like most other applications), but requires escaping (even in raw string literals - see referenced cython issue).
- The workaround: replace all instances of the first path separator with the (lesser-used, but still acceptable) second one which works for cython without escaping.