### PR TITLE
Fix codegen error during cmake/configure phase

### DIFF
--- a/openage/codegen/codegen.py
+++ b/openage/codegen/codegen.py
@@ -218,6 +218,10 @@ def get_codegen_depends(outputwrapper):
             # depends.
             continue
 
+        if filename is None:
+            # some modules have __file__ == None, we don't want those either.
+            continue
+
         if module.__package__ == '':
             continue
 


### PR DESCRIPTION
When a Python package which has no `__init__.py` is imported during codegen,
the codegen dependency detector crashed because that package's `__file__`
member is `None` instead of `str`.

With this pull request, that edge case is detected.

Bug encountered on Arch Linux with the module `mpl_toolkits` (see the below error log).

I'm not sure why exactly a package like `mpl_toolkits` (part of `python-matplotlib`) was imported in the first place, which may be a bug in itself, and why that package doesn't have a `__init__.py` (which may be a bug in that package), but this fix is useful in any case.

```
./configure is a convenience script:
it creates the build directory,  symlinks it,
and invokes cmake for an out-of-source build.

Nobody is stopping you from skipping ./configure and our Makefile,
and using CMake directly (e.g. when packaging, or using an IDE).
For your convenience, ./configure even prints the direct CMake invocation!

         build_type | Debug
       cxx_compiler | g++
          cxx_flags | 
   exe_linker_flags | 
     install_prefix | /usr/local
module_linker_flags | 
shared_linker_flags | 

config options:

          backtrace | if_available
gperftools-profiler | if_available
gperftools-tcmalloc | False
            inotify | if_available
            ncurses | if_available
             opengl | if_available
             vulkan | if_available

bindir:
/tmp/oa2/.bin/g++-debug-Oauto-sanitize-none/

invocation:
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='' -DCMAKE_EXE_LINKER_FLAGS='' -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_MODULE_LINKER_FLAGS='' -DCMAKE_SHARED_LINKER_FLAGS='' -DCXX_OPTIMIZATION_LEVEL=auto -DCXX_SANITIZE_FATAL=False -DCXX_SANITIZE_MODE=none -DWANT_BACKTRACE=if_available -DWANT_GPERFTOOLS_PROFILER=if_available -DWANT_GPERFTOOLS_TCMALLOC=False -DWANT_INOTIFY=if_available -DWANT_NCURSES=if_available -DWANT_OPENGL=if_available -DWANT_VULKAN=if_available -- /tmp/oa2

(now running cmake:)



 ___  ______ _______ _______ ___
|  _)/ _____|_______|_______|_  |
| | ( (____  _____      _     | |    ___  ____  _____ ____  _____  ____ _____
| |  \____ \|  ___)    | |    | |   / _ \|  _ \| ___ |  _ \(____ |/ _  | ___ |
| |_ _____) ) |        | |   _| |  | |_| | |_| | ____| | | / ___ ( (_| | ____|
|___|______/|_|        |_|  (___|   \___/|  __/|_____)_| |_\_____|\___ |_____)
                                         |_|                     (_____|

Welcome to the SFT technologies computer-aided openage build system!

You have chosen, or been chosen, to attempt the daring task of building openage.
If you have installed all the dependencies that are conveniently listed in
[doc/building.md], this _might_ just work!

If it doesn't, consider reporting the issue: https://github.com/SFTtech/openage
Or ask for help:
  * Matrix: #sfttech:matrix.org
  * IRC:    #sfttech on freenode.net

-- Using python interpreter: /usr/bin/python3
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/oa2/openage/__main__.py", line 133, in <module>
    sys.exit(main())
  File "/tmp/oa2/openage/__main__.py", line 126, in main
    return args.entrypoint(args, cli.error)
  File "/tmp/oa2/openage/codegen/main.py", line 131, in main
    generated, depends = codegen(Directory(os.getcwd()).root, mode)
  File "/tmp/oa2/openage/codegen/codegen.py", line 165, in codegen
    depends = {os.path.abspath(path) for path in get_codegen_depends(wrapper)}
  File "/tmp/oa2/openage/codegen/codegen.py", line 165, in <setcomp>
    depends = {os.path.abspath(path) for path in get_codegen_depends(wrapper)}
  File "/tmp/oa2/openage/codegen/codegen.py", line 224, in get_codegen_depends
    if not filename.endswith('.py'):
AttributeError: 'NoneType' object has no attribute 'endswith'
CMake Error at buildsystem/codegen.cmake:25 (message):
  failed to get target list from codegen invocation
Call Stack (most recent call first):
  libopenage/CMakeLists.txt:17 (codegen_run)


-- Configuring incomplete, errors occurred!
See also "/tmp/oa2/.bin/g++-debug-Oauto-sanitize-none/CMakeFiles/CMakeOutput.log".
```
