### PR TITLE
Add 'make all' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ MAKEARGS += $(if $(VERBOSE),,--no-print-directory)
 .PHONY: default
 default: build
 
+.PHONY: all
+all: default
+
 $(BUILDDIR):
 	@echo "call ./configure to initialize the build directory."
 	@echo "also see ./configure --help, and doc/building.md"


### PR DESCRIPTION
`all` is a recommended target according to the [GNU make documentation](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html). Eclipse (and other IDEs so I've heard) like to call `make all` by default to trigger a build, so this should be less of a problem now.

For this project, `all` just runs the `default` target. Nothing special was added.