### PR TITLE
Fixing MacOSX Workflow

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Brew update
         run: brew update
       - name: Brew install DeJaVu fonts
-        run: brew tap homebrew/cask-fonts && brew cask install font-dejavu-sans
+        run: brew tap homebrew/cask-fonts && brew cask install font-dejavu
       - name: Upgrade cmake
         run: brew upgrade cmake
       - name: Install dependencies with homebrew


### PR DESCRIPTION
The DejaVu font in `homebrew-cask-fonts` was renamed. Updating the CI correspondingly.

> Rename DejaVu fonts  [PR#2010](https://github.com/Homebrew/homebrew-cask-fonts/pull/2010)
> Cask includes sans, serif, and mono versions – not only the sans.

https://github.com/Homebrew/homebrew-cask-fonts/commit/e9e8d48f6ee9529422d010fb3ec9e6a455ef9ba0