### PR TITLE
Gui improvements

### DIFF
--- a/assets/qml/BindsHelp.qml
+++ b/assets/qml/BindsHelp.qml
@@ -10,10 +10,11 @@ Column {
 
 	Text {
 		id: dummyText
+		font.pointSize: 9
 	}
 
 	Text {
-		font.pointSize: dummyText.font.pointSize + 7
+		font.pointSize: dummyText.font.pointSize + 3
 
 		color: "white"
 		text: gameControl.mode ? gameControl.mode.name : "No Mode"
@@ -23,13 +24,14 @@ Column {
 		model: gameControlObj.mode ? gameControlObj.mode.binds : undefined
 
 		Text {
+			font.pointSize: dummyText.font.pointSize
 			color: "white"
 			text: modelData
 		}
 	}
 
 	Text {
-		font.pointSize: dummyText.font.pointSize + 7
+		font.pointSize: dummyText.font.pointSize + 3
 
 		color: "white"
 		text: "Global Bindings"
@@ -39,6 +41,7 @@ Column {
 		model: OA.Engine.globalBinds
 
 		Text {
+			font.pointSize: dummyText.font.pointSize
 			color: "white"
 			text: modelData
 		}

--- a/assets/qml/IngameHud.qml
+++ b/assets/qml/IngameHud.qml
@@ -230,6 +230,85 @@ Item {
 					anchors.fill: parent
 					tornBottom: false
 				}
+
+				Item {
+					anchors.fill: parent
+					id: selection_single_panel
+					visible: root.actionMode.selection_size == 1
+
+					Text {
+						anchors.top: parent.top
+						anchors.topMargin: metricsUnit * 2
+						anchors.left: parent.left
+						anchors.leftMargin: metricsUnit * 2
+
+						id: selected_name
+
+						color: "black"
+						text: root.actionMode.selection_name
+						font.pointSize: 16
+					}
+
+					Text {
+						anchors.bottom: selected_name.bottom
+						anchors.left: selected_name.right
+						anchors.leftMargin: metricsUnit * 1
+
+						id: selected_type
+
+						color: "black"
+						opacity: 0.8
+						text: root.actionMode.selection_type
+					}
+
+					Text {
+						anchors.top: selected_name.bottom
+						anchors.left: selected_name.left
+						anchors.topMargin: metricsUnit / 2
+
+						id: selected_owner
+
+						color: "black"
+						text: root.actionMode.selection_hp
+					}
+
+					Text {
+						anchors.top: selected_owner.bottom
+						anchors.left: selected_owner.left
+						anchors.topMargin: metricsUnit * 2
+
+						color: "black"
+						text: root.actionMode.selection_attrs
+					}
+
+					Text {
+						anchors.top: parent.top
+						anchors.right: parent.right
+						anchors.topMargin: metricsUnit * 2
+						anchors.rightMargin: metricsUnit * 2
+
+						color: "black"
+						text: root.actionMode.selection_owner
+					}
+
+				}
+
+				Item {
+					anchors.fill: parent
+					id: selection_group_panel
+					visible: root.actionMode.selection_size > 1
+
+					Text {
+						anchors.top: parent.top
+						anchors.topMargin: metricsUnit * 2
+						anchors.left: parent.left
+						anchors.leftMargin: metricsUnit * 2
+
+						color: "black"
+						text: root.actionMode.selection_name
+						font.pointSize: 14
+					}
+				}
 			}
 		}
 

--- a/assets/qml/IngameHud.qml
+++ b/assets/qml/IngameHud.qml
@@ -24,6 +24,9 @@ Item {
 	readonly property string srcSuffix: ".slp.png"
 	property string hudImageSource: srcPrefix + (pad + civIndex).slice(-pad.length) + srcSuffix
 
+	readonly property string iconsPrefix: "image://by-filename/converted/interface/"
+	readonly property string iconsBorder: "image://by-filename/converted/interface/53003.slp.png.1"
+
 	width: 1289
 	height: 960
 
@@ -256,7 +259,15 @@ Item {
 
 						id: selected_icon
 
-						source: "image://by-filename/converted/interface/50730.slp.png.2"
+						source: root.actionMode.selection_icon ? iconsPrefix + root.actionMode.selection_icon : iconsBorder
+					}
+					Image {
+						anchors.centerIn: selected_icon
+
+						width: 50
+						height: 50
+
+						source: iconsBorder
 					}
 
 					Text {

--- a/assets/qml/IngameHud.qml
+++ b/assets/qml/IngameHud.qml
@@ -141,7 +141,7 @@ Item {
 					id: epoch
 					anchors.centerIn: parent
 					color: "white"
-					text: root.playerName + (actionMode.ability.length ? (" (" + actionMode.ability + ")") : "")
+					text: root.playerName
 				}
 			}
 
@@ -306,6 +306,21 @@ Item {
 
 						color: "black"
 						text: root.actionMode.selection_name
+						font.pointSize: 14
+					}
+				}
+
+				Item {
+					anchors.left: parent.left
+					anchors.right: parent.right
+					anchors.bottom: parent.bottom
+					anchors.bottomMargin: metricsUnit * 3
+					visible: actionMode.ability.length
+
+					Text {
+						anchors.centerIn: parent
+
+						text: actionMode.ability
 						font.pointSize: 14
 					}
 				}

--- a/assets/qml/IngameHud.qml
+++ b/assets/qml/IngameHud.qml
@@ -137,11 +137,20 @@ Item {
 				Layout.fillWidth: true
 				Layout.minimumWidth: epoch.implicitWidth
 
-				Text {
-					id: epoch
+				Rectangle {
 					anchors.centerIn: parent
-					color: "white"
-					text: root.playerName
+					width: 200
+					height: metricsUnit * 2.5
+
+					color: "black"
+
+					Text {
+						id: epoch
+						anchors.centerIn: parent
+
+						color: "white"
+						text: root.playerName
+					}
 				}
 			}
 
@@ -289,6 +298,7 @@ Item {
 
 						color: "black"
 						text: root.actionMode.selection_owner
+						horizontalAlignment: Text.AlignRight
 					}
 
 				}

--- a/assets/qml/IngameHud.qml
+++ b/assets/qml/IngameHud.qml
@@ -245,11 +245,24 @@ Item {
 					id: selection_single_panel
 					visible: root.actionMode.selection_size == 1
 
-					Text {
+					Image {
 						anchors.top: parent.top
 						anchors.topMargin: metricsUnit * 2
 						anchors.left: parent.left
 						anchors.leftMargin: metricsUnit * 2
+
+						width: 50
+						height: 50
+
+						id: selected_icon
+
+						source: "image://by-filename/converted/interface/50730.slp.png.2"
+					}
+
+					Text {
+						anchors.top: selected_icon.top
+						anchors.left: selected_icon.right
+						anchors.leftMargin: metricsUnit * 1.2
 
 						id: selected_name
 
@@ -259,9 +272,9 @@ Item {
 					}
 
 					Text {
-						anchors.bottom: selected_name.bottom
+						anchors.verticalCenter: selected_name.verticalCenter
 						anchors.left: selected_name.right
-						anchors.leftMargin: metricsUnit * 1
+						anchors.leftMargin: metricsUnit * 1.2
 
 						id: selected_type
 
@@ -273,17 +286,17 @@ Item {
 					Text {
 						anchors.top: selected_name.bottom
 						anchors.left: selected_name.left
-						anchors.topMargin: metricsUnit / 2
+						anchors.topMargin: metricsUnit
 
-						id: selected_owner
+						id: selected_hp
 
 						color: "black"
 						text: root.actionMode.selection_hp
 					}
 
 					Text {
-						anchors.top: selected_owner.bottom
-						anchors.left: selected_owner.left
+						anchors.top: selected_hp.bottom
+						anchors.left: selected_icon.left
 						anchors.topMargin: metricsUnit * 2
 
 						color: "black"

--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 the openage authors. See copying.md for legal info.
+# Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 """
 Entry point for the code compliance checker.
@@ -183,7 +183,7 @@ def main(args):
         if args.fix and auto_fixes:
             remainfound = "remain%s" % plural
         else:
-            remainfound = ("were" if issues_count > 1 else "was") + "found"
+            remainfound = ("were" if issues_count > 1 else "was") + " found"
 
         print("==> \x1b[33;1m{num} issue{plural}\x1b[m {remainfound}."
               "".format(num=issues_count,

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 the openage authors. See copying.md for legal info.
+// Copyright 2013-2019 the openage authors. See copying.md for legal info.
 
 #include "engine.h"
 

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -466,8 +466,12 @@ void Engine::register_tick_action(TickHandler *handler) {
 	this->on_engine_tick.push_back(handler);
 }
 
-void Engine::register_drawhud_action(HudHandler *handler) {
-	this->on_drawhud.push_back(handler);
+void Engine::register_drawhud_action(HudHandler *handler, int order) {
+	if (order < 0) {
+		this->on_drawhud.insert(this->on_drawhud.begin(), handler);
+	} else {
+		this->on_drawhud.push_back(handler);
+	}
 }
 
 void Engine::register_draw_action(DrawHandler *handler) {

--- a/libopenage/engine.h
+++ b/libopenage/engine.h
@@ -181,8 +181,9 @@ public:
 
 	/**
 	 * register a hud drawing handler, drawn in hud coordinates.
+	 * order: 1 above, -1 below
 	 */
-	void register_drawhud_action(HudHandler *handler);
+	void register_drawhud_action(HudHandler *handler, int order = 1);
 
 	/**
 	 * register a draw handler, run in game coordinates.

--- a/libopenage/engine.h
+++ b/libopenage/engine.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 the openage authors. See copying.md for legal info.
+// Copyright 2013-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/engine.h
+++ b/libopenage/engine.h
@@ -44,6 +44,7 @@ namespace renderer {
 class Font;
 class FontManager;
 class TextRenderer;
+class Color;
 
 } // openage::renderer
 
@@ -260,7 +261,7 @@ public:
 	/**
 	 * render text with the at a position with specified font size
 	 */
-	void render_text(coord::viewport position, size_t size, const char *format, ...) ATTRIBUTE_FORMAT(4, 5);
+	void render_text(coord::viewport position, size_t size, const renderer::Color &color, const char *format, ...) ATTRIBUTE_FORMAT(5, 6);
 
 	/**
 	 * move the phys3 camera incorporated in the engine

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -742,7 +742,7 @@ void GameControl::set_engine(Engine *engine) {
 		this->engine = engine;
 
 		// add handlers
-		this->engine->register_drawhud_action(this);
+		this->engine->register_drawhud_action(this, -1);
 
 		auto &action = this->engine->get_action_manager();
 

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "game_control.h"
 

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -847,7 +847,8 @@ void GameControl::announce_current_player_name() {
 
 void ActionMode::announce_current_selection() {
 
-	emit this->gui_signals.selection_changed(this->selection);
+	Player* player = this->game_control->get_current_player();
+	emit this->gui_signals.selection_changed(this->selection, player);
 }
 
 bool GameControl::on_drawhud() {

--- a/libopenage/game_control.cpp
+++ b/libopenage/game_control.cpp
@@ -6,6 +6,7 @@
 #include "error/error.h"
 #include "gamestate/game_spec.h"
 #include "log/log.h"
+#include "renderer/color.h"
 #include "terrain/terrain_chunk.h"
 #include "util/strings.h"
 
@@ -308,6 +309,7 @@ void ActionMode::on_game_control_set() {
 				input->remove_context(top_ctxt);
 			}
 			this->announce_buttons_type();
+			this->announce_current_selection();
 		});
 	};
 
@@ -346,6 +348,7 @@ void ActionMode::on_game_control_set() {
 			this->selecting && !this->type_focus) {
 
 			this->selection->drag_update(mousepos_camgame);
+			this->announce_current_selection();
 			return true;
 		}
 		return false;
@@ -453,6 +456,10 @@ void ActionMode::render() {
 
 		this->announce_resources();
 
+		if (this->selection && this->selection->get_units_count() > 0) {
+			this->announce_current_selection();
+		}
+
 		// when a building is being placed
 		if (this->type_focus) {
 			auto txt = this->type_focus->default_texture();
@@ -463,7 +470,7 @@ void ActionMode::render() {
 		}
 	}
 	else {
-		engine->render_text({0, 140}, 12, "Action Mode requires a game");
+		engine->render_text({0, 140}, 12, renderer::Colors::WHITE, "Action Mode requires a game");
 	}
 
 	ENSURE(this->selection != nullptr, "selection not set");
@@ -834,7 +841,13 @@ void GameControl::announce_current_player_name() {
 		emit this->gui_signals.current_player_name_changed(
 			"[" + std::to_string(player->color) + "] " + player->name);
 		emit this->gui_signals.current_civ_index_changed(player->civ->civ_id);
+
 	}
+}
+
+void ActionMode::announce_current_selection() {
+
+	emit this->gui_signals.selection_changed(this->selection);
 }
 
 bool GameControl::on_drawhud() {

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -148,6 +148,7 @@ public slots:
 signals:
 	void resource_changed(game_resource resource, int amount);
 	void population_changed(int demand, int capacity, bool warn);
+	void selection_changed(UnitSelection *unit_selection);
 	void ability_changed(const std::string &ability);
 	void buttons_type_changed(const ActionButtonsType type);
 
@@ -190,6 +191,8 @@ private:
 	 * (if changed)
 	 */
 	void announce_buttons_type();
+
+	void announce_current_selection();
 
 	/**
 	 * decides which type of right mouse click command
@@ -335,6 +338,7 @@ signals:
 
 	void current_player_name_changed(const std::string &current_player_name);
 	void current_civ_index_changed(int current_civ_index);
+	void is_selected_unit_changed(bool is_selected_unit);
 
 private:
 	GameControl *game_control;

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/game_control.h
+++ b/libopenage/game_control.h
@@ -148,7 +148,7 @@ public slots:
 signals:
 	void resource_changed(game_resource resource, int amount);
 	void population_changed(int demand, int capacity, bool warn);
-	void selection_changed(UnitSelection *unit_selection);
+	void selection_changed(const UnitSelection *unit_selection, const Player *player);
 	void ability_changed(const std::string &ability);
 	void buttons_type_changed(const ActionButtonsType type);
 

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "generator.h"
 

--- a/libopenage/gamestate/generator.cpp
+++ b/libopenage/gamestate/generator.cpp
@@ -134,7 +134,8 @@ Generator::Generator(qtsdl::GuiItemLink *gui_link)
 	this->setv("player_radius", 10);
 	this->setv("load_filename", "/tmp/default_save.oas");
 	this->setv("from_file", false);
-	this->set_csv("player_names", std::vector<std::string>{"name1", "name2"});
+	// TODO pick the users name
+	this->set_csv("player_names", std::vector<std::string>{"Jonas", "Michael"});
 }
 
 std::shared_ptr<GameSpec> Generator::get_spec() const {
@@ -145,7 +146,7 @@ std::vector<std::string> Generator::player_names() const {
 	auto result = this->get_csv("player_names");
 
 	// gaia is player 0
-	result.insert(result.begin(), "gaia");
+	result.insert(result.begin(), "Gaia");
 
 	return result;
 }

--- a/libopenage/gui/actions_list_model.cpp
+++ b/libopenage/gui/actions_list_model.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 the openage authors. See copying.md for legal info.
+// Copyright 2016-2019 the openage authors. See copying.md for legal info.
 
 #include "actions_list_model.h"
 
@@ -91,6 +91,7 @@ void ActionsListModel::set_active_buttons(const ActionButtonsType &active_button
 		this->add_button(32, -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_UNIV");
 		this->add_button(28, -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_RTWC");
 		this->add_button(37, -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_WNDR");
+		// the go back button is not in this slp (is in hudactions.slp.png)
 		this->endResetModel();
 		break;
 
@@ -109,6 +110,7 @@ void ActionsListModel::set_active_buttons(const ActionButtonsType &active_button
 		this->add_button(42, -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_WCTW4");
 		this->add_button(36, -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_GTCA2");
 		this->add_button(7,  -1, static_cast<int>(GroupIDs::NoGroup), "BUILDING_CSTL");
+		// the go back button is not in this slp (is in hudactions.slp.png)
 		this->endResetModel();
 		break;
 

--- a/libopenage/gui/engine_link.cpp
+++ b/libopenage/gui/engine_link.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "engine_link.h"
 
@@ -89,6 +89,8 @@ void EngineLink::on_global_binds_changed(const std::vector<std::string>& global_
 			return QString::fromStdString(s);
 		}
 	);
+
+	new_global_binds.sort();
 
 	if (this->global_binds != new_global_binds) {
 		this->global_binds = new_global_binds;

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -164,7 +164,12 @@ void ActionModeLink::on_selection_changed(UnitSelection *unit_selection) {
 			if (u->has_attribute(attr_type::hitpoints) && u->has_attribute(attr_type::damaged)) {
 				auto &hp = u->get_attribute<attr_type::hitpoints>();
 				auto &dm = u->get_attribute<attr_type::damaged>();
-				this->selection_hp = QString::fromStdString("[====] "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
+				// TODO replace ascii health bar with real one
+				if (hp.hp >= 200) {
+					this->selection_hp = QString::fromStdString("[========] "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
+				} else {
+					this->selection_hp = QString::fromStdString("[====] "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
+				}
 			} else {
 				this->selection_hp = QString::fromStdString("-");
 			}

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "game_control_link.h"
 
@@ -159,6 +159,7 @@ void ActionModeLink::on_selection_changed(UnitSelection *unit_selection) {
 				auto &own_attr = u->get_attribute<attr_type::owner>();
 				this->selection_owner = QString::fromStdString(
 						own_attr.player.name + "\n"  + own_attr.player.civ->civ_name);
+				// TODO find the team status of the player
 			}
 
 			if (u->has_attribute(attr_type::hitpoints) && u->has_attribute(attr_type::damaged)) {

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -144,7 +144,7 @@ void ActionModeLink::on_population_changed(int demand, int capacity, bool warn) 
 	emit this->population_changed();
 }
 
-void ActionModeLink::on_selection_changed(UnitSelection *unit_selection) {
+void ActionModeLink::on_selection_changed(const UnitSelection *unit_selection, const Player *player) {
 	this->selection = unit_selection;
 
 	if (this->selection->get_units_count() == 1) {
@@ -165,7 +165,10 @@ void ActionModeLink::on_selection_changed(UnitSelection *unit_selection) {
 				auto &own_attr = u->get_attribute<attr_type::owner>();
 				if (own_attr.player.civ->civ_id != 0) { // not gaia
 					this->selection_owner = QString::fromStdString(
-						own_attr.player.name + "\n" + own_attr.player.civ->civ_name);
+						own_attr.player.name + "\n" + own_attr.player.civ->civ_name + "\n" +
+						(!player || *player == own_attr.player ? ""
+						: player->is_ally(own_attr.player) ? "Ally" : "Enemy")
+					);
 					// TODO find the team status of the player
 				} else {
 					this->selection_owner = QString::fromStdString(" ");

--- a/libopenage/gui/game_control_link.cpp
+++ b/libopenage/gui/game_control_link.cpp
@@ -153,6 +153,12 @@ void ActionModeLink::on_selection_changed(UnitSelection *unit_selection) {
 			Unit *u = ref.get();
 
 			this->selection_name = QString::fromStdString(u->unit_type->name());
+			// the icons are split into two sprites
+			if (u->unit_type->unit_class == gamedata::unit_classes::BUILDING) {
+				this->selection_icon = QString::fromStdString("50706.slp.png." + std::to_string(u->unit_type->icon));
+			} else {
+				this->selection_icon = QString::fromStdString("50730.slp.png." + std::to_string(u->unit_type->icon));
+			}
 			this->selection_type = QString::fromStdString("(type: " + std::to_string(u->unit_type->id()) + " " + u->top()->name() + ")");
 
 			if (u->has_attribute(attr_type::owner)) {

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -164,6 +164,8 @@ private:
 	QString selection_owner;
 	QString selection_hp;
 	QString selection_attrs;
+
+	std::string progress(float progress, int size);
 };
 
 class EditorModeLink;

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -150,7 +150,7 @@ private slots:
 	void on_ability_changed(const std::string &ability);
 	void on_buttons_type_changed(const ActionButtonsType buttons_type);
 	void on_population_changed(int demand, int capacity, bool warn);
-	void on_selection_changed(UnitSelection *unit_selection);
+	void on_selection_changed(const UnitSelection *unit_selection, const Player *player);
 
 private:
 	virtual void on_core_adopted() override;
@@ -158,7 +158,7 @@ private:
 	QString ability;
 	QString population;
 	bool population_warn;
-	UnitSelection *selection;
+	const UnitSelection *selection;
 
 	QString selection_name;
 	QString selection_icon;

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -122,6 +122,7 @@ class ActionModeLink : public qtsdl::Inherits<OutputModeLink, ActionModeLink> {
 	Q_PROPERTY(int selection_size READ get_selection_size NOTIFY selection_changed)
 
 	Q_PROPERTY(QString selection_name MEMBER selection_name NOTIFY selection_changed)
+	Q_PROPERTY(QString selection_icon MEMBER selection_icon NOTIFY selection_changed)
 	Q_PROPERTY(QString selection_type MEMBER selection_type NOTIFY selection_changed)
 	Q_PROPERTY(QString selection_owner MEMBER selection_owner NOTIFY selection_changed)
 	Q_PROPERTY(QString selection_hp MEMBER selection_hp NOTIFY selection_changed)
@@ -160,6 +161,7 @@ private:
 	UnitSelection *selection;
 
 	QString selection_name;
+	QString selection_icon;
 	QString selection_type;
 	QString selection_owner;
 	QString selection_hp;

--- a/libopenage/gui/game_control_link.h
+++ b/libopenage/gui/game_control_link.h
@@ -119,6 +119,14 @@ class ActionModeLink : public qtsdl::Inherits<OutputModeLink, ActionModeLink> {
 	Q_PROPERTY(QString population READ get_population NOTIFY population_changed)
 	Q_PROPERTY(bool population_warn READ get_population_warn NOTIFY population_changed)
 
+	Q_PROPERTY(int selection_size READ get_selection_size NOTIFY selection_changed)
+
+	Q_PROPERTY(QString selection_name MEMBER selection_name NOTIFY selection_changed)
+	Q_PROPERTY(QString selection_type MEMBER selection_type NOTIFY selection_changed)
+	Q_PROPERTY(QString selection_owner MEMBER selection_owner NOTIFY selection_changed)
+	Q_PROPERTY(QString selection_hp MEMBER selection_hp NOTIFY selection_changed)
+	Q_PROPERTY(QString selection_attrs MEMBER selection_attrs NOTIFY selection_changed)
+
 public:
 	ActionModeLink(QObject *parent=nullptr);
 	virtual ~ActionModeLink();
@@ -126,6 +134,7 @@ public:
 	QString get_ability() const;
 	QString get_population() const;
 	bool get_population_warn() const;
+	int get_selection_size() const;
 
 	Q_INVOKABLE void act(const QString &action);
 
@@ -134,11 +143,13 @@ signals:
 	void action_triggered(const std::string &ability);
 	void buttons_type_changed(const ActionButtonsType buttons_type);
 	void population_changed();
+	void selection_changed();
 
 private slots:
 	void on_ability_changed(const std::string &ability);
 	void on_buttons_type_changed(const ActionButtonsType buttons_type);
 	void on_population_changed(int demand, int capacity, bool warn);
+	void on_selection_changed(UnitSelection *unit_selection);
 
 private:
 	virtual void on_core_adopted() override;
@@ -146,6 +157,13 @@ private:
 	QString ability;
 	QString population;
 	bool population_warn;
+	UnitSelection *selection;
+
+	QString selection_name;
+	QString selection_type;
+	QString selection_owner;
+	QString selection_hp;
+	QString selection_attrs;
 };
 
 class EditorModeLink;

--- a/libopenage/renderer/color.cpp
+++ b/libopenage/renderer/color.cpp
@@ -31,4 +31,7 @@ bool Color::operator!=(const Color &other) const {
 	return !operator==(other);
 }
 
+Color Colors::WHITE = {255, 255, 255, 255};
+Color Colors::BLACK = {  0,   0,   0, 255};
+
 }} // openage::renderer

--- a/libopenage/renderer/color.cpp
+++ b/libopenage/renderer/color.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "color.h"
 

--- a/libopenage/renderer/color.h
+++ b/libopenage/renderer/color.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/renderer/color.h
+++ b/libopenage/renderer/color.h
@@ -9,6 +9,7 @@ namespace renderer {
 
 class Color {
 public:
+
 	Color();
 
 	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
@@ -21,6 +22,14 @@ public:
 	uint8_t g;
 	uint8_t b;
 	uint8_t a;
+
+};
+
+class Colors {
+public:
+
+	static Color WHITE;
+	static Color BLACK;
 
 };
 

--- a/libopenage/unit/producer.cpp
+++ b/libopenage/unit/producer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 #include <initializer_list>
 
@@ -97,6 +97,7 @@ ObjectProducer::ObjectProducer(const Player &owner, const GameSpec &spec, const 
 
 	// copy the class type
 	this->unit_class = this->unit_data.unit_class;
+	this->icon = this->unit_data.icon_id;
 
 	// for now just look for type names ending with "_D"
 	this->decay = unit_data.name.substr(unit_data.name.length() - 2) == "_D";
@@ -531,6 +532,7 @@ BuildingProducer::BuildingProducer(const Player &owner, const GameSpec &spec, co
 
 	// copy the class type
 	this->unit_class = this->unit_data.unit_class;
+	this->icon = this->unit_data.icon_id;
 
 	// find suitable sounds
 	int creation_sound = this->unit_data.train_sound;

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -8,6 +8,7 @@
 #include "../coord/tile.h"
 #include "../engine.h"
 #include "../log/log.h"
+#include "../renderer/text.h"
 #include "../terrain/terrain.h"
 #include "action.h"
 #include "command.h"
@@ -21,7 +22,7 @@ UnitSelection::UnitSelection(Engine *engine)
 	:
 	selection_type{selection_type_t::nothing},
 	drag_active{false},
-	font_size{12},
+	font_size{14},
 	engine{engine} {
 }
 
@@ -77,14 +78,6 @@ bool UnitSelection::on_drawhud() {
 		}
 	}
 	glColor3f(1.0, 1.0, 1.0); // reset
-
-	// display details of single selected unit
-	if (this->units.size() == 1) {
-		auto &ref = this->units.begin()->second;
-		if (ref.is_valid()) {
-			this->show_attributes(ref.get());
-		}
-	}
 
 	// ui graphics 3404 and 3405
 	return true;
@@ -277,42 +270,6 @@ void UnitSelection::all_invoke(Command &cmd) {
 			// TODO: queue_cmd returns ability which allows playing of sound
 			u.second.get()->queue_cmd(cmd);
 		}
-	}
-}
-
-void UnitSelection::show_attributes(Unit *u) {
-	std::vector<std::string> lines;
-	lines.push_back(u->top()->name());
-	lines.push_back("type: "+std::to_string(u->unit_type->id()));
-
-	if (u->has_attribute(attr_type::owner)) {
-		auto &own_attr = u->get_attribute<attr_type::owner>();
-		lines.push_back(own_attr.player.name);
-	}
-	if (u->has_attribute(attr_type::hitpoints) && u->has_attribute(attr_type::damaged)) {
-		auto &hp = u->get_attribute<attr_type::hitpoints>();
-		auto &dm = u->get_attribute<attr_type::damaged>();
-		lines.push_back("hitpoints: "+std::to_string(dm.hp)+"/"+std::to_string(hp.hp));
-	}
-	if (u->has_attribute(attr_type::resource)) {
-		auto &res_attr = u->get_attribute<attr_type::resource>();
-		lines.push_back("resource: "+std::to_string(res_attr.amount)+" "+std::to_string(res_attr.resource_type));
-	}
-	if (u->has_attribute(attr_type::building)) {
-		auto &build_attr = u->get_attribute<attr_type::building>();
-		lines.push_back("built: "+std::to_string(build_attr.completed));
-	}
-	if (u->has_attribute(attr_type::garrison)) {
-		auto &garrison_attr = u->get_attribute<attr_type::garrison>();
-		lines.push_back("garrison: "+std::to_string(garrison_attr.content.size()));
-	}
-
-	// render text
-	int vpos = 160;
-	this->engine->render_text({0, vpos}, 20, "%s", u->unit_type->name().c_str());
-	for (auto &s : lines) {
-		vpos -= this->font_size;
-		engine->render_text({0, vpos}, this->font_size, "%s", s.c_str());
 	}
 }
 

--- a/libopenage/unit/selection.cpp
+++ b/libopenage/unit/selection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "selection.h"
 
@@ -22,7 +22,6 @@ UnitSelection::UnitSelection(Engine *engine)
 	:
 	selection_type{selection_type_t::nothing},
 	drag_active{false},
-	font_size{14},
 	engine{engine} {
 }
 

--- a/libopenage/unit/selection.h
+++ b/libopenage/unit/selection.h
@@ -82,11 +82,11 @@ public:
 	 */
 	void all_invoke(Command &cmd);
 
+	int get_units_count() { return this->units.size(); }
+
+	UnitReference & get_first_unit() { return this->units.begin()->second; }
+
 private:
-	/**
-	 * Must be given a valid unit to display text attribute indicators.
-	 */
-	void show_attributes(Unit *);
 
 	/**
 	 * Check whether the currently selected units may be selected at the same time

--- a/libopenage/unit/selection.h
+++ b/libopenage/unit/selection.h
@@ -82,9 +82,9 @@ public:
 	 */
 	void all_invoke(Command &cmd);
 
-	int get_units_count() { return this->units.size(); }
+	int get_units_count() const { return this->units.size(); }
 
-	UnitReference & get_first_unit() { return this->units.begin()->second; }
+	const UnitReference & get_first_unit() const { return this->units.begin()->second; }
 
 private:
 

--- a/libopenage/unit/selection.h
+++ b/libopenage/unit/selection.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -105,7 +105,6 @@ private:
 	bool drag_active;
 	// TODO: turn these into a C++17 optional
 	coord::camgame start = {0, 0}, end = {0, 0};
-	int font_size;
 
 	/**
 	 * Engine where this selection is attached to.

--- a/libopenage/unit/unit_type.h
+++ b/libopenage/unit/unit_type.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -179,6 +179,11 @@ public:
 	 * The set of graphics used for this type
 	 */
 	graphic_set graphics;
+
+	/**
+	 * The index of the icon representing this unit
+	 */
+	int icon;
 
 	/**
 	 * the square dimensions of the placement

--- a/libopenage/util/fps.cpp
+++ b/libopenage/util/fps.cpp
@@ -42,6 +42,10 @@ void FrameCounter::frame() {
 		fps = 1e9 * this->frame_count_weighted / this->frame_length_sum_weighted;
 	}
 
+	if (count % 20 == 0) {
+		display_fps = fps;
+	}
+
 	count += 1;
 }
 

--- a/libopenage/util/fps.cpp
+++ b/libopenage/util/fps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2016 the openage authors. See copying.md for legal info.
+// Copyright 2013-2019 the openage authors. See copying.md for legal info.
 
 #include "fps.h"
 

--- a/libopenage/util/fps.h
+++ b/libopenage/util/fps.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2016 the openage authors. See copying.md for legal info.
+// Copyright 2013-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/util/fps.h
+++ b/libopenage/util/fps.h
@@ -18,6 +18,9 @@ public:
 	/** auto-updated to always contain the current FPS value */
 	float fps;
 
+	/** auto-updated every 20 frames to always contain the current FPS value */
+	float display_fps;
+
 	/** contains the number of completed frames */
 	uint64_t count;
 

--- a/libopenage/util/profiler.cpp
+++ b/libopenage/util/profiler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include "profiler.h"
 #include "../engine.h"

--- a/libopenage/util/profiler.cpp
+++ b/libopenage/util/profiler.cpp
@@ -2,6 +2,7 @@
 
 #include "profiler.h"
 #include "../engine.h"
+#include "../renderer/color.h"
 #include "misc.h"
 
 #include <chrono>
@@ -171,7 +172,7 @@ void Profiler::draw_legend() {
 
 		glColor4f(0.2, 0.2, 0.2, 1);
 		coord::viewport position = coord::viewport{box_x + PROFILER_COM_BOX_WIDTH + 2, box_y + 2};
-		this->engine->render_text(position, 12, "%s", com.second.display_name.c_str());
+		this->engine->render_text(position, 12, renderer::Colors::WHITE, "%s", com.second.display_name.c_str());
 
 		offset += PROFILER_COM_BOX_HEIGHT + 2;
 	}

--- a/openage/convert/gamedata/unit.py
+++ b/openage/convert/gamedata/unit.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2017 the openage authors. See copying.md for legal info.
+# Copyright 2013-2019 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,too-many-lines
 
@@ -560,7 +560,7 @@ class UnitObject(Exportable):
         (READ_EXPORT, "dead_unit_id", "int16_t"),        # unit id to become on death
         (READ, "placement_mode", "int8_t"),              # 0=placable on top of others in scenario editor, 5=can't
         (READ, "can_be_built_on", "int8_t"),             # 1=no footprints
-        (READ, "icon_id", "int16_t"),                    # frame id of the icon slp (57029) to place on the creation button
+        (READ_EXPORT, "icon_id", "int16_t"),             # frame id of the icon slp (57029) to place on the creation button
         (READ, "hidden_in_editor", "int8_t"),
         (READ, "old_portrait_icon_id", "int16_t"),
         (READ, "enabled", "int8_t"),                     # 0=unlocked by research, 1=insta-available


### PR DESCRIPTION
Some small gui improvements. There always have been those small gui things that make the first glance of the game little bit... so:

- Moved the unit info to the qml
- Cleaned the player name and abilty info
- Default debug overlay to invisible
- Slower fps updates so they are readable 

![Screenshot from 2019-09-20 18-07-55](https://user-images.githubusercontent.com/6997990/65337826-9d95d180-dbd1-11e9-926d-66f5b390d78f.png)

(Health bar is placeholder (next pr))

Edit (simonsan): Closes #611 