### PR TITLE
Updating some code using C++17

### DIFF
--- a/libopenage/coord/coord.h.template
+++ b/libopenage/coord/coord.h.template
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 the openage authors. See copying.md for legal info.
+// Copyright 2016-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -46,12 +46,8 @@ struct Coord{{ camelcase }}Absolute {
 	constexpr Coord{{ camelcase }}Absolute({{ formatted_members("const CoordType &{}") }}) : {{ formatted_members("{0}{{{0}}}") }} {}
 
 	// copy constructor + assignment operator
-	constexpr Coord{{ camelcase }}Absolute(const Coord{{ camelcase }}Absolute &other) : {{ formatted_members("{0}{{other.{0}}}") }} {}
-	constexpr Coord{{ camelcase }}Absolute &operator =(const Coord{{ camelcase }}Absolute &other) {
-		{{ formatted_members("this->{0} = other.{0};", join_with="\n\t\t") }}
-
-		return *this;
-	}
+	constexpr Coord{{ camelcase }}Absolute(const Coord{{ camelcase }}Absolute &other) = default;
+	constexpr Coord{{ camelcase }}Absolute &operator =(const Coord{{ camelcase }}Absolute &other) = default;
 
 	constexpr Absolute operator +(const Relative &other) const {
 		return Absolute({{ formatted_members("this->{0} + other.{0}") }});
@@ -110,12 +106,8 @@ struct Coord{{ camelcase }}Relative {
 	constexpr Coord{{ camelcase }}Relative({{ formatted_members("const CoordType &{}") }}) : {{ formatted_members("{0}{{{0}}}") }} {}
 
 	// copy constructor and assignment operator
-	constexpr Coord{{ camelcase }}Relative(const Relative &other) : {{ formatted_members("{0}{{other.{0}}}") }} {}
-	constexpr Coord{{ camelcase }}Relative &operator =(const Relative &other) {
-		{{ formatted_members("this->{0} = other.{0};", join_with="\n\t\t") }}
-
-		return *this;
-	}
+	constexpr Coord{{ camelcase }}Relative(const Coord{{ camelcase }}Relative &other) = default;
+	constexpr Coord{{ camelcase }}Relative &operator =(const Coord{{ camelcase }}Relative &other) = default;
 
 	constexpr Relative operator +() const {
 		return Relative({{ formatted_members("+this->{}") }});

--- a/libopenage/datastructure/constexpr_map.h
+++ b/libopenage/datastructure/constexpr_map.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <array>
+#include <type_traits>
 #include <utility>
 
 #include "../error/error.h"
@@ -95,7 +96,7 @@ private:
 	/**
 	 * The entries associated with this map.
 	 */
-	const std::array<std::pair<K, V>, count> values;
+	std::array<std::pair<K, V>, count> values;
 };
 
 /**
@@ -130,5 +131,20 @@ template<typename K, typename V, typename... Entries>
 constexpr auto create_const_map(Entries&&... entry) {
 	return ConstMap<K, V, sizeof...(entry)>{entry...};
 }
+
+/**
+ * Template deduction guide to deduce the Key-Value types
+ * for the ConstMap from the paired entries passed.
+ *
+ * usage: constexpr ConstMap boss{std::pair{k0, v0}, std::pair{k1, v1}, ...};
+ *
+ * Note: Use when automatic type deduction is desirable.
+ *       For manually specifying types, use the other method.
+ */
+template<typename Entry, typename... Rest,
+         typename = std::enable_if_t<std::conjunction_v<std::is_same<Entry, Rest>...>>>
+ConstMap(Entry, Rest&&...) -> ConstMap<typename Entry::first_type,
+                                       typename Entry::second_type,
+                                       1 + sizeof...(Rest)>;
 
 } // openage::datastructure

--- a/libopenage/datastructure/tests.cpp
+++ b/libopenage/datastructure/tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 #include "tests.h"
 
@@ -170,19 +170,19 @@ void constexpr_map() {
 	static_assert(not create_const_map<int, int>(std::make_pair(42, 0),
 	                                             std::make_pair(13, 37)).contains(9001),
 	              "uncontained element seems to be contained.");
-#ifndef _MSC_VER // HACK: MSVC doesn't have full C++14 constexpr support
+
 	static_assert(create_const_map<int, int>(std::make_pair(42, 9001),
 	                                         std::make_pair(13, 37)).get(42) == 9001,
 	              "fetched wrong value");
 	static_assert(create_const_map<int, int>(std::make_pair(42, 9001),
 	                                         std::make_pair(13, 37)).get(13) == 37,
 	              "fetched wrong value");
-#endif
-	constexpr auto cmap = create_const_map<int, int>(
-		std::make_pair(0, 0),
-		std::make_pair(13, 37),
-		std::make_pair(42, 9001)
-	);
+
+	constexpr ConstMap cmap {
+		std::pair(0, 0),
+		std::pair(13, 37),
+		std::pair(42, 9001)
+	};
 
 	cmap.contains(0) or TESTFAIL;
 	not cmap.contains(18) or TESTFAIL;


### PR DESCRIPTION
- constexpr_map: complete rewrite using `std::array` and relaxed `constexpr` functions.
- make special members for the coordinate base classes use `default`.