### PR TITLE
Revert "Remove pillow from dependencies"

### DIFF
--- a/doc/build_instructions/arch_linux.md
+++ b/doc/build_instructions/arch_linux.md
@@ -4,7 +4,7 @@
 
 This command should provide required packages for Arch Linux installation:
 
-`sudo pacman -S --needed eigen python python-jinja python-numpy python-pygments cython libepoxy libogg libpng ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus python-pylint python-toml qt5-declarative qt5-quickcontrols`
+`sudo pacman -S --needed eigen python python-jinja python-pillow python-numpy python-pygments cython libepoxy libogg libpng ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus python-pylint python-toml qt5-declarative qt5-quickcontrols`
 
 If you don't have a compiler installed, you can select between these commands to install it:
  - `sudo pacman -S --needed gcc`

--- a/doc/build_instructions/debian.md
+++ b/doc/build_instructions/debian.md
@@ -1,6 +1,6 @@
 # Prerequisite steps for Debian Sid users
 
  - `sudo apt-get update`
- - `sudo apt-get install cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pip python3-pygments python3-toml qml-module-qtquick-controls qtdeclarative5-dev`
+ - `sudo apt-get install cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pil python3-pip python3-pygments python3-toml qml-module-qtquick-controls qtdeclarative5-dev`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/fedora.md
+++ b/doc/build_instructions/fedora.md
@@ -2,6 +2,6 @@
 
 Run the following command:
 
-`sudo dnf install clang cmake eigen3-devel fontconfig-devel gcc-c harfbuzz-devel libepoxy-devel libogg-devel libopusenc-devel libpng-devel opusfile-devel python3-Cython python3-devel python3-jinja2 python3-numpy python3-pygments python3-toml SDL2-devel SDL2_image-devel++ qt5-qtdeclarative-devel qt5-qtquickcontrols`
+`sudo dnf install clang cmake eigen3-devel fontconfig-devel gcc-c harfbuzz-devel libepoxy-devel libogg-devel libopusenc-devel libpng-devel opusfile-devel python3-Cython python3-devel python3-jinja2 python3-numpy python3-pillow python3-pygments python3-toml SDL2-devel SDL2_image-devel++ qt5-qtdeclarative-devel qt5-qtquickcontrols`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/freebsd.md
+++ b/doc/build_instructions/freebsd.md
@@ -2,7 +2,7 @@
 
 This command should provide required packages for FreeBSD installation:
 
-`sudo pkg install cmake cython eigen3 harfbuzz opus-tools opusfile png py-numpy py-pygments py-toml pylint python qt5 sdl2 sdl2_image`
+`sudo pkg install cmake cython eigen3 harfbuzz opus-tools opusfile png py-numpy py-pillow py-pygments py-toml pylint python qt5 sdl2 sdl2_image`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.
 

--- a/doc/build_instructions/opensuse_13.2.md
+++ b/doc/build_instructions/opensuse_13.2.md
@@ -6,6 +6,6 @@ if all packages can be installed.
 
 - `zypper addrepo http://download.opensuse.org/repositories/devel:languages:python3/openSUSE_13.2/devel:languages:python3.repo`
 - `zypper refresh`
-- `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc49-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel pkgconfig python3-Cython python3-Jinja2 python3-Pygments python3-toml python3-devel`
+- `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc49-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel pkgconfig python3-Cython python3-Jinja2 python3-Pillow python3-Pygments python3-toml python3-devel`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/opensuse_tumbleweed.md
+++ b/doc/build_instructions/opensuse_tumbleweed.md
@@ -1,5 +1,5 @@
 # Prerequisite steps for openSUSE users (openSUSE Tumbleweed)
 
- - `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel pkgconfig python3-Cython python3-Jinja2 python3-Pygments python3-toml python3-devel`
+ - `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel pkgconfig python3-Cython python3-Jinja2 python3-Pillow python3-Pygments python3-toml python3-devel`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/os_x_10.14_mojave.md
+++ b/doc/build_instructions/os_x_10.14_mojave.md
@@ -12,7 +12,7 @@ brew install qt5
 brew install -cc=clang llvm@8
 export PATH="/usr/local/opt/llvm@8/bin:$PATH:/usr/local/lib:/usr/local/opt/llvm/bin"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/lib"
-pip3 install pygments cython numpy pyreadline toml jinja2
+pip3 install pygments cython numpy pillow pyreadline toml jinja2
 ```
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies:

--- a/doc/build_instructions/ubuntu.md
+++ b/doc/build_instructions/ubuntu.md
@@ -1,6 +1,6 @@
 # Prerequisite steps for Ubuntu users (Ubuntu 18.04)
 
  - `sudo apt-get update`
- - `sudo apt-get install cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pip python3-pygments python3-toml qml-module-qtquick-controls qtdeclarative5-dev`
+ - `sudo apt-get install cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-pil python3-pip python3-pygments python3-toml qml-module-qtquick-controls qtdeclarative5-dev`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -36,7 +36,7 @@ __NOTE:__ You need to manually make sure and doublecheck if the system you are b
 ### Python Modules
  Open a command prompt at `<Python 3 installation directory>/Scripts`
 
-    pip install cython numpy pygments pyreadline Jinja2
+    pip install cython numpy pillow pygments pyreadline Jinja2
 
 _Note:_ Make sure the Python 3 instance you're installing these scripts for is the one you call `python` in CMD
 _Note:_ Also ensure that `python` and `python3` both point to the correct and the same version of Python 3

--- a/doc/building.md
+++ b/doc/building.md
@@ -32,6 +32,7 @@ Dependency list:
     C     cython >=0.25
     C     cmake >=3.16
       A   numpy
+      A   python imaging library (PIL) -> pillow
      RA   toml
     CR    opengl >=3.3
     CR    libepoxy

--- a/openage/__init__.py
+++ b/openage/__init__.py
@@ -39,6 +39,7 @@ else:
         "Cython        {cython}\n"
         "Jinja2        {jinja2}\n"
         "NumPy         {numpy}\n"
+        "Pillow        {pillow}\n"
         "Pygments      {pygments}\n"
         "\n"
         "== C++ =="
@@ -54,6 +55,7 @@ else:
         cython=config.CYTHONVERSION,
         jinja2=config.JINJAVERSION,
         numpy=config.NUMPYVERSION,
+        pillow=config.PILVERSION,
         pygments=config.PYGMENTSVERSION,
     )
 


### PR DESCRIPTION
Reverts SFTtech/openage#1283

hehe, we still have `PIL` code, which we either have to remove, or keep pillow as dependency. I think having `PIL.Image` is quite handy.