### PR TITLE
versions: provide nyan and runtime sdl versions

### DIFF
--- a/libopenage/config.cpp.in
+++ b/libopenage/config.cpp.in
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2020 the openage authors. See copying.md for legal info.
 
 // ${AUTOGEN_WARNING}
 
@@ -7,7 +7,6 @@
 namespace openage {
 namespace config {
 
-const char *const version = "${VERSION_FULL_STRING}";
 const char *const config_option_string = "${CONFIG_OPTION_STRING}";
 
 }} // openage::config

--- a/libopenage/config.h.in
+++ b/libopenage/config.h.in
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2020 the openage authors. See copying.md for legal info.
 
 // ${AUTOGEN_WARNING}
 
@@ -18,7 +18,6 @@
 namespace openage {
 namespace config {
 
-extern const char *const version;
 extern const char *const config_option_string;
 
 constexpr const char *buildsystem_sourcefile_dir = "${CMAKE_SOURCE_DIR}/";

--- a/libopenage/engine.cpp
+++ b/libopenage/engine.cpp
@@ -26,6 +26,7 @@
 #include "util/opengl.h"
 #include "util/strings.h"
 #include "util/timer.h"
+#include "versions/compiletime.h"
 
 /**
  * Main openage namespace to store all things that make the have to do with the game.
@@ -281,7 +282,7 @@ bool Engine::draw_debug_overlay() {
 	// Draw version string in the lower left corner
 	this->render_text(
 		{5, 35}, 20, renderer::Colors::WHITE,
-		"openage %s", config::version
+		"openage %s", versions::engine_version
 	);
 	this->render_text(
 		{5, 15}, 12, renderer::Colors::WHITE,

--- a/libopenage/gamestate/game_save.cpp
+++ b/libopenage/gamestate/game_save.cpp
@@ -10,6 +10,7 @@
 #include "../unit/producer.h"
 #include "../unit/unit.h"
 #include "../unit/unit_type.h"
+#include "../versions/compiletime.h"
 #include "game_main.h"
 #include "game_save.h"
 #include "game_spec.h"
@@ -73,7 +74,7 @@ void save(openage::GameMain *game, const std::string &fname) {
 	// metadata
 	file << save_label << std::endl;
 	file << save_version << std::endl;
-	file << config::version << std::endl;
+	file << versions::engine_version << std::endl;
 
 	// how many chunks
 	std::vector<coord::chunk> used = game->terrain->used_chunks();

--- a/libopenage/versions/CMakeLists.txt
+++ b/libopenage/versions/CMakeLists.txt
@@ -1,5 +1,9 @@
+configure_file(compiletime.h.in compiletime.h)
+configure_file(compiletime.cpp.in compiletime.cpp)
+
 add_sources(libopenage
-    versions.cpp
+	${CMAKE_CURRENT_BINARY_DIR}/compiletime.cpp
+	versions.cpp
 )
 
 pxdgen(

--- a/libopenage/versions/compiletime.cpp.in
+++ b/libopenage/versions/compiletime.cpp.in
@@ -1,0 +1,12 @@
+// Copyright 2020-2020 the openage authors. See copying.md for legal info.
+
+// ${AUTOGEN_WARNING}
+
+#include "compiletime.h"
+
+namespace openage::versions {
+
+const char *const engine_version = "${VERSION_FULL_STRING}";
+const char *const nyan_version = "${nyan_VERSION}";
+
+} // namespace openage::versions

--- a/libopenage/versions/compiletime.h.in
+++ b/libopenage/versions/compiletime.h.in
@@ -1,0 +1,12 @@
+// Copyright 2020-2020 the openage authors. See copying.md for legal info.
+
+// ${AUTOGEN_WARNING}
+
+#pragma once
+
+namespace openage::versions {
+
+extern const char *const engine_version;
+extern const char *const nyan_version;
+
+} // namespace openage::versions

--- a/libopenage/versions/versions.cpp
+++ b/libopenage/versions/versions.cpp
@@ -1,36 +1,49 @@
 // Copyright 2020-2020 the openage authors. See copying.md for legal info.
 
+#include "versions.h"
+
+#ifndef __APPLE__
 #include <gnu/libc-version.h>
+#endif
+
 #include <SDL2/SDL.h>
 #include <sstream>
 
-#include "versions.h"
+#include "versions/compiletime.h"
+#include "../util/strings.h"
 
-using namespace std;
+namespace openage::versions {
 
-namespace openage
-{
+std::map<std::string, std::string> get_version_numbers() {
+	std::map<std::string, std::string> version_numbers;
 
-map<string,string> get_version_numbers()
-{
-	map<string,string> version_numbers;
+	// https://wiki.libsdl.org/SDL_VERSION
+	SDL_version sdl_compiled_version;
+	SDL_VERSION(&sdl_compiled_version);
+	version_numbers.emplace("SDL", util::sformat("%d.%d.%d",
+	                                             sdl_compiled_version.major,
+	                                             sdl_compiled_version.minor,
+	                                             sdl_compiled_version.patch));
 
-	//Add SDL version number
-	SDL_version compiled;
-	SDL_VERSION(&compiled)
 
-	string s;
-	s.append(to_string(compiled.major));
-	s.append(".");
-	s.append(to_string(compiled.minor));
-	s.append(".");
-	s.append(to_string(compiled.patch));
+	SDL_version sdl_runtime_version;
+	SDL_GetVersion(&sdl_runtime_version);
+	version_numbers.emplace("SDL_runtime", util::sformat("%d.%d.%d",
+	                                                     sdl_runtime_version.major,
+	                                                     sdl_runtime_version.minor,
+	                                                     sdl_runtime_version.patch));
 
-	version_numbers.insert(pair<string,string>("SDL", s));
+#ifdef __APPLE__
+	// TODO: i'm too stupid to find a get_version() for the apple libc
+	//       please add it here if you know it.
+	version_numbers.emplace("libc_runtime", "Apple");
+#else
+	version_numbers.emplace("libc_runtime", gnu_get_libc_version());
+#endif
 
-	//Add libc version number
-	version_numbers.insert(pair<string,string>("libc",gnu_get_libc_version()));
+	version_numbers.emplace("nyan", nyan_version);
 
 	return version_numbers;
 }
-} // namespace openage
+
+} // namespace openage::versions

--- a/libopenage/versions/versions.h
+++ b/libopenage/versions/versions.h
@@ -2,21 +2,23 @@
 
 #pragma once
 
-// pxd: from libcpp.string cimport string
 // pxd: from libcpp.map cimport map
 #include <map>
+// pxd: from libcpp.string cimport string
+#include <string>
 
 #include "../util/compiler.h"
 
 
-namespace openage {
+namespace openage::versions {
 
 /**
- * gets some int
+ * return a mapping of tool name to tool version,
+ * for various components of the engine.
  *
  * pxd:
- *
  * map[string,string] get_version_numbers() except +
  */
 OAAPI std::map<std::string,std::string> get_version_numbers();
-}
+
+} // namespace openage::versions

--- a/openage/versions/CMakeLists.txt
+++ b/openage/versions/CMakeLists.txt
@@ -3,5 +3,5 @@ add_cython_modules(
 )
 
 add_py_modules(
-    __init__.py
+	__init__.py
 )


### PR DESCRIPTION
I've added the nyan version and some simple example of compiletime/runtime versions of SDL.

Also, I've fixed some style issues and beautified the code, and added the preprocessor thingy for macOS.