### PR TITLE
Add clang-tidy to buildsystem checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,6 @@ option(
 )
 
 if(ENABLE_CLANG_TIDY)
-	set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 	set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*,performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*,readability-*,llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, llvm-prefer-register-over-unsigned, google-readability-casting -extra-arg=-std=c++17")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,13 +141,12 @@ endif()
 option(
 	ENABLE_CLANG_TIDY
 	"activate clang tidy messages"
-	ON
+	OFF
 )
 
 if(ENABLE_CLANG_TIDY)
 	set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 	set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*,performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*,readability-*,llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, llvm-prefer-register-over-unsigned, google-readability-casting -extra-arg=-std=c++17")
-
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,10 +141,13 @@ endif()
 option(
 	ENABLE_CLANG_TIDY
 	"activate clang tidy messages"
-	OFF
+	ON
 )
+
 if(ENABLE_CLANG_TIDY)
-	set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-*,readability-*")
+	set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
+	set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*,performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*,readability-*,llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, llvm-prefer-register-over-unsigned, google-readability-casting -extra-arg=-std=c++17")
+
 endif()
 
 

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ checkfast:
 checkall:
 	python3 -m buildsystem.codecompliance --all
 
+.PHONY: diagnose
+diagnose:
+	python3 -m buildsystem.diagnose --all
+
 .PHONY: checkchanged
 checkchanged:
 	python3 -m buildsystem.codecompliance --all --only-changed-files=origin/master

--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -47,7 +47,6 @@ def parse_args():
                            "copyright year matches the git history."))
     cli.add_argument("--clangtidy", action="store_true",
                      help="check the cpp code with clang-tidy")
-
     cli.add_argument("--fix", action="store_true",
                      help=("try to automatically fix the found issues"))
 

--- a/buildsystem/codecompliance/clangtidy.py
+++ b/buildsystem/codecompliance/clangtidy.py
@@ -12,10 +12,10 @@ from .util import findfiles
 
 def find_issues(check_files, dirnames):
     """ Invokes the external clang-tidy tool. """
-    invocation = ['clang-tidy', '-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*, ' + 
-                  'performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*, ' + 
-                  'llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, ' + 
-                  'llvm-prefer-register-over-unsigned,google-readability-casting ' + 
+    invocation = ['clang-tidy', '-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*, ' +
+                  'performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*, ' +
+                  'llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, ' +
+                  'llvm-prefer-register-over-unsigned,google-readability-casting ' +
                   '-extra-arg=-std=c++17']
 
     if check_files is not None:

--- a/buildsystem/codecompliance/clangtidy.py
+++ b/buildsystem/codecompliance/clangtidy.py
@@ -1,0 +1,27 @@
+# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+
+import subprocess
+
+from .cppstyle import filter_file_list
+from .util import findfiles
+
+
+def find_issues(check_files, dirnames):
+    """ Invokes the external clang-tidy tool. """
+
+    invocation = ['clang-tidy', '-checks=-*,readability-*']
+
+    if check_files is not None:
+        filenames = filter_file_list(check_files, dirnames)
+    else:
+        filenames = filter_file_list(findfiles(dirnames), dirnames)
+
+    invocation.extend(filenames)
+
+    try:
+        retcode = subprocess.check_call(invocation)
+    except subprocess.CalledProcessError as exc:
+        retcode = exc.returncode
+
+    if retcode:
+        yield ("clang-tidy issue", f"clang-tidy exited with return code {retcode}", None)

--- a/buildsystem/codecompliance/clangtidy.py
+++ b/buildsystem/codecompliance/clangtidy.py
@@ -16,7 +16,7 @@ def find_issues(check_files, dirnames):
                   'performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*, ' +
                   'llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, ' +
                   'llvm-prefer-register-over-unsigned,google-readability-casting ' +
-                  '-extra-arg=-std=c++17']
+                  '-extra-arg=-std=c++17 -fix']
 
     if check_files is not None:
         filenames = filter_file_list(check_files, dirnames)

--- a/buildsystem/codecompliance/clangtidy.py
+++ b/buildsystem/codecompliance/clangtidy.py
@@ -1,4 +1,8 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+
+"""
+Checks Cpp files with clang-tidy
+"""
 
 import subprocess
 
@@ -8,8 +12,11 @@ from .util import findfiles
 
 def find_issues(check_files, dirnames):
     """ Invokes the external clang-tidy tool. """
-
-    invocation = ['clang-tidy', '-checks=-*,readability-*']
+    invocation = ['clang-tidy', '-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*, ' + 
+                  'performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*, ' + 
+                  'llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, ' + 
+                  'llvm-prefer-register-over-unsigned,google-readability-casting ' + 
+                  '-extra-arg=-std=c++17']
 
     if check_files is not None:
         filenames = filter_file_list(check_files, dirnames)

--- a/buildsystem/codecompliance/clangtidy.py
+++ b/buildsystem/codecompliance/clangtidy.py
@@ -12,11 +12,9 @@ from .util import findfiles
 
 def find_issues(check_files, dirnames):
     """ Invokes the external clang-tidy tool. """
-    invocation = ['clang-tidy', '-checks=cppcoreguidelines-*,clang-analyzer-*,bugprone-*, ' +
-                  'performance-*,portability-*,misc-*,modernize-*,hicpp-*,cert-*, ' +
-                  'llvm-twine-local,llvm-prefer-isa-or-dyn-cast-in-conditionals, ' +
-                  'llvm-prefer-register-over-unsigned,google-readability-casting ' +
-                  '-extra-arg=-std=c++17 -fix']
+    invocation = ['clang-tidy', '-checks=clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,' +
+                  '-clang-analyzer-optin.performance.Padding,cppcoreguidelines-*,performance-*,llvm-*,' +
+                  'bugprone-*,cert-*, -extra-arg=-std=c++17 -fix']
 
     if check_files is not None:
         filenames = filter_file_list(check_files, dirnames)

--- a/buildsystem/diagnose/__init__.py
+++ b/buildsystem/diagnose/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+
+"""
+TODO: Write something here
+
+"""

--- a/buildsystem/diagnose/__main__.py
+++ b/buildsystem/diagnose/__main__.py
@@ -1,0 +1,268 @@
+# Copyright 2014-2019 the openage authors. See copying.md for legal info.
+
+"""
+Entry point for the code diagnose module.
+"""
+
+import argparse
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+
+
+def parse_args():
+    """ Returns the raw argument namespace. """
+
+    cli = argparse.ArgumentParser()
+    cli.add_argument("--clangtidy", action="store_true",
+                     help="check the cpp code with clang-tidy")
+    cli.add_argument("--fast", action="store_true",
+                     help="do all checks that can be performed quickly")
+    cli.add_argument("--all", action="store_true",
+                     help="do all checks, even the really slow ones")
+    cli.add_argument("--only-changed-files", metavar='GITREF',
+                     help=("slow checks are only done on files that have "
+                           "changed since GITREF."))
+    cli.add_argument("--textfiles", action="store_true",
+                     help="check text files for whitespace issues")
+    cli.add_argument("--headerguards", action="store_true",
+                     help="check all header guards")
+    cli.add_argument("--cppstyle", action="store_true",
+                     help=("check the cpp code style"))
+    cli.add_argument("--pystyle", action="store_true",
+                     help=("check whether the python code complies with "
+                           "(a selected subset of) pep8."))
+    cli.add_argument("--pylint", action="store_true",
+                     help=("run pylint on the python code"))
+    cli.add_argument("--filemodes", action="store_true",
+                     help=("check whether files in the repo have the "
+                           "correct access bits (-> 0644) "))
+    cli.add_argument("--authors", action="store_true",
+                     help=("check whether all git authors are in copying.md. "
+                           "repo must be a git repository."))
+    cli.add_argument("--legal", action="store_true",
+                     help="check whether all sourcefiles have legal headers")
+    cli.add_argument("--test-git-change-years", action="store_true",
+                     help=("when doing legal checks, test whether the "
+                           "copyright year matches the git history."))
+
+    cli.add_argument("--fix", action="store_true",
+                     help=("try to automatically fix the found issues"))
+
+    args = cli.parse_args()
+    process_args(args, cli.error)
+
+    return args
+
+
+def process_args(args, error):
+    """
+    Sanitizes the given argument namespace, modifying it in the process.
+
+    Calls error (with a string argument) in case of errors.
+    """
+    # this method is very flat; artificially nesting it would be bullshit.
+    # pylint: disable=too-many-branches
+
+    if args.fast or args.all:
+        # enable "fast" tests
+        args.headerguards = True
+        args.legal = True
+        args.authors = True
+        args.textfiles = True
+        args.cppstyle = True
+        args.filemodes = True
+
+    if args.all:
+        # enable tests that take a bit longer
+
+        args.pystyle = True
+        args.pylint = True
+        args.test_git_change_years = True
+        args.clangtidy = True
+
+    if not any((args.headerguards, args.legal, args.authors, args.pystyle,
+                args.cppstyle, args.test_git_change_years, args.pylint,
+                args.filemodes, args.textfiles, args.clangtidy)):
+        error("no checks were specified")
+
+    has_git = bool(shutil.which('git'))
+    is_git_repo = os.path.isdir('.git')
+
+    if args.only_changed_files and not all((has_git, is_git_repo)):
+        error("can not check only changed files: git is required")
+
+    if args.authors:
+        if not all((has_git, is_git_repo)):
+            # non-fatal fail
+            print("can not check author list for compliance: git is required")
+            args.authors = False
+
+    if args.test_git_change_years:
+        if not args.legal:
+            error("--test-git-change-years may only be passed with --legal")
+
+        if not all((has_git, is_git_repo)):
+            error("--test-git-change-years requires git")
+
+    if args.pystyle:
+        if not importlib.util.find_spec('pep8') and \
+           not importlib.util.find_spec('pycodestyle'):
+
+            error("pep8 or pycodestyle python module "
+                  "required for style checking")
+
+    if args.pylint:
+        if not importlib.util.find_spec('pylint'):
+            error("pylint python module required for linting")
+
+    if args.clangtidy:
+        has_clangtidy = bool(shutil.which('clang-tidy'))
+        if not has_clangtidy:
+            error("--clang-tidy requires clang-tidy")
+
+
+def get_changed_files(gitref):
+    """
+    return a list of changed files
+    """
+    invocation = ['git', 'diff', '--name-only', '--diff-filter=ACMRTUXB',
+                  gitref]
+
+    try:
+        file_list = subprocess.check_output(invocation)
+
+    except subprocess.CalledProcessError as exc:
+        raise Exception(
+            "could not determine list of recently-changed files with git"
+        ) from exc
+
+    return set(file_list.decode('ascii').strip().split('\n'))
+
+
+def main(args):
+    """
+    Takes an argument namespace as returned by parse_args.
+
+    Calls find_all_issues(main args, list of files to consider)
+
+    Returns True if no issues were found.
+    """
+    if args.only_changed_files:
+        check_files = get_changed_files(args.only_changed_files)
+    else:
+        check_files = None
+
+    auto_fixes = list()
+    fixes_possible = False
+
+    issues_count = 0
+    for title, text, apply_fix in find_all_issues(args, check_files):
+        issues_count += 1
+        print("\x1b[33;1mWARNING\x1b[m {}: {}".format(title, text))
+
+        if apply_fix:
+            fixes_possible = True
+
+            if args.fix:
+                print("        This will be fixed automatically.")
+                auto_fixes.append(apply_fix)
+            else:
+                print("        This can be fixed automatically.")
+
+        # nicely seperate warnings
+        print()
+
+    if args.fix and auto_fixes:
+        print("\x1b[33;1mApplying %d "
+              "automatic fixes...\x1b[m" % len(auto_fixes))
+
+        for auto_fix in auto_fixes:
+            print(auto_fix())
+            issues_count -= 1
+
+        print()
+
+    if issues_count > 0:
+        plural = "s" if issues_count > 1 else ""
+
+        if args.fix and auto_fixes:
+            remainfound = "remain%s" % plural
+        else:
+            remainfound = ("were" if issues_count > 1 else "was") + " found"
+
+        print("==> \x1b[33;1m{num} issue{plural}\x1b[m {remainfound}."
+              "".format(num=issues_count,
+                        plural=plural,
+                        remainfound=remainfound))
+
+        if not args.fix and fixes_possible:
+            print("When invoked with --fix, I can try"
+                  "to automatically resolve some of the issues.\n")
+
+    return issues_count == 0
+
+
+def find_all_issues(args, check_files=None):
+    """
+    Invokes all the individual issue checkers, and yields their returned
+    issues.
+
+    If check_files is not None, all other files are ignored during the
+    more resource-intense checks.
+    That is, check_files is the set of files to verify.
+
+    Yields tuples of (title, text) that are displayed as warnings.
+    """
+    if args.headerguards:
+        from .headerguards import find_issues
+        yield from find_issues('libopenage')
+
+    if args.authors:
+        from .authors import find_issues
+        yield from find_issues()
+
+    if args.pystyle:
+        from .pystyle import find_issues
+        yield from find_issues(check_files, ('openage', 'buildsystem'))
+
+    if args.cppstyle:
+        from .cppstyle import find_issues
+        yield from find_issues(check_files, ('libopenage',))
+
+    if args.pylint:
+        from .pylint import find_issues
+        yield from find_issues(check_files, ('openage', 'buildsystem'))
+
+    if args.textfiles:
+        from .textfiles import find_issues
+        yield from find_issues(
+            ('openage', 'libopenage', 'buildsystem', 'doc', 'legal'),
+            ('.pxd', '.pyx', '.pxi', '.py',
+             '.h', '.cpp', '.template',
+             '', '.txt', '.md', '.conf',
+             '.cmake', '.in', '.yml', '.supp', '.desktop'))
+
+    if args.legal:
+        from .legal import find_issues
+        yield from find_issues(check_files,
+                               ('openage', 'buildsystem', 'libopenage'),
+                               args.test_git_change_years)
+
+    if args.filemodes:
+        from .modes import find_issues
+        yield from find_issues(check_files, ('openage', 'buildsystem',
+                                             'libopenage'))
+
+    if args.clangtidy:
+        from .clangtidy import find_issues
+        yield from find_issues(check_files, ('libopenage',))
+
+
+if __name__ == '__main__':
+    if main(parse_args()):
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/buildsystem/diagnose/clangtidy.py
+++ b/buildsystem/diagnose/clangtidy.py
@@ -5,6 +5,7 @@ Checks Cpp files with clang-tidy
 """
 
 import subprocess
+import buildsystem
 
 from .cppstyle import filter_file_list
 from .util import findfiles

--- a/buildsystem/diagnose/cppstyle.py
+++ b/buildsystem/diagnose/cppstyle.py
@@ -1,0 +1,118 @@
+# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+
+"""
+Checks some code style rules for cpp files.
+"""
+
+import re
+
+from .util import findfiles, readfile, issue_str_line
+
+# spaces missing in `if () {` and `for`, `while`, ...
+MISSING_SPACES_RE = re.compile(
+    # on of the folowing, the first group is used for the column where
+    # the pointer is going to show
+    r"(?:"
+    # a ) folowed by a { without a space between
+    r"(?:\)(\{))|"
+    # a if/for/while folowed by a ( without a space between
+    r"(?:\s+(?:if|for|while)(\())"
+    r")"
+)
+
+# extra spaces before a ;
+EXTRA_SPACES_RE = re.compile(
+    # on of the folowing, the first group is used for the column where
+    # the pointer is going to show
+    r"(?:"
+    # a space before a ";"
+    r"(?:(\s+);)"
+    r")"
+)
+
+# indentation fails looking at a file
+INDENT_FAIL_RE = re.compile(
+    # leading whitespace fail
+    r"(?:"
+    r"(\n\t*[ ]+\t+)"         # \n tab* space+ tab+
+    r")"
+)
+
+# we need both because we look at the file first.
+# indentation fails when looking at a line
+INDENT_FAIL_LINE_RE = re.compile(
+    # leading whitespace fail
+    r"(?:"
+    r"(^\t*[ ]+\t+)"          # tab* space+ tab+
+    r")"
+)
+
+
+def filter_file_list(check_files, dirnames):
+    """
+    Yields all those files in check_files that are in one of the directories
+    and end in '.cpp' or '.h' and some other conditions.
+    """
+    for filename in check_files:
+        if not (filename.endswith('.cpp') or filename.endswith('.h')):
+            continue
+
+        if filename.endswith('.gen.h') or filename.endswith('.gen.cpp'):
+            # TODO all this for now, until someone fixes the codegen.
+            continue
+
+        if any(filename.startswith(dirname) for dirname in dirnames):
+            yield filename
+
+
+def find_issues(check_files, dirnames):
+    """
+    Finds all issues in the given directories (filtered by check_files).
+    """
+
+    if check_files is not None:
+        filenames = filter_file_list(check_files, dirnames)
+    else:
+        filenames = filter_file_list(findfiles(dirnames), dirnames)
+
+    for filename in filenames:
+        data = readfile(filename)
+        analyse_each_line = False
+
+        if MISSING_SPACES_RE.search(data) or\
+           EXTRA_SPACES_RE.search(data) or\
+           INDENT_FAIL_RE.search(data):
+
+            analyse_each_line = True
+
+        # if there are possible issues perform a per line analysis
+        if analyse_each_line:
+            yield from find_issues_with_lines(data, filename)
+
+
+def find_issues_with_lines(data, filename):
+    """
+    Checks a file for issues per line
+    """
+
+    for num, line in enumerate(data.splitlines(True), start=1):
+
+        match = MISSING_SPACES_RE.search(line)
+        if match:
+            start = match.start(1) + match.start(2)
+            end = start + 1
+            yield issue_str_line("Missing space",
+                                 filename, line, num,
+                                 (start, end))
+
+        match = EXTRA_SPACES_RE.search(line)
+        if match:
+            yield issue_str_line("Extra space",
+                                 filename, line, num,
+                                 (match.start(1), match.end(1)))
+
+        match = INDENT_FAIL_LINE_RE.search(line)
+        if match:
+            yield issue_str_line("Wrong indentation",
+                                 filename, line, num,
+                                 (match.start(1), match.end(1)))

--- a/buildsystem/diagnose/util.py
+++ b/buildsystem/diagnose/util.py
@@ -1,0 +1,125 @@
+# Copyright 2014-2018 the openage authors. See copying.md for legal info.
+
+"""
+Some utilities.
+"""
+
+import os
+
+
+SHEBANG = "#!/.*\n(#?\n)?"
+
+FILECACHE = {}
+BADUTF8FILES = set()
+
+
+def has_ext(fname, exts):
+    """
+    Returns true if fname ends in any of the extensions in ext.
+    """
+    for ext in exts:
+        if ext == '':
+            if os.path.splitext(fname)[1] == '':
+                return True
+        elif fname.endswith(ext):
+            return True
+
+    return False
+
+
+def readfile(filename):
+    """
+    reads the file, and returns it as a str object.
+
+    if the file has already been read in the past,
+    returns it from the cache.
+    """
+    if filename not in FILECACHE:
+        with open(filename, 'rb') as fileobj:
+            data = fileobj.read()
+
+        try:
+            data = data.decode('utf-8')
+        except UnicodeDecodeError:
+            data = data.decode('utf-8', errors='replace')
+            BADUTF8FILES.add(filename)
+
+        FILECACHE[filename] = data
+
+    return FILECACHE[filename]
+
+
+def writefile(filename, new_content):
+    """
+    writes the file and update it in the cache.
+    """
+    if filename in BADUTF8FILES:
+        raise Exception("%s: cannot write due to utf8-errors." % filename)
+
+    with open(filename, 'w') as fileobj:
+        fileobj.write(new_content)
+
+    FILECACHE[filename] = new_content
+
+
+def findfiles(paths, exts=None):
+    """
+    yields all files in paths with names ending in an ext from exts.
+
+    If exts is None, all extensions are accepted.
+
+    hidden dirs and files are ignored.
+    """
+    for path in paths:
+        for filename in os.listdir(path):
+            if filename.startswith('.'):
+                continue
+
+            filename = os.path.join(path, filename)
+
+            if os.path.isdir(filename):
+                yield from findfiles((filename,), exts)
+                continue
+
+            if exts is None or has_ext(filename, exts):
+                yield filename
+
+
+def issue_str(title, filename, fix=None):
+    """
+    Creates a formated (title, text) desciption of an issue.
+
+    TODO use this function and issue_str_line for all issues, so the format
+    can be easily changed (exta text, colors, etc)
+    """
+    return (title, filename, fix)
+
+
+# gread hint, pylint. thank you so much.
+# pylint: disable=too-many-arguments
+def issue_str_line(title, filename, line, line_number, highlight, fix=None):
+    """
+    Creates a formated (title, text) desciption of an issue with information
+    about the location in the file.
+    line:        line content
+    line_number: line id in the file
+    highlight:   a tuple of (start, end), where
+        start:   match start in the line
+        end:     match end in the line
+    """
+
+    start, end = highlight
+    start += 1
+    line = line.replace("\n", "").replace("\t", " ")
+
+    return (
+        title,
+        (
+            filename + "\n"
+            "\tline: " + str(line_number) + "\n"   # line number
+            "\tat:   '" + line + "'\n"             # line content
+            "\t      " + (' ' * start) +           # mark position with ^
+            "\x1b[32;1m^" + ("~" * (end - start)) + "\x1b[m"
+        ),
+        fix
+    )


### PR DESCRIPTION
Fixes #1060 continued from PR #1063 

Regarding #49 

Plan is: 

- [ ] Add a `diagnose` python-module that is making the checks after you call `./configure` (compile-commands.json) and add several other code-checks (clazy, etc.).
- [ ] Add a make target: `make diagnose` for all that checkups
- [ ] Export a (todo) list with warnings and errors for better overview
