### PR TITLE
Fix: builds failed if libncurses was missing

### DIFF
--- a/libopenage/event/demo/gui.cpp
+++ b/libopenage/event/demo/gui.cpp
@@ -260,7 +260,6 @@ void Gui::log(const std::string &msg) {
 	this->log_msgs.push_front(msg);
 }
 
+} // openage::event::demo
 
 #endif
-
-} // openage::event::demo


### PR DESCRIPTION
A wrongly placed `#endif` caused some trouble when building without ncurses.