### PR TITLE
Make pylint shut up after update to 1.8.1

### DIFF
--- a/openage/convert/dataformat/data_definition.py
+++ b/openage/convert/dataformat/data_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 the openage authors. See copying.md for legal info.
+# Copyright 2014-2018 the openage authors. See copying.md for legal info.
 
 """
 Output format specification for data to write.
@@ -33,6 +33,13 @@ class DataDefinition(StructDefinition):
         """
         create a text snippet to represent the csv data
         """
+
+        # pylint: disable=too-many-locals
+
+        # TODO: This method is in SERIOUS need of some refactoring, e.g. extracting methods.
+        #       However, this will become obsolete with the upcoming sprite metadata files,
+        #       so we hope to get away with not touchin it. If you need to make modifications
+        #       here, you are going to fix this pile of crap first.
 
         member_types = self.members.values()
         csv_column_types = list()

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """ Entry point for all of the asset conversion. """
 
@@ -236,16 +236,24 @@ def wanna_use_wine():
     if not which("wine"):
         return False
 
-    print("  Should we call wine to determine an AOE installation? [Y/n]")
-    while True:
-        user_selection = input("> ")
-        if user_selection.lower() in {"yes", "y", ""}:
-            return True
-        elif user_selection.lower() in {"no", "n"}:
-            return False
+    answer = None
+    long_prompt = True
+    while answer is None:
+        if long_prompt:
+            print("  Should we call wine to determine an AOE installation? [Y/n]")
+            long_prompt = False
         else:
             # TODO: text-adventure here
             print("  Don't know what you want. Use wine? [Y/n]")
+
+        user_selection = input("> ")
+        if user_selection.lower() in {"yes", "y", ""}:
+            answer = True
+
+        elif user_selection.lower() in {"no", "n"}:
+            answer = False
+
+    return answer
 
 
 def set_custom_wineprefix():
@@ -308,9 +316,11 @@ def query_source_dir(proposals):
             sourcedir = user_selection
         sourcedir = expand_relative_path(sourcedir)
         if Path(sourcedir).is_dir():
-            return sourcedir
+            break
         else:
             warn("No valid existing directory: {}".format(sourcedir))
+
+    return sourcedir
 
 
 def acquire_conversion_source_dir(root=None):
@@ -646,3 +656,5 @@ def main(args, error):
     else:
         print("assets are up to date; no conversion is required.")
         print("override with --force.")
+
+    return 0

--- a/openage/convert/slp_converter_pool.py
+++ b/openage/convert/slp_converter_pool.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """
 Multiprocessing-based SLP-to-texture converter service.
@@ -117,8 +117,8 @@ class SLPConverterPool:
         if isinstance(result, BaseException):
             err("exception in worker process: %s" % result)
             raise result
-        else:
-            return result
+
+        return result
 
     def __enter__(self):
         return self

--- a/openage/util/decorators.py
+++ b/openage/util/decorators.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """
 Some utility function decorators
@@ -14,9 +14,11 @@ def run_once(func):
 
     def wrapper(*args, **kwargs):
         """ Returned function wrapper. """
-        if not wrapper.has_run:
-            wrapper.has_run = True
-            return func(*args, **kwargs)
+        if wrapper.has_run:
+            return None
+
+        wrapper.has_run = True
+        return func(*args, **kwargs)
 
     wrapper.has_run = False
     return wrapper

--- a/openage/util/files.py
+++ b/openage/util/files.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 """
 Some file handling utilities
 """
@@ -35,12 +35,14 @@ def read_nullterminated_string(fileobj, maxlen=255):
         char = ord(read_guaranteed(fileobj, 1))
 
         if char == 0:
-            return bytes(result)
+            break
         else:
             result.append(char)
 
         if len(result) > maxlen:
             raise Exception("Null-terminated string too long.")
+
+    return bytes(result)
 
 
 def which(filename):

--- a/openage/util/fslike/union.py
+++ b/openage/util/fslike/union.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """
 Provides Union, a utility class for combining multiple FSLikeObjects to a
@@ -187,6 +187,7 @@ class Union(FSLikeObject):
         for path in self.candidate_paths(parts):
             if path.writable():
                 return path.mkdirs()
+        return None
 
     def rmdir(self, parts):
         found = False

--- a/openage/util/iterators.py
+++ b/openage/util/iterators.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """
 Provides all sorts of iterator-related stuff.
@@ -10,6 +10,7 @@ def denote_last(iterable):
     Similar to enumerate, this iterates over an iterable, and yields
     tuples of item, is_last.
     """
+    # pylint: disable=stop-iteration-return
     iterator = iter(iterable)
     current = next(iterator)
 

--- a/openage/util/iterators.py
+++ b/openage/util/iterators.py
@@ -1,55 +1,20 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 """
 Provides all sorts of iterator-related stuff.
 """
 
 
-class ListIterator:
-    """
-    An iterator type for list-like objects, i.e. objects
-    that implement __getitem__.
-    """
-
-    # pylint: disable=too-few-public-methods
-
-    def __init__(self, listobject):
-        self.pos = 0
-        self.listobject = listobject
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        try:
-            result = self.listobject[self.pos]
-            self.pos += 1
-            return result
-        except IndexError:
-            raise StopIteration from None
-
-
 def denote_last(iterable):
     """
     Similar to enumerate, this iterates over an iterable, and yields
     tuples of item, is_last.
-
-    is_last is True for the last item before StopIteration, and False
-    for all others.
     """
     iterator = iter(iterable)
+    current = next(iterator)
 
-    next_ = next(iterator)
-    is_last = False
+    for future in iterator:
+        yield current, False
+        current = future
 
-    while True:
-        current = next_
-        try:
-            next_ = next(iterator)
-        except StopIteration:
-            is_last = True
-
-        yield current, is_last
-
-        if is_last:
-            raise StopIteration
+    yield current, True

--- a/openage/util/struct.py
+++ b/openage/util/struct.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 """
 Provides some classes designed to expand the functionality of struct.struct
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from struct import Struct
 
 from ..util.files import read_guaranteed
-from .iterators import ListIterator
 
 
 class NamedStructMeta(type):
@@ -191,7 +190,7 @@ class NamedStruct(metaclass=NamedStructMeta):
         return {attr: getattr(self, attr) for attr in self._attributes}
 
     def __iter__(self):
-        return ListIterator(self)
+        return iter(self)
 
     def __repr__(self):
         return str(type(self)) + ": " + repr(self.as_dict())


### PR DESCRIPTION
This includes and thus closes #938.

* [x] Remove `ListIterator`, builtin function `iter` does the same
* [x] Rewrite `denote_last` to be more concise, disable warning
* [x] Add some explicit `return` statements
* [x] Modify control flow so that pylint understands it
* [x] Silence complexity warning in code we are going to shitcan anyway