### PR TITLE
This change allows the openage git repository checkout to be located in a directory that is a symlink

### DIFF
--- a/buildsystem/check_py_file_list.py
+++ b/buildsystem/check_py_file_list.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 """
 Tests whether the files listed via add_py_module are consistent with the
@@ -21,13 +21,14 @@ def main():
     args = cli.parse_args()
 
     with open(args.py_file_list) as fileobj:
-        listed = set(os.path.normpath(filepath) for filepath in fileobj.read().strip().split(';'))
+        listed = set(os.path.realpath(os.path.normpath(filepath))
+                     for filepath in fileobj.read().strip().split(';'))
         if listed == {''}:
             listed = set()
 
     actual = set()
     for dirname, _, files in os.walk('openage'):
-        dirname = os.path.abspath(dirname)
+        dirname = os.path.realpath(os.path.abspath(dirname))
         for filename in files:
             if filename.endswith('.py'):
                 actual.add(os.path.join(dirname, filename))

--- a/buildsystem/cythonize.py
+++ b/buildsystem/cythonize.py
@@ -58,7 +58,7 @@ def read_list_from_file(filename):
     with open(filename) as fileobj:
         data = fileobj.read().strip()
 
-    data = [os.path.normpath(filename) for filename in data.split(';')]
+    data = [os.path.realpath(os.path.normpath(filename)) for filename in data.split(';')]
     if data == ['']:
         return []
 
@@ -141,7 +141,7 @@ def main():
                 # system include
                 continue
 
-            if os.path.abspath(filename) not in depends:
+            if os.path.realpath(os.path.abspath(filename)) not in depends:
                 print("\x1b[31mERR\x1b[m unlisted dependency: " + filename)
                 sys.exit(1)
 

--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -414,7 +414,7 @@ def main():
               "from {} header{}...".format(hdr_count, plural))
 
     for filename in args.all_files:
-        filename = os.path.abspath(filename)
+        filename = os.path.realpath(os.path.abspath(filename))
         if not filename.startswith(cppdir):
             print("pxdgen source file is not in " + cppdir + ": " + filename)
             sys.exit(1)


### PR DESCRIPTION
e.g.
Local git repo is located at: /home/userA/workspace/openage
/home/userA/workspace is a symlink to /mnt/data/workspace

Before /mnt/data/workspace/openage/run.py was compared with /home/userA/workspace/openage/run.py and therefore not recognized as the same file.

Now actual and listed are transformed to the canonical name