### PR TITLE
pylint: get rid of workarounds

### DIFF
--- a/buildsystem/codecompliance/pylint.py
+++ b/buildsystem/codecompliance/pylint.py
@@ -21,17 +21,8 @@ def find_issues(check_files, dirnames):
 
     invocation = ['--rcfile=etc/pylintrc', '--reports=n']
 
-    # pylint crashes with multiprocessing when cython modules are present
-    if any(findfiles(dirnames, [".so"])):
-        print("Cython modules found, using single process linting.")
-    else:
-        from multiprocessing import cpu_count
-        invocation.append("--jobs={:d}".format(cpu_count()))
-
-    ignored_modules = list(find_pyx_modules(dirnames))
-    ignored_modules.append('numpy')
-
-    invocation.append('--ignored-modules=' + ','.join(ignored_modules))
+    from multiprocessing import cpu_count
+    invocation.append("--jobs={:d}".format(cpu_count()))
 
     if check_files is None:
         invocation.extend(dirnames)

--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -28,7 +28,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-whitelist=openage.convert.opus.opusenc
 
 
 [REPORTS]


### PR DESCRIPTION
closes #1038 
Also we can get away without `ignored_modules` by adding the necessary ones to `extension-pkg-whitelist`.