### PR TITLE
Read number of SWGB blend modes from .dat file

### DIFF
--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -698,6 +698,11 @@ class AoCProcessor:
                     # Effect has no type
                     continue
 
+                if effect_type == 3:
+                    if effect["attr_b"].get_value() < 0:
+                        # Upgrade to invalid unit
+                        continue
+
                 if effect_type == 102:
                     if effect["attr_d"].get_value() < 0:
                         # Tech disable effect with no tech id specified

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -17,7 +17,7 @@ from ..value_object.read.media.blendomatic import Blendomatic
 from ..value_object.read.media_types import MediaType
 
 
-def get_blendomatic_data(args):
+def get_blendomatic_data(args, blend_mode_count=None):
     """
     reads blendomatic.dat
 
@@ -30,7 +30,7 @@ def get_blendomatic_data(args):
     blendomatic_path = game_edition.media_paths[MediaType.BLEND][0]
     blendomatic_dat = args.srcdir[blendomatic_path].open('rb')
 
-    return Blendomatic(blendomatic_dat)
+    return Blendomatic(blendomatic_dat, blend_mode_count)
 
 
 def convert(args):
@@ -98,7 +98,14 @@ def convert_metadata(args):
 
     if args.game_version[0] not in (GameEdition.ROR, GameEdition.AOE2DE):
         yield "blendomatic.dat"
-        blend_data = get_blendomatic_data(args)
+
+        if args.game_version[0] is GameEdition.SWGB:
+            blend_mode_count = gamespec[0]["blend_mode_count_swgb"].get_value()
+            blend_data = get_blendomatic_data(args, blend_mode_count)
+
+        else:
+            blend_data = get_blendomatic_data(args)
+
         blend_data.save(args.targetdir, "blendomatic")
         # data_formatter.add_data(blend_data.dump("blending_modes"))
 

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -217,7 +217,7 @@ class Blendomatic(GenieStructure):
     # };
     blendomatic_header = Struct("< I I")
 
-    def __init__(self, fileobj):
+    def __init__(self, fileobj, custom_mode_count=None):
         super().__init__()
 
         buf = fileobj.read(Blendomatic.blendomatic_header.size)
@@ -227,6 +227,12 @@ class Blendomatic(GenieStructure):
 
         dbg("%d blending modes, each %d tiles",
             blending_mode_count, tile_count)
+
+        if custom_mode_count:
+            blending_mode_count = custom_mode_count
+
+            dbg("reading only the first %d blending modes",
+                custom_mode_count)
 
         blending_mode = Struct("< I %dB" % (tile_count))
 

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -48,8 +48,10 @@ class EmpiresDat(GenieStructure):
                 (READ_GEN, "civ_count_swgb", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
                 (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
-                (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
-                (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
+                # Number of blend modes used in the game?
+                (READ_GEN, "blend_mode_count_swgb", StorageType.INT_MEMBER, "int32_t"),
+                # Number of blend modes that they wanted to use??
+                (READ_GEN, "blend_mode_count_max_swgb", StorageType.INT_MEMBER, "int32_t"),
             ])
 
         # terrain header data


### PR DESCRIPTION
The blendomatic reader now uses an entry from the .dat file for the number of blend modes it has to read. Previously it used the information in the header which defined an incorrect size. The .dat file entry is unique to SWGB and its purpose was unknown before. According to @withmorten, the blend mode count that is read is probably hardcoded and not read from the .dat, so we cannot test whether the entry is the actual blend mode count. But if it works... ¯\\\_(ツ)_/¯

