### PR TITLE
buildsystem: use run.py from the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,9 @@ target_compile_options(pyext_libopenage INTERFACE
 target_link_libraries(pyext_libopenage INTERFACE libopenage)
 set(PYEXT_LINK_LIBRARY pyext_libopenage)
 
-add_cython_modules(EMBED NOINSTALL run.py)
-add_py_modules(BININSTALL run.py AS openage)
+configure_file(run.py.in run.py)
+add_cython_modules(EMBED NOINSTALL ${CMAKE_CURRENT_BINARY_DIR}/run.py)
+add_py_modules(BININSTALL ${CMAKE_CURRENT_BINARY_DIR}/run.py AS openage)
 add_subdirectory(openage/)
 
 python_finalize()

--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -427,7 +427,9 @@ def parse_args():
 def main():
     """ CLI entry point """
     args = parse_args()
-    cppdir = Path("libopenage").absolute()
+    cppname = "libopenage"
+    cppdir = Path(cppname).absolute()
+    out_cppdir = Path(args.output_dir) / cppname
 
     if args.verbose:
         hdr_count = len(args.all_files)
@@ -442,9 +444,9 @@ def main():
             print("pxdgen source file is not in " + cppdir + ": " + filename)
             sys.exit(1)
 
-        # join args.output_dir with relative path from CWD
-        pxdfile_relpath = filename.with_suffix('.pxd').relative_to(CWD)
-        pxdfile = args.output_dir / pxdfile_relpath
+        # join out_cppdir with relative path from cppdir
+        pxdfile_relpath = filename.with_suffix('.pxd').relative_to(cppdir)
+        pxdfile = out_cppdir / pxdfile_relpath
 
         if args.verbose:
             print("creating '{}' for '{}':".format(pxdfile, filename))
@@ -463,7 +465,7 @@ def main():
         # create empty __init__.py in all parent directories.
         # Cython requires this; else it won't find the .pxd files.
         for dirname in pxdfile_relpath.parents:
-            template = args.output_dir / dirname / "__init__"
+            template = out_cppdir / dirname / "__init__"
             for extension in ("py", "pxd"):
                 initfile = template.with_suffix("." + extension)
                 if not initfile.exists():

--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -87,14 +87,13 @@ function(add_cython_modules)
 			set_source_files_properties("${CPPNAME}" PROPERTIES GENERATED ON)
 
 			# construct some hopefully unique target name
-			file(RELATIVE_PATH TARGETNAME "${CMAKE_SOURCE_DIR}" "${source}")
-			string(REGEX REPLACE "\\.pyx?$" "" TARGETNAME "${TARGETNAME}")
-			string(REGEX REPLACE "/" "_" TARGETNAME "${TARGETNAME}")
+			set(TARGETNAME "${REL_CURRENT_SOURCE_DIR}/${OUTPUTNAME}")
+			string(REPLACE "/" "_" TARGETNAME "${TARGETNAME}")
 
 			# generate the pretty module name
-			file(RELATIVE_PATH PRETTY_MODULE_NAME "${CMAKE_SOURCE_DIR}" "${source}")
-			string(REGEX REPLACE "\\.pyx?$" "" PRETTY_MODULE_NAME "${PRETTY_MODULE_NAME}")
-			string(REGEX REPLACE "/" "." PRETTY_MODULE_NAME "${PRETTY_MODULE_NAME}")
+			set(PRETTY_MODULE_NAME "${REL_CURRENT_SOURCE_DIR}/${OUTPUTNAME}")
+			string(REPLACE "/" "." PRETTY_MODULE_NAME "${PRETTY_MODULE_NAME}")
+			string(REGEX REPLACE "^\\." "" PRETTY_MODULE_NAME "${PRETTY_MODULE_NAME}")
 			set(PRETTY_MODULE_PROPERTIES "")
 
 			if(EMBED_NEXT)

--- a/run.py.in
+++ b/run.py.in
@@ -10,6 +10,9 @@ This file is Cythonized with an embedded interpreter, producing ./run,
 which satisifies that requirement.
 """
 
-if __name__ == '__main__':
+if __name__ == '__main__@SOME_UNDEFINED_VARIABLE_CMAKE_WILL_REMOVE@':
     from openage.__main__ import main
     main()
+else:
+    print("Running this in the source directory is not supported.",
+    "Please use `make run` or `bin/run.py` to start instead.")


### PR DESCRIPTION
- disallow running `run.py.in` directly
- fix `cleancython` target
- skip creating `__init__.p{xd,y}` in the top-level binary directory