### PR TITLE
Make ConcurrentQueue support both copy-constructible and move-constructible elements

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -127,6 +127,7 @@ _the openage authors_ are:
 | Aristotelis Dossas          | teldosas                    | teldosas à gmail dawt com                         |
 | Martin Sandsmark            | martin                      | martin dawt sandsmark à kde dawt org              |
 | Merlin Stollenwerk          | Mese96                      | merlin-stollenwerk à past-development dawt de     |
+| 段清楠 Duan Qingnan         | duanqn                      | duanqn_own_1 à yeah dawt net                      |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/datastructure/tests.h
+++ b/libopenage/datastructure/tests.h
@@ -1,13 +1,12 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2020 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <functional>
 #include <stddef.h>
+#include <mutex>
 
-namespace openage {
-namespace datastructure {
-namespace tests {
+namespace openage::datastructure::tests {
 
 /**
  * simplest priority queue element that supports reordering.
@@ -24,9 +23,7 @@ struct heap_elem {
 	}
 };
 
-} // namespace tests
-} // namespace datastructure
-} // namespace openage
+} // namespace openage::datastructure::tests
 
 namespace std {
 

--- a/openage/testing/testlist.py
+++ b/openage/testing/testlist.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2020 the openage authors. See copying.md for legal info.
 
 """ Lists of all possible tests; enter your tests here. """
 
@@ -74,6 +74,7 @@ def tests_cpp():
     """
 
     yield "openage::coord::tests::coord"
+    yield "openage::datastructure::tests::concurrent_queue"
     yield "openage::datastructure::tests::constexpr_map"
     yield "openage::datastructure::tests::pairing_heap"
     yield "openage::job::tests::test_job_manager"


### PR DESCRIPTION
Thought this might be useful...
Test with `make test` -- 1 issue (my email is not in copying.md)