### PR TITLE
Fix broken freenode badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To play, you require *an original AoE II : TC installation or [AoE II: HD](http:
 (installation via [Wine](https://www.winehq.org/) or [Steam-Linux](doc/media_convert.md#how-to-use-the-original-game-assets)).
 
 [![github stars](https://img.shields.io/github/stars/SFTtech/openage.svg)](https://github.com/SFTtech/openage/stargazers)
-[![#sfttech on Freenode](https://img.shields.io/Freenode/%23sfttech.png)](https://webchat.freenode.net/?channels=sfttech)
+[![#sfttech on Freenode](https://img.shields.io/badge/chat-on%20freenode-brightgreen)](https://webchat.freenode.net/?channels=sfttech)
 [![#sfttech on matrix.org](https://img.shields.io/badge/matrix-%23sfttech-blue.svg)](https://riot.im/app/#/room/#sfttech:matrix.org)
 [![quality badge](https://img.shields.io/badge/cuteness-overload-orange.svg)](http://www.emergencykitten.com/)
 


### PR DESCRIPTION
The freenode badge in the README is currently broken, it reads `404 | badge not found`. This replaces the badge by `chat | on freenode`.