### PR TITLE
Start openage explicitly from shipped Python version

### DIFF
--- a/buildsystem/templates/openage.bat.in
+++ b/buildsystem/templates/openage.bat.in
@@ -4,7 +4,7 @@
 rem @AUTOGEN_WARNING@
 
 set INST_DIR=%CD%
-set PATH=%INST_DIR%\@CMAKE_INSTALL_BINDIR@;%INST_DIR%\@CMAKE_PY_INSTALL_PREFIX@
+set PATH=%INST_DIR%\@CMAKE_INSTALL_BINDIR@;
 set XDG_DATA_HOME=%INST_DIR%\share
 
-python.exe -m openage
+call "%INST_DIR%\@CMAKE_PY_INSTALL_PREFIX@\python.exe" -m openage

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -4,7 +4,8 @@
 
 ### More than one python installation
 
-If you have two (or more) different python installations on your computer try to unset the directory of all python installations from PATH to make sure `openage.bat` takes our own `python.exe` from the installDir.
+If you have two (or more) different python installations on your computer edit the `openage.bat` in the install directory:
+Replace the line `python.exe -m openage` with `call "%INST_DIR%\python\python.exe" -m openage` to start `python.exe` explicitly.
 
 ## Asset Conversion
 


### PR DESCRIPTION
This fixes the error we get, when calling python from the PATH. With this we call our shipped Python directly.