### PR TITLE
Try to use Steam path.

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -114,6 +114,7 @@ _the openage authors_ are:
 | Benedikt Freisen            | roybaer                     | b dawt freisen à gmx dawt net                     |
 | Finn Günther                | Kawzeg                      | kawzeg à gmail dawt com                           |
 | Akshit Sharma               | akshit-sharma               | akshit9sharma à gmail dawt com                    |
+| Jacek Wielemborek           | d33tah                      | d33tah à gmail dawt com                           |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -25,6 +25,8 @@ STANDARD_PATH_IN_32BIT_WINEPREFIX =\
     "drive_c/Program Files/Microsoft Games/Age of Empires II/"
 STANDARD_PATH_IN_64BIT_WINEPREFIX =\
     "drive_c/Program Files (x86)/Microsoft Games/Age of Empires II/"
+STANDARD_PATH_IN_WINEPREFIX_STEAM = \
+    "drive_c/Program Files (x86)/Steam/steamapps/common/Age2HD/"
 REGISTRY_KEY = \
     "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Microsoft Games\\"
 REGISTRY_SUFFIX_AOK = "Age of Empires\\2.0"
@@ -377,8 +379,10 @@ def source_dir_proposals(call_wine):
     if "WINEPREFIX" in os.environ:
         yield "$WINEPREFIX/" + STANDARD_PATH_IN_32BIT_WINEPREFIX
         yield "$WINEPREFIX/" + STANDARD_PATH_IN_64BIT_WINEPREFIX
+        yield "$WINEPREFIX/" + STANDARD_PATH_IN_WINEPREFIX_STEAM
     yield "~/.wine/" + STANDARD_PATH_IN_32BIT_WINEPREFIX
     yield "~/.wine/" + STANDARD_PATH_IN_64BIT_WINEPREFIX
+    yield "~/.wine/" + STANDARD_PATH_IN_WINEPREFIX_STEAM
 
     if not call_wine:
         # user wants wine not to be called


### PR DESCRIPTION
The logic here is that there might be a Wine bug preventing the game
from fully installing (and thus having the registry key installed), but
the assets are there. This was the case for me and thought it might not
be that rare and worth trying to work around.

The actual Wine bug was that Steam was trying to keep installing MSVC
forever in a loop, at each startup attempt.