### PR TITLE
enum.h: add missing self-reference in assignment operator

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -123,6 +123,7 @@ _the openage authors_ are:
 | Lorenzo Gaifas              | brisvag                     | brisvag à gmail dawt com                          |
 | Shim Myeongseob             | violet716                   | zzangsim231 à gmail dawt com                      |
 | Serhan Tutar                | randomnoise                 | serhantutar à outlook dawt com                    |
+| Georgy Komarov              | jubnzv                      | jubnzv à gmail dawt com                           |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/util/enum.h
+++ b/libopenage/util/enum.h
@@ -137,6 +137,7 @@ public:
 
 	constexpr Enum &operator =(const DerivedType &value) {
 		this->value = &value;
+		return *this;
 	}
 
 	constexpr const DerivedType *operator ->() const {

--- a/libopenage/util/enum.h
+++ b/libopenage/util/enum.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2019 the openage authors. See copying.md for legal info.
 
 #pragma once
 


### PR DESCRIPTION
Add missing self-reference in overloaded assignment operator.