### PR TITLE
doc: update windows build instructions for improved qt5 port

### DIFF
--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -24,11 +24,11 @@
 ### vcpkg packages
  Set up [vcpkg](https://github.com/Microsoft/vcpkg#quick-start). Open a command prompt at `<vcpkg directory>`
 
-    vcpkg install dirent libepoxy fontconfig freetype harfbuzz opus opusfile qt5 sdl2 sdl2-image libpng
+    vcpkg install dirent libepoxy fontconfig freetype harfbuzz opus opusfile qt5-base qt5-declarative sdl2 sdl2-image libpng
 
- _Note:_ Building and installing `qt5` using vcpkg takes a lot of space-time.
- You might want to install [the prebuilt version](https://www.qt.io/download-open-source/) instead.
- Include `-DCMAKE_PREFIX_PATH=<QT5 directory>` in the cmake configure command.
+ _Note:_ The `qt5` port in vcpkg has been split into multiple packages, build times are acceptable now.
+ If you want, you can still use [the prebuilt version](https://www.qt.io/download-open-source/) instead.
+ If you do so, include `-DCMAKE_PREFIX_PATH=<QT5 directory>` in the cmake configure command.
 
 ### The "other missing" dependencies
  **opus-tools (for `opusenc`)**


### PR DESCRIPTION
They fixed the `qt5` port in vcpkg, updated build instructions to reflect that.