### PR TITLE
buildsystem: no transitive linkage for internally used libraries

### DIFF
--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 the openage authors. See copying.md for legal info.
+# Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 # main C++ library definitions.
 # dependency and source file setup for the resulting library.
@@ -270,7 +270,7 @@ target_include_directories(libopenage
 # all the libraries are not exposed
 # to the public api of libopenage
 target_link_libraries(libopenage
-	PUBLIC
+	PRIVATE
 		Threads::Threads
 		nyan::nyan
 		Eigen3::Eigen


### PR DESCRIPTION
if the linking is declared PUBLIC, e.g. all the python modules that
link against libopenage would link to all of libopenage's dependencies
again. when one of those, e.g. libnyan.so, is updated, the module will be
linked again. this means if e.g. libnyan is updated, all python modules
are relinked. this commit removes this transitive linking, and python
modules won't be rebuilt any more.