### PR TITLE
More CI variety

### DIFF
--- a/.kevin
+++ b/.kevin
@@ -5,16 +5,17 @@
 
 
 sanity_check:
-	- skip              (? if job == "debian" ?)
+	- skip              (? if job != "arch-clang" ?)
 	make checkall
 
 # Various optimisation options can affect warnings compiler generates.
 # Make sure both release and debug are tested. Arch job has more checks,
 # so it should run debug, while Debian can test build in release.
 configure:
-	- env: mode=debug              (? if job != "debian" ?)
-	- env: mode=release            (? if job == "debian" ?)
-	./configure --mode=${mode} --ccache --download-nyan
+	- env: mode=release compiler=gcc            (? if job == "debian" ?)
+	- env: mode=debug   compiler=gcc            (? if job == "arch-gcc" ?)
+	- env: mode=debug   compiler=clang          (? if job == "arch-clang" ?)
+	./configure --mode=${mode} --compiler=${compiler} --flags="-Werror" --ccache --download-nyan
 
 build: configure
 	make -j$(nproc) build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ message("${PROJECT_NAME} ${PROJECT_VERSION}
 
          compiler | ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}
        build type | ${CMAKE_BUILD_TYPE}
-         cxxflags | ${CMAKE_CXX_FLAGS}
+         cxxflags | ${CMAKE_CXX_FLAGS} ${EXTRA_FLAGS}
  build type flags | ${${BUILD_TYPE_CXX_FLAGS}}
         build dir | ${CMAKE_BINARY_DIR}
    install prefix | ${CMAKE_INSTALL_PREFIX}

--- a/libopenage/console/draw.cpp
+++ b/libopenage/console/draw.cpp
@@ -36,7 +36,7 @@ void to_opengl(Engine *engine, Console *console) {
 	bool slowblinking_visible = (monotime % 300000000 < 150000000);
 
 	for (coord::term_t x = 0; x < console->buf.dims.x; x++) {
-		coord::camhud chartopleft{chartopleft.x = topleft.x + console->charsize.x * x, 0};
+		coord::camhud chartopleft{topleft.x + console->charsize.x * x, 0};
 
 		for (coord::term_t y = 0; y < console->buf.dims.y; y++) {
 			chartopleft.y = topleft.y - console->charsize.y * y;

--- a/libopenage/renderer/font/font.cpp
+++ b/libopenage/renderer/font/font.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2018 the openage authors. See copying.md for legal info.
 
 #include "font.h"
 
@@ -117,9 +117,11 @@ void Font::initialize(FT_Library ft_library) {
 		throw Error(MSG(err) << "Failed to set font face size to " << this->description.size);
 	}
 
-	// TODO Replace this trickery with hb_ft_font_create_referenced for harfbuzz version > 1.0
 	hb_ft_font_create_referenced(ft_face);
-	this->hb_font = hb_ft_font_create(ft_face, (hb_destroy_func_t) FT_Done_Face);
+	// lambda with static_cast to help gcc understand this is ok
+	this->hb_font = hb_ft_font_create(ft_face, [] (void *user_data) -> void {
+		FT_Done_Face(static_cast<FT_FaceRec_ *>(user_data));
+	});
 }
 
 Font::~Font() {

--- a/libopenage/renderer/opengl/buffer.cpp
+++ b/libopenage/renderer/opengl/buffer.cpp
@@ -11,8 +11,7 @@ namespace opengl {
 
 GlBuffer::GlBuffer(size_t size, GLenum usage)
 	: GlSimpleObject([] (GLuint handle) { glDeleteBuffers(1, &handle); } )
-	, size(size)
-	, usage(usage) {
+	, size(size) {
 	GLuint handle;
 	glGenBuffers(1, &handle);
 	this->handle = handle;
@@ -23,8 +22,7 @@ GlBuffer::GlBuffer(size_t size, GLenum usage)
 
 GlBuffer::GlBuffer(const uint8_t *data, size_t size, GLenum usage)
 	: GlSimpleObject([] (GLuint handle) { glDeleteBuffers(1, &handle); } )
-	, size(size)
-	, usage(usage) {
+	, size(size) {
 	GLuint handle;
 	glGenBuffers(1, &handle);
 	this->handle = handle;

--- a/libopenage/renderer/opengl/buffer.h
+++ b/libopenage/renderer/opengl/buffer.h
@@ -35,9 +35,6 @@ public:
 private:
 	/// The size in bytes of this buffer.
 	size_t size;
-
-	/// The GL usage hint for this buffer.
-	GLenum usage;
 };
 
 }}} // openage::renderer::opengl

--- a/libopenage/renderer/shader_program.h
+++ b/libopenage/renderer/shader_program.h
@@ -20,6 +20,8 @@ class Texture2d;
 
 class ShaderProgram {
 public:
+	virtual ~ShaderProgram() = default;
+
 	// Template dispatches for uniform variable setting.
 	void update_uniform_input(UniformInput*) {}
 

--- a/openage/cvar/config_file.py
+++ b/openage/cvar/config_file.py
@@ -4,7 +4,7 @@
 Load and save the configuration : file <-> console var system
 """
 
-from ..log import info
+from ..log import info, spam
 
 
 def load_config_file(path, set_cvar_func, loaded_files=None):
@@ -34,7 +34,7 @@ def load_config_file(path, set_cvar_func, loaded_files=None):
 
     with path.open() as config:
         for line in config:
-            print("Reading config line: %s" % line)
+            spam("Reading config line: %s" % line)
             lstrip = line.lstrip()
             if not lstrip or lstrip.startswith("#"):
                 continue


### PR DESCRIPTION
This fixes a bug where `EXTRA_FLAGS` were not printed in the configuration overview. 
Also, we now have a second arch build with clang, and `-Werror` is turned on for all builds.
The open project configuration for kevin on `ci.sft.mx`  has already been adapted.
Fixes for the remaining warnings are included.