### PR TITLE
Add quit button

### DIFF
--- a/assets/qml/GeneratorControl.qml
+++ b/assets/qml/GeneratorControl.qml
@@ -72,6 +72,13 @@ Item {
 				text: "reload_assets"
 				onClicked: gameSpec.invalidate()
 			}
+
+			ButtonFlat {
+				Layout.fillWidth: true
+
+				text: "quit"
+				onClicked: game.engine.stop()
+			}
 		}
 
 		Text {

--- a/copying.md
+++ b/copying.md
@@ -109,6 +109,7 @@ _the openage authors_ are:
 | Arne Sellmann               | PythonicChemist             | arne dawt sellmann à gmx dawt de                  |
 | Rafael X. Morales Georgi    | chocoladisco                | chocoladisco à gmail dawt com                     |
 | Marcel Schneider            | schnema123                  | marcelschneider5 à outlook dawt de                |
+| Samuel Grigolato            | samuelgrigolato             | samuel dawt grigolato à gmail dawt com            |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/gui/engine_link.cpp
+++ b/libopenage/gui/engine_link.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #include "engine_link.h"
 
@@ -70,6 +70,10 @@ QObject* EngineLink::provider(QQmlEngine *engine, QJSEngine*) {
 
 QStringList EngineLink::get_global_binds() const {
 	return this->global_binds;
+}
+
+void EngineLink::stop() {
+	this->core->stop();
 }
 
 void EngineLink::on_global_binds_changed(const std::vector<std::string>& global_binds) {

--- a/libopenage/gui/engine_link.h
+++ b/libopenage/gui/engine_link.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -57,6 +57,8 @@ public:
 	}
 
 	QStringList get_global_binds() const;
+
+	Q_INVOKABLE void stop();
 
 signals:
 	void global_binds_changed();


### PR DESCRIPTION
This is a third attempt to #616. It builds upon #620, #621 and this specific @TheJJ's comment:

> For this issue, and because we have no server part, I think its enough to just add a button that then calls a function where we can do more complicated things in the future. For now, it can just call Engine::stop().