### PR TITLE
Fix Clang-10 warnings & fix configure script

### DIFF
--- a/configure
+++ b/configure
@@ -129,6 +129,9 @@ def get_compiler(args, parser):
         # map alias -> actual compiler
         aliases = {
             "clang": "clang++",
+            "clang-8": "clang++-8",
+            "clang-9": "clang++-9",
+            "clang-10": "clang++-10",
             "gcc": "g++",
         }
 

--- a/libopenage/log/file_logsink.cpp
+++ b/libopenage/log/file_logsink.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2020 the openage authors. See copying.md for legal info.
 
 #include "file_logsink.h"
 
@@ -8,13 +8,12 @@
 #include "message.h"
 #include "logsource.h"
 
-namespace openage {
-namespace log {
+namespace openage::log {
 
 
 FileSink::FileSink(const char *filename, bool append)
 	:
-	outfile{filename, std::ios_base::out | append ? std::ios_base::app : std::ios_base::trunc} {}
+	outfile{filename, std::ios_base::out | (append ? std::ios_base::app : std::ios_base::trunc)} {}
 
 
 void FileSink::output_log_message(const message &msg, LogSource *source) {
@@ -27,4 +26,4 @@ void FileSink::output_log_message(const message &msg, LogSource *source) {
 	this->outfile << msg.text << std::endl;
 }
 
-}} // namespace openage::log
+} // namespace openage::log

--- a/libopenage/rng/rng.cpp
+++ b/libopenage/rng/rng.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2020 the openage authors. See copying.md for legal info.
 
 #include "rng.h"
 
@@ -10,17 +10,14 @@
 #include "../util/hash.h"
 #include "../error/error.h"
 
-
-namespace openage {
-
-
 /**
  * Contains an easy to use and fast random number generator.
  *
  * This was never designed or intended as a cryptographic-quality,
  * RNG, so don't use it as one. If you do, I'll tell my mom.
  */
-namespace rng {
+
+namespace openage::rng {
 
 
 // Key for seed hashing, just some hardcoded key
@@ -34,8 +31,7 @@ RNG::RNG(uint64_t v1) {
 	this->seed(v1);
 }
 
-
-RNG::RNG(const void *data, size_t len) {
+[[maybe_unused]] RNG::RNG(const void *data, size_t len) {
 	this->seed(data, len);
 }
 
@@ -139,7 +135,7 @@ void RNG::fill_real(double *dat, size_t len) {
 	act_fill(
 		dat, this->state, len,
 		[](double v, double *d, size_t i) {
-			d[i] = v / RNG::max();
+			d[i] = v / (double) RNG::max();
 		}
 	);
 }
@@ -224,4 +220,4 @@ uint64_t random_seed() {
 }
 
 
-}} // namespace openage::rng
+} // namespace openage::rng

--- a/libopenage/rng/rng.h
+++ b/libopenage/rng/rng.h
@@ -1,12 +1,11 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2020 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <iostream>
 #include <string>
 
-namespace openage {
-namespace rng {
+namespace openage::rng {
 
 
 /** \class RNG
@@ -19,10 +18,9 @@ public:
 	 * Creates an rng and seeds it with the 64 bit seed
 	 * @param seed The inital seed for the following number generation.
 	 */
-	RNG(uint64_t seed);
+	explicit RNG(uint64_t seed);
 
-
-	/**
+        [[maybe_unused]] /**
 	 * Initializes the rng using data from the buffer pointed to by data
 	 * @param data The buffer that contains data for seeding the rng
 	 * @param count The number of bytes in the buffer
@@ -38,7 +36,7 @@ public:
 	 * @param instr The string from which the rng is serialized
 	 * @throws Error if the rng cannot be read from the string
 	 */
-	RNG(const std::string &instr);
+	explicit RNG(const std::string &instr);
 
 
 	/**
@@ -47,7 +45,7 @@ public:
 	 * @param instream The input stream for serializing the rng
 	 * @throws Error if stream initialization fails
 	 */
-	RNG(std::istream &instream);
+	explicit RNG(std::istream &instream);
 
 
 	/**
@@ -152,7 +150,7 @@ public:
 	/**
 	 * Writes the rng state to a string
 	 */
-	std::string to_string() const;
+	[[nodiscard]] std::string to_string() const;
 
 
 	/**
@@ -176,7 +174,7 @@ private:
 	/**
 	 * The internal state array
 	 */
-	uint64_t state[2];
+	uint64_t state[2]{};
 
 
 	/**
@@ -212,4 +210,4 @@ uint64_t time_seed();
 uint64_t random_seed();
 
 
-}} // namespace openage::rng
+} // namespace openage::rng


### PR DESCRIPTION
 buildsystem: Fix CXX aliases for different clang-versions

Clang-10 bugfix: error: implicit conversion from 'uint64_t' (aka 'unsigned long') to 'double' changes value from 18446744073709551615 to 18446744073709551616

Clang-10 bugfix: operator '?:' has lower precedence than '|'; '|' will be evaluated first

