### PR TITLE
Check if cython modules were built and imported correctly

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -120,7 +120,7 @@ _the openage authors_ are:
 | Nicholas Schmidt            | schmidtnicholas             | schmidtnicholas111 à gmail dawt com               |
 | Antti Aalto                 | Anakonda                    | antti dawt aalto dawt 10 à gmail dawt com         |
 | Simon San                   | simonsan                    | simon à systemli dawt org                         |
-| Lorenzo Gaifas              | brisvag                     | brisvag à gmail dawt org                          |
+| Lorenzo Gaifas              | brisvag                     | brisvag à gmail dawt com                          |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/CMakeLists.txt
+++ b/openage/CMakeLists.txt
@@ -12,6 +12,10 @@ add_py_modules(
 	NOINSTALL devmode.py
 )
 
+add_cython_modules(
+	cython_check.pyx
+)
+
 add_subdirectory(cabextract)
 add_subdirectory(codegen)
 add_subdirectory(convert)

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 """
 Behold: The central entry point for all of openage.
@@ -114,9 +114,12 @@ def main(argv=None):
             config.DEVMODE = False
         if args.devmode:
             config.DEVMODE = True
+            from . import cython_check
+            cython_check.this_is_true()
     except ImportError:
-        if args.no_devmode or args.devmode:
-            print("code was not yet generated, ignoring devmode activation request")
+        cli.error("code was not yet generated. "
+                  "Did you run the command from the build directory (bin/)?\n"
+                  "See doc/building.md for more information.")
 
     if "asset_dir" in args and args.asset_dir:
         if not os.path.exists(args.asset_dir):

--- a/openage/cython_check.pyx
+++ b/openage/cython_check.pyx
@@ -1,0 +1,11 @@
+# Copyright 2019-2019 the openage authors. See copying.md for legal info.
+
+"""
+The only purpose of this module is to be imported by __main__.py
+in order to verify if the cython modules were correctly compiled
+and called from the build directory.
+"""
+
+
+def this_is_true():
+    return True


### PR DESCRIPTION
Added an empty cython module to be imported by main when running:

`python3 -m openage [...]`

If the import fails, the parser complains and suggests to compile the project or run the command from the build directory.

There was already an ImportError check in place, which I fused with mine, though I wonder if checking for `config` is already enough. I'm sure there is a less ugly way of doing this.
Also, apparently a similar error message was already implemented, but instead of getting redirected to the argparser, it was printed on screen **before** the python errors (which is why I didn't even see it).