### PR TITLE
Fix windows build

### DIFF
--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 """
 Auto-generates PXD files from annotated C++ headers.
@@ -462,19 +462,15 @@ def main():
 
         # create empty __init__.py in all parent directories.
         # Cython requires this; else it won't find the .pxd files.
-        dirname = os.path.abspath(os.path.dirname(pxdfile))
-        while dirname.startswith(args.output_dir):
+        for dirname in pxdfile_relpath.parents:
+            template = args.output_dir / dirname / "__init__"
             for extension in ("py", "pxd"):
-                initfile = os.path.join(dirname, "__init__.%s" % extension)
-                if not os.path.isfile(initfile):
+                initfile = template.with_suffix("." + extension)
+                if not initfile.exists():
                     print("\x1b[36mpxdgen: create package index %s\x1b[0m" % (
-                        os.path.relpath(initfile, CWD)))
+                        initfile.relative_to(CWD)))
 
-                    with open(initfile, "w"):
-                        pass
-
-            # parent dir
-            dirname = os.path.dirname(dirname)
+                    initfile.touch()
 
 
 if __name__ == '__main__':

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -54,6 +54,9 @@ find_package(Epoxy REQUIRED)
 find_package(HarfBuzz 1.0.0 REQUIRED)
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+find_package(Threads REQUIRED)
+
 set(QT_VERSION_REQ "5.9")
 find_package(Qt5Core ${QT_VERSION_REQ} REQUIRED)
 find_package(Qt5Quick ${QT_VERSION_REQ} REQUIRED)
@@ -268,7 +271,7 @@ target_include_directories(libopenage
 # to the public api of libopenage
 target_link_libraries(libopenage
 	PUBLIC
-		pthread
+		Threads::Threads
 		nyan::nyan
 		Eigen3::Eigen
 		${PNG_LIBRARIES}

--- a/libopenage/event/demo/main.cpp
+++ b/libopenage/event/demo/main.cpp
@@ -1,4 +1,6 @@
-// Copyright 2016-2018 the openage authors. See copying.md for legal info.
+// Copyright 2016-2019 the openage authors. See copying.md for legal info.
+
+#include "main.h"
 
 #include <chrono>
 #include <ratio>

--- a/libopenage/event/demo/main.h
+++ b/libopenage/event/demo/main.h
@@ -1,14 +1,15 @@
-// Copyright 2018-2018 the openage authors. See copying.md for legal info.
+// Copyright 2018-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
+#include "../../util/compiler.h"
 // pxd: from libcpp cimport bool
 
 
 namespace openage::event::demo {
 
 // pxd: void curvepong(bool disable_gui, bool no_human) except +
-void curvepong(bool disable_gui, bool no_human);
+OAAPI void curvepong(bool disable_gui, bool no_human);
 
 
 } // openage::event::demo

--- a/libopenage/renderer/tests.cpp
+++ b/libopenage/renderer/tests.cpp
@@ -1,5 +1,7 @@
 // Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
+#include "tests.h"
+
 #include <cstdlib>
 #include <epoxy/gl.h>
 #include <functional>

--- a/libopenage/renderer/tests.h
+++ b/libopenage/renderer/tests.h
@@ -1,7 +1,8 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
+#include "../util/compiler.h"
 // pxd: from libopenage.util.path cimport Path
 #include "../util/path.h"
 
@@ -11,6 +12,6 @@ namespace renderer {
 namespace tests {
 
 // pxd: void renderer_demo(int demo_id, Path path) except +
-void renderer_demo(int demo_id, util::Path path);
+OAAPI void renderer_demo(int demo_id, util::Path path);
 
 }}} // openage::renderer::tests


### PR DESCRIPTION
Summary:
- Improve path handling in `buildsystem/pxdgen.py` that fails to match using `str.startswith`.
- Improve thread library target to use instead of `pthread`. Fixes #1062.
- Decorate the DLL interfaces used by the cython extensions with `OAAPI`, which otherwise cause link errors.