### PR TITLE
Update Qt version requirement from 5.5 to 5.9

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -52,7 +52,7 @@ Dependency list:
        S  pycodestyle
     C     pygments
        S  pylint
-    CR    qt5 >=5.5 (Core, Quick, QuickControls modules)
+    CR    qt5 >=5.9 (Core, Quick, QuickControls modules)
     CR  O vulkan
 
       A   An installed version of any of the following (wine is your friend).

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -62,7 +62,7 @@ find_package(Epoxy REQUIRED)
 find_package(HarfBuzz 1.0.0 REQUIRED)
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
-set(QT_VERSION_REQ "5.5")
+set(QT_VERSION_REQ "5.9")
 find_package(Qt5Core ${QT_VERSION_REQ} REQUIRED)
 find_package(Qt5Quick ${QT_VERSION_REQ} REQUIRED)
 


### PR DESCRIPTION
This solves the issue of automoc not being able to parse compact namespaces in Qt 5.5. This issue is resolved in Qt 5.9. This fixes #1043.