### PR TITLE
Add option for asset conversion without --force

### DIFF
--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -12,7 +12,7 @@ from ..util.strings import format_progress
 from .service.init.conversion_required import conversion_required
 from .service.init.mount_asset_dirs import mount_asset_dirs
 from .tool.interactive import interactive_browser
-from .tool.subtool.acquire_sourcedir import acquire_conversion_source_dir
+from .tool.subtool.acquire_sourcedir import acquire_conversion_source_dir, wanna_convert
 from .tool.subtool.version_select import get_game_version
 
 
@@ -175,7 +175,7 @@ def main(args, error):
     from ..assets import get_asset_path
     outdir = get_asset_path(args.output_dir)
 
-    if args.force or conversion_required(outdir, args):
+    if args.force or wanna_convert() or conversion_required(outdir, args):
         if not convert_assets(outdir, args, srcdir):
             return 1
     else:

--- a/openage/convert/service/init/conversion_required.py
+++ b/openage/convert/service/init/conversion_required.py
@@ -13,9 +13,8 @@ def conversion_required(asset_dir, args):
 
     Sets options in args according to what sorts of conversion are required.
 
-    TODO: Reimplement for new converter.
+    TODO: Reimplement change detection for new converter.
     """
-
     version_path = asset_dir / 'converted' / changelog.ASSET_VERSION_FILENAME
     # determine the version of assets
     try:

--- a/openage/convert/tool/subtool/acquire_sourcedir.py
+++ b/openage/convert/tool/subtool/acquire_sourcedir.py
@@ -32,6 +32,24 @@ def expand_relative_path(path):
     return os.path.realpath(os.path.expandvars(os.path.expanduser(path)))
 
 
+def wanna_convert():
+    """
+    Ask the user if assets should be converted.
+    """
+    answer = None
+    while answer is None:
+        print("  Do you want to convert assets? [Y/n]")
+
+        user_selection = input("> ")
+        if user_selection.lower() in {"yes", "y", ""}:
+            answer = True
+
+        elif user_selection.lower() in {"no", "n"}:
+            answer = False
+
+    return answer
+
+
 def wanna_use_wine():
     """
     Ask the user if wine should be used.

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -1,9 +1,10 @@
-# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+# Copyright 2015-2020 the openage authors. See copying.md for legal info.
 
 """
 Holds the game entry point for openage.
 """
 
+from ..convert.tool.subtool.acquire_sourcedir import wanna_convert
 from ..log import err, info
 
 
@@ -56,7 +57,7 @@ def main(args, error):
     root["cfg"].mount(get_config_path(args.cfg_dir))
 
     # ensure that the assets have been converted
-    if conversion_required(root["assets"], args):
+    if wanna_convert() or conversion_required(root["assets"], args):
         # try to get previously used source dir
         asset_location_path = root["cfg"] / "asset_location"
         try:


### PR DESCRIPTION
Since the asset format change detection was deactivated in #1151, the converter would no longer convert any assets by default. The reason for this is that the requirement for conversion was built into the change detection mechanism. (This should be fixed once we have a proper change detection again)

As a quick fix I added a prompt that asks the user if they want to convert the assets, so new users are not as confused.