### PR TITLE
Compiler features check failure for VS 2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ set(PYTHON_MIN_VERSION 3.4)
 set(CYTHON_MIN_VERSION 0.25)
 
 # CMake policies
-foreach(pol CMP0071  # enable automoc for generated files
+foreach(pol
+        CMP0067  # honor language standard in try_compile()
+        CMP0071  # enable automoc for generated files
        )
 	if (POLICY ${pol})
 		cmake_policy(SET ${pol} NEW)


### PR DESCRIPTION
Possible fix for #968.

### TODO
* Need to test on second machine. @benapetr, @zuntrax: please give this a try.