### PR TITLE
doc: update Fedora build prerequisites for Fedora 27

### DIFF
--- a/doc/build_instructions/fedora.md
+++ b/doc/build_instructions/fedora.md
@@ -1,3 +1,3 @@
-# Prerequisite steps for Fedora users (Fedora >= 22)
+# Prerequisite steps for Fedora users (Fedora >= 27)
 
-`sudo dnf install cmake gcc-c++ clang SDL2-devel SDL2_image-devel python3-Cython python3-devel python3-numpy python3-pillow python3-pygments libepoxy-devel libogg-devel libopus-devel libpng-devel opusfile-devel fontconfig-devel harfbuzz-devel qt5-qtdeclarative-devel qt5-qtquickcontrols`
+`sudo dnf install cmake gcc-c++ clang SDL2-devel SDL2_image-devel flex doxygen python3-Cython python3-devel python3-numpy python3-pillow python3-pygments python3-jinja2 libepoxy-devel libogg-devel libopusenc-devel libpng-devel opusfile-devel fontconfig-devel harfbuzz-devel qt5-qtdeclarative-devel qt5-qtquickcontrols`


### PR DESCRIPTION
Not sure what to do about nyan; there certainly isn't a fedora package for it, so right now I'm just going to assume Fedora users can follow the instructions given when configure is run.