### PR TITLE
engine: remove usage of deprecated std::hash::result_type

### DIFF
--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -199,8 +199,8 @@ std::string to_string(const openage::game_resource &res);
  */
 template<> struct hash<openage::game_resource> {
 	typedef underlying_type<openage::game_resource>::type underlying_type;
-	typedef hash<underlying_type>::result_type result_type;
-	result_type operator()( const openage::game_resource& arg ) const {
+
+	size_t operator()(const openage::game_resource &arg) const {
 		hash<underlying_type> hasher;
 		return hasher(static_cast<underlying_type>(arg));
 	}

--- a/libopenage/gamestate/score.h
+++ b/libopenage/gamestate/score.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2018 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -127,10 +127,11 @@ std::string to_string(const openage::score_category &cat);
  * hasher for score_category
  * TODO decide if needed, not used at the moment
  */
-template<> struct hash<openage::score_category> {
+template<>
+struct hash<openage::score_category> {
 	typedef underlying_type<openage::score_category>::type underlying_type;
-	typedef hash<underlying_type>::result_type result_type;
-	result_type operator()( const openage::score_category& arg ) const {
+
+	size_t operator()(const openage::score_category &arg) const {
 		hash<underlying_type> hasher;
 		return hasher(static_cast<underlying_type>(arg));
 	}

--- a/libopenage/unit/ability.h
+++ b/libopenage/unit/ability.h
@@ -373,8 +373,8 @@ std::string to_string(const openage::ability_type &at);
 template<>
 struct hash<openage::ability_type> {
 	typedef underlying_type<openage::ability_type>::type underlying_type;
-	typedef hash<underlying_type>::result_type result_type;
-	result_type operator()(const openage::ability_type &arg) const {
+
+	size_t operator()(const openage::ability_type &arg) const {
 		hash<underlying_type> hasher;
 		return hasher(static_cast<underlying_type>(arg));
 	}

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -20,9 +20,7 @@ namespace std {
 template<> struct hash<openage::gamedata::unit_classes> {
 	typedef underlying_type<openage::gamedata::unit_classes>::type underlying_type;
 
-	typedef hash<underlying_type>::result_type result_type;
-
-	result_type operator()(const openage::gamedata::unit_classes &arg) const {
+	size_t operator()(const openage::gamedata::unit_classes &arg) const {
 		hash<underlying_type> hasher;
 		return hasher(static_cast<underlying_type>(arg));
 	}

--- a/libopenage/unit/command.h
+++ b/libopenage/unit/command.h
@@ -28,8 +28,8 @@ namespace std {
 template<>
 struct hash<openage::command_flag> {
 	typedef underlying_type<openage::command_flag>::type underlying_type;
-	typedef hash<underlying_type>::result_type result_type;
-	result_type operator()(const openage::command_flag &arg) const {
+
+	size_t operator()(const openage::command_flag &arg) const {
 		hash<underlying_type> hasher;
 		return hasher(static_cast<underlying_type>(arg));
 	}


### PR DESCRIPTION
newer gcc spams us with warnings about this.