### PR TITLE
[Refactor] util/system.py free_memory() single exit point

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -106,6 +106,7 @@ _the openage authors_ are:
 | Tushar Maheshwari           | tusharpm                    | tushar27192 à gmail dawt com                      |
 | Piotr Szpetkowski           | piotr-szpetkowski           | piotr dawt szpetkowski à pyquest dawt space       |
 | Julian Guillotel            | arialwhite                  | julian dawt gullotel à gmail dawt com             |
+| Arne Sellmann               | PythonicChemist             | arne dawt sellmann à gmx dawt de                  |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/util/system.py
+++ b/openage/util/system.py
@@ -18,22 +18,21 @@ def free_memory():
     >>> free_memory() > 0
     True
     """
+    memory = INF
+
     if platform.startswith('linux'):
         pattern = re.compile('^MemAvailable: +([0-9]+) kB\n$')
         with open('/proc/meminfo') as meminfo:
             for line in meminfo:
                 match = pattern.match(line)
-                if not match:
-                    continue
-                return 1024 * int(match.group(1))
-        return INF
-
-    if platform == "darwin":
+                if match:
+                    memory = 1024 * int(match.group(1))
+                    break
+    elif platform == "darwin":
         # TODO
-        return INF
-    if platform == "win32":
+        pass
+    elif platform == "win32":
         # TODO
-        return INF
+        pass
 
-    # unknown platform
-    return INF
+    return memory


### PR DESCRIPTION
I changed the function so that there is a single and clear exit point. I set memory to INF at the start to silence the linter although I would prefer it in the else branch personally.