### PR TITLE
codecompliance: ignore merge-commit-dates

### DIFF
--- a/buildsystem/codecompliance/legal.py
+++ b/buildsystem/codecompliance/legal.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 the openage authors. See copying.md for legal info.
+# Copyright 2014-2018 the openage authors. See copying.md for legal info.
 
 """
 Checks the legal headers of all files.
@@ -53,7 +53,7 @@ def get_git_change_year(filename):
     """ Returns git-log's opinion on when the file was last changed. """
 
     invocation = [
-        'git', 'log', '-1', '--format=%ad', '--date=short', '--',
+        'git', 'log', '-1', '--format=%ad', '--date=short', '--no-merges', '--',
         filename
     ]
 


### PR DESCRIPTION
When a PR gets merged in another year than the commits are dated,
the expected copyright year in the changed files changes to the
merge-commits year. This makes the copyright year wrong according to our
codecompliance check.
This might happen, because of a PR gets merged in a year after the last
change, or because the PR got rebased without '--ignore-date'.