### PR TITLE
PyInterface: Rearrange pyobject pxd annotations

### DIFF
--- a/libopenage/pyinterface/exctranslate.h
+++ b/libopenage/pyinterface/exctranslate.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -132,7 +132,7 @@ OAAPI void init_exc_message(log::message *msg, const std::string &filename, unsi
  *
  * pxd:
  *
- * void (*set_exc_translation_funcs) (
+ * void set_exc_translation_funcs(
  *     void (*)(Error *)       except * with gil,
  *     void (*)(PyException *) except * with gil,
  *     cppbool (*)()                    with gil,


### PR DESCRIPTION
Rearrange the code to generate a single namespace statement in `pyobject.pxd`, currently the only file with two of those. This leads the way to enforce a consistent style on pxd annotations in a header file. Once complete, `pxdgen` can be upgraded to identify potential interfaces to decorate with `OAAPI`.

Includes a few modifications using modern C++ syntax.