### PR TITLE
doc: fix table formatting in terrain.md.

### DIFF
--- a/doc/media/terrain.md
+++ b/doc/media/terrain.md
@@ -110,16 +110,16 @@ blending mode id correction:
 
 
 stored mode | terrain type  | corrected mode
-------------|---------------|---------------
-          0 | dirt, grass   | 1
-          1 | farms         | 3
-          2 | beach         | 2
-          3 | water         | 0
-          4 | shallows      | 1
-          5 | roads         | 4
-          6 | ice           | 5
-          7 | snow          | 6
-          8 | not assigned  | 4
+-----------:|---------------|---------------
+0           | dirt, grass   | 1
+1           | farms         | 3
+2           | beach         | 2
+3           | water         | 0
+4           | shallows      | 1
+5           | roads         | 4
+6           | ice           | 5
+7           | snow          | 6
+8           | not assigned  | 4
 
 Terrain elevations
 ------------------


### PR DESCRIPTION
Github's new parser understands the spaces at the start of these table rows to be a code block. Moving them to the start of the line fixes the issue; I added `---:` to the header column to right-align these numbers in the rendered document.