### PR TITLE
[Umbrella] Adding Github workflows

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,-clang-analyzer-optin.performance.Padding'
+HeaderFilterRegex: 'src/.*|unittest/.*'
+CheckOptions:
+...

--- a/.github/workflows-support/install-tar-wrapper.sh
+++ b/.github/workflows-support/install-tar-wrapper.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# This file was taken from dosbox-staging,
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
+# It's licensed under the terms of the GPL-2.0-or-later license.
+# Modifications Copyright 2020-2020 the openage authors.
+# See copying.md for further legal info.
+
+# This script creates a simple wrapper for tar that performs as follows
+# when run under a GitHub workflow:
+#   * always returns success
+#   * replaces gzip with zstd
+#
+# Usage: install-tar-wrapper.sh /path/of/real/tar /path/to/wrapper/tar
+#
+# The purpose of the tar-wrapper is to work-around two issues with
+# GitHub's cache implementation:
+#   * GitHub honors tar's non-zero return code even if all
+#     files and directories were created from hot-cache correctly.
+#   * GitHub only uses gzip with standard compression, which is
+#     less performant than zstd in all three dimensions:
+#       - compression ratio
+#       - compression rate
+#       - decompression rate
+#
+# In the case of long-lived caches, we want great compression and
+# fast extraction.  Zstandard gives us 500+MB/s extraction regardless
+# of the amount of compression achieved, so we simply maximize our
+# compression at creation-time.
+#
+# zstd_opts="-T0 --adapt --long=31 --no-progress -v" can be exchanged with
+# zstd_opts="-T0 -19 --long=31 --no-progress -v" (or even up to --ultra -22)
+# for even more compression
+
+set -euo pipefail
+
+# Check arguments
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 /path/of/real/tar /path/to/wrapper/tar"
+  exit 1
+fi
+tar_bin="$1"
+wrapper="$2"
+zstd_opts="-T0 --adapt --long=31 --no-progress -v"
+
+cat << EOF > "${wrapper}"
+#!/bin/bash
+set -euo pipefail
+rcode=0
+# If we're running outside of GitHub then run tar normally
+if [[ -z "\${GITHUB_WORKFLOW:-}" ]]; then
+    "${tar_bin}" "\$@"
+    rcode="\$?"
+# Otherwise use zstd and ignore tar's return-code
+else
+    first_arg="\${1/z/}"
+    shift
+    [[ "\${first_arg}" == "-x" ]] && decomp="-d" || decomp=""
+    set +e -x
+    "${tar_bin}" \\
+        --warning=none \\
+        --use-compress-program="zstd ${zstd_opts} \${decomp}" \\
+        "\${first_arg}" "\$@"
+fi
+exit "\${rcode}"
+EOF
+chmod +x "${wrapper}"

--- a/.github/workflows-support/requirements.txt
+++ b/.github/workflows-support/requirements.txt
@@ -1,0 +1,6 @@
+Cython==0.29.16
+Jinja2==2.11.1
+numpy==1.18.3
+Pillow==6.2.1
+Pygments==2.6.1
+pyreadline==2.1

--- a/.github/workflows-support/reset-brew.sh
+++ b/.github/workflows-support/reset-brew.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This file was taken from dosbox-staging,
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
+# It's licensed under the terms of the GPL-2.0-or-later license.
+# Modifications Copyright 2020-2020 the openage authors.
+# See copying.md for further legal info.
+
+# This script removes all existing brew packages, and then
+# re-installs some important basic packages (listed below).
+#
+# Usage: ./reset-brew.sh
+#
+set -xuo pipefail
+set +e
+
+# Pre-cleanup size
+sudo du -sch /usr/local 2> /dev/null
+
+# Uninstall all packages
+# shellcheck disable=SC2046
+brew remove --force $(brew list) --ignore-dependencies
+# shellcheck disable=SC2046
+brew cask remove --force $(brew cask list)
+
+# Reinstall important packages
+brew install git git-lfs python curl wget jq binutils zstd gnu-tar
+
+# Clean the brew cache
+rm -rf "$(brew --cache)"
+
+# Post-clean up size
+sudo du -sch /usr/local 2> /dev/null
+
+# This script is best-effort, so always return success
+exit 0

--- a/.github/workflows-support/response_file.txt
+++ b/.github/workflows-support/response_file.txt
@@ -1,0 +1,12 @@
+dirent
+eigen3
+fontconfig
+freetype
+harfbuzz
+libepoxy
+libogg
+libpng
+opus
+opusfile
+sdl2
+sdl2-image

--- a/.github/workflows-support/set-mac-env.sh
+++ b/.github/workflows-support/set-mac-env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Set CI environment variables
+
+echo 'export PATH="$(brew --prefix)/opt/llvm/bin:/usr/local/opt/ccache/libexec:$PATH"' >> ~/.bash_profile
+source ~/.bash_profile
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/lib"
+export LDFLAGS="-L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib,$LDFLAGS"
+export CPPFLAGS="-I$(brew --prefix)/opt/llvm/include,$CPPFLAGS"

--- a/.github/workflows-support/shrink-brew.sh
+++ b/.github/workflows-support/shrink-brew.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# This file was taken from dosbox-staging,
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
+# It's licensed under the terms of the GPL-2.0-or-later license.
+# Modifications Copyright 2020-2020 the openage authors.
+# See copying.md for further legal info.
+
+# This script reduces the size of a brew-managed installation on macOS.
+# Its main use is to shrink this area to fit within GitHub's cache
+# limits however it can also be used by end-users wanting to save space.
+#
+# Note that this script remove alot of content deemed unecessary for our
+# purposes such as ruby, go, grade, azure, etc..) so using on your
+# home system is probably not what you want :-)
+#
+# Usage: ./shrink-brew.sh
+#
+set -xuo pipefail
+set +e
+
+# Ensure we have sudo rights
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+user="${SUDO_USER}"
+group="$(id -g "${user}")"
+
+# If we don't have /usr/local then brew hasn't installed anything yet
+cd /usr/local || exit 0
+
+# Purge unecessary bloat
+for dir in lib/ruby Cellar/go Cellar/gradle Cellar/azure-cli lib/node_modules \
+share/powershell Caskroom/fastlane Cellar/ruby opt/AGPM Caskroom Cellar/node \
+miniconda Cellar/python@2 Cellar/git lib/python2.7 Cellar/git-lfs Cellar/subversion \
+Cellar/maven Cellar/aria2 Homebrew/Library/Homebrew/os/mac/pkgconfig/fuse \
+.com.apple.installer.keep microsoft; do
+    rm -rf "${dir}" || true
+done
+
+# Cleanup permissions and attributes
+chflags nouchg .
+find . -type d -exec xattr -c {} +
+find . -type f -exec xattr -c {} +
+chown -R "${user}:${group}" ./*
+find . ! -path . -type d -exec chmod 770 {} +
+
+# Binary-stripping is *extremely* verbose, so we send these to the ether
+find Cellar -name '*' -a ! -iname 'strip' -type f -perm +111 -exec strip {} + &> /dev/null
+find Cellar -name '*.a' -type f -exec strip {} + &> /dev/null
+
+# Post-cleanup size check
+du -sch . 2> /dev/null
+
+# This entire script is best-effort, so always return success
+exit 0
+

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,151 @@
+name: Code analysis
+on: [push, pull_request]
+
+jobs:
+  run_linters:
+    name: Code compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install python3-setuptools
+          sudo apt-get install -y --no-install-recommends python3-dev python3-pip pylint3 python3-pycodestyle
+      - name: Sanity check
+        run: make checkall
+
+  build_clang_static_analyzer:
+    name: Clang-tidy static analyzer
+    runs-on: ubuntu-latest
+#   needs: run_linters  # If make checkall has no issues anymore, we can activate that.
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache (ccache)
+        uses: actions/cache@v1.0.2
+        id: cache-ccache
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-clang-tidy-ccache
+          restore-keys: |
+            ${{ runner.os }}-clang-tidy-ccache
+      - name: Setup apt repositories
+        run: |
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' -y
+      - run:  sudo apt-get update -q
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends ccache cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pil python3-pip python3-pygments pylint3 python3-pycodestyle python3-setuptools qml-module-qtquick-controls qtdeclarative5-dev flex make
+      - name: Install Clang compiler collection
+        run: |
+            sudo apt-get install -y clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 clangd-9 clang-tidy-9
+            export CXX=clang++-9
+            export CC=clang-9
+      - name: Install scan-build (Python version)
+        run:  sudo pip3 install scan-build beautifulsoup4 html5lib
+      - name: Show environment settings
+        shell: bash
+        run: |
+          set -x
+          uname -a
+          uname -s
+          uname -m
+          env
+      - name: Generate build files
+        run: |
+          set -x
+          ./configure --compiler=clang++-9 --mode=debug --flags="-Werror" --ccache --download-nyan
+          intercept-build make -j$(nproc) build
+      - name: Analyze
+        run:  analyze-build -v -o report --html-title="openage (${GITHUB_SHA:0:8})"
+      - uses: actions/upload-artifact@master
+        with:
+          name: report
+          path: report
+      - name: Summarize report
+        run: |
+          # summary
+          echo "Full report is included in build Artifacts"
+          echo
+          chmod u+x ./buildsystem/scripts/count-bugs.py && ./buildsystem/scripts/count-bugs.py 40 report/*/index.html
+
+  build_clang_tidy_fixes:
+    name: Clang-tidy fixes
+    runs-on: ubuntu-latest
+#   needs: run_linters  # If make checkall has no issues anymore, we can activate that.
+    steps:
+      - uses: actions/checkout@v1
+      - name: Cache (ccache)
+        uses: actions/cache@v1.0.2
+        id: cache-ccache
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-clang-tidy-ccache
+          restore-keys: |
+            ${{ runner.os }}-clang-tidy-ccache
+      - name: Setup apt repositories
+        run: |
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' -y
+      - run:  sudo apt-get update -q
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends ccache cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pil python3-pip python3-pygments pylint3 python3-pycodestyle python3-setuptools qml-module-qtquick-controls qtdeclarative5-dev flex make
+      - name: Install Clang compiler collection
+        run: |
+            sudo apt-get install -y clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 clangd-9 clang-tidy-9
+            export CXX=clang++-9
+            export CC=clang-9
+      - name: Show environment settings
+        shell: bash
+        run: |
+          set -x
+          uname -a
+          uname -s
+          uname -m
+          env
+      - name: Generate build files
+        run: |
+          set -x
+          ./configure --compiler=clang++-9 --mode=debug --flags="-Werror" --ccache --download-nyan
+      - name: Show folder structure
+        run: ls -als */**
+      - name: Analyze
+        run: |
+          echo "Here we run the script, still to debug what's not working there"
+#         chmod u+x ./buildsystem/scripts/ci/run-clang-tidy.py && ./buildsystem/scripts/ci/run-clang-tidy.py -clang-tidy-binary "/usr/bin/clang-tidy" -j "$(nproc)" -export-fixes "clang-tidy-fixes_${GITHUB_SHA:0:8}"  -p ".bin/"
+
+#         as soon as we have a clang-format file, we can format the exported fixes directly in the way we need it with
+#         adding -format -style
+#         -config ".clang-tidy"
+#         add checks beside the standard checks
+
+  build_clang_format_fixes:
+    name: Clang-format fixes
+    runs-on: ubuntu-latest
+#   needs: run_linters  # If make checkall has no issues anymore, we can activate that.
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup apt repositories
+        run: |
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' -y
+      - run:  sudo apt-get update -q
+      - name: Install Clang compiler collection
+        run: |
+            sudo apt-get install -y clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 clangd-9 clang-tidy-9
+            export CXX=clang++-9
+            export CC=clang-9
+      - name: Show environment settings
+        shell: bash
+        run: |
+          set -x
+          uname -a
+          uname -s
+          uname -m
+          env
+      - name: Generate clang-format fixes
+        run: |
+          echo "Here we generate the fix and upload it as an artifact"
+          set -x

--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -1,31 +1,126 @@
-name: MacOSX-CI
+name: MacOS 10.15
 on: [push, pull_request]
+env: 
+  QT_INSTALL_VERSION: '5.14.2'
+  CCACHE_COMPRESS: 1
+  CCACHE_MAXSIZE:  '1G'
+  CCACHE_DIR: '${{ github.workspace }}/.ccache'
+  CI_CFG_VERSION: 'github-mac-0.1.0-dev'
 
 jobs:
   macosx-build:
-    runs-on: macOS-latest
+    name: LLVM/Clang10+ with ${{ matrix.python-version }}
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+          python-version: [python@3, python@3.8]
+
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Prepare tar-zstd for the cache
+        run: |
+          brew install zstd gnu-tar
+          chmod u+x ./.github/workflows-support/install-tar-wrapper.sh && ./.github/workflows-support/install-tar-wrapper.sh /usr/local/bin/gtar /usr/local/bin/tar
+
+      - name: Cache (pip)
+        uses: actions/cache@v1.1.2
+        id: cache-pip-dep
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-cache-pip-${{ hashFiles('.github/workflows-support/requirements.txt') }}-${{ matrix.python-version }}
+
+      - name: Cache (homebrew)
+        uses: actions/cache@v1.1.2
+        id: cache-homebrew
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: /usr/local/
+          key: ${{ runner.os }}-cache-brew-${{ hashFiles('.github/workflows/macosx-ci.yml') }}-${{ matrix.python-version }}
+
+      - name: Cache (ccache)
+        uses: actions/cache@v1.1.2
+        id: cache-ccache
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: '${{ github.workspace }}/.ccache'
+          key: ${{ runner.os }}-cache-ccache
+
+      - name: Cache (Qt)
+        uses: actions/cache@v1.1.2
+        id: cache-qt
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_INSTALL_VERSION }}
+
+      - name: Cleanup before caching of brew
+        run: |
+          brew cleanup
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
+      - name: Hardreset Brew
+        run: chmod u+x ./.github/workflows-support/reset-brew.sh && ./.github/workflows-support/reset-brew.sh
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
       - name: Brew update-reset
         run: brew update-reset
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
       - name: Brew update
         run: brew update
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
       - name: Brew install DeJaVu fonts
         run: brew tap homebrew/cask-fonts && brew cask install font-dejavu
-      - name: Upgrade cmake
-        run: brew upgrade cmake
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
       - name: Install dependencies with homebrew
-        run: brew install freetype cmake python3 qt5 flex make libepoxy fontconfig harfbuzz sdl2 sdl2_image opus libogg opusfile libpng eigen
-      - name: Install LLVM
-        run: brew install -cc=clang llvm@8
-      - name: Setting environment variables
-        run: export PATH="/usr/local/opt/llvm@8/bin:$PATH:/usr/local/lib:/usr/local/opt/llvm/bin" && export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/lib"
+        run: brew install freetype ccache cmake ${{ matrix.python-version }} flex make libepoxy fontconfig harfbuzz sdl2 sdl2_image opus libogg opusfile libpng eigen llvm
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2.6.2
+        with:
+          host: 'mac'
+          version: ${{ env.QT_INSTALL_VERSION }}
+          mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+
+      - name: Shrink brew
+        run: sudo chmod u+x ./.github/workflows-support/shrink-brew.sh && sudo ./.github/workflows-support/shrink-brew.sh
+        if: steps.cache-homebrew.outputs.cache-hit != 'true'
+
       - name: Install python3 dependencies
-        run: pip3 install pygments cython numpy pillow pyreadline jinja2
-      - name: Configure 
-        run: ./configure --compiler=clang++ --mode=debug --download-nyan 
+        run: pip3 install  -r ".github/workflows-support/requirements.txt"
+        if: steps.cache-pip-dep.outputs.cache-hit != 'true'
+
+      - name: Upgrade python3 dependencies
+        run: pip3 install --upgrade -r ".github/workflows-support/requirements.txt"
+        if: steps.cache-pip-dep.outputs.cache-hit == 'true'
+
+      - name: Show environment settings
+        shell: bash
+        run: |
+          set -x
+          uname -a
+          uname -s
+          uname -m
+          env
+
+      - name: Set environment and run ./configure 
+        run: |
+          chmod u+x ./.github/workflows-support/set-mac-env.sh && ./.github/workflows-support/set-mac-env.sh
+          ./configure --compiler=$(brew --prefix)/opt/llvm/bin/clang++ --mode=debug --ccache --flags="-Wfatal-errors" --download-nyan -- -DCMAKE_PREFIX_PATH=${Qt5_DIR}
+
       - name: Build
-        run: make
+        run: make build -j"$(sysctl -n hw.physicalcpu || echo 4)"
+
       - name: Test
         run: make test
+
+      - name: Install
+        run: make install DESTDIR=/tmp/openage

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -1,0 +1,65 @@
+name: Ubuntu-CI
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    if:
+      contains(github.repository, 'SFTtech')==false # CI for forks, lets this job run just outside of the main repo
+    strategy:
+      matrix:
+        cc: [gcc, clang-9]
+    runs-on: ubuntu-latest
+    env:
+      CC: ${{matrix.cc}}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+      - name: Cache (ccache)
+        uses: actions/cache@v1.0.2
+        id: cache-ccache
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-${{matrix.cc}}-ccache
+          restore-keys: |
+            ${{ runner.os }}-${{matrix.cc}}-ccache
+      - name: Setup apt repositories
+        run: |
+          if [ $CC = clang-9 ]; then
+            sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' -y
+          fi
+      - name: Update apt repositories
+        run: sudo apt-get update -q
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends ccache cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pil python3-pip python3-pygments pylint3 python3-pycodestyle qml-module-qtquick-controls qtdeclarative5-dev flex make
+      - name: Install C compiler
+        run: |
+          if [ $CC = clang-9 ]; then
+            sudo apt-get install -y --no-install-recommends clang-9 lld-9 libc++-9-dev libc++abi-9-dev clang-tools-9
+            export CXX=clang++-9
+            export CC=clang-9
+          else
+            sudo apt-get install -y --no-install-recommends $CC g++
+          fi
+      - name: Show environment settings
+        shell: bash
+        run: |
+          set -x
+          uname -a
+          uname -s
+          uname -m
+          env
+      - name: Generate build files
+        run: |
+          if [ $CC = clang-9 ]; then
+            ./configure --compiler=clang++-9 --mode=debug --flags="-Werror" --ccache --download-nyan
+          else
+            ./configure --mode=debug --flags="-Werror" --ccache --download-nyan 
+          fi
+      - name: Build
+        run: make -j$(nproc) build
+      - name: Test
+        run: make tests
+      - name: Install
+        run: make install DESTDIR=/tmp/openage

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,241 @@
+name: Windows 10
+on: [push, pull_request]
+env:
+  QT_INSTALL_VERSION: '5.14.2'
+  vcpkgResponseFile: '${{ github.workspace }}\.github\workflows-support\response_file.txt'
+  vcpkgGitCommitID: '28ab0b15cd7cdc1004cac9a28a5ecab198c161b9'        # Updated 26/04/2020
+  nyanGitCommitID: '03a996994b87803b5a8ff6ed0e85ab730163aa2d'         # Updated 27/04/2020
+  CI_CFG_VERSION: 'github-win-0.1.0-dev'
+
+jobs:
+  build_windows_msvc:
+    name: MSVC2019 (${{ matrix.arch }}) (${{ matrix.build-type }}) Python ${{ matrix.python-version }}
+    runs-on: windows-2019
+    continue-on-error: false                                          # DEBUG: set to true
+    strategy:
+      fail-fast: false
+      matrix:
+          arch: [x64] #[Win32, x64]
+          qt64: [win64_msvc2017_64] #[win64_mingw73, win64_msvc2017_64]
+          env-bit: [64] #[64, 32]
+          triplet: [x64-windows] #[x64-windows, x86-windows]
+          python-version: [3.8.2, 3.7.7]
+          python-platform: [amd64] #[amd64,]
+          build-type: [RelWithDebInfo] #[RelWithDebInfo, Debug]       #DEBUG builds: use second bracket
+    steps:
+      - name: Export shell environment variables
+        uses: lukka/set-shell-env@v1.0
+        with:
+          PreferredToolArchitecture: '${{matrix.arch}}'
+          PYTHON_INSTALL_DIR: '${{ runner.workspace }}\deps\Python${{ matrix.python-version }}-${{ matrix.python-platform }}-dbg'
+          NOWARN_FLAGS: '-noWarn:C4251;C4101;C4275;D9002'
+
+#         -noWarn
+#         C4251 - dll-interface
+#         C4275 - non dll-interface class used as base for dll-interface class
+#         C4101 - unreferenced local variable
+#         D9002 - ignoring unknown option '-fwrapv' (cl.exe)
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache (Qt)
+        uses: actions/cache@v1.1.2
+        id: cache-qt
+        with:
+          path: '../Qt'
+          key: '${{ runner.os }}-QtCache-${{ env.QT_INSTALL_VERSION }}'
+
+      - name: Cache (Python)
+        uses: actions/cache@v1.1.2
+        id: cache-python
+        with:
+          path: '${{ env.PYTHON_INSTALL_DIR }}\'
+          key: '${{ runner.os }}-PythonCache-v${{ matrix.python-version }}-${{ matrix.python-platform }}-dbg'
+
+# TODO: Packaging
+#      - name: Cache (Dejavu)
+#        uses: actions/cache@v1.1.2
+#        id: cache-dejavu
+#        with:
+#          path: 'C:\ProgramData\chocolatey\lib\dejavufonts'
+#          key: ${{ runner.os }}-ChocoCache-Dejavu-${{ hashFiles('.github/workflows/windows-ci.yml') }}
+
+      - name: Cache (Flex)
+        uses: actions/cache@v1.1.2
+        id: cache-flex
+        with:
+          path: 'C:\ProgramData\chocolatey\lib\winflexbison3'
+          key: ${{ runner.os }}-ChocoCache-Flex-${{ hashFiles('.github/workflows/windows-ci.yml') }}
+
+      - name: Cache (nyan)
+        uses: actions/cache@v1.1.2
+        id: cache-nyan
+        with:
+          path: '${{ runner.workspace }}\deps\nyan\'
+          key: ${{ runner.os }}-NyanCache-CommitHash${{ env.nyanGitCommitID }}-${{ matrix.build-type }}
+
+      # Pinned CMake here
+      - name: Install pinned CMake Version
+        uses: lukka/get-cmake@v3.17.1
+
+      - name: Prepare Environment
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars${{ matrix.env-bit }}.bat"
+        shell: cmd
+
+#       TODO: Waiting for Upstream Issue: https://github.com/actions/setup-python/issues/86
+#       To pull in debug binaries and stdlib
+#      - name: Set up Python
+#        uses: actions/setup-python@vX.Y.Z
+#        with:
+#         python-version: ${{ matrix.python-version }}
+#         with-debug: true
+
+      - name: Download Python
+        uses: carlosperate/download-file-action@v1.0.3
+        id: download-python
+        with:
+         file-url: 'https://www.python.org/ftp/python/${{ matrix.python-version }}/python-${{ matrix.python-version }}-${{ matrix.python-platform }}.exe'
+         file-name: 'python-${{ matrix.python-version }}-${{ matrix.python-platform }}.exe'
+         location: '${{ runner.workspace }}\dl\'
+        if: steps.cache-python.outputs.cache-hit != 'true'
+
+      - name: Print downloaded the file path
+        run: echo "The file was downloaded to ${{ steps.download-python.outputs.file-path }}"
+        shell: cmd
+        if: steps.cache-python.outputs.cache-hit != 'true'
+
+      - name: Install Python debug (x64) # we need debug binaries and precompiled standard libraries
+        run: |
+          Start-Process -FilePath "${{ runner.workspace }}\dl\python-${{ matrix.python-version }}-${{ matrix.python-platform }}.exe" -ArgumentList "/quiet Include_debug=1 Include_dev=1 Include_lib=1 Include_pip=1 PrependPath=1 CompileAll=1 InstallAllUsers=0 TargetDir=${{ env.PYTHON_INSTALL_DIR }}\" -Verb runas -Wait
+        if: matrix.arch == 'x64' && steps.cache-python.outputs.cache-hit != 'true'
+        shell: pwsh
+
+      - name: Display Python version
+        run: ${{ env.PYTHON_INSTALL_DIR }}\python.exe -c "import sys; print(sys.version)"
+        shell: cmd
+
+      - name: Upgrade Python pip
+        run: |
+          ${{ env.PYTHON_INSTALL_DIR }}\python.exe -m pip install --upgrade pip
+        shell: cmd
+
+      - name: Install Python dependencies
+        run: ${{ env.PYTHON_INSTALL_DIR }}\Scripts\pip.exe install -r ".github/workflows-support/requirements.txt"
+        if: steps.cache-python.outputs.cache-hit != 'true'
+
+      - name: Install Qt (x64)
+        uses: jurplel/install-qt-action@v2.6.2
+        with:
+          host: 'windows'
+          version: '${{ env.QT_INSTALL_VERSION }}'
+          mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
+          arch: ${{ matrix.qt64 }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        if: matrix.arch == 'x64'
+
+      - name: Install Vcpkg dependencies
+        uses: lukka/run-vcpkg@v2.1
+        with:
+          vcpkgArguments: '@${{ env.vcpkgResponseFile }}'
+          vcpkgTriplet: '${{ matrix.triplet }}'
+          vcpkgGitCommitId: '${{ env.vcpkgGitCommitID }}'
+          vcpkgDirectory: '${{ runner.workspace }}\deps\vcpkg'
+          cleanAfterBuild: 'true'
+          appendedCacheKey: '${{ hashFiles(env.vcpkgResponseFile) }}'
+
+      - name: Install dependencies with Chocolatey
+        uses: crazy-max/ghaction-chocolatey@v1.1.0
+        with:
+          args: install winflexbison3
+        if: steps.cache-flex.outputs.cache-hit != 'true'
+
+#       TODO: Packaging
+#      - name: Install Dejavu fonts with Chocolatey
+#        uses: crazy-max/ghaction-chocolatey@v1.1.0
+#        with:
+#          args: install dejavufonts
+#        if: steps.cache-dejavu.outputs.cache-hit != 'true'
+
+      - name:  Show environment settings
+        run: |
+          Set-PSDebug -Trace 1
+          systeminfo
+          gci env:
+          Set-PSDebug -Trace 0
+        shell: pwsh
+
+      - name: Clone nyan repository
+        run: |
+          git clone https://github.com/SFTtech/nyan.git ${{ runner.workspace }}\deps\nyan
+          cd ${{ runner.workspace }}\deps\nyan
+          git reset --hard ${{ env.nyanGitCommitID }}
+        if: steps.cache-nyan.outputs.cache-hit != 'true'
+
+      - name: 'nyan: Generate build files & run build procedure'
+        uses: lukka/run-cmake@v2.3
+        env:
+          CMAKE_VERBOSE_MAKEFILE: TRUE
+          PATH: '${{ env.PYTHON_INSTALL_DIR }}; ${{ env.PYTHON_INSTALL_DIR }}\Scripts; ${env:PATH}'
+        with:
+          useVcpkgToolchainFile: True
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeListsTxtPath: '${{ runner.workspace }}\deps\nyan\CMakeLists.txt'
+          buildDirectory: '${{ runner.workspace }}\deps\nyan\build\'
+          cmakeAppendedArgs: '-DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -DFLEX_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe'
+          buildWithCMake: true
+          buildWithCMakeArgs: '--config ${{ matrix.build-type }} -- -nologo -m -v:m ${{ env.NOWARN_FLAGS }}'
+        if: steps.cache-nyan.outputs.cache-hit != 'true'
+
+      - name: 'openage: Generate build files & run build procedure'
+        uses: lukka/run-cmake@v2.3
+        env:
+          CMAKE_VERBOSE_MAKEFILE: TRUE
+          PATH: '${{ env.PYTHON_INSTALL_DIR }}; ${{ env.PYTHON_INSTALL_DIR }}\Scripts; ${env:PATH}'
+        with:
+          useVcpkgToolchainFile: True
+          cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+          cmakeListsTxtPath: '${{ github.workspace }}\CMakeLists.txt'
+          buildDirectory: '${{ runner.workspace }}\build-openage\'
+          cmakeAppendedArgs: '-DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -DPYTHON_DIR=${{ env.PYTHON_INSTALL_DIR }}\ -DCMAKE_PREFIX_PATH=${Qt5_DIR} -Dnyan_DIR=${{ runner.workspace }}\deps\nyan\build\'
+          buildWithCMake: true
+          buildWithCMakeArgs: '--config ${{ matrix.build-type }} -- -nologo -m -v:m ${{ env.NOWARN_FLAGS }}'
+
+#       Toolchain file for CMake could be also taken from here
+#       -DCMAKE_TOOLCHAIN_FILE="${{ env.RUNVCPKG_VCPKG_ROOT }}\scripts\buildsystems\vcpkg.cmake"
+#       if useVcpkgToolchainFile is set to 'False'
+
+#      - name: Show directory tree (DEBUG)
+#        run: Get-ChildItem -Path "<PATH>"
+#        shell: pwsh
+
+#      TODO: Preparations for running/packaging steps
+#      - name: Copy Font
+#        run: |
+#          MD "C:\Windows\Fonts\DejaVu Serif"
+#
+#          COPY /B /Y "C:\ProgramData\chocolatey\lib\dejavufonts\dejavu-fonts-ttf-2.37\ttf\DejaVuSerif*" "C:\Windows\Fonts\DejaVu Serif\"
+#
+#          COPY /B /Y "C:\ProgramData\chocolatey\lib\dejavufonts\dejavu-fonts-ttf-2.37\fontconfig\57-dejavu-serif.conf" "${{ env.RUNVCPKG_VCPKG_ROOT }}\installed\x64-windows\tools\fontconfig\fonts\conf.d\"
+#        shell: cmd
+
+#      TODO: Investigate for broken output of Test command
+#      - name: Run Tests
+#        run: |
+#          Install-Script -Name Invoke-Process
+#          Invoke-Process -FilePath ${{ runner.workspace }}\build-openage\run.exe -ArgumentList 'test -a'
+#        shell: pwsh
+#        env:
+#          PYTHONHOME: '${{ env.PYTHON_INSTALL_DIR }}\'
+#          FONTCONFIG_PATH: '${{ env.RUNVCPKG_VCPKG_ROOT }}\installed\x64-windows\tools\fontconfig\fonts\'
+#          QML2_IMPORT_PATH: '${Qt5_DIR}\qml'
+#          PATH: '${{ env.RUNVCPKG_VCPKG_ROOT }}\installed\x64-windows\bin;${Qt5_DIR}\bin;${{ runner.workspace }}\deps\nyan\build\nyan\;${{ runner.workspace }}\build-openage\libopenage\${{ matrix.build-type }}\;${{ env.PYTHON_INSTALL_DIR }}; ${{ env.PYTHON_INSTALL_DIR }}\Scripts; ${env:PATH}'
+
+#      TODO: Virus scan before publishing
+#      - name: Windows Defender AV Scan
+#        shell: powershell
+#        run: |
+#          Get-MpComputerStatus
+#          Start-MpScan -ScanPath "<PATH>"
+#          echo $?

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Dependencies, Building and Running
   Operating System    | Build status
   :------------------:|:--------------:
   Debian Sid          | [Todo: Kevin #11](https://github.com/SFTtech/kevin/issues/11)
-  MacOSX 10.14        | [![Build Status](https://travis-ci.org/SFTtech/openage.svg?branch=master)](https://travis-ci.org/SFTtech/openage)
+  MacOSX 10.14        | ![MacOSX builds](https://github.com/SFTtech/openage/workflows/MacOSX%20builds/badge.svg)
   Windows 10 - x64    | [![Build status](https://ci.appveyor.com/api/projects/status/66sx35key94u740e?svg=true)](https://ci.appveyor.com/project/simonsan/openage-sl215)
 
 

--- a/buildsystem/scripts/ci/count-bugs.py
+++ b/buildsystem/scripts/ci/count-bugs.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2019 Patryk Obara <patryk.obara@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""
+This script prints a summary snippet of information out of reports created
+by scan-build or analyze-build for Clang's static code analysis.
+
+This script counts the number of reported issues and compares that
+against provided maximum. if the count exceeds the maximum then the
+script will return a status of 1 (failure), otherwise the script
+returns 0 (success).
+
+If you prefer to not set a maximum, then supply a negative maximum
+such as -1.  If a maximum is not provided on the command line then
+the internally-defined maximum is used.
+
+Usage: ./count-warnings.py [max-issues] path/to/report/index.html
+
+Examples:
+ use internal maximum: ./count-bugs.py path/to/report/index.html
+ permit any quantity:  ./count-bugs.py -1 path/to/report/index.html
+ limit count to 48:    ./count-bugs.py 48 path/to/report/index.html
+
+"""
+# This script depends on BeautifulSoup module, if you're distribution is
+# missing it, you can use pipenv to install it for virtualenv spanning only
+# this repo: pipenv install beautifulsoup4 html5lib
+
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+
+import os
+
+from bs4 import BeautifulSoup
+
+# Maximum allowed number of issues. This is used if the user does
+# not prove a maximum via the first command-line arugment.
+#
+MAX_ISSUES = 40
+
+def summary_values(summary_table):
+    if not summary_table:
+        return
+    for row in summary_table.find_all('tr'):
+        description = row.find('td', 'SUMM_DESC')
+        value = row.find('td', 'Q')
+        if description is None or value is None:
+            continue
+        yield description.get_text(), int(value.get_text())
+
+
+def read_soup(index_html):
+    with open(index_html) as index:
+        soup = BeautifulSoup(index, 'html5lib')
+        tables = soup.find_all('table')
+        summary = tables[1]
+        return dict(summary_values(summary))
+
+
+def find_longest_name_length(names):
+    return max(len(x) for x in names)
+
+
+def print_summary(issues):
+    summary = list(issues.items())
+    size = find_longest_name_length(issues.keys()) + 1
+    for warning, count in sorted(summary, key=lambda x: -x[1]):
+        print('  {text:{field_size}s}: {count}'.format(
+            text=warning, count=count, field_size=size))
+    print()
+
+def parse_args(argv):
+    # Guard: show the usage block for incorrect usage
+    if len(argv) not in [2, 3]:
+        print(__doc__)
+        sys.exit(1)
+    # Guard: check if the provided report file exists
+    report = argv[-1]
+    if not os.path.isfile(report):
+        print("{}: no such file".format(report))
+        sys.exit(1)
+	# Good scenario: set our maximum and return it with the log
+    max_issues = MAX_ISSUES if len(argv) == 2 else int(argv[1])
+    return max_issues, report
+
+
+def main(argv):
+    rcode = 0
+    max_issues, report = parse_args(argv)
+    bug_types = read_soup(report)
+    total = bug_types.pop('All Bugs')
+    if bug_types:
+        print("Bugs grouped by type:\n")
+        print_summary(bug_types)
+
+    print('Total: {} bugs'.format(total), end='')
+    if max_issues >= 0:
+        print(' (out of {} allowed)\n'.format(max_issues))
+        if total > max_issues:
+            print('Error: upper limit of allowed bugs is', max_issues)
+            rcode = 1
+    else:
+        print('\n')
+
+    return rcode
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main(sys.argv))

--- a/buildsystem/scripts/ci/run-clang-tidy.py
+++ b/buildsystem/scripts/ci/run-clang-tidy.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+#
+#===- run-clang-tidy.py - Parallel clang-tidy runner ---------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# Taken from:
+# https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/master/clang-tidy/tool/run-clang-tidy.py
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+from __future__ import print_function
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+try:
+  import yaml
+except ImportError:
+  yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+def find_compilation_database(path):
+  """Adjusts the directory until a compilation database is found."""
+  result = './'
+  while not os.path.isfile(os.path.join(result, path)):
+    if os.path.realpath(result) == '/':
+      print('Error: could not find compilation database.')
+      sys.exit(1)
+    result += '../'
+  return os.path.realpath(result)
+
+
+def make_absolute(f, directory):
+  if os.path.isabs(f):
+    return f
+  return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                        header_filter, extra_arg, extra_arg_before, quiet,
+                        config):
+  """Gets a command line for clang-tidy."""
+  start = [clang_tidy_binary]
+  if header_filter is not None:
+    start.append('-header-filter=' + header_filter)
+  if checks:
+    start.append('-checks=' + checks)
+  if tmpdir is not None:
+    start.append('-export-fixes')
+    # Get a temporary file. We immediately close the handle so clang-tidy can
+    # overwrite it.
+    (handle, name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+    os.close(handle)
+    start.append(name)
+  for arg in extra_arg:
+      start.append('-extra-arg=%s' % arg)
+  for arg in extra_arg_before:
+      start.append('-extra-arg-before=%s' % arg)
+  start.append('-p=' + build_path)
+  if quiet:
+      start.append('-quiet')
+  if config:
+      start.append('-config=' + config)
+  start.append(f)
+  return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+  """Merge all replacement files in a directory into a single file"""
+  # The fixes suggested by clang-tidy >= 4.0.0 are given under
+  # the top level key 'Diagnostics' in the output yaml files
+  mergekey="Diagnostics"
+  merged=[]
+  for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+    content = yaml.safe_load(open(replacefile, 'r'))
+    if not content:
+      continue # Skip empty files.
+    merged.extend(content.get(mergekey, []))
+
+  if merged:
+    # MainSourceFile: The key is required by the definition inside
+    # include/clang/Tooling/ReplacementsYaml.h, but the value
+    # is actually never used inside clang-apply-replacements,
+    # so we set it to '' here.
+    output = { 'MainSourceFile': '', mergekey: merged }
+    with open(mergefile, 'w') as out:
+      yaml.safe_dump(output, out)
+  else:
+    # Empty the file:
+    open(mergefile, 'w').close()
+
+
+def check_clang_apply_replacements_binary(args):
+  """Checks if invoking supplied clang-apply-replacements binary works."""
+  try:
+    subprocess.check_call([args.clang_apply_replacements_binary, '--version'])
+  except:
+    print('Unable to run clang-apply-replacements. Is clang-apply-replacements '
+          'binary correctly specified?', file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
+
+
+def apply_fixes(args, tmpdir):
+  """Calls clang-apply-fixes on a given directory."""
+  invocation = [args.clang_apply_replacements_binary]
+  if args.format:
+    invocation.append('-format')
+  if args.style:
+    invocation.append('-style=' + args.style)
+  invocation.append(tmpdir)
+  subprocess.call(invocation)
+
+
+def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
+  """Takes filenames out of queue and runs clang-tidy on them."""
+  while True:
+    name = queue.get()
+    invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                     tmpdir, build_path, args.header_filter,
+                                     args.extra_arg, args.extra_arg_before,
+                                     args.quiet, args.config)
+
+    proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = proc.communicate()
+    if proc.returncode != 0:
+      failed_files.append(name)
+    with lock:
+      sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+      if len(err) > 0:
+        sys.stdout.flush()
+        sys.stderr.write(err.decode('utf-8'))
+    queue.task_done()
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '
+                                   'in a compilation database. Requires '
+                                   'clang-tidy and clang-apply-replacements in '
+                                   '$PATH.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-clang-apply-replacements-binary', metavar='PATH',
+                      default='clang-apply-replacements',
+                      help='path to clang-apply-replacements binary')
+  parser.add_argument('-checks', default=None,
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default')
+  parser.add_argument('-config', default=None,
+                      help='Specifies a configuration in YAML/JSON format: '
+                      '  -config="{Checks: \'*\', '
+                      '                       CheckOptions: [{key: x, '
+                      '                                       value: y}]}" '
+                      'When the value is empty, clang-tidy will '
+                      'attempt to find a file named .clang-tidy for '
+                      'each source file in its parent directories.')
+  parser.add_argument('-header-filter', default=None,
+                      help='regular expression matching the names of the '
+                      'headers to output diagnostics from. Diagnostics from '
+                      'the main file of each translation unit are always '
+                      'displayed.')
+  if yaml:
+    parser.add_argument('-export-fixes', metavar='filename', dest='export_fixes',
+                        help='Create a yaml file to store suggested fixes in, '
+                        'which can be applied with clang-apply-replacements.')
+  parser.add_argument('-j', type=int, default=0,
+                      help='number of tidy instances to be run in parallel.')
+  parser.add_argument('files', nargs='*', default=['.*'],
+                      help='files to be processed (regex on path)')
+  parser.add_argument('-fix', action='store_true', help='apply fix-its')
+  parser.add_argument('-format', action='store_true', help='Reformat code '
+                      'after applying fixes')
+  parser.add_argument('-style', default='file', help='The style of reformat '
+                      'code after applying fixes')
+  parser.add_argument('-p', dest='build_path',
+                      help='Path used to read a compile command database.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true',
+                      help='Run clang-tidy in quiet mode')
+  args = parser.parse_args()
+
+  db_path = 'compile_commands.json'
+
+  if args.build_path is not None:
+    build_path = args.build_path
+  else:
+    # Find our database
+    build_path = find_compilation_database(db_path)
+
+  try:
+    invocation = [args.clang_tidy_binary, '-list-checks']
+    invocation.append('-p=' + build_path)
+    if args.checks:
+      invocation.append('-checks=' + args.checks)
+    invocation.append('-')
+    if args.quiet:
+      # Even with -quiet we still want to check if we can call clang-tidy.
+      with open(os.devnull, 'w') as dev_null:
+        subprocess.check_call(invocation, stdout=dev_null)
+    else:
+      subprocess.check_call(invocation)
+  except:
+    print("Unable to run clang-tidy.", file=sys.stderr)
+    sys.exit(1)
+
+  # Load the database and extract all files.
+  database = json.load(open(os.path.join(build_path, db_path)))
+  files = [make_absolute(entry['file'], entry['directory'])
+           for entry in database]
+
+  max_task = args.j
+  if max_task == 0:
+    max_task = multiprocessing.cpu_count()
+
+  tmpdir = None
+  if args.fix or (yaml and args.export_fixes):
+    check_clang_apply_replacements_binary(args)
+    tmpdir = tempfile.mkdtemp()
+
+  # Build up a big regexy filter from all command line arguments.
+  file_name_re = re.compile('|'.join(args.files))
+
+  return_code = 0
+  try:
+    # Spin up a bunch of tidy-launching threads.
+    task_queue = queue.Queue(max_task)
+    # List of files with a non-zero return code.
+    failed_files = []
+    lock = threading.Lock()
+    for _ in range(max_task):
+      t = threading.Thread(target=run_tidy,
+                           args=(args, tmpdir, build_path, task_queue, lock, failed_files))
+      t.daemon = True
+      t.start()
+
+    # Fill the queue with files.
+    for name in files:
+      if file_name_re.search(name):
+        task_queue.put(name)
+
+    # Wait for all threads to be done.
+    task_queue.join()
+    if len(failed_files):
+      return_code = 1
+
+  except KeyboardInterrupt:
+    # This is a sad hack. Unfortunately subprocess goes
+    # bonkers with ctrl-c and we start forking merrily.
+    print('\nCtrl-C detected, goodbye.')
+    if tmpdir:
+      shutil.rmtree(tmpdir)
+    os.kill(0, 9)
+
+  if yaml and args.export_fixes:
+    print('Writing fixes to ' + args.export_fixes + ' ...')
+    try:
+      merge_replacement_files(tmpdir, args.export_fixes)
+    except:
+      print('Error exporting fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code=1
+
+  if args.fix:
+    print('Applying fixes ...')
+    try:
+      apply_fixes(args, tmpdir)
+    except:
+      print('Error applying fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code=1
+
+  if tmpdir:
+    shutil.rmtree(tmpdir)
+  sys.exit(return_code)
+
+if __name__ == '__main__':
+  main()

--- a/copying.md
+++ b/copying.md
@@ -208,7 +208,11 @@ cmake modules ([3-clause BSD license](/legal/BSD-3-clause))
  - `buildsystem/modules/FindGPerfTools.cmake` (taken from [VAST](https://github.com/mavam/vast))
  - `buildsystem/modules/FindOpusfile.cmake` (taken from [Unvanquished](https://github.com/Unvanquished/Unvanquished))
 
-
+From [Kevin R Croft <krcroft@gmail.com>](https://github.com/kcgen) ([GPL 2.0+](/legal/GPLv2))
+ - `buildsystem/scripts/ci/install-tar-wrapper.sh`
+ - `buildsystem/scripts/ci/reset-brew.sh`
+ - `buildsystem/scripts/ci/shrink-brew.sh`
+ 
 #### Disclaimer
 
 Notes about this file:

--- a/legal/Apachev2.0-LLVM
+++ b/legal/Apachev2.0-LLVM
@@ -1,0 +1,278 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2007-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/legal/GPLv2
+++ b/legal/GPLv2
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.


### PR DESCRIPTION
ci:  adding windows and ubuntu workflows,
doc: adding status badges for mac and win to readme.md

For the caching there is still some fine-tuning needed in the future. I'm also waiting for an increase of the limit and possibility to cache `vcpkg/installed`-dir of github-actions (actions/cache#6) and adding vcpkg packages to the virtual env (actions/virtual-environments#11) and that Qt gets added to the images (actions/virtual-environments#8). That overall could lower the win build for around 12 minutes.

The Ubuntu-CI is **not running** inside this main repo, but just outside for any forks of **openage**. People can make future use of this for pre-diagnosing `clang-tidy`-errors or `clang-format`-stuff inside their forked repositories. This functionality (clang-tidy and clang-format) is not added with this PR though and might come in the future.

### Win
- [ ] Investigate after build test output not being forwarded by shell
- [ ] Packaging Nightly builds directly on Github Releases
- [ ] Look into `install prefix` on x64 target being `program files (x86)` => [Around this function](https://gitlab.kitware.com/cmake/cmake/blob/8065a686ddcb54b10fd6758eca24280f3e68926b/Modules/CMakeGenericSystem.cmake#L68-156) (thanks tu) (**can't reproduce for now, later?**)
- [ ] User PWSH interface to [Windows Defender](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/command-line-arguments-windows-defender-antivirus) to scan package before publishing
- [x] Make use of Compiler Cache ([clcache](https://github.com/frerich/clcache/wiki/Integration), [cclash](https://github.com/inorton/cclash))
- [x] Add build matrix for cases ([versions of Python (Upstream Issue)](https://github.com/actions/setup-python/issues/86) or included in [win environments](https://github.com/actions/virtual-environments/issues/786), versions of compilers)
  - [x] Python 
  - [x] MSVC would be a good start into a build matrix => only Visual Studio 2019 on newest Windows builds
  - [x] Architecture is not needed now, but prepared, as we are not building/testing/packaging for 32bit platforms currently 
- [x] Add caching for vcpkg-dir using [run-vcpkg](https://github.com/marketplace/actions/run-vcpkg) ([example](https://github.com/lukka/CppBuildTasks-Validation/blob/master/.github/workflows/hosted-basic-cache-submod_vcpkg.yml) using [run-cmake](https://github.com/marketplace/actions/run-cmake) as well)

### Win-MSYS2
- [ ] MSYS2 could be an easy replacement where we could build on gcc/g++ and clang as well in a build matrix setup (would be easy to cache as well, one folder)
- [ ] Packaging Nightly builds directly on Github Releases
- [ ] Make use of ccache

### Linux
- [ ] New `make` targets
  - [ ] Code Analysis: Get [clang-tidy](https://github.com/StableCoder/cmake-scripts/blob/master/tools.cmake) [**script**](https://github.com/SFTtech/openage/pull/1196/files#diff-d328e269e5afad08dfe2dd3910ec4896) to work and let it upload a fixes-patch as artifact (#1157)
  - [ ] Code Formatting: Get [clang-format](https://github.com/StableCoder/cmake-scripts/blob/master/formatting.cmake) to work and let it upload a fixes-patch as artifact (#1167)
Ideas:  
  - [ ] [Sanitizer builds](https://github.com/StableCoder/cmake-scripts/blob/master/sanitizers.cmake)?
  - [ ] [Code coverage reports](https://github.com/StableCoder/cmake-scripts/blob/master/code-coverage.cmake)?
  - [ ] [VVVerbose builds](https://github.com/StableCoder/cmake-scripts/blob/master/compiler-options.cmake)?
  - [ ] [Dependency Graph](https://github.com/StableCoder/cmake-scripts/blob/master/dependency-graph.cmake)
- [x] Lockfile: Use config for the same system as lockfile so config changes rebuild cache 
- [x] File headers: Add header from copying.md to scripts

### Mac
- [ ] Packaging?
- [x] Add build matrix for cases (versions of Python, versions of compilers)
- [x] Check current workflow for `fonts` problem
- [x] Wait for the 2 GiB individual cache limit and cache brew+llvm, use brew again to install Qt