### PR TITLE
renderer: fix usage of optional and misc

### DIFF
--- a/libopenage/renderer/opengl/buffer.cpp
+++ b/libopenage/renderer/opengl/buffer.cpp
@@ -45,6 +45,10 @@ void GlBuffer::upload_data(const uint8_t *data, size_t offset, size_t size) {
 }
 
 void GlBuffer::bind(GLenum target) const {
+	if (unlikely(!bool(this->handle))) {
+		throw Error(MSG(err) << "OpenGL buffer has been moved out of.");
+	}
+
 	glBindBuffer(target, *this->handle);
 }
 

--- a/libopenage/renderer/opengl/buffer.cpp
+++ b/libopenage/renderer/opengl/buffer.cpp
@@ -17,7 +17,7 @@ GlBuffer::GlBuffer(size_t size, GLenum usage)
 	this->handle = handle;
 
 	this->bind(GL_COPY_WRITE_BUFFER);
-	glBufferData(GL_COPY_WRITE_BUFFER, size, 0, usage);
+	glBufferData(GL_COPY_WRITE_BUFFER, size, nullptr, usage);
 }
 
 GlBuffer::GlBuffer(const uint8_t *data, size_t size, GLenum usage)

--- a/libopenage/renderer/opengl/context.cpp
+++ b/libopenage/renderer/opengl/context.cpp
@@ -60,7 +60,7 @@ static gl_context_capabilities find_capabilities() {
 	}
 	SDL_GL_MakeCurrent(test_window, test_context);
 
-	gl_context_capabilities caps;
+	gl_context_capabilities caps{};
 
 	GLint temp;
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &temp);
@@ -133,13 +133,13 @@ GlContext::~GlContext() {
 
 GlContext::GlContext(GlContext &&other)
 	: gl_context(other.gl_context)
-	, capabilities(std::move(other.capabilities)) {
+	, capabilities(other.capabilities) {
 	other.gl_context = nullptr;
 }
 
 GlContext& GlContext::operator=(GlContext &&other) {
 	this->gl_context = other.gl_context;
-	this->capabilities = std::move(other.capabilities);
+	this->capabilities = other.capabilities;
 	other.gl_context = nullptr;
 
 	return *this;

--- a/libopenage/renderer/opengl/context.h
+++ b/libopenage/renderer/opengl/context.h
@@ -55,7 +55,7 @@ private:
 	SDL_GLContext gl_context;
 
 	/// Context capabilities.
-	gl_context_capabilities capabilities;
+	gl_context_capabilities capabilities{};
 };
 
 }}} // openage::renderer::opengl

--- a/libopenage/renderer/opengl/framebuffer.cpp
+++ b/libopenage/renderer/opengl/framebuffer.cpp
@@ -21,13 +21,13 @@ GlFramebuffer::GlFramebuffer(std::vector<const GlTexture2d*> textures)
 	std::vector<GLenum> drawBuffers;
 
 	size_t colorTextureCount = 0;
-	for (size_t i = 0; i < textures.size(); i++) {
+	for (auto const& texture : textures) {
 		// TODO figure out attachment points from pixel formats
-		if (textures[i]->get_info().get_format() == resources::pixel_format::depth24) {
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, textures[i]->get_handle(), 0);
+		if (texture->get_info().get_format() == resources::pixel_format::depth24) {
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texture->get_handle(), 0);
 		} else {
 			auto attachmentPoint = GL_COLOR_ATTACHMENT0 + colorTextureCount++;
-			glFramebufferTexture2D(GL_FRAMEBUFFER, attachmentPoint, GL_TEXTURE_2D, textures[i]->get_handle(), 0);
+			glFramebufferTexture2D(GL_FRAMEBUFFER, attachmentPoint, GL_TEXTURE_2D, texture->get_handle(), 0);
 			drawBuffers.push_back(attachmentPoint);
 		}
 	}

--- a/libopenage/renderer/opengl/geometry.cpp
+++ b/libopenage/renderer/opengl/geometry.cpp
@@ -19,11 +19,12 @@ GlGeometry::GlGeometry()
 
 GlGeometry::GlGeometry(const resources::MeshData &mesh)
 	: Geometry(geometry_t::mesh) {
-	GlBuffer verts(mesh.get_data().data(), mesh.get_data().size());
+	GlBuffer verts_buf(mesh.get_data().data(), mesh.get_data().size());
+	GlVertexArray verts_array(verts_buf, mesh.get_info());
 
 	this->mesh = GlMesh {
-		std::move(verts),
-		GlVertexArray (verts, mesh.get_info()),
+		std::move(verts_buf),
+		std::move(verts_array),
 		{},
 		{},
 		mesh.get_data().size() / mesh.get_info().vert_size(),

--- a/libopenage/renderer/opengl/geometry.cpp
+++ b/libopenage/renderer/opengl/geometry.cpp
@@ -64,7 +64,7 @@ void GlGeometry::draw() const {
 		if (mesh.indices) {
 			mesh.indices->bind(GL_ELEMENT_ARRAY_BUFFER);
 
-			glDrawElements(mesh.primitive, mesh.vert_count, *mesh.index_type, 0);
+			glDrawElements(mesh.primitive, mesh.vert_count, *mesh.index_type, nullptr);
 		} else {
 			glDrawArrays(GL_TRIANGLE_STRIP, 0, mesh.vert_count);
 		}

--- a/libopenage/renderer/opengl/renderer.cpp
+++ b/libopenage/renderer/opengl/renderer.cpp
@@ -42,6 +42,7 @@ std::unique_ptr<Geometry> GlRenderer::add_bufferless_quad() {
 
 std::unique_ptr<RenderTarget> GlRenderer::create_texture_target(std::vector<Texture2d*> textures) {
 	std::vector<const GlTexture2d*> gl_textures;
+	gl_textures.reserve(textures.size());
 	for (auto tex : textures) {
 		gl_textures.push_back(static_cast<const GlTexture2d*>(tex));
 	}

--- a/libopenage/renderer/opengl/shader.cpp
+++ b/libopenage/renderer/opengl/shader.cpp
@@ -31,7 +31,7 @@ GlShader::GlShader(const resources::ShaderSource &src)
 
 	// load shader source
 	const char* data = src.get_source().c_str();
-	glShaderSource(handle, 1, &data, 0);
+	glShaderSource(handle, 1, &data, nullptr);
 
 	// compile shader source
 	glCompileShader(handle);
@@ -45,7 +45,7 @@ GlShader::GlShader(const resources::ShaderSource &src)
 		glGetShaderiv(handle, GL_INFO_LOG_LENGTH, &loglen);
 
 		std::vector<char> infolog(loglen);
-		glGetShaderInfoLog(handle, loglen, 0, infolog.data());
+		glGetShaderInfoLog(handle, loglen, nullptr, infolog.data());
 
 		throw Error(MSG(err) << "Failed to compiler shader:\n" << infolog.data() );
 	}

--- a/libopenage/renderer/opengl/shader_program.cpp
+++ b/libopenage/renderer/opengl/shader_program.cpp
@@ -25,7 +25,7 @@ static void check_program_status(GLuint program, GLenum what_to_check) {
 		glGetProgramiv(program, GL_INFO_LOG_LENGTH, &loglen);
 
 		std::vector<char> infolog(loglen);
-		glGetProgramInfoLog(program, loglen, 0, infolog.data());
+		glGetProgramInfoLog(program, loglen, nullptr, infolog.data());
 
 		const char *what_str = [=] {
 			switch (what_to_check) {
@@ -50,7 +50,7 @@ GlShaderProgram::GlShaderProgram(const std::vector<resources::ShaderSource> &src
 	this->handle = handle;
 
 	std::vector<GlShader> shaders;
-	for (auto src : srcs) {
+	for (auto const& src : srcs) {
 		GlShader shader(src);
 		glAttachShader(handle, shader.get_handle());
 		shaders.push_back(std::move(shader));
@@ -88,7 +88,7 @@ GlShaderProgram::GlShaderProgram(const std::vector<resources::ShaderSource> &src
 			handle,
 			i_unif,
 			name.size(),
-			0,
+			nullptr,
 			&count,
 			&type,
 			name.data()
@@ -134,7 +134,7 @@ GlShaderProgram::GlShaderProgram(const std::vector<resources::ShaderSource> &src
 			handle,
 			i_attrib,
 			name.size(),
-			0,
+			nullptr,
 			&size,
 			&type,
 			name.data()
@@ -269,7 +269,7 @@ bool GlShaderProgram::has_uniform(const char* name) {
 }
 
 void GlShaderProgram::set_unif(UniformInput *in, const char *unif, void const* val, GLenum type) {
-	GlUniformInput *unif_in = static_cast<GlUniformInput*>(in);
+	auto *unif_in = static_cast<GlUniformInput*>(in);
 
 	if (unlikely(this->uniforms.count(unif) == 0)) {
 		throw Error(MSG(err) << "Tried to set uniform " << unif << " that does not exist in the shader program.");

--- a/libopenage/renderer/opengl/simple_object.cpp
+++ b/libopenage/renderer/opengl/simple_object.cpp
@@ -2,13 +2,15 @@
 
 #include "simple_object.h"
 
+#include <utility>
+
 
 namespace openage {
 namespace renderer {
 namespace opengl {
 
 GlSimpleObject::GlSimpleObject(std::function<void(GLuint)> delete_fun)
-	: delete_fun(delete_fun) {}
+	: delete_fun(std::move(delete_fun)) {}
 
 GlSimpleObject::GlSimpleObject(GlSimpleObject&& other)
 	: handle(other.handle)

--- a/libopenage/renderer/resources/mesh_data.cpp
+++ b/libopenage/renderer/resources/mesh_data.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstring>
+#include <utility>
 
 #include "../../error/error.h"
 #include "../../datastructure/constexpr_map.h"
@@ -36,12 +37,12 @@ size_t vertex_input_count(vertex_input_t in) {
 }
 
 VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs, vertex_layout_t layout, vertex_primitive_t primitive)
-	: inputs(inputs)
+	: inputs(std::move(inputs))
 	, layout(layout)
 	, primitive(primitive) {}
 
 VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs, vertex_layout_t layout, vertex_primitive_t primitive, index_t index_type)
-	: inputs(inputs)
+	: inputs(std::move(inputs))
 	, layout(layout)
 	, primitive(primitive)
 	, index_type(index_type) {}

--- a/libopenage/renderer/resources/texture_data.cpp
+++ b/libopenage/renderer/resources/texture_data.cpp
@@ -89,8 +89,8 @@ Texture2dData::Texture2dData(const util::Path &path, bool use_metafile) {
 		throw Error(MSG(err) << "Texture " << native_path << " uses an unsupported format.");
 	}
 
-	uint32_t w = uint32_t(surface->w);
-	uint32_t h = uint32_t(surface->h);
+	auto w = uint32_t(surface->w);
+	auto h = uint32_t(surface->h);
 
 	size_t data_size = surf_fmt.BytesPerPixel * surface->w * surface->h;
 
@@ -118,8 +118,8 @@ Texture2dData::Texture2dData(const util::Path &path, bool use_metafile) {
 	this->info = Texture2dInfo(w, h, pix_fmt, align, std::move(subtextures));
 }
 
-Texture2dData::Texture2dData(Texture2dInfo &&info, std::vector<uint8_t> &&data)
-	: info(std::move(info))
+Texture2dData::Texture2dData(Texture2dInfo const& info, std::vector<uint8_t> &&data)
+	: info(info)
 	, data(std::move(data)) {}
 
 Texture2dData Texture2dData::flip_y() {

--- a/libopenage/renderer/resources/texture_data.h
+++ b/libopenage/renderer/resources/texture_data.h
@@ -24,10 +24,10 @@ public:
 	///
 	/// Uses SDL Image internally. For supported image file types,
 	/// see the SDL_Image initialization in the engine.
-	Texture2dData(const util::Path &path, bool use_metafile = false);
+	Texture2dData(const util::Path& path, bool use_metafile = false);
 
 	/// Construct by moving the information and raw texture data from somewhere else.
-	Texture2dData(Texture2dInfo &&info, std::vector<uint8_t> &&data);
+	Texture2dData(Texture2dInfo const& info, std::vector<uint8_t>&& data);
 
 	/// Flips the texture along the Y-axis and returns the flipped data with the same info.
 	/// Sometimes necessary when converting between storage modes.

--- a/libopenage/renderer/resources/texture_info.cpp
+++ b/libopenage/renderer/resources/texture_info.cpp
@@ -62,9 +62,8 @@ const Texture2dSubInfo& Texture2dInfo::get_subtexture(size_t subid) const {
 	if (subid < this->subtextures.size()) {
 		return this->subtextures[subid];
 	}
-	else {
-		throw Error(MSG(err) << "Unknown subtexture requested: " << subid);
-	}
+
+	throw Error(MSG(err) << "Unknown subtexture requested: " << subid);
 }
 
 std::pair<int, int> Texture2dInfo::get_subtexture_size(size_t subid) const {

--- a/libopenage/renderer/resources/texture_subinfo.h
+++ b/libopenage/renderer/resources/texture_subinfo.h
@@ -17,13 +17,13 @@ namespace resources {
  * are within one texture file. */
 struct Texture2dSubInfo {
 	/// The subtexture position within the atlas
-	uint32_t x, y;
+	uint32_t x{}, y{};
 
 	/// The subtexture size
-	uint32_t w, h;
+	uint32_t w{}, h{};
 
 	/// Position of the subtexture's center within the atlas
-	uint32_t cx, cy;
+	uint32_t cx{}, cy{};
 
 	/// Initializes the info from a CSV line containing its members.
 	Texture2dSubInfo(const std::string& line);

--- a/libopenage/renderer/tests.cpp
+++ b/libopenage/renderer/tests.cpp
@@ -28,7 +28,7 @@ namespace tests {
 	opengl::GlContext::check_error();    \
 	printf("after %s\n", txt);
 
-void renderer_demo_0(util::Path path) {
+void renderer_demo_0(const util::Path& path) {
 	opengl::GlWindow window("openage renderer test", 800, 600);
 
 	auto renderer = window.make_renderer();

--- a/libopenage/renderer/text.cpp
+++ b/libopenage/renderer/text.cpp
@@ -58,10 +58,10 @@ TextRenderer::TextRenderer()
 }
 
 TextRenderer::~TextRenderer() {
-	if (this->vbo) {
+	if (this->vbo != 0u) {
 		glDeleteBuffers(1, &this->vbo);
 	}
-	if (this->ibo) {
+	if (this->ibo != 0u) {
 		glDeleteBuffers(1, &this->ibo);
 	}
 }
@@ -145,8 +145,8 @@ void TextRenderer::render() {
 		unsigned int num_elements = 0;
 
 		for (auto &pass : batch.passes) {
-			float x = static_cast<float>(pass.x);
-			float y = static_cast<float>(pass.y);
+			auto x = static_cast<float>(pass.x);
+			auto y = static_cast<float>(pass.y);
 
 			std::vector<codepoint_t> glyphs = font->get_glyphs(pass.text);
 

--- a/libopenage/renderer/texture.cpp
+++ b/libopenage/renderer/texture.cpp
@@ -9,10 +9,10 @@
 namespace openage {
 namespace renderer {
 
-Texture2d::Texture2d(resources::Texture2dInfo info)
+Texture2d::Texture2d(const resources::Texture2dInfo& info)
 	: info(info) {}
 
-Texture2d::~Texture2d() {}
+Texture2d::~Texture2d() = default;
 
 const resources::Texture2dInfo& Texture2d::get_info() const {
 	return this->info;

--- a/libopenage/renderer/texture.h
+++ b/libopenage/renderer/texture.h
@@ -27,7 +27,7 @@ public:
 
 protected:
 	/// Constructs the base with the given information.
-	Texture2d(resources::Texture2dInfo);
+	Texture2d(const resources::Texture2dInfo&);
 
 	/// Information about the size, format, etc. of this texture.
 	resources::Texture2dInfo info;

--- a/libopenage/renderer/texture_array.cpp
+++ b/libopenage/renderer/texture_array.cpp
@@ -6,10 +6,10 @@
 namespace openage {
 namespace renderer {
 
-Texture2dArray::Texture2dArray(resources::Texture2dInfo info)
+Texture2dArray::Texture2dArray(const resources::Texture2dInfo& info)
 	: layer_info(info) {}
 
-Texture2dArray::~Texture2dArray() {}
+Texture2dArray::~Texture2dArray() = default;
 
 resources::Texture2dInfo const& Texture2dArray::get_info() const {
 	return this->layer_info;

--- a/libopenage/renderer/texture_array.h
+++ b/libopenage/renderer/texture_array.h
@@ -25,7 +25,7 @@ public:
 
 protected:
 	/// Constructs the base class.
-	Texture2dArray(resources::Texture2dInfo);
+	Texture2dArray(const resources::Texture2dInfo&);
 
 	/// Information about the size, format, etc. of every layer in this array.
 	resources::Texture2dInfo layer_info;

--- a/libopenage/renderer/window.cpp
+++ b/libopenage/renderer/window.cpp
@@ -17,19 +17,19 @@ bool Window::should_close() const {
 	return this->should_be_closed;
 }
 
-void Window::add_mouse_button_callback(mouse_button_cb_t cb) {
+void Window::add_mouse_button_callback(const mouse_button_cb_t& cb) {
 	this->on_mouse_button.push_back(cb);
 }
 
-void Window::add_mouse_wheel_callback(mouse_wheel_cb_t cb) {
+void Window::add_mouse_wheel_callback(const mouse_wheel_cb_t& cb) {
 	this->on_mouse_wheel.push_back(cb);
 }
 
-void Window::add_key_callback(key_cb_t cb) {
+void Window::add_key_callback(const key_cb_t& cb) {
 	this->on_key.push_back(cb);
 }
 
-void Window::add_resize_callback(resize_cb_t cb) {
+void Window::add_resize_callback(const resize_cb_t& cb) {
 	this->on_resize.push_back(cb);
 }
 

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -29,10 +29,10 @@ public:
 	using mouse_wheel_cb_t = std::function<void(SDL_MouseWheelEvent const&)>;
 	using resize_cb_t = std::function<void(size_t, size_t)>;
 
-	void add_key_callback(key_cb_t);
-	void add_mouse_button_callback(mouse_button_cb_t);
-	void add_mouse_wheel_callback(mouse_wheel_cb_t);
-	void add_resize_callback(resize_cb_t);
+	void add_key_callback(const key_cb_t&);
+	void add_mouse_button_callback(const mouse_button_cb_t&);
+	void add_mouse_wheel_callback(const mouse_wheel_cb_t&);
+	void add_resize_callback(const resize_cb_t&);
 
 	/// Force the window to the given size. It's generally not a good idea to use this,
 	/// as it makes the window jump around wierdly.


### PR DESCRIPTION
Fixes #1058 . Also applies some good practice fixes from clang-tidy.