### PR TITLE
Buildsystem updated to FindPython3.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ perf.data*
 .vscode
 .idea
 
+# Virtual Environments
+/.venv/
+
 # macOS
 .DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-# Copyright 2013-2017 the openage authors. See copying.md for legal info.
+# Copyright 2013-2020 the openage authors. See copying.md for legal info.
 
-cmake_minimum_required(VERSION 3.8.0)
-# required for CMAKE_CXX_STANDARD for C++17
+cmake_minimum_required(VERSION 3.12)
+
+# required for FindPython3.cmake
+# >3.8 required for CMAKE_CXX_STANDARD for C++17
 
 # main build configuration file
 
@@ -47,6 +49,7 @@ foreach(pol
         CMP0071  # enable automoc for generated files
         CMP0072  # prefers GLVND by default FindOpenGL
         CMP0048  # project() command manages VERSION variables
+        CMP0094  # take the first satisfying Python version
        )
 	if (POLICY ${pol})
 		cmake_policy(SET ${pol} NEW)

--- a/buildsystem/scripts/EmbedPython.cmake
+++ b/buildsystem/scripts/EmbedPython.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 the openage authors. See copying.md for legal info.
+# Copyright 2017-2020 the openage authors. See copying.md for legal info.
 
 if(NOT forward_variables)
 	message(FATAL_ERROR "CMake configuration variables not available. Please include(ForwardVariables.cmake)")
@@ -24,7 +24,7 @@ execute_process(COMMAND
 )
 
 execute_process(COMMAND
-	"${python}" "${buildsystem_dir}/scripts/copy_modules.py"
+	"${PYTHON}" "${buildsystem_dir}/scripts/copy_modules.py"
 	numpy PIL pyreadline readline
 	"${CMAKE_INSTALL_PREFIX}/${py_install_prefix}"
 )

--- a/buildsystem/scripts/EmbedWinDependencies.cmake
+++ b/buildsystem/scripts/EmbedWinDependencies.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 the openage authors. See copying.md for legal info.
+# Copyright 2017-2020 the openage authors. See copying.md for legal info.
 
 if(NOT forward_variables)
 	message(FATAL_ERROR "CMake configuration variables not available. Please include(ForwardVariables.cmake)")
@@ -68,9 +68,7 @@ endif()
 if((EXISTS ${POWERSHELL_COMMAND}) AND (EXISTS ${APPLOCAL_SCRIPT}))
 	foreach(file ${CMAKE_INSTALL_MANIFEST_FILES})
 		if(file MATCHES "\\.dll$")
-			# DEBUG
-			# message(STATUS "Use this command manually for diagnosing: ${POWERSHELL_COMMAND} ${APPLOCAL_SCRIPT} -targetBinary ${file} -installedDir ${vcpkg_dir}/bin -tlogFile ${LOGFILES_DIR}/applocal.log -copiedFilesLog ${LOGFILES_DIR}/applocal_copied_files.log!")
-
+			message(STATUS "Calling applocal.ps1 with ${file}.")
 			execute_process(COMMAND "${POWERSHELL_COMMAND}" "${APPLOCAL_SCRIPT}"
 					-targetBinary "${file}"
 					-installedDir "${vcpkg_dir}/bin"

--- a/doc/building.md
+++ b/doc/building.md
@@ -30,7 +30,7 @@ Dependency list:
     C     gcc >=7 or clang >=5
     CRA   python >=3.6
     C     cython >=0.25
-    C     cmake >=3.8.0
+    C     cmake >=3.12
       A   numpy
       A   python imaging library (PIL) -> pillow
     CR    opengl >=3.3


### PR DESCRIPTION
Early testing for pulling in CMake 3.12 as Minimum dependency and using Python3.cmake instead of our own FindPython implementation

Fixes #1225