### PR TITLE
doc: fix python-jinja installation instructions for arch linux

### DIFF
--- a/doc/build_instructions/arch_linux.md
+++ b/doc/build_instructions/arch_linux.md
@@ -4,7 +4,7 @@
 
 This command should provide required packages for Arch Linux installation:
 
-`sudo pacman -S --needed python python-jinja2 python-pillow python-numpy python-pygments cython libepoxy libogg libpng ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus python-pylint qt5-declarative qt5-quickcontrols`
+`sudo pacman -S --needed python python-jinja python-pillow python-numpy python-pygments cython libepoxy libogg libpng ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus python-pylint qt5-declarative qt5-quickcontrols`
 
 If you don't have a compiler installed, you can select between these commands to install it:
  - `sudo pacman -S --needed gcc`


### PR DESCRIPTION
Just a small problem I've found while studying the docs and configuring a development environment on my machine. There is currently no `python-jinja2` package in arch's repo, the correct one seems to be `python-jinja` (note that it does install version 2 of the library as required).

More: https://www.archlinux.org/packages/community/any/python-jinja/