### PR TITLE
Fixed typo

### DIFF
--- a/configure
+++ b/configure
@@ -389,7 +389,7 @@ def parse_args():
     cli.add_argument("--py-prefix", default=None,
                      help="python module installation directory prefix")
     cli.add_argument("--dry-run", action='store_true',
-                     help="just print the cmake invocation without callint it")
+                     help="just print the cmake invocation without calling it")
     cli.add_argument("--cmake-binary", default="cmake",
                      help="path to the cmake binary")
     cli.add_argument("--ninja", action="store_true",

--- a/copying.md
+++ b/copying.md
@@ -120,6 +120,7 @@ _the openage authors_ are:
 | Nicholas Schmidt            | schmidtnicholas             | schmidtnicholas111 à gmail dawt com               |
 | Antti Aalto                 | Anakonda                    | antti dawt aalto dawt 10 à gmail dawt com         |
 | Simon San                   | simonsan                    | simon à systemli dawt org                         |
+| Lorenzo Gaifas              | brisvag                     | brisvag à gmail dawt org                          |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
Just a quick typo fix in the help of ./configure.