### PR TITLE
Add support for unpatched Age of Empires 2: The Conquerors

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -111,6 +111,7 @@ _the openage authors_ are:
 | Marcel Schneider            | schnema123                  | marcelschneider5 à outlook dawt de                |
 | Samuel Grigolato            | samuelgrigolato             | samuel dawt grigolato à gmail dawt com            |
 | Andrew Thompson             | mrwerdo331@me.com           | mrwerdo331 à me dawt com                          |
+| Benedikt Freisen            | roybaer                     | b dawt freisen à gmx dawt net                     |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/driver.py
+++ b/openage/convert/driver.py
@@ -10,7 +10,7 @@ from tempfile import gettempdir
 
 from ..log import info, dbg
 from .opus import opusenc
-from .game_versions import GameVersion
+from .game_versions import GameVersion, has_x1_p1
 from .blendomatic import Blendomatic
 from .changelog import (ASSET_VERSION, ASSET_VERSION_FILENAME,
                         GAMESPEC_VERSION_FILENAME)
@@ -45,7 +45,10 @@ def get_string_resources(args):
 
     elif srcdir["language.dll"].is_file():
         from .pefile import PEFile
-        for name in ["language.dll", "language_x1.dll", "language_x1_p1.dll"]:
+        names = ["language.dll", "language_x1.dll"]
+        if has_x1_p1(args.game_versions):
+            names.append("language_x1_p1.dll")
+        for name in names:
             pefile = PEFile(srcdir[name].open('rb'))
             stringres.fill_from(pefile.resources().strings)
             count += 1
@@ -77,8 +80,10 @@ def get_gamespec(srcdir, game_versions, dont_pickle):
 
     if GameVersion.age2_hd_ak in game_versions:
         filename = "empires2_x2_p1.dat"
-    else:
+    elif has_x1_p1(game_versions):
         filename = "empires2_x1_p1.dat"
+    else:
+        filename = "empires2_x1.dat"
 
     cache_file = os.path.join(gettempdir(), "{}.pickle".format(filename))
 

--- a/openage/convert/game_versions.py
+++ b/openage/convert/game_versions.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """Detect the version of the original game"""
 
@@ -43,7 +43,7 @@ class GameVersion(enum.Enum):
     age2_tc = (
         11.76,
         "Age of Empires 2: The Conquerors",
-        Support.nope,
+        Support.yes,
         {'age2_x1/age2_x1.exe', 'data/empires2_x1.dat'},
     )
     age2_tc_10c = (
@@ -120,3 +120,14 @@ def get_game_versions(srcdir):
         if all(srcdir.joinpath(path).is_file()
                for path in version.required_files):
             yield version
+
+
+def has_x1_p1(versions):
+    """
+    Determine whether any of the versions has patch 1, i.e. the *_x1_p1.* files
+    """
+    for ver in versions:
+        for ver_file in ver.required_files:
+            if "x1_p1" in ver_file:
+                return True
+    return False

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from . import changelog
-from .game_versions import GameVersion, get_game_versions, Support
+from .game_versions import GameVersion, get_game_versions, Support, has_x1_p1
 
 from ..log import warn, info, dbg
 from ..util.files import which
@@ -82,7 +82,8 @@ def mount_drs_archives(srcdir, game_versions=None):
                   "gamedata")
     else:
         mount_drs("data/gamedata_x1.drs", "gamedata")
-        mount_drs("data/gamedata_x1_p1.drs", "gamedata")
+        if has_x1_p1(game_versions):
+            mount_drs("data/gamedata_x1_p1.drs", "gamedata")
 
     return result
 


### PR DESCRIPTION
With these modifications the converter will only use the `foo_x1_p1.bar` files with patched versions of AoE2.
The result looks fully functional, i.e. I can run `run` and see a game screen.