### PR TITLE
Fix CMake warnings

### DIFF
--- a/buildsystem/modules/FindGPerfTools.cmake
+++ b/buildsystem/modules/FindGPerfTools.cmake
@@ -1,7 +1,7 @@
 # This file was taken from VAST,
 # Copyright 2014-2014 Matthias Vallentin.
 # It's licensed under the terms of the 3-clause BSD license.
-# Modifications Copyright 2014-2015 the openage authors.
+# Modifications Copyright 2014-2020 the openage authors.
 # See copying.md for further legal info.
 
 # Tries to find Gperftools.
@@ -45,7 +45,7 @@ set(GPERFTOOLS_LIBRARIES ${GPERFTOOLS_TCMALLOC_AND_PROFILER})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-	Gperftools
+	GPerfTools
 	DEFAULT_MSG
 	GPERFTOOLS_LIBRARIES
 	GPERFTOOLS_INCLUDE_DIR)

--- a/buildsystem/modules/FindInotify.cmake
+++ b/buildsystem/modules/FindInotify.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 the openage authors. See copying.md for legal info.
+# Copyright 2014-2020 the openage authors. See copying.md for legal info.
 
 # This module defines
 #
@@ -8,6 +8,6 @@
 find_path(INOTIFY_INCLUDE_DIR sys/inotify.h HINTS /usr/include/${CMAKE_LIBRARY_ARCHITECTURE})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(inotify DEFAULT_MSG INOTIFY_INCLUDE_DIR)
+find_package_handle_standard_args(Inotify DEFAULT_MSG INOTIFY_INCLUDE_DIR)
 
 mark_as_advanced(INOTIFY_INCLUDE_DIR)

--- a/buildsystem/modules/FindNumpy.cmake
+++ b/buildsystem/modules/FindNumpy.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016-2016 the openage authors. See copying.md for legal info.
+# Copyright 2016-2020 the openage authors. See copying.md for legal info.
 
 # This module defines:
 #
@@ -11,6 +11,6 @@ py_exec("import numpy; print(numpy.get_include())" NUMPY_INCLUDE_DIR)
 
 
 include("FindPackageHandleStandardArgs")
-find_package_handle_standard_args(numpy REQUIRED_VARS NUMPY_INCLUDE_DIR)
+find_package_handle_standard_args(Numpy REQUIRED_VARS NUMPY_INCLUDE_DIR)
 
 mark_as_advanced(NUMPY_INCLUDE_DIR)

--- a/buildsystem/modules/FindOpusfile.cmake
+++ b/buildsystem/modules/FindOpusfile.cmake
@@ -1,7 +1,7 @@
 # This file was taken from Unvanquished,
 # Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
 # It's licensed under the terms of the 3-clause OpenBSD license.
-# Modifications Copyright 2014-2017 the openage authors.
+# Modifications Copyright 2014-2020 the openage authors.
 # See copying.md for further legal info.
 
 # - Find opus library
@@ -9,7 +9,7 @@
 # This module defines
 #  OPUS_INCLUDE_DIRS   - where to find opus/opus.h, opus/opusfile.h, etc
 #  OPUS_LIBRARIES      - List of libraries when using libopus
-#  OPUS_FOUND          - True if opus is found.
+#  OPUSFILE_FOUND      - True if opus is found.
 
 # find the opusfile header, defines our api.
 find_path(OPUSFILE_INCLUDE_DIR
@@ -43,7 +43,7 @@ mark_as_advanced(OPUS_LIBRARY)
 # handle the QUIETLY and REQUIRED arguments and set OPUS_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Opus DEFAULT_MSG OPUSFILE_LIBRARY OPUS_LIBRARY OPUS_INCLUDE_DIR)
+find_package_handle_standard_args(Opusfile DEFAULT_MSG OPUSFILE_LIBRARY OPUS_LIBRARY OPUS_INCLUDE_DIR)
 
 # export the variables
 set(OPUS_LIBRARIES "${OPUSFILE_LIBRARY}" "${OPUS_LIBRARY}")


### PR DESCRIPTION
Fixing the warnings due to different naming schemes in the `find_package`-commands and the `find_package_handle_standard_args`.

>The package name passed to `find_package_handle_standard_args` (<CMake module name>) does not match the name of the calling package (<CMake module name>).  This can lead to problems in calling code that expects `find_package` result variables (e.g., `_FOUND`) to follow a certain pattern.