### PR TITLE
pxdgen: fix `path.relative_to` usage

### DIFF
--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -470,7 +470,7 @@ def main():
                 initfile = template.with_suffix("." + extension)
                 if not initfile.exists():
                     print("\x1b[36mpxdgen: create package index %s\x1b[0m" % (
-                        initfile.relative_to(CWD)))
+                        initfile.relative_to(args.output_dir)))
 
                     initfile.touch()
 

--- a/buildsystem/python.cmake
+++ b/buildsystem/python.cmake
@@ -328,6 +328,10 @@ function(python_finalize)
 	write_on_change("${CMAKE_BINARY_DIR}/py/pxd_list" "${pxd_list};${generated_pxd_list}")
 	set(CYTHONIZE_TIMEFILE "${CMAKE_BINARY_DIR}/py/cythonize_timefile")
 	add_custom_command(OUTPUT "${CYTHONIZE_TIMEFILE}"
+		# remove unneeded files from the previous builds (if any)
+		COMMAND "${CMAKE_COMMAND}" -E remove -f
+			"${CMAKE_BINARY_DIR}/__init__.py"
+			"${CMAKE_BINARY_DIR}/__init__.pxd"
 		COMMAND "${PYTHON}" -m buildsystem.cythonize
 		"${CMAKE_BINARY_DIR}/py/cython_modules"
 		"${CMAKE_BINARY_DIR}/py/cython_modules_embed"


### PR DESCRIPTION
Fixes #1093.

Tested with a build directory on a different path.
@TheJJ, please check if this fixes the gentoo build.

Side-note: could that be added to Kevin also?

Edit: added buildsystem logic to [avoid hitting #1095](https://github.com/SFTtech/openage/issues/1095#issuecomment-469499833).