### PR TITLE
Changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [0.4.0].
+
+Individual changelogs for the individual engine parts are stored in the [doc/changelogs](doc/changelogs) folder.

--- a/doc/changelogs/engine/v0.0.0.md
+++ b/doc/changelogs/engine/v0.0.0.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes for version [v0.0.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [0.0.0] - 2013-08-23 (non-public)
+### Added
+- Add documentation for technical and gameplay features of AoE2
+- Architecture ideas
+- Codestyle examples for C++
+- Add `.gitignore` file
+- Include gameplay ideas
+- Add initial roadmap
+- License project und GPL3+
+- Add README
+
+## Full commit log
+
+https://github.com/SFTtech/openage/releases/tag/v0.0.0

--- a/doc/changelogs/engine/v0.0.0.md
+++ b/doc/changelogs/engine/v0.0.0.md
@@ -1,4 +1,4 @@
-# Changelog
+# [0.0.0] - 2013-08-23 (non-public)
 All notable changes for version [v0.0.0] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [0.0.0] - 2013-08-23 (non-public)
-### Added
+## Added
 - Add documentation for technical and gameplay features of AoE2
 - Architecture ideas
 - Codestyle examples for C++

--- a/doc/changelogs/engine/v0.1.0.md
+++ b/doc/changelogs/engine/v0.1.0.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes for version [v0.1.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [0.1.0] - 2013-08-24 (non-public)
+### Added
+- Render town center and castle on left/right mouse click
+- Frame counter
+- Logging
+- Add resize listener
+- Add input handler
+- Docstrings for engine interface
+- Engine interface definition
+- Add Gaben graphic
+- Texture drawing
+- Build scripts for `debug` and `release`
+- Doxygen integration
+- CMake configuration
+
+### Changed
+- Adjusted `run` function and project root finding
+- Dynamically insert project name in doxyfile
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.0.0...v0.1.0

--- a/doc/changelogs/engine/v0.1.0.md
+++ b/doc/changelogs/engine/v0.1.0.md
@@ -1,4 +1,4 @@
-# Changelog
+# [0.1.0] - 2013-08-24 (non-public)
 All notable changes for version [v0.1.0] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [0.1.0] - 2013-08-24 (non-public)
-### Added
+## Added
 - Render town center and castle on left/right mouse click
 - Frame counter
 - Logging
@@ -21,7 +20,7 @@ Note that not all changes up until [v0.2.3] were tracked, since the project was 
 - Doxygen integration
 - CMake configuration
 
-### Changed
+## Changed
 - Adjusted `run` function and project root finding
 - Dynamically insert project name in doxyfile
 

--- a/doc/changelogs/engine/v0.2.0.md
+++ b/doc/changelogs/engine/v0.2.0.md
@@ -1,4 +1,4 @@
-# Changelog
+# [0.2.0] - 2013-10-01 (non-public)
 All notable changes for version [v0.2.0] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [0.2.0] - 2013-10-01 (non-public)
-### Added
+## Added
 - Rendering team colors
 - Save palettes to PNG file
 - Convert SLP frame image data to PNG format

--- a/doc/changelogs/engine/v0.2.0.md
+++ b/doc/changelogs/engine/v0.2.0.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes for version [v0.2.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [0.2.0] - 2013-10-01 (non-public)
+### Added
+- Rendering team colors
+- Save palettes to PNG file
+- Convert SLP frame image data to PNG format
+- Palette version check
+- Scan `interfac.drs` for color tables of SLPs
+- SLP parsing
+- SLP file format documentation
+- DRS file format documentation
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.1.0...v0.2.0

--- a/doc/changelogs/engine/v0.2.1.md
+++ b/doc/changelogs/engine/v0.2.1.md
@@ -1,0 +1,47 @@
+# Changelog
+All notable changes for version [v0.2.1] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [0.2.1] - 2014-07-14
+### Added
+- Audio manager that loads OPUS sound files
+- Read CSV data to engine
+- Conversion of gamedata (`empires2_x1_p1.dat` file) to CSV format
+- Add IRC channel for SFTtech to README
+- Instructions for contributing
+- `patternmask.dat` file format documentation
+- Documentation for original AoE2 pathfinder
+- Add list of gameplay feature ideas
+- Quit game by pressing `ESC`
+- Add list of Microsoft language identification strings
+- Implement coordinate system
+- Add ID list for terrain SLPs of AoE2
+- Terrain blending documentation for AoE2
+- `blendomatic.dat` file format documentation
+- Render terrain textures
+- Documentation for AoE2 sound files
+- Save SLP metadata to file
+- Creating and rendering texture atlases
+- Add instructions for meia conversion to README
+- Document example values for unit damage
+- Terrain file documentation
+- More codestyle examples for C++
+- Infrastructure for debug console
+
+### Changed
+- Grahics system now enforces shaders and uses vertex buffers
+- Split conversion of SLP into multiple modules
+
+### Fixed
+- Send logging to console only if engine is running
+- Free FPS counter text
+- Free file content for player color files
+- Free console font
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.2.0...v0.2.1

--- a/doc/changelogs/engine/v0.2.1.md
+++ b/doc/changelogs/engine/v0.2.1.md
@@ -1,4 +1,4 @@
-# Changelog
+# [0.2.1] - 2014-07-14
 All notable changes for version [v0.2.1] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [0.2.1] - 2014-07-14
-### Added
+## Added
 - Audio manager that loads OPUS sound files
 - Read CSV data to engine
 - Conversion of gamedata (`empires2_x1_p1.dat` file) to CSV format
@@ -32,11 +31,11 @@ Note that not all changes up until [v0.2.3] were tracked, since the project was 
 - More codestyle examples for C++
 - Infrastructure for debug console
 
-### Changed
+## Changed
 - Grahics system now enforces shaders and uses vertex buffers
 - Split conversion of SLP into multiple modules
 
-### Fixed
+## Fixed
 - Send logging to console only if engine is running
 - Free FPS counter text
 - Free file content for player color files

--- a/doc/changelogs/engine/v0.2.2.md
+++ b/doc/changelogs/engine/v0.2.2.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes for version [v0.2.2] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [v0.2.2] - 2014-07-27
+### Added
+- Dynamic struct member function generation
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.2.1...v0.2.2

--- a/doc/changelogs/engine/v0.2.2.md
+++ b/doc/changelogs/engine/v0.2.2.md
@@ -1,4 +1,4 @@
-# Changelog
+# [v0.2.2] - 2014-07-27
 All notable changes for version [v0.2.2] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [v0.2.2] - 2014-07-27
-### Added
+## Added
 - Dynamic struct member function generation
 
 ## Full commit log

--- a/doc/changelogs/engine/v0.2.3.md
+++ b/doc/changelogs/engine/v0.2.3.md
@@ -1,4 +1,4 @@
-# Changelog
+# [0.2.3] - 2014-11-18
 All notable changes for version [v0.2.3] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
 
-## [0.2.3] - 2014-11-18
-### Added
+## Added
 - `gperftools` profiler
 - Reminder in `contributing.md` to add oneself when contributing for the first time
 - Toggle HUD drawing with `F1` hotkey
@@ -35,7 +34,7 @@ Note that not all changes up until [v0.2.3] were tracked, since the project was 
 - Feature demos of engine modules
 - Add support for extracting `.cab` files
 
-### Changed
+## Changed
 - Split up game specification code generation
 - Improve unknown enum value error message
 - Change hotkeys for screenshot and blending toggle from `KEYDOWN` to `KEYUP`
@@ -53,7 +52,7 @@ Note that not all changes up until [v0.2.3] were tracked, since the project was 
 - Converted documentation to Markdown format
 - Buildsystem overhaul
 
-### Fixed
+## Fixed
 - Fix `path.cpp` compilation error in mac clang
 - Fix warnings on 32 bit systems
 - Divide negatives in renderer correctly

--- a/doc/changelogs/engine/v0.2.3.md
+++ b/doc/changelogs/engine/v0.2.3.md
@@ -1,0 +1,79 @@
+# Changelog
+All notable changes for version [v0.2.3] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+Note that not all changes up until [v0.2.3] were tracked, since the project was not available on Github as an SFTtech/openage repository. The commit hiistory can be accessed via the git log though. Feel free to add missing changes to this file, if you have time to look through a thousand commits.
+
+## [0.2.3] - 2014-11-18
+### Added
+- `gperftools` profiler
+- Reminder in `contributing.md` to add oneself when contributing for the first time
+- Toggle HUD drawing with `F1` hotkey
+- Toggle debug overlay with `F4` hotkey
+- Add `contributing.md` with basic Pull Request how-to
+- Add argument '--version' to executable
+- `.desktop` file and placeholder icon
+- Include GPL3+ legal headers in code files
+- Draft for campaign editor
+- Ideas for AI features
+- Automatic asset updating with `inotify()`
+- Include timestamp and numbering in screenshot filename
+- Version number now displayed in lower left corner
+- Basic unit behavior
+    - Attack
+    - Move
+    - Gather
+- A* pathfinding
+- Build instructions for Ubuntu
+- Build instructions for Arch Linux
+- Build instructions for Fedora
+- Build instructions for OpenSUSE
+- Build instructions for Mac OS X
+- Media conversion of AoE2: HD edition (patch 4.3)
+- Feature demos of engine modules
+- Add support for extracting `.cab` files
+
+### Changed
+- Split up game specification code generation
+- Improve unknown enum value error message
+- Change hotkeys for screenshot and blending toggle from `KEYDOWN` to `KEYUP`
+- Load gamedata and UI separately
+- Rewrite of DRS and SLP documentation files with more info
+- Move terrain logic to own subfolder
+- Use "British" as default civ instead of "Gaia"
+- Change data directory location to `./assets` subfolder
+- Use $(MAKE) variable in main Makefile instead of explicitely calling `make`
+- Move platform specific includes to separate header file
+- Refactor the opusfile CMake rules into own module
+- Include `termios.h` instead of `termio.h`
+- Move finding Python in separate CMake module
+- Better documentation of project architecture structure
+- Converted documentation to Markdown format
+- Buildsystem overhaul
+
+### Fixed
+- Fix `path.cpp` compilation error in mac clang
+- Fix warnings on 32 bit systems
+- Divide negatives in renderer correctly
+- Use platform-independent `gettempdir` instead of `/tmp/` in converter
+- Play correct building creation and destruction sounds
+- Add `-Wno-mismatched-tags` flag for llvm builds to prevent Travis warnings
+- Cleanup of C++ code with `cppcheck`
+- Fix include of OpenGL headers on OS X systems
+- Fix reserved identifier violations
+- Fix ambiguous call to `abs` for llvm compiler
+- Fix `SDL2_image` include directory hints for OS X systems
+- Fix inclusion of `pty.h` header
+- Fix A* for Xcode 6.0
+- Fix format specifier for `long long` data types
+- Add AoE2: HD Edition to supported asset source versions
+- Fix dead link to `milestones.md` in `development.md`
+- Fix dead link to `milestones.md` in `tasks.md`
+- Use capitals for headlines and first word of bullet points
+- Various horrible typos (#13, #17, #19, #20, #21, #105, #119, #146)
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.2.2...v0.2.3

--- a/doc/changelogs/engine/v0.3.0-alpha.md
+++ b/doc/changelogs/engine/v0.3.0-alpha.md
@@ -1,11 +1,10 @@
-# Changelog
+# [0.3.0-alpha] - 2019-06-12
 All notable changes for version [v0.3.0-alpha] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
 
-## [0.3.0-alpha] - 2019-06-12
-### Added
+## Added
 - Add OpenSAGE to the list of related projects
 - Check if cython modules were built and imported correctly
 - Add new technical overview to README
@@ -134,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source media versioning and simple diffing
 - Media conversion for AoE2: HD Edition version 4.0
 
-### Changed
+## Changed
 - Consistently use `openage::util::hash_combine()`
 - Convert source directory finding improvements
 - Rearrange pyobject `pxd` annotations to enforce consistent style
@@ -163,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleanup color logic in old renderer
 - Update doxyfile with doxywizard
 - Blacklist pythontex in buildsystem
-- Check for asdf in codecompliance
+- Check for A_S_D_F in codecompliance
 - Require cython 0.25
 - Surround `engine::run` with try catch block
 - Doxygen generation improvements
@@ -213,14 +212,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update macOS build instructions
 - Update Arch Linux build instructions
 
-### Deprecated
+## Deprecated
 - Complete engine rewrite in progress
     - Old lockstep gamestate will be replaced with curve-based event system
     - Data storage will change from CSV files to storage in `nyan` format
     - Data management will be replaced with a nyan database
     - Old OpenGL renderer due to being replaced with more efficient renderer using Vulkan and OpenGL
 
-### Removed
+## Removed
 - Remove `DoublyLinkedList` implementation
 - Remove `--data=assets` argument from `.desktop` file command
 - Remove user input (file path) from regular expression extension check
@@ -233,7 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Get rid of pylint workarounds
 - No more transitive linking of internally used libraries
 
-### Fixed
+## Fixed
 - Fix `path.relative_to` usage for pxdgen
 - Fix mingw Windows build
 - Fix cyclic dependency on unnecessary timefile in buildsystem
@@ -302,4 +301,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Full commit log
 
 https://github.com/SFTtech/openage/compare/v0.3.0...v0.3.0-alpha
-

--- a/doc/changelogs/engine/v0.3.0-alpha.md
+++ b/doc/changelogs/engine/v0.3.0-alpha.md
@@ -1,0 +1,305 @@
+# Changelog
+All notable changes for version [v0.3.0-alpha] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+## [0.3.0-alpha] - 2019-06-12
+### Added
+- Add OpenSAGE to the list of related projects
+- Check if cython modules were built and imported correctly
+- Add new technical overview to README
+- Add instructions to reproduce 'evolution video' on Youtube channel
+- Add logo version optimized for printing
+- Use GNU gold linker by default
+- Add information in `stemplet-dat.md`
+- Use C++17 as new code standard
+- Out-of-source-tree builds
+- Add proton/steam play as a way to obtain assets
+- Support for building openage under a virtualenv
+- Lazy log message formatting
+- Add support for unpatched Age of Empires 2: The Conquerors
+- Parallel cythonization for build process
+- Initial implementation of new core simulation
+- Add `readwrite` and `append` modes for opening files
+- Add quit button
+- Add donation button to README
+- Option for automatic correction of copyright years
+- Add new SLP draw commands to converter
+- Show known compiler versions in CMake error message
+- Bunch of new gameplay ideas
+- Adapt converter to support all Genie Engine games
+- Add Debian build instructions
+- Link to nyan library
+- Remember previous asset location
+- Resource capacities
+- Buildings limits
+- Windows installer package
+- Introduce interactive conversion shell
+- Add convenience options for using ccache in CMake
+- Support debugging with gdbgui
+- Add Gentoo build instructions
+- Troubleshooting guide
+- Break into debugger on throwing an exception
+- Add Windows documentation and build instructions
+- Windows native support using MSVC - Visual Studio 2017
+- Add FreeBSD build instructions
+- Add FreeBSD support
+- Add python profiling helper class
+- New renderer (initial abstraction implementation)
+- Add researching (aka technologies)
+- Implement mouse controlled game window movement
+- More enhanced filter options for converter: `--no-graphics` and `--no-scripts`
+- Buildsystem benchmarks
+- Allow customization of config and asset dir in buildysystem
+- Prefix-matching for tests
+- Documentation of blending mask lookup table (AoE2)
+- Ignore compiled QML in `.gitignore`
+- Obfuscation for Email addresses in `copying.md`
+- Introduce Mac-specific shims for `utimenstat()` and for `stat.st_mtim`
+- Tau as math constant
+- Unit life cycle management
+- Scores (AoE2)
+- `separate-shared-context` mode in GUI
+- Implement siphash
+- Qualified QML imports for the openage objects
+- Population logic
+- Quaternion
+- Log Qt version
+- Add codecompliance check for Markdown
+- Use multiprocessing with pylint
+- Implement market pricing
+- Documentation of original gameplay features
+    - Accuracy formulas
+    - Market prices
+    - Monks
+    - Rams
+    - Alarm
+    - Town Bell
+    - Waypoints
+    - Pathfinding
+    - Villagers
+    - Formations
+    - AoE1 civilization/unit stats
+    - Multiplayer chat messsaging in AoC
+    - Multiplayer communication protocol
+    - Selection mechanics
+    - Better damage formula
+    - Number of projectiles per garrisoned unit
+- Caching of gamedata files
+- Convert AoE2: African Kingdoms expansion
+- Resource bundles
+- Repair action
+- Option to start game after assets have loaded
+- Instructions for developing with Qt Creator
+- Player teams
+- Inform about the `gl-debug` option when `gl error` is detected
+- Switch to other player via hotkey
+- Build menus
+- Keep building after finishing a building
+- Check for .qml files for legal headers
+- Add documentation about resuming construction of buildings
+- GL debug option for better OpenGL backtrace
+- Render the GUI into an FBO
+- Selection box actions
+- Show the color of the active player in building menu icons
+- multiarch installdir and version for packaging
+- Add documentation for openage nyan usage
+- Optional FPS limiter
+- Unit command queue
+- GUI dynamic middle part of the HUD
+- Adding CVar subsystem
+- Dynamic key bindings
+- Documentation updates to gamedata structs in converter logic
+- Documentation for damage calculations in AoE2
+- `ENSURE` macro for assertions
+- Support for kevin CI
+- GUI ingame background assets adaptation
+- Add guide to download assets with SteamCMD
+- Add asset downloading guide for Steam version to `media_convert.md`
+- Option to convert a single SLP file from a DRS archive
+- Draw all available hotkeys in the right corner
+- Add QtQuick ingame GUI
+- Introduce `GameVersion` enum for better game version checks
+- Added OpenRCT2 as a likeminded project
+- Villagers bring their resources to the correct buildings
+- Support clang on Mac OS X
+- Matrix class with artihmetics
+- Vector class with arithmetics
+- Text renderer with support for colors
+- Ingame console UTF-8 backspace support
+- Engine profiler
+- New official logo
+- Converter parses terrain blobs
+- Source media versioning and simple diffing
+- Media conversion for AoE2: HD Edition version 4.0
+
+### Changed
+- Consistently use `openage::util::hash_combine()`
+- Convert source directory finding improvements
+- Rearrange pyobject `pxd` annotations to enforce consistent style
+- C++14 logic for `constexpr` functions
+- Let converter use memoryviews in visgrep
+- Register files generated by buildsystem as byproducts
+- New simpler `Enum` implementation that also works on Windows
+- Coordinate system rewrite
+- Require C++ compiler to support C++17 features
+- Rename mentions of "Mac OS X" to macOS
+- Directly use `CMAKE_DL_LIBS` CMake variable for linked libraries
+- Add the default Steam Linux AoE2 path to the media conversion examples
+- `free_memory()` in `util/system.py` has single exit point now
+- Use binary mode for files in C++
+- Include other Genie Engine games (AoE1, SWGB) in README
+- Test compilation in release mode too
+- Use libpng directly to create screenshots
+- Update C-style cast to `static_cast` in `program.cpp`
+- Update DRS file format conversion
+- Move contact table to the top of README
+- Logo SVG improvements
+- Save alpha channel in screenshots
+- Add hint about restarting Steam for SteamCMD conversion
+- Euclidean distance optimization
+- Use libopus instead of opusenc binary for audio conversion
+- Cleanup color logic in old renderer
+- Update doxyfile with doxywizard
+- Blacklist pythontex in buildsystem
+- Check for asdf in codecompliance
+- Require cython 0.25
+- Surround `engine::run` with try catch block
+- Doxygen generation improvements
+- Make audio system optional
+- Set verbosity level of spammy runtime messages to `debug` or `spam`
+- Force colored CMake output in kevin builds
+- Textfiles code compliance improvements
+- Attributes system improvements
+- Codestyle simplifications and extensions
+- Handle pep8 module renaming to pycodestyle
+- pylint is now imported, not invoked
+- Rebind `STOP_GAME` to `SHIFT` + `ESC`
+- Cleanup Python `include`s
+- Propose paths for conversion `source_dir`, including Wine prefixes
+- Depend on a newer cython 0.23 version
+- Append selection with SHIFT key instead of CTRL
+- Apply asset path expansion in both `AGE2DIR` var and input path
+- Switch to `#pragma once` header guard instead of constructed unique preprocessor variables
+- Cythonize rgba matrix calculation for converter palette lookups
+- Use typedef `sighandler_t` for WIN32
+- Use C++11 chrono for crossplatform timing
+- Tweaks for configuring via cmake on MSYS2
+- Use `math::PI` instead of `M_PI`
+- Expanded the critical section in logger to include `init()`
+- Texture bin packing improvements in SLP converter
+- Optimize texture frame merging in SLP converter
+- Change copyright dates to 2016
+- Enable backtrace collection by default
+- Expand environment variables and ~ in asset path of converter
+- Let build steps depend on each other
+- Better graphics handling for unit data
+- Improvments to the team colors shader
+- Do not enforce `release` or `debug` build in buildysystem
+- Text rendering using HarfBuzz and vbo's, removing `FTGL`
+- Clean up buildsystem
+- Gameplay ideas restructured and extended with ideas from r/aoe2
+- `Gamemain` split across several classes
+- Seperate existing map rendering code into `GameRenderer`
+- Input handling and UI rendering now done in `GameControl`
+- `GameControl` splits existing input code into `EditorMode` and `ActionMode`
+- `DataManager` renamed to `GameSpec`
+- File loading for `Terrain` now done by `GameSpec` so it only needs loading once
+- Construct `Terrain` objects by just using meta data
+- Update Ubuntu instructions
+- Update openSUSE build instructions
+- Update Fedora build instructions for Fedora 22
+- Update macOS build instructions
+- Update Arch Linux build instructions
+
+### Deprecated
+- Complete engine rewrite in progress
+    - Old lockstep gamestate will be replaced with curve-based event system
+    - Data storage will change from CSV files to storage in `nyan` format
+    - Data management will be replaced with a nyan database
+    - Old OpenGL renderer due to being replaced with more efficient renderer using Vulkan and OpenGL
+
+### Removed
+- Remove `DoublyLinkedList` implementation
+- Remove `--data=assets` argument from `.desktop` file command
+- Remove user input (file path) from regular expression extension check
+- Remove Travis CI support (replaced with kevin)
+- Network and binary compatibility with original game as project goals
+- Remove crossplatform folder and move everything to `util` subfolder
+- Remove unsused lambda captures
+- Remove usage of deprecated `std::hash::result_type`
+- Remove deprecated `std::unary_function` usage
+- Get rid of pylint workarounds
+- No more transitive linking of internally used libraries
+
+### Fixed
+- Fix `path.relative_to` usage for pxdgen
+- Fix mingw Windows build
+- Fix cyclic dependency on unnecessary timefile in buildsystem
+- Fix reference to openage directory to represent canonical form
+- Fix table formatting in `terrain.md`
+- Add missing `<algorithm>` inclusions for `std::min` and `std::max`
+- Fix cythonization for cython 0.29
+- Fix codegen error during cmake/configure phase
+- Support directories that are symlinks for building
+- Fix overly specific headerguard regex in buildsystem
+- Ignore merge commit dates for copyright year
+- Let automoc depend on codegen
+- Fix case-ignoring-dir-test for caseignoring filesystems
+- Fix font glyph memory allocations
+- Fix cython calling static member method in C++
+- Fix units getting stuck when dropsite is not found
+- Fix a cvar python type
+- Fix `ConstMap` type errors
+- Fix python loglevels
+- Fix older compiler invocations
+- Fix build on macOS computers that don't have Sierra && XCode 8
+- Build cython generated files with reduced warnings
+- Fix building with GCC7
+- Fix RGB endianness used in pixel transfer
+- Fix missing braces warnings for subobject initialization
+- Fix codegen path in comments
+- Fix ownerless projectlies causing crash
+- Fix broken audio log messages
+- Fix pylint complaining about kevin
+- Fix build with libbacktrace, clean up log includes
+- Do not show version numbers if the gamespec hash changes
+- Purge engine singleton
+- `noexcept` annotation for all move constructors/assignment operators in GUI
+- Fix wrong priority handling for union in `util` module
+- Add `/usr/bin/env python3` to `FindPython.cmake`
+- Limit building completion to 100%
+- Set `cxx_standard` to fix qt bug
+- Fix encoding error in data formatter of converter
+- Drop invalid interpreters when finding Python
+- Fix Mac OS X clang compile errors
+- Add missing source reference in CMakeLists.txt
+- Fix building placement segfault
+- Added a missing call to call in the C++ examples
+- Fix failure of automatic doc creation, if a parent directory has a white space
+- Correct graphic for idle gathering villager carrying zero amount
+- Fix missing `DEVMODE = True` line in config.py
+- Check if executable of build dependencies was found
+- Reset the amount gathered upon switching resource type
+- Find language file location for AoE2: HD Edition version 3.X
+- Fix runtime dependency check
+- Fix python library dir finding
+- Fix villagers not holding ressources when idle
+- Fix dead units receiving damage
+- Suppress false positives for pylint 1.5.1
+- Check for compiler's `thread_local` support
+- Fix villagers not stopping to gather resources when moved away
+- Add missing dependencies `python-pygments`, `python-pylint` and `cython` under Arch Linux
+- Fix broken link to `building.md` in `copying.md`
+- Include `-L<dir>` flag for linking against python
+- Fix confusion of AoE2: HD Edition with AoC 1.0c
+- Remove deadlock in `JobManager`/`Worker`
+- Fix SLP conversion issues from [v0.3.0] release
+- Stub some unused/unimplemented stuff on WIN32, so it can compile
+- Various horrible typos (#453, #496, #507, #639, #713, #757, #801, #823, #861, #925, #960, #1020, #1106)
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.3.0...v0.3.0-alpha
+

--- a/doc/changelogs/engine/v0.3.0.md
+++ b/doc/changelogs/engine/v0.3.0.md
@@ -1,0 +1,110 @@
+# Changelog
+All notable changes for version [v0.3.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+## [0.3.0] - 2015-07-28
+### Added
+- New gameplay features
+    - Projectile arcs and ranged attack
+    - Dropsites
+    - Garrisoning
+    - Gathering from resource objects
+    - Quicksave/Quickload
+    - Selection boxes
+    - Display HP bar
+    - Switch to correct villager graphics when gathering
+    - Auto-task idle units
+    - Villager commands and building
+    - Show building outlines on selected buildings
+- cython-based C++-/Python interface
+    - Handle openage as shared library
+    - Move C++ source files to `./libopenage` subdirectory
+    - Move Python source files to `./openage` subdirectory
+    - Integrate cython into buildsystem
+- New logging system
+- Add testing for the coordinate system
+- CI caching
+- Customizable key bindings
+- More ideas for AI
+- Add documentation for buildings in AoE2
+- Add a CMake 'doc' target that explains why doc generation will not work
+- Add documentation and instructions for ingame development build hotkeys
+- Star count in README
+- Enable call graph generation in doxygen
+- Test cases for job manager
+- Add tests for pathfinder
+- Use C++14 as new standard
+- `for_each` function for containers
+- Random number generator (XORShift)
+- Introduce namespaced math constants available on all plattforms
+- Add a mode indicator label in map view
+- Color support for CMake
+- Add new discovered variables in `empires.dat` gamedata to converter logic
+- `TerrainObject`s handle building annexes using child/parent spaces
+- `UnitTexture` class handles delta graphics
+
+### Changed
+- Change `./configure` instruction compiler argument to use `gcc` and `clang` instead of `gnu` and `llvm`
+- Use SVG build status image instead of PNG in README
+- Moved documentation files to `./doc` subdirectory
+- Abort build on checkfull fail
+- Replace GLEW with libepoxy
+- Run `make checkfull` before compiling
+- Improve check for C++14 and clang
+- Align dependencies column in `building.md`
+- Improve portability of the CMake detection of opus location
+- use `unsigned int` C++ data type instead of non-standard `uint`
+- Use `_WIN32` macros instead of `WIN32` in CMake
+- Codestyle example updates and simplifications
+- Assure that multiple jobs are executed on the same background thread
+- Jobs can check whether they should be aborted and abort themselves
+- Integrate new job groups into the dynamic audio loading implementation
+- Load missing textures lazily
+- Change uneeded `shared_ptr` references to `unique_ptr`
+- Ensure `glew.h` is loaded before `gl.h`
+- Use pairing heap in pathfinding
+- Look for sound files in both `sounds.drs` and `sounds_x1.drs` folders
+
+### Removed
+- Duplicate code for accessing engine camera
+- SDL memleak example
+- Remove leftover config sections for coverity
+
+### Fixed
+- Gameplay fixes
+    - Ungarrisoning no longer loses units
+    - Prevent ranged units from freezing when garrisoning them
+    - Make decaying units face correct direction and disappear after a short time
+    - Stop segfaulting when gather target is removed
+    - Garrison restricted to allied buildings
+    - Siege now only placable on land
+    - Buildings take time to train a unit
+    - Units can ungarrison while the building is training something
+- Clean annexed buildings properly from memory
+- Visual fixes for dock/ships
+- Fix the CMake `cmp0054` policy for using quoted if evaluation
+- Fix segfault when shutting down
+- Fix `Tile.get_pos_on_chunk()` to return the position of the tile on the chunk
+- Case sensitivity fixes
+- Fix crashes for missing arguments when calling executable
+- Clean up comments in converter code
+- Ignore empty `gamedata.drs` when converting
+- Relocate phys3 hashing to correct file
+- Fix wrong start offset of delta graphics
+- Add forgotten comment line separators in csv output
+- Fix judgement of `child_errno`
+- Do not assign lambda to variable
+- Fix new[]/delete mismatch
+- Fix error messages for legal header copyright years
+- Fix codecompliance script to be compatible with git rebase and cherry-pick
+- Fix conversion of `empires.dat` file strings with garbage data past their \0 terminators
+- Pass strings as `const` references instead of copying them
+- Better pep8 compliance
+- Various horrible typos (#301, #307)
+
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.2.3...v0.3.0

--- a/doc/changelogs/engine/v0.3.0.md
+++ b/doc/changelogs/engine/v0.3.0.md
@@ -1,11 +1,10 @@
-# Changelog
+# [0.3.0] - 2015-07-28
 All notable changes for version [v0.3.0] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
 
-## [0.3.0] - 2015-07-28
-### Added
+## Added
 - New gameplay features
     - Projectile arcs and ranged attack
     - Dropsites
@@ -45,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TerrainObject`s handle building annexes using child/parent spaces
 - `UnitTexture` class handles delta graphics
 
-### Changed
+## Changed
 - Change `./configure` instruction compiler argument to use `gcc` and `clang` instead of `gnu` and `llvm`
 - Use SVG build status image instead of PNG in README
 - Moved documentation files to `./doc` subdirectory
@@ -67,12 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use pairing heap in pathfinding
 - Look for sound files in both `sounds.drs` and `sounds_x1.drs` folders
 
-### Removed
+## Removed
 - Duplicate code for accessing engine camera
 - SDL memleak example
 - Remove leftover config sections for coverity
 
-### Fixed
+## Fixed
 - Gameplay fixes
     - Ungarrisoning no longer loses units
     - Prevent ranged units from freezing when garrisoning them
@@ -103,7 +102,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pass strings as `const` references instead of copying them
 - Better pep8 compliance
 - Various horrible typos (#301, #307)
-
 
 ## Full commit log
 

--- a/doc/changelogs/engine/v0.4.0.md
+++ b/doc/changelogs/engine/v0.4.0.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes for version [v0.4.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
+
+## [0.4.0] - 2019-06-27
+### Added
+- Add Windows installer reference to README and build instructions
+- Release process documentation
+
+### Changed
+- Use `applocal.ps1` for resolving and deploying Qt dependencies on Windows
+- Clarify logical process of single- and multiplayer architecture
+
+### Fixed
+- Fix Windows 64-bit installer package to include nyan and correct python zip file
+- Start Windows version of openage explicitly from shipped Python version
+- Various horrible typos (#1131)
+
+## Full commit log
+
+https://github.com/SFTtech/openage/compare/v0.3.0-alpha...v0.4.0

--- a/doc/changelogs/engine/v0.4.0.md
+++ b/doc/changelogs/engine/v0.4.0.md
@@ -1,19 +1,18 @@
-# Changelog
+# [0.4.0] - 2019-06-27
 All notable changes for version [v0.4.0] are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since release [v0.4.0].
 
-## [0.4.0] - 2019-06-27
-### Added
+## Added
 - Add Windows installer reference to README and build instructions
 - Release process documentation
 
-### Changed
+## Changed
 - Use `applocal.ps1` for resolving and deploying Qt dependencies on Windows
 - Clarify logical process of single- and multiplayer architecture
 
-### Fixed
+## Fixed
 - Fix Windows 64-bit installer package to include nyan and correct python zip file
 - Start Windows version of openage explicitly from shipped Python version
 - Various horrible typos (#1131)

--- a/doc/changelogs/nyan_api/v0.1.0.md
+++ b/doc/changelogs/nyan_api/v0.1.0.md
@@ -1,0 +1,12 @@
+# [0.1.0] - 2019-05-20
+All notable changes for version [v0.1.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Added
+Initial draft. Contains 99% of the features from AoE1, AoE2 and SWGB.
+
+## Reference visualization
+
+* [Gamedata](https://github.com/SFTtech/openage/blob/317947efc7219c5bc049a8b6c20fb79ce75f8323/doc/nyan/aoe2_nyan_tree.svg)

--- a/doc/changelogs/nyan_api/v0.2.0.md
+++ b/doc/changelogs/nyan_api/v0.2.0.md
@@ -1,0 +1,274 @@
+# [0.2.0] - 2019-06-29
+All notable changes for version [v0.2.0] are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Added
+### Ability module
+- Add `CommandSoundAbility(Ability)` object; plays a sound when the ability is intiated by the player
+- Add `ExecutionSoundAbility(Ability)` object; plays a sound while the ability is executed by the game entity
+- Add `AnimationOverrideAbility(Ability)` object; overrides other abilities' animation with `AnimationOverride` objects
+- Add `source_fee : float` member to `ExchangeResources`; multiplier for `source_resources` member
+- Add `target_fee : float` member to `ExchangeResources`; multiplier for `target_resources` member
+- Add `exchange_mode : ExchangeMode` member to `ExchangeResources`; multiplier for `target_resources` member
+- Add `search_range : float` member to `DropResources`; used for limiting the search range for finding a drop site
+- Add `allowed_types : set(GameEntityType)` member to `DropResources`; used to define the game entity types where the resources can be dropped off
+- Add `blacklisted_game_entities : set(GameEntity)` member to `DropResources`; exceptions for allowed game entity types
+- Add `carry_progress : set(CarryProgress)` member to `Gather`; used for carry amount progression
+- Add `interrupt_cooldown : float` member to `Cloak`
+- Add `allowed_types : set(GameEntityType)` member to `EnterContainer`
+- Add `blacklisted_game_entities : set(GameEntity)` member to `EnterContainer`
+- Add `allowed_types : set(GameEntityType)` member to `SendBackToTask`
+- Add `blacklisted_game_entities : set(GameEntity)` member to `SendBackToTask`
+- Add `spawning_area_offset_x : float` member to `ShootProjectile`; used for location of spawn area
+- Add `spawning_area_offset_y : float` member to `ShootProjectile`; used for location of spawn area
+- Add `spawning_area_offset_z : float` member to `ShootProjectile`; used for location of spawn area
+- Add `starting_progress : int` member to `Constructable`; used for defining the construction progress when game entity is spawned
+- Add `attribute : Attribute` member to `Damageable`; specifies the attribute whos progression is tracked
+- Add `despawn_condition : set(DespawnCondition)` member to `Despawn`; used for triggering despawns
+- Add `despawn_time : float` member to `Despawn`; used for duration of ability
+- Add `state_change : StateChanger` member to `Despawn`; used for state change during despawning
+- Add `death_time : float` member to `Die`; time until completion of ability
+- Add `state_change : StateChanger` member to `Die`; used for state change during death
+
+### Auxilary module
+- Add `AdjacentTilesVariant(Variant)` object; variant based on adjacent game entities
+- Add `LureType(Entity)` object; used by `Lure` effect/resistance for matching
+- Add `ProgressType(Entity)` object; used by `TimeRelativeProgress` effect/resistance for matching
+- Add `Contruct(ProgressType)` object; used for construction progress
+- Add `SendToContainerType(Entity)` object; used by `SendToContainer` effect/resistance for matching
+- Add `InverseLinar(DropoffType)` object; used for calculations influenced by dropoffs
+- Add `Cost(Entity)` object; unifies previous approaches of referencing `ResourceAmount` or `AttributeAmount`
+- Add `ResourceCost(Cost)` object; for payments with resources
+- Add `AttributeCost(Cost)` object; for payments with attribute points
+- Add `PaymentMode(Entity)` object; used by `Cost` object to determine payment due date
+- Add `Advance(PaymentMode)` object
+- Add `Adaptive(PaymentMode)` object
+- Add `Arrear(PaymentMode)` object
+- Add `StateChanger(Entity)` object; can influence the state of a game entity
+- Add `TechResearched(AvailabilityPrerequisite)` object; is true if the referenced tech is researched by the player
+- Add `GameEntityProgress(AvailabilityPrerequisite)` object; is true if the player owns a game entity that has reached this progress
+- Add `ProgressStatus(Entity)` object; used by `GameEntityProgress` to define desired status for fulfillment
+- Add `TerrainOverlay(Progress)` object; overlays `Terrain` stored in `OverlayTerrain` ability after a certain progress is reached
+- Add `StateChangeProgress(Progress)` object; changes state of a game entity after a certain progress is reached
+- Add `Normal(MoveMode)` object
+- Add `ExchangeMode(Entity)` object; used by `ExchangeResources` ability to customize exchanges further
+- Add `Fixed(ExchangeMode)` object; used for default resource exchanges
+- Add `Volatile(ExchangeMode)` object; used for adjusting resource amounts after transactions
+- Add `VolatileFlat(Volatile)` object; mimics AoE2 market behaviour
+- Add `ExchangeScope(Entity)` object; used for global or local resource exchanges involving multiple players
+- Add `AoE1TradeRoute(TradeRoute)` object; used for AoE1 trading machanics
+- Add `AttributeSetting(Entity)` object; used for setting attribute values of game entities
+- Add `DespawnCondition(Entity)` object; used for triggering despawn abilities
+- Add `ResourceSpotsDepleted(DespawnCondition)` object; used for triggering despawn abilities when resource spots are empty
+- Add `Timer(DespawnCondition)` object; used for triggering despawn abilities after a time limit
+- Add `ProjectilePassThrough(DeathCondition)` object; used for triggering death for projectiles
+- Add `ProjectileHitTerrain(DeathCondition)` object; used for triggering death for projectiles
+- Add `priority : int` member to `Variant`; decides which variant is applied first
+- Add `limit : int` member to `TerrainAmbiant`; limits the number of ambient objects created on a chunk of terrain
+- Add `starting_amount : int` member to `ResourceSpot`; sets the starting amount of a resource spot
+- Add `sound : Sound` member to `Cheat`; played on activation
+- Add `ability_preference : orderedset(Ability)` member to `GameEntityStance`; indicates which abilities can be used when a game entity has a certain stance
+- Add `type_preference : orderedset(GameEntityType)` member to `GameEntityStance`; indicates which game entity types are targeted with the abilities
+- Add `range : float` member to `Follow(MoveMode)`; sets the range at which the game entity follows the target
+- Add `creation_sound : Sound` member to `CreatableGameEntity`; plays when game entity is spawned
+- Add `research_sound : Sound` member to `ResearchableTech`; plays when tech finishes researching
+- Add `trade_resource : Resource` member to `TradeRoute`; defines the traded resource
+- Add `start_trade_post : GameEntity` member to `TradeRoute`; defines the type of game entity that has to be the start of the trade route
+- Add `end_trade_post : GameEntity` member to `TradeRoute`; defines the type of game entity that has to be the end of the trade route
+- Add `carry_progress : set(CarryProgress)` member to `Container`; used for carry progression of container
+- Add `state_change : StateChanger` member to `StorageElement`; changes state of a game entity if storage element is in container
+- Add `dispersion_dropoff : DropoffType` member to `Accuracy`; dynamic multiplier for accuracy dispersion
+
+### Effect module
+- Add `TimeRelativeAttributeChange(ContinuousEffect)` object; changes attribute points in a fixed amount of time
+- Add `TimeRelativeAttributeDecrease(TimeRelativeAttributeChange)` object; decreases attribute points in a fixed amount of time
+- Add `TimeRelativeAttributeIncrease(TimeRelativeAttributeChange)` object; increases attribute points in a fixed amount of time
+- Add `TimeRelativeProgress(ContinuousEffect)` object; changes progress in a fixed amount of time
+- Add `TimeRelativeProgressDecrease(TimeRelativeProgress)` object; decreases progress in a fixed amount of time
+- Add `TimeRelativeProgressIncrease(TimeRelativeProgress)` object; decreases progress in a fixed amount of time
+- Add `type : LureType` member to `Lure`; used for matching with the corresponding resistance object
+- Add `min_chance_success : optional(float)` member to `Convert`; defines minimum guaranteed chance for conversion to succeed
+- Add `max_chance_success : optional(float)` member to `Convert`; defines maximum guaranteed chance for conversion to succeed
+- Add `type : SendToContainerType` member to `SendToContainerType`; used for matching with the corresponding resistance object
+
+### Modifier module
+- Add `CreationAttributeCost` object; multiplier for creation attribute costs
+- Add `CreationResourceCost` object; multiplier for creation resource costs
+- Add `ResearchAttributeCost` object; multiplier for research attribute costs
+- Add `ResearchResourceCost` object; multiplier for research resource costs
+- Add `TimeRelativeProgress(EffectMultiplierModifier)` object; multiplier for effects
+- Add `TimeRelativeAttributeChange(EffectMultiplierModifier)` object; multiplier for effects
+- Add `Terrain(FlatAttributeChangeModifier)` object; multiplier for effects
+- Add `ElevationDifferenceHigh(FlatAttributeChangeModifier)` object; multiplier for effects
+- Add `Unconditional(FlatAttributeChangeModifier)` object; multiplier for effects
+- Add `Terrain(FlatAttributeChangeModifier)` object; multiplier for resistances
+- Add `ElevationDifferenceLow(FlatAttributeChangeModifier)` object; multiplier for resistances
+- Add `Unconditional(FlatAttributeChangeModifier)` object; multiplier for resistances
+- Add `DepositResourcesOnProgress(Modifier)` object; used for dropping off resources after building buildings
+- Add `InContainerDiscreteEffect(Modifier)` object; used for applying effects to the game entity when in a container
+- Add `InContainerContinuousEffect(Modifier)` object; used for applying effects to the game entity when in a container
+- Add `RefundOnDeath(Modifier)` object; used for giving back resources on death
+- Add `DiplomaticLineOfSight(Modifier)` object; used for diplomacy viewpoints
+- Add `creatables : set(CreatableGameEntity)` member to `CreationTime`; used for limiting the bonus to specified creatables
+
+### Resistance module
+- Add `TimeRelativeAttributeChange(ContinuousResistance)` object; changes attribute points in a fixed amount of time
+- Add `TimeRelativeAttributeDecrease(TimeRelativeAttributeChange)` object
+- Add `TimeRelativeAttributeIncrease(TimeRelativeAttributeChange)` object
+- Add `TimeRelativeProgress(ContinuousResistance)` object
+- Add `TimeRelativeProgressDecrease(TimeRelativeProgress)` objectrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+- Add `TimeRelativeProgressIncrease(TimeRelativeProgress)` object
+- Add `type : LureType` member to `Lure`; used for matching with the corresponding effect object
+- Add `type : SendToContainerType` member to `SendToContainer`; used for matching with the corresponding effect object
+- Add `ignore_containers : set(Container)` member to `SendToContainer`; lets resistor ignore defined set of containers
+- Add `resource_spot : resourceSpot` member to `MakeHarvestable`; used for matching with the corresponding effect object
+
+## Changed
+### Ability module
+- Change type of `states` member in `Transform` from `set(TransformState)` to `set(StateChanger)`
+- Change type of `initial_state` member in `Transform` from `TransformState` to `StateChanger`
+- Change type of `target_state` member in `TransformTo` from `TransformState` to `StateChanger`
+- Change type of `manual_cost` member in `Restock` from `set(ResourceAmount)` to `Cost`
+- Change type of `auto_cost` member in `Restock` from `set(ResourceAmount)` to `Cost`
+- Change type of `attributes` member in `Live` from `set(Attribute)` to `set(AttributeSetting)`
+- Move `target_mode` member from `ShootProjectile` to `Projectile`
+- Rename `UnitStance` object to `GameEntityStance`
+- Rename `TradeResources` object to `ExchangeResources`
+- Rename `RegenerateResource` object to `RegenerateResourceSpot`
+- Rename `Stealth` object to `Cloak`
+- Rename `Decay` object to `Despawn`
+- Rename `mode` member of `Move` to `modes`
+- Rename `flag` member of `RallyPoint` to `indicator`
+- Rename `units` member of `Create` to `creatables`
+- Rename `techs` member of `Research` to `researchables`
+- Rename `sell_resources` member of `ExchangeResources` to `source_resources`
+- Rename `receive_resources` member of `ExchangeResources` to `target_resources`
+- Rename `ingame_help` member of `Named` to `long_description`
+- Rename `tile_width` member of `TileRequirement` to `tiles_x`
+- Rename `tile_height` member of `TileRequirement` to `tiles_y`
+- Rename `flatten_terrain` member of `Foundation` to `flatten_ground`
+- Rename `terrain` member of `OverlayTerrain` to `terrain_overlay`
+- Rename `condition` member of `Die` to `death_conditions`
+
+### Auxilary module
+- Change type of `modifiers` member in `Civilization` from `Modifier` to `ScopedModifier`
+- Change type of `progress_sprite` member in `AnimationProgress` from `Animation` to `AnimationOverride`
+- Change type of `cost` member in `CreatableGameEntity` from `set(ResourceAmount)` to `Cost`
+- Change type of `cost` member in `ResearchableTech` from `set(ResourceAmount)` to `Cost`
+- Change type of `conflicts` member in `StorageElement` from `set(GameEntity)` to `set(StorageElement)`
+- Rename `ChanceType` object to `ConvertType`
+- Rename `Default` object to `Fallback`
+- Rename `Prerequiste` object to `AvailabilityPrerequisite`
+- Rename `AnimatedProgress` object to `AnimationProgress`
+- Rename `UnitStance` object to `GameEntityStance`
+- Rename `UnitFormation` object to `GameEntityFormation`
+- Rename `AttributeDeathCondition` object to `AttributeInterval`
+- Rename `Self(ModifierScope)` object to `Standard`
+- Rename `chance` member of `RandomVariant` to `chance_share`
+- Rename `tech_tree_help` member of `Civilization` to `long_description`
+- Rename `ingame_help` member of `Tech` to `long_description`
+- Rename `ambient` member of `Terrain` to `ambience` and change its type from `orderedset(TerrainAmbient)` to `set(TerrainAmbient)`
+- Rename `max_density` member of `TerrainAmbient` to `density`
+- Rename `type` member of `ResourceSpot` to `resource`
+- Rename `impact` member of `Cheat` to `changes`
+- Rename `negation` member of `AvailabilityPrerequisite` to `mode`
+
+### Effect module
+- Change type of `cost` member in `CostEffect` from `set(AttributeAmount)` to `Cost`
+- Rename `ChanceEffect` object to `Convert` and change the type of its `type` member from `ChanceType` to `ConvertType`
+- Rename `SendToStorage` object to `SendToContainer` and change its parent from `ContinuousEffect` to `DiscreteEffect`
+- Rename `min_range_to_destination` member of `Lure` to `min_distance_to_destination`
+- Rename `AoE2Conversion` object to `AoE2Convert`
+
+### Modifier module
+- Change type of `provider_abilities` member in `AoE2ProjectileAmount` from `ApplyDiscreteEffect` to `set(ApplyDiscreteEffect)`
+- Change type of `receiver_abilities` member in `AoE2ProjectileAmount` from `ApplyDiscreteEffect` to `set(ApplyDiscreteEffect)`
+- Rename `PercentageModifier` object to `MultiplierModifier`
+- Rename `AttributeModifier` object to `AttributeSettingsValue`
+- Rename `MoveSpeedModifier` object to `MoveSpeed`
+- Rename `ReloadTimeModifier` object to `ReloadTime`
+- Rename `GatheringEfficiencyModifier` object to `GatheringEfficiency`
+- Rename `GatheringRateModifier` object to `GatheringRate`
+- Rename `StorageElementModifier` object to `StorageElementCapacity`
+- Rename `ContainerCapacityModifier` object to `ContainerCapacity`
+- Rename `CreationTimeModifier` object to `CreationTime`
+- Rename `EffectPercentageModifier` object to `EffectMultiplierModifier`
+- Rename `ResistancePercentageModifier` object to `ResistanceMultiplierModifier`
+- Rename `FlyoverModifier` object to `Flyover`
+- Rename `StrayModifier` object to `Stray`
+- Rename `RevealModifier` object to `Reveal`
+- Rename `AlwaysHerdModifier` object to `AlwaysHerd`
+- Rename `TechUnlockModifier` object to `InstantTechResearch`
+- Rename `AbsoluteProjectileAmountModifier` object to `AbsoluteProjectileAmount`
+- Rename `AoE2ProjectileAmountModifier` object to `AoE2ProjectileAmount`
+- Rename `ContinuousResourceModifier` object to `ContinuousResource` and set `Modifier` as only direct parent
+- Rename `rate` member of `ContinuousResource` to `rates`
+- Rename `provider_ability` member of `AoE2ProjectileAmount` to `provider_abilities`
+- Rename `receiver_ability` member of `AoE2ProjectileAmount` to `receiver_abilities`
+
+### Resistance module
+- Change type of `cost` member in `CostResistance` from `set(AttributeAmount)` to `Cost`
+- Change type of `resist_condition` member in `MakeHarvestable` from `set(AvailabilityRequirement)` to `set(HarvestableRequirement)`
+- Rename `FlatResistance(ContinuousResistance)` object to `FlatAttributeChange`
+- Rename `FlatAttributeDecreaseResistance(FlatAttributeChange)` (continuous branch) object to `FlatAttributeDecrease`
+- Rename `FlatAttributeIncreaseResistance(FlatAttributeChange)` (continuous branch) object to `FlatAttributeIncrease`
+- Rename `FlatAttributeResistance(DiscreteResistance)` object to `FlatAttributeChange`
+- Rename `FlatAttributeDecreaseResistance(FlatAttributeChange)` (discrete branch) object to `FlatAttributeDecrease`
+- Rename `FlatAttributeIncreaseResistance(FlatAttributeChange)` (discrete branch) object to `FlatAttributeIncrease`
+- Rename `LureResistance(ContinuousResistance)` object to `Lure`
+- Rename `SendToStorageResistance(ContinuousResistance)` object to `SendToContainer` and change its parent from `ContinuousResistance` to `DiscreteResistance`
+- Rename `HarvestableResistance(Discreteresistance)` object to `MakeHarvestable`
+- Rename `ChanceResistance(Discreteresistance)` object to `Convert` and change the type of its `type` member from `ChanceType` to `ConvertType`
+- Rename `AoE2ConversionResistance(Convert)` object to `AoE2Convert`
+- Rename `protection_recharge_time` member of `AoE2Convert` to `protection_round_recharge_time`
+
+## Removed
+### Ability module
+- Remove `SoundAbility(Ability)` object; functionality split into `ExecutionSoundAbility` and `CommandSoundAbility`
+- Remove `Construct(Ability)` object; is now an effect
+- Remove `TransferResourceWithModifier(Ability)` object; merged into `ExchangeResources`
+- Remove `AttackGround(ShootProjectile)` object
+- Remove `accept_on_construction` member from `DropSite`; now handled by a modifier
+- Remove `die_on_hit` member from `Projectile`; now handled as death condition
+- Remove `pass_through_range` member from `Projectile`; now handled as death condition
+- Remove `progress` member from `OverlayTerrain`; any progress can now change terrain overlays
+
+### Auxilary module
+- Remove `DiplomaticSetup(Entity)` object; functionality replaced by `DiplomaticPatch`
+- Remove `Exponential(DropoffType)` object; might be reintroduced in a later release
+- Remove `AnimatedTerrain(Terrain)` object; now handled by .terrain definition file and renderer
+- Remove `TechPrerequiste(Prerequisite)` object; functionality replaced by `TechResearched`
+- Remove `BuildingPrerequiste(Prerequisite)` object; functionality replaced by `GameEntityProgress`
+- Remove `TransformState(Entity)` object; functionality replaced by `StateChanger`
+- Remove `Guard(MoveMode)` object; functionality integrated into `Follow`
+- Remove `Constructable(Entity)` object
+- Remove `NearestTradeRoute(Entity)` object
+- Remove `graphic_set` member from `Civilization`; now handled by `civ_setup` member
+- Remove `diplo_setup` member from `Civilization`; now handled by `civ_setup` member
+- Remove `modifiers` member from `Cheat`
+- Remove `enable_abilities` member from `Progress`; now handled by `StateChangeProgress` specialization
+- Remove `disable_abilities` member from `Progress`; now handled by `StateChangeProgress` specialization
+- Remove `enable_modifiers` member from `Progress`; now handled by `StateChangeProgress` specialization
+- Remove `disable_modifiers` member from `Progress`; now handled by `StateChangeProgress` specialization
+- Remove `attribute` member from `DamageProgress`; member was obselete
+- Remove `min_value` member from `Attribute`; now stored in `AttributeSetting`
+- Remove `max_value` member from `Attribute`; now stored in `AttributeSetting`
+- Remove `enable_abilities` member from `StorageElement`; now handled by `state_change` member
+- Remove `disable_abilities` member from `StorageElement`; now handled by `state_change` member
+- Remove `enable_modifiers` member from `StorageElement`; now handled by `state_change` member
+- Remove `disable_modifiers` member from `StorageElement`; now handled by `state_change` member
+
+### Modifier module
+- Remove `DiscreteModifier(Modifier)` object; might be introduced back later
+- Remove `DiscreteResourceModifier(DiscreteModifier)` object; might be introduced back later
+- Remove `CreationCostModifier(MultiplierModifier)` object; split into `CreationAttributeCost` and `CreationResourceCost`
+- Remove `ResearchCostModifier(MultiplierModifier)` object; split into `ResearchAttributeCost` and `ResearchResourceCost`
+- Remove `ConstructionTimeModifier(MultiplierModifier)` object; moved to effect bonus
+- Remove `ElevationModifier(FlatAttributeChangeModifier)` object; replaced by `ElevationDifferenceHigh` modifier
+- Remove `ContinuousModifier(Modifier)` object; might be introduced back later
+
+## Reference visualization
+
+* [Gamedata](https://github.com/SFTtech/openage/blob/45b8992dc836d239c9f22cae8404a8b2cc16c8ef/doc/nyan/aoe2_nyan_tree.svg)

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -86,6 +86,7 @@ For tiny stuff like typo fixes, just create your PR and be done with it.
 
 - "Release early and often!" also applies to pull requests!
   - Once your branch has some visible work, create `[WIP]` pull request
+  - Give the pull request a description of what you did or want to do, so we can discuss it
   - Make sure you are in the `copying.md` file
   - People will be able to look at your code and give feedback
   - You'll get free checks from the build bot

--- a/doc/nyan/aoe2_nyan_tree.svg
+++ b/doc/nyan/aoe2_nyan_tree.svg
@@ -2236,10 +2236,10 @@
       /><text x="2" font-size="14px" y="34.2188" clip-path="url(#clipPath60)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >ContinuousResistance</text
     ></g
-    ><g fill="rgb(255,175,175)" fill-opacity="0.4902" transform="translate(4910,3660)" stroke-opacity="0.4902" stroke="rgb(255,175,175)"
+    ><g fill="rgb(255,175,175)" fill-opacity="0.4902" transform="translate(4900,3810)" stroke-opacity="0.4902" stroke="rgb(255,175,175)"
     ><rect x="0.5" width="158.5" height="78.5" y="0.5" clip-path="url(#clipPath48)" stroke="none"
     /></g
-    ><g transform="translate(4910,3660)"
+    ><g transform="translate(4900,3810)"
     ><rect fill="none" x="0.5" width="158.5" height="78.5" y="0.5" clip-path="url(#clipPath48)"
       /><text x="25" font-size="14px" y="18.1094" clip-path="url(#clipPath48)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >AttributeRate</text
@@ -2455,10 +2455,10 @@
       /><text x="4" font-size="14px" y="34.2188" clip-path="url(#clipPath5)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >GameEntityType</text
     ></g
-    ><g fill="rgb(255,175,175)" fill-opacity="0.4902" transform="translate(4910,3570)" stroke-opacity="0.4902" stroke="rgb(255,175,175)"
+    ><g fill="rgb(255,175,175)" fill-opacity="0.4902" transform="translate(4900,3720)" stroke-opacity="0.4902" stroke="rgb(255,175,175)"
     ><rect x="0.5" width="158.5" height="78.5" y="0.5" clip-path="url(#clipPath48)" stroke="none"
     /></g
-    ><g transform="translate(4910,3570)"
+    ><g transform="translate(4900,3720)"
     ><rect fill="none" x="0.5" width="158.5" height="78.5" y="0.5" clip-path="url(#clipPath48)"
       /><text x="13" font-size="14px" y="18.1094" clip-path="url(#clipPath48)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >AttributeAmount</text
@@ -2888,9 +2888,9 @@
       ><text x="5" font-size="14px" y="87.5469" clip-path="url(#clipPath75)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >restock_time : float</text
       ><text x="5" font-size="14px" y="103.6562" clip-path="url(#clipPath75)" font-family="sans-serif" stroke="none" xml:space="preserve"
-      >manual_cost : set(ResourceAmount)</text
+      >manual_cost : Cost</text
       ><text x="5" font-size="14px" y="119.7656" clip-path="url(#clipPath75)" font-family="sans-serif" stroke="none" xml:space="preserve"
-      >auto_cost : set(ResourceAmount)</text
+      >auto_cost : Cost</text
       ><text x="5" font-size="14px" y="135.875" clip-path="url(#clipPath75)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >amount : int</text
     ></g
@@ -3792,37 +3792,37 @@
       >Despawn</text
       ><path fill="none" d="M1 40.2188 L329 40.2188" clip-path="url(#clipPath78)"
       /><text x="5" font-size="14px" y="55.3281" clip-path="url(#clipPath78)" font-family="sans-serif" stroke="none" xml:space="preserve"
-      >despawn_condition : set(DespawnCondition)</text
+      >despawn_conditions : set(DespawnCondition)</text
       ><text x="5" font-size="14px" y="71.4375" clip-path="url(#clipPath78)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >despawn_time : float</text
       ><text x="5" font-size="14px" y="87.5469" clip-path="url(#clipPath78)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >state_change : StateChanger</text
     ></g
     ><g fill="rgb(255,175,175)" fill-opacity="0.4902" transform="translate(3300,2010)" stroke-opacity="0.4902" stroke="rgb(255,175,175)"
-    ><rect x="0.5" width="198.5" height="78.5" y="0.5" clip-path="url(#clipPath46)" stroke="none"
+    ><rect x="0.5" width="258.5" height="98.5" y="0.5" clip-path="url(#clipPath40)" stroke="none"
     /></g
     ><g transform="translate(3300,2010)"
-    ><rect fill="none" x="0.5" width="198.5" height="78.5" y="0.5" clip-path="url(#clipPath46)"
-      /><text x="77" font-size="14px" y="18.1094" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
+    ><rect fill="none" x="0.5" width="258.5" height="98.5" y="0.5" clip-path="url(#clipPath40)"
+      /><text x="107" font-size="14px" y="18.1094" clip-path="url(#clipPath40)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >Taunt</text
-      ><path fill="none" d="M1 40.2188 L199 40.2188" clip-path="url(#clipPath46)"
-      /><text x="5" font-size="14px" y="55.3281" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" xml:space="preserve"
+      ><path fill="none" d="M1 40.2188 L259 40.2188" clip-path="url(#clipPath40)"
+      /><text x="5" font-size="14px" y="55.3281" clip-path="url(#clipPath40)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >activation_message : text</text
-      ><text x="5" font-size="14px" y="71.4375" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" xml:space="preserve"
+      ><text x="5" font-size="14px" y="71.4375" clip-path="url(#clipPath40)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >display_message : TranslatedString</text
-      ><text x="5" font-size="14px" y="87.5469" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" xml:space="preserve"
+      ><text x="5" font-size="14px" y="87.5469" clip-path="url(#clipPath40)" font-family="sans-serif" stroke="none" xml:space="preserve"
       >sound : Sound</text
     ></g
-    ><g fill="rgb(0,255,0)" fill-opacity="0.4902" transform="translate(5150,3460)" stroke-opacity="0.4902" stroke="rgb(0,255,0)"
-    ><rect x="0.5" width="198.5" height="78.5" y="0.5" clip-path="url(#clipPath46)" stroke="none"
+    ><g fill="rgb(0,255,0)" fill-opacity="0.4902" transform="translate(5130,3460)" stroke-opacity="0.4902" stroke="rgb(0,255,0)"
+    ><rect x="0.5" width="238.5" height="78.5" y="0.5" clip-path="url(#clipPath9)" stroke="none"
     /></g
-    ><g transform="translate(5150,3460)"
-    ><rect fill="none" x="0.5" width="198.5" height="78.5" y="0.5" clip-path="url(#clipPath46)"
-      /><text x="83" font-size="14px" y="18.1094" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
+    ><g transform="translate(5130,3460)"
+    ><rect fill="none" x="0.5" width="238.5" height="78.5" y="0.5" clip-path="url(#clipPath9)"
+      /><text x="103" font-size="14px" y="18.1094" clip-path="url(#clipPath9)" font-family="sans-serif" stroke="none" font-weight="bold" xml:space="preserve"
       >Live</text
-      ><path fill="none" d="M1 40.2188 L199 40.2188" clip-path="url(#clipPath46)"
-      /><text x="5" font-size="14px" y="55.3281" clip-path="url(#clipPath46)" font-family="sans-serif" stroke="none" xml:space="preserve"
-      >attributes : set(Attribute)</text
+      ><path fill="none" d="M1 40.2188 L239 40.2188" clip-path="url(#clipPath9)"
+      /><text x="5" font-size="14px" y="55.3281" clip-path="url(#clipPath9)" font-family="sans-serif" stroke="none" xml:space="preserve"
+      >attributes : set(AttributeSetting)</text
     ></g
     ><g fill="rgb(0,255,0)" fill-opacity="0.4902" transform="translate(4830,1780)" stroke-opacity="0.4902" stroke="rgb(0,255,0)"
     ><rect x="0.5" width="218.5" height="78.5" y="0.5" clip-path="url(#clipPath20)" stroke="none"
@@ -5204,7 +5204,7 @@
     ><g transform="translate(5240,2450)"
     ><path fill="none" d="M10.5 10.5 L10.5 1010.5" clip-path="url(#clipPath136)"
     /></g
-    ><g stroke-dasharray="8,5" stroke-miterlimit="5" transform="translate(5060,3670)" stroke-linecap="butt"
+    ><g stroke-dasharray="8,5" stroke-miterlimit="5" transform="translate(5050,3820)" stroke-linecap="butt"
     ><path fill="none" d="M80.5 10.5 L10.5 10.5" clip-path="url(#clipPath116)"
       /><path fill="none" stroke-miterlimit="10" stroke-dasharray="none" d="M69.2417 4 L80.5 10.5 L69.2417 17" clip-path="url(#clipPath116)" stroke-linecap="square"
     /></g
@@ -5629,7 +5629,7 @@
     ><path fill="none" d="M50.5 10.5 L10.5 10.5" clip-path="url(#clipPath100)"
       /><path fill="none" stroke-miterlimit="10" stroke-dasharray="none" d="M39.2417 4 L50.5 10.5 L39.2417 17" clip-path="url(#clipPath100)" stroke-linecap="square"
     /></g
-    ><g stroke-dasharray="8,5" stroke-miterlimit="5" transform="translate(5060,3620)" stroke-linecap="butt"
+    ><g stroke-dasharray="8,5" stroke-miterlimit="5" transform="translate(5050,3770)" stroke-linecap="butt"
     ><path fill="none" d="M80.5 10.5 L10.5 10.5" clip-path="url(#clipPath116)"
       /><path fill="none" stroke-miterlimit="10" stroke-dasharray="none" d="M69.2417 4 L80.5 10.5 L69.2417 17" clip-path="url(#clipPath116)" stroke-linecap="square"
     /></g

--- a/doc/nyan/aoe2_nyan_tree.uxf
+++ b/doc/nyan/aoe2_nyan_tree.uxf
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<diagram program="umlet" version="13.3">
+<?xml version="1.0" encoding="UTF-8"?><diagram program="umlet" version="13.3">
   <help_text>// Uncomment the following line to change the fontsize and font:
 // fontsize=10
 // fontfamily=SansSerif //possible: SansSerif,Serif,Monospaced
@@ -2038,16 +2037,16 @@ resources : ResourceSpot</panel_attributes>
   <element>
     <id>UMLClass</id>
     <coordinates>
-      <x>5150</x>
+      <x>5130</x>
       <y>3460</y>
-      <w>200</w>
+      <w>240</w>
       <h>80</h>
     </coordinates>
     <panel_attributes>*Live*
 bg=green
 
 --
-attributes : set(Attribute)</panel_attributes>
+attributes : set(AttributeSetting)</panel_attributes>
     <additional_attributes/>
   </element>
   <element>
@@ -2055,8 +2054,8 @@ attributes : set(Attribute)</panel_attributes>
     <coordinates>
       <x>3300</x>
       <y>2010</y>
-      <w>200</w>
-      <h>80</h>
+      <w>260</w>
+      <h>100</h>
     </coordinates>
     <panel_attributes>*Taunt*
 bg=pink
@@ -2123,7 +2122,7 @@ sound : Sound</panel_attributes>
 bg=green
 
 --
-despawn_condition : set(DespawnCondition)
+despawn_conditions : set(DespawnCondition)
 despawn_time : float
 state_change : StateChanger</panel_attributes>
     <additional_attributes/>
@@ -3823,8 +3822,8 @@ bg=green
 auto_restock : bool
 target : RestockableResourceSpot
 restock_time : float
-manual_cost : set(ResourceAmount)
-auto_cost : set(ResourceAmount)
+manual_cost : Cost
+auto_cost : Cost
 amount : int</panel_attributes>
     <additional_attributes/>
   </element>
@@ -4543,8 +4542,8 @@ blacklisted_entities : set(GameEntity)</panel_attributes>
   <element>
     <id>UMLClass</id>
     <coordinates>
-      <x>4910</x>
-      <y>3570</y>
+      <x>4900</x>
+      <y>3720</y>
       <w>160</w>
       <h>80</h>
     </coordinates>
@@ -4559,8 +4558,8 @@ amount : int</panel_attributes>
   <element>
     <id>Relation</id>
     <coordinates>
-      <x>5060</x>
-      <y>3620</y>
+      <x>5050</x>
+      <y>3770</y>
       <w>100</w>
       <h>30</h>
     </coordinates>
@@ -4918,8 +4917,8 @@ rate : float</panel_attributes>
   <element>
     <id>UMLClass</id>
     <coordinates>
-      <x>4910</x>
-      <y>3660</y>
+      <x>4900</x>
+      <y>3810</y>
       <w>160</w>
       <h>80</h>
     </coordinates>
@@ -6833,8 +6832,8 @@ ignore_containers : set(Container)</panel_attributes>
   <element>
     <id>Relation</id>
     <coordinates>
-      <x>5060</x>
-      <y>3670</y>
+      <x>5050</x>
+      <y>3820</y>
       <w>100</w>
       <h>30</h>
     </coordinates>

--- a/doc/nyan/api_reference/reference_ability.md
+++ b/doc/nyan/api_reference/reference_ability.md
@@ -248,9 +248,9 @@ Blacklist for specific game entities that would be covered by `allowed_types`, b
 
 ```python
 Despawn(Ability):
-    despawn_condition : set(DespawnCondition)
-    despawn_time      : float
-    state_change      : StateChanger
+    despawn_conditions : set(DespawnCondition)
+    despawn_time       : float
+    state_change       : StateChanger
 ```
 
 Second stage of a "clean exit" that removes the game entity from the current game. The ability is can be used when a `Die` ability was executed by the same game entity or if the game entity has no `Die` ability. `Despawn` is triggered if at least one of the conditions in `despawn_conditions` is fulfilled. There can only be one `Despawn` ability active at the same time. If more than one `Despawn` abilities are enabled, the least recently enabled one of them is used.

--- a/doc/nyan/api_reference/reference_aux.md
+++ b/doc/nyan/api_reference/reference_aux.md
@@ -1611,7 +1611,7 @@ The changes to the game entity as a set of patches. Only the created game entity
 **priority**
 When many variants are chosen, this member influences the order in which the patches from their `changes` member are applied. Patches from variants with higher priority value are applied first.
 
-## aux.variant.type.AdjacencyVariant
+## aux.variant.type.AdjacentTilesVariant
 
 ```python
 AdjacentTilesVariant(Variant):

--- a/doc/releasing.md
+++ b/doc/releasing.md
@@ -3,13 +3,13 @@
 * Bump the version number in `openage_version`. Given `0.y.z`, both `0.y.(z+1)` and `0.(y+1).0` are valid. The latter will probably be more common, but which of those you choose doesn't really matter.
 
   Read up on [Semver](https://semver.org) for details. People often seem to overlook the special rules for initial development versions. Please avoid prerelease versions (`-alpha`, `-beta`, `-rc.1`, ...) for now. We might decide to include build metadata like date or commit hash, that's up for discussion.
-* Move `changelog.md` to `doc/changelog/$VERSION.md` and create an empty new one.
+* Create a new changelog named `doc/changelogs/engine/$VERSION.md`.
 * Commit, PR, merge, pull as usual.
 * OPTIONAL: Set up [commit signing](https://help.github.com/en/articles/managing-commit-signature-verification), signing tags will make a "verified" badge show up on the release later.
 * Tag the merge commit, something like `git tag -s v0.5.0`. The prefixed `v` is mandatory.
 * Push the tag to GitHub.
 * Use the GitHub web interface to publish a release from the tag. Make it look nice, see previous release description. If in doubt, save the draft and have someone else proof read it. Also include the changelog.
 * In the future, kevin will automatically attach build artifacts like installers to the release. For now, you will need to do that manually. Have fun setting up a windows build environment or if you feel like being lazy, go bug someone who already has. Actually, taking care of where to build for windows before publishing the release might not be a bad idea.
-* OPTIONAL: Brag on social media. /r/openage and AoE2 Discords might be the right place to do so.
+* OPTIONAL: Brag on social media. /r/openage, /r/aoe2 and AoE2 Discords might be the right place to do so.
 
 If you need help or are not completely sure what you are doing, ask in [`#sfttech:matrix.org`](https://riot.im/app/#/room/#sfttech:matrix.org) and highlight `zuntrax` or someone else who has done it before. Better having someone help you than screwing up a release.


### PR DESCRIPTION
Changelog for engine development that happened until our last release (v0.4.0).

The pre-SFTtech/openage time is not as documented as the other releases because the main source of information is the git log (which is huge). For all changes after SFTtech/openage was created, I used PRs as orientation.

- [x] Engine changelog
- [x] Modding API changelog