### PR TITLE
opusenc: correct malformed opus comments

### DIFF
--- a/openage/convert/opus/opusenc.pyx
+++ b/openage/convert/opus/opusenc.pyx
@@ -201,7 +201,7 @@ cdef int write_opus_comment(ogg.ogg_stream_state *os, ogg.ogg_packet *op):
     Returns non-zero on failure.
     '''
     vendor = b'openage asset converter'
-    buf = b''.join((b'OpusTags', len(vendor).to_bytes(1, 'little'), vendor,
+    buf = b''.join((b'OpusTags', len(vendor).to_bytes(4, 'little'), vendor,
                     b'\x00\x00\x00\x00'))  # number of comments following
 
     op.packet = buf


### PR DESCRIPTION
I somehow used a one byte length field for the vendor string, which should be 4 bytes long.
should fix #972 