### PR TITLE
Link to Liberapay team page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Development Blog | [blog.openage.sft.mx](https://blog.openage.sft.mx)
 Forum | [<img src="https://www.redditstatic.com/about/assets/reddit-logo.png" alt="reddit" height="22"/> /r/openage](https://www.reddit.com/r/openage/)
 Matrix Chat | [`#sfttech:matrix.org`](https://riot.im/app/#/room/#sfttech:matrix.org)
 IRC Chat | [`irc.freenode.net #sfttech`](https://webchat.freenode.net/?channels=sfttech)
-Money Sink | [![money sink](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/SFTtech/donate)
+Money Sink | [![money sink](https://liberapay.com/assets/widgets/donate.svg)](https://liberapay.com/SFTtech)
 
 
 The foundation of **openage**:


### PR DESCRIPTION
Readme now links to our Liberapay team page instead of directly redirecting people to the donation form.