### PR TITLE
[WIP] Autodrop and work

### DIFF
--- a/doc/nyan/api_reference/reference_aux.md
+++ b/doc/nyan/api_reference/reference_aux.md
@@ -1180,6 +1180,7 @@ A set of requirements that unlock the technology for the researching game entity
 Resource(Entity):
     name        : TranslatedString
     max_storage : int
+    autodrop    : bool
 ```
 
 Defines a resource that can be used in the game. Adding a resources will give an amount of 0 of that resource to all players. The current amount of resources can be influenced by the abilities and modifiers of game entities.
@@ -1189,6 +1190,9 @@ The name of the resource as a translatable string.
 
 **max_storage**
 Maximum amount of resources that can be stored at a time by the player.
+
+**autodrop**
+Determines whether a villager does not need a dropsite.
 
 ## aux.resource.ResourceContingent
 
@@ -1220,7 +1224,7 @@ The maximum contingent size.
 ```python
 ResourceAmount(Entity):
     type   : Resource
-    amount : int
+    amount : float
 ```
 
 A fixed amount of a certain resource.

--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #include <string>
 #include <cmath>
@@ -7,6 +7,20 @@
 #include "resource.h"
 
 namespace openage {
+
+ClassicResources::ClassicResources()
+	:
+	resources{{wood, "wood"},
+	          {food, "food"},
+	          {gold, "gold"},
+	          {stone, "stone"}} {
+}
+
+// TODO remove, here for transition period
+const Resource* ClassicResources::to_resource(game_resource& id) {
+	static ClassicResources cr = ClassicResources();
+	return &cr.get_resource((int) id);
+}
 
 ResourceBundle Resources::create_bundle() const {
 	return ResourceBundle(*this);

--- a/libopenage/gamestate/resource.h
+++ b/libopenage/gamestate/resource.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,11 +15,11 @@ class ResourceBundle;
 class Resource {
 public:
 
-	Resource();
-
 	virtual int id() const = 0;
 
 	virtual std::string name() const = 0;
+
+	virtual bool autodrop() const = 0;
 
 	// TODO add images and icons
 
@@ -28,20 +28,35 @@ public:
 class ResourceProducer : public Resource {
 public:
 
-	ResourceProducer(int id, std::string name)
+	ResourceProducer(int id, std::string name, bool autodrop = false)
 		:
 		_id{id},
-		_name{name} { }
+		_name{name},
+		_autodrop{autodrop} { }
 
 	int id() const override { return _id; }
 
 	std::string name() const override { return _name; }
 
+	bool autodrop() const override { return _autodrop; }
+
 private:
 
 	int _id;
 	std::string _name;
+	bool _autodrop;
 };
+
+
+// TODO remove, here for backwards compatibility
+enum class game_resource : int {
+	wood = 0,
+	food = 1,
+	gold = 2,
+	stone = 3,
+	RESOURCE_TYPE_COUNT = 4
+};
+
 
 /**
  * All the resources.
@@ -54,15 +69,13 @@ private:
 class Resources {
 public:
 
-	Resources();
-
 	virtual unsigned int get_count() const = 0;
 
 	virtual const Resource& get_resource(int id) const = 0;
 
 	ResourceBundle create_bundle() const;
 
-	// TODO remove when the engine is fully decupled from the data
+	// TODO remove when the engine is fully decoupled from the data
 	static const int wood = 0;
 	static const int food = 1;
 	static const int gold = 2;
@@ -73,30 +86,18 @@ public:
 class ClassicResources : public Resources {
 public:
 
-	ClassicResources()
-		:
-		resources{{Resources::wood, "wood"},
-		          {Resources::food, "food"},
-		          {Resources::gold, "gold"},
-		          {Resources::stone, "stone"}} {
-	}
+	ClassicResources();
 
 	unsigned int get_count() const override { return 4; }
 
 	const Resource& get_resource(int id) const override { return this->resources[id]; };
 
+	// TODO remove, here for transition period
+	static const Resource* to_resource(game_resource& id);
+
 private:
 
 	const ResourceProducer resources[4];
-};
-
-// TODO remove, here for backwards compatibility
-enum class game_resource : int {
-	wood = 0,
-	food = 1,
-	gold = 2,
-	stone = 3,
-	RESOURCE_TYPE_COUNT = 4
 };
 
 

--- a/libopenage/unit/action.cpp
+++ b/libopenage/unit/action.cpp
@@ -1099,9 +1099,26 @@ void GatherAction::update_in_range(unsigned int time, Unit *targeted_resource) {
 
 				// transfer using gather rate
 				double amount = worker.gather_rate[worker_resource.resource_type]
-				                * resource_attr.gather_rate * time;
-				worker_resource.amount += amount;
-				resource_attr.amount -= amount;
+								* resource_attr.gather_rate * time;
+
+				if (amount > resource_attr.amount) {
+					amount = resource_attr.amount;
+					resource_attr.amount = 0;
+				}
+				else {
+					resource_attr.amount -= amount;
+				}
+
+				bool autodrop = ClassicResources::to_resource(resource_attr.resource_type)->autodrop();
+				if (autodrop) {
+					// resources directly to player
+					auto &player = this->entity->get_attribute<attr_type::owner>().player;
+					player.receive(worker_resource.resource_type, amount);
+				}
+				else {
+					// resources to worker
+					worker_resource.amount += amount;
+				}
 			}
 		}
 	}

--- a/libopenage/unit/action.h
+++ b/libopenage/unit/action.h
@@ -556,6 +556,25 @@ private:
 	UnitReference nearest_dropsite(game_resource res_type);
 };
 
+
+/**
+ * Work at a workplace
+ */
+class WorkAction: public TargetAction {
+public:
+	WorkAction(Unit *e, UnitReference tar);
+	virtual ~WorkAction();
+
+	void update_in_range(unsigned int time, Unit *target_unit) override;
+	void on_completion() override;
+	void on_completion_in_range(int) override {};
+	bool completed_in_range(Unit *) const override { return target.is_valid(); }
+	std::string name() const override { return "work"; }
+
+private:
+	UnitReference target;
+};
+
 /**
  * attacks another unit
  */

--- a/libopenage/unit/attribute.h
+++ b/libopenage/unit/attribute.h
@@ -1,10 +1,11 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <map>
-#include <algorithm>
+#include <unordered_set>
 
 #include "../coord/tile.h"
 #include "../gamedata/unit.gen.h"
@@ -73,6 +74,8 @@ enum class attr_type {
 	resource,
 	resource_generator,
 	worker,
+	workplace,
+	workforce,
 	storage,
 	multitype,
 	garrison
@@ -579,6 +582,52 @@ public:
 	 * The ResourceBundle class is used but instead of amounts it stores gather rates.
 	 */
 	ResourceBundle gather_rate;
+};
+
+
+/**
+ * A place that workers can work and based on the work force resources are produced.
+ */
+template<> class Attribute<attr_type::workplace>: public SharedAttributeContainer {
+public:
+	Attribute()
+		:
+		SharedAttributeContainer{attr_type::workplace} {}
+
+	std::shared_ptr<AttributeContainer> copy() const override {
+		return std::make_shared<Attribute<attr_type::workplace>>(*this);
+	}
+
+	/**
+	 * The max number of workers.
+	 */
+	int capacity;
+
+	/**
+	 * The production rate for each resource per worker.
+	 * The ResourceBundle class is used but instead of amounts it stores productions rates.
+	 */
+	ResourceBundle production;
+
+};
+
+/**
+ * The workforce of a place that workers can work and based on the work force resources are produced.
+ */
+template<> class Attribute<attr_type::workforce>: public UnsharedAttributeContainer {
+public:
+	Attribute()
+		:
+		UnsharedAttributeContainer{attr_type::workforce} {}
+
+	std::shared_ptr<AttributeContainer> copy() const override {
+		return std::make_shared<Attribute<attr_type::workforce>>(*this);
+	}
+
+	/**
+	 * The units that are working.
+	 */
+	std::vector<UnitReference> workers;
 };
 
 /**

--- a/libopenage/unit/unit_container.cpp
+++ b/libopenage/unit/unit_container.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 #include "unit_container.h"
 
@@ -44,6 +44,10 @@ Unit *UnitReference::get() const {
 		throw Error{MSG(err) << "Unit reference is no longer valid"};
 	}
 	return this->data->unit_ptr;
+}
+
+bool UnitReference::operator==(const UnitReference &other) const {
+	return this->get() == other.get();
 }
 
 

--- a/libopenage/unit/unit_container.h
+++ b/libopenage/unit/unit_container.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -52,12 +52,14 @@ public:
 	UnitReference();
 
 	/**
-	 * create referece by unit id
+	 * create reference by unit id
 	 */
 	UnitReference(const UnitContainer *c, id_t id, Unit *);
 
 	bool is_valid() const;
 	Unit *get() const;
+
+	bool operator==(const UnitReference &other) const;
 
 private:
 


### PR DESCRIPTION
Added support for resources that are gather by the villagers to go directly to the player instead of the dropsite logic.

Autodrop is enabled per Resource.

Good examples are the Favor from AoM and all resources in AoE 3.

Talking about Favor, I was thinking how temple from AoM would work or Farms from AoE 3.

So, I added shared attribute `workplace` and unshared attribute `workforce` and the corresponding `WorkAction`.

(for testing, to enable the autodrop)
``` diff
ClassicResources::ClassicResources()
	:
	resources{{wood, "wood"},
-	          {food, "food"},
+	          {food, "food", true},
	          {gold, "gold"},
	          {stone, "stone"}} {
}
```