### PR TITLE
macOS touch ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ perf.data*
 
 # IDEs
 .vscode
+
+# macOS
+.DS_Store

--- a/buildsystem/codecompliance/legal.py
+++ b/buildsystem/codecompliance/legal.py
@@ -38,8 +38,8 @@ THIRDPARTYLEGALHEADER = re.compile(
     "((#|//) .*\\n)*"
 
     # the openage copyright
-    "(#|//) (Modifications|Other (data|code)|Everything else) "
-    + OPENAGE_AUTHORS + "\n"
+    "(#|//) (Modifications|Other (data|code)|Everything else) " +
+    OPENAGE_AUTHORS + "\n"
     "(#|//) See copying\\.md for further legal info\\.\n")
 
 # Empty files (consisting of only comments) don't require a legal header.

--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -166,9 +166,12 @@ foreach(PYTHON ${PYTHON_INTERPRETERS})
 		py_get_config_var(LIBDIR PYTHON_LIBRARY_DIR)
 		py_get_config_var(LIBPL PYTHON_LIBPL)
 		py_get_config_var(LDLIBRARY PYTHON_LIBRARY_NAME)
-		find_library(PYTHON_LIBRARIES ${PYTHON_LIBRARY_NAME}
+		py_get_config_var(VERSION PYTHON_VERSION)
+
+		find_library(PYTHON_LIBRARIES "${PYTHON_LIBRARY_NAME}" "libpython${PYTHON_VERSION}.dylib"
 			PATHS "${PYTHON_LIBRARY_DIR}" "${PYTHON_LIBPL}"
 		)
+
 	endif()
 
 	# there's a static_assert that tests the Python version.

--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 # Find Python
 # ~~~~~~~~~~~

--- a/copying.md
+++ b/copying.md
@@ -110,6 +110,7 @@ _the openage authors_ are:
 | Rafael X. Morales Georgi    | chocoladisco                | chocoladisco à gmail dawt com                     |
 | Marcel Schneider            | schnema123                  | marcelschneider5 à outlook dawt de                |
 | Samuel Grigolato            | samuelgrigolato             | samuel dawt grigolato à gmail dawt com            |
+| Andrew Thompson             | mrwerdo331@me.com           | mrwerdo331 à me dawt com                          |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -18,6 +18,15 @@ OutputMode::OutputMode(qtsdl::GuiItemLink *gui_link)
 	gui_link{gui_link} {
 }
 
+OutputMode::~OutputMode() {
+	// An empty deconstructor prevents our clients from needing
+	// to implement one.
+	//
+	// The deconstructor is needed in the first place to stop
+	// the compiler from generating ud2 (undefined) instructors
+	// for the body of this method.
+}
+
 void OutputMode::announce() {
 	emit this->gui_signals.announced(this->name());
 

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -56,6 +56,7 @@ signals:
 class OutputMode : public input::InputContext {
 public:
 	explicit OutputMode(qtsdl::GuiItemLink *gui_link);
+	virtual ~OutputMode();
 
 	/**
 	 * Is this mode able to be used?

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 
 namespace openage {
 

--- a/libopenage/gui/guisys/private/gui_application_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_application_impl.cpp
@@ -26,7 +26,9 @@ GuiApplicationImpl::~GuiApplicationImpl() {
 
 void GuiApplicationImpl::processEvents() {
 	assert(std::this_thread::get_id() == this->owner);
+#ifndef __APPLE__
 	this->app.processEvents();
+#endif
 }
 
 namespace {

--- a/libopenage/gui/guisys/private/gui_application_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_application_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #include "gui_application_impl.h"
 

--- a/libopenage/gui/guisys/private/gui_event_queue_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_event_queue_impl.cpp
@@ -4,6 +4,9 @@
 
 #include <cassert>
 
+#ifdef __APPLE__
+#include <QCoreApplication>
+#endif
 #include <QThread>
 
 #include "../public/gui_event_queue.h"
@@ -24,7 +27,11 @@ GuiEventQueueImpl* GuiEventQueueImpl::impl(GuiEventQueue *event_queue) {
 
 void GuiEventQueueImpl::process_callbacks() {
 	assert(QThread::currentThread() == this->thread);
+#ifdef __APPLE__
+	if (QThread::currentThread() != QCoreApplication::instance()->thread()) this->callback_processor.processEvents();
+#else
 	this->callback_processor.processEvents();
+#endif
 }
 
 QThread* GuiEventQueueImpl::get_thread() {

--- a/libopenage/gui/guisys/private/gui_event_queue_impl.cpp
+++ b/libopenage/gui/guisys/private/gui_event_queue_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #include "gui_event_queue_impl.h"
 

--- a/libopenage/gui/guisys/private/platforms/context_extraction_cocoa.mm
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_cocoa.mm
@@ -12,7 +12,24 @@
 namespace qtsdl {
 
 std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
-	return std::tuple<QVariant, WId>{};
+
+	assert(window);
+
+	NSOpenGLContext *current_context = [NSOpenGLContext currentContext];
+	assert(current_context);
+
+	NSView *view = nullptr;
+
+	SDL_SysWMinfo wm_info;
+	SDL_VERSION(&wm_info.version);
+
+
+	if (SDL_GetWindowWMInfo(window, &wm_info)) {
+		NSWindow *ns_window = wm_info.info.cocoa.window;
+		view = [ns_window contentView];
+		assert(view);
+	}
+	return std::make_tuple(QVariant::fromValue<QCocoaNativeContext>(QCocoaNativeContext(current_context)), reinterpret_cast<WId>(view));
 }
 
 std::tuple<QVariant, std::function<void()>> extract_native_context_and_switchback_func(SDL_Window *window) {


### PR DESCRIPTION
There are a few things in this pull request:

1. This reapplies the magic commit from #852 to making rendering work again.
2. Qt elements were flickering... they no longer are.
3. Python libraries wasn't being detected automatically. The solution in the commit is terrible but works. This is trying to solve this issue: #994 
4. Fixes a crash when closing the game window using the red x button (again on macs). A deconstructor had this instruction in its method body: [ud2](https://hjlebbink.github.io/x86doc/html/UD2.html)