### PR TITLE
Fix Windows 64-bit installer package

### DIFF
--- a/buildsystem/scripts/EmbedPython.cmake
+++ b/buildsystem/scripts/EmbedPython.cmake
@@ -1,11 +1,16 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2019 the openage authors. See copying.md for legal info.
 
 if(NOT forward_variables)
 	message(FATAL_ERROR "CMake configuration variables not available. Please include(ForwardVariables.cmake)")
 endif()
 
 include("${buildsystem_dir}/modules/DownloadCache.cmake")
-set(python_embed_zip "python-${py_version}-embed-win32.zip")
+if(sizeof_void_p EQUAL 8)
+	set(py_arch "amd64")
+else()
+	set(py_arch "win32")
+endif()
+set(python_embed_zip "python-${py_version}-embed-${py_arch}.zip")
 set(python_zip_download_path "${downloads_dir}/${python_embed_zip}")
 # TODO: disable downloading for CI builds. <Need CI first>
 download_cache(

--- a/buildsystem/templates/ForwardVariables.cmake.in
+++ b/buildsystem/templates/ForwardVariables.cmake.in
@@ -1,4 +1,4 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2019 the openage authors. See copying.md for legal info.
 
 # @AUTOGEN_WARNING@
 
@@ -16,6 +16,7 @@ set(downloads_dir "@CMAKE_BINARY_DIR@/downloads")
 set(python "@PYTHON@")
 set(py_install_prefix "@CMAKE_PY_INSTALL_PREFIX@")
 set(py_version "@PYTHONLIBS_VERSION_STRING@")
+set(sizeof_void_p @CMAKE_SIZEOF_VOID_P@)
 set(vcpkg_dir "@vcpkg_dir@")
 set(windeployqt "@windeployqt@")
 

--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -64,6 +64,9 @@ _Note:_ If you want to build the x64 version, please add `-G "Visual Studio 15 2
  Now, execute `<openage directory>/run.exe` and enjoy!
 
 ## Packaging
+ - **Doesn't work with vcpkg installed Qt submodules.** [Open issue for `windeployqt`](https://github.com/microsoft/vcpkg/issues/1654).
+ - Install [NSIS](https://sourceforge.net/projects/nsis/files/latest/download).
+
  Open a command prompt at `<openage directory>\build` (or use the one from the building step):
 
     cpack -C RelWithDebInfo

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -299,6 +299,10 @@ install(TARGETS libopenage
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+if(WIN32)
+	install(FILES $<TARGET_FILE:nyan::nyan>
+		DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 
 ##################################################


### PR DESCRIPTION
- Fix the installer script to include `nyan.dll` in the package.
- Use `CMAKE_SIZEOF_VOID_P` to choose the python zip file according to the target architecture.

TODO:
- Check if someone uses `ARM64` for Windows. [Python binaries unavailable.](https://www.python.org/ftp/python/3.7.3/).