### PR TITLE
make --devmode and --no-devmode mutually exclusive through argparse

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -130,6 +130,7 @@ _the openage authors_ are:
 | 段清楠 Duan Qingnan          | duanqn                      | duanqn_own_1 à yeah dawt net                      |
 | Sean Ramey                  | SeanRamey                   | sramey40 à gmail dawt com                         |
 | D R Siddhartha              | drs-11                      | siddharthadr11 à gmail dawt com                   |
+| Martin Matějek              | mmtj                        | martin dawt matejek à gmx dawt com                |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -52,14 +52,15 @@ def main(argv=None):
                             help="increase verbosity")
     global_cli.add_argument("--quiet", "-q", action='count', default=0,
                             help="decrease verbosity")
-    global_cli.add_argument("--devmode", action="store_true",
-                            help="force-enable development mode")
-    global_cli.add_argument("--no-devmode", action="store_true",
-                            help="force-disable devlopment mode")
     global_cli.add_argument("--trap-exceptions", action="store_true",
                             help=("upon throwing an exception a debug break is "
                                   "triggered. this will crash openage if no "
                                   "debugger is present"))
+    devmodes = global_cli.add_mutually_exclusive_group()
+    devmodes.add_argument("--devmode", action="store_true",
+                          help="force-enable development mode")
+    devmodes.add_argument("--no-devmode", action="store_true",
+                          help="force-disable development mode")
 
     # shared directory arguments for most subcommands
     cfg_cli = argparse.ArgumentParser(add_help=False)
@@ -108,9 +109,6 @@ def main(argv=None):
 
     # process the shared args
     set_loglevel(verbosity_to_level(args.verbose - args.quiet))
-
-    if args.no_devmode and args.devmode:
-        cli.error("can't force enable and disable devmode at the same time")
 
     try:
         from . import config


### PR DESCRIPTION
As newcomer to this project I don't fully understand the need for having two separate devmode overrides, so I didn't touch that logic.

Nevertheless, it seems to me that manually enforcing mutual exclusion of `--devmode` and `--no-devmode` might be error prone and could be handled entirely within argparse.

Downside of this change is that we lose custom error string here, but in this case it IMO shouldn't matter that much as these two options are opposite of each other.