### PR TITLE
Create auxilary files for game edition/expansion information

### DIFF
--- a/cfg/converter/games/game_editions.toml
+++ b/cfg/converter/games/game_editions.toml
@@ -1,0 +1,136 @@
+# game edition config file for openage
+
+file_version = "1.0"
+
+[AOC]
+name = "Age of Empires 2: The Conqueror's"
+game_edition_id = "AOC"
+support = "yes"
+targetmod = [ "aoe2-base", "aoe2-base-graphics" ]
+expansions = [ ]
+
+  [AOC.mediapaths]
+  datfile = [ "data/empires2_x1_p1.dat" ]
+  gamedata = [ "data/gamedata_x1_p1.drs" ]
+  graphics = [ "data/graphics.drs" ]
+  language = [ "language.dll", "language_x1.dll", "language_x1_p1.dll" ]
+  palettes = [ "data/interfac.drs" ]
+  sounds = [ "data/sounds.drs", "data/sounds_x1.drs" ]
+  interface = [ "data/interfac.drs" ]
+  terrain = [ "data/terrain.drs" ]
+  blend = [ "data/blendomatic.dat" ]
+
+[AOK]
+name = "Age of Empires 2: Age of Kings"
+game_edition_id = "AOK"
+support = "nope"
+targetmod = [ ]
+expansions = [ ]
+
+  [AOK.mediapaths]
+  datfile = [ "data/empires2.dat" ]
+  gamedata = [ "data/gamedata.drs" ]
+  graphics = [ "data/graphics.drs" ]
+  palettes = [ "data/interfac.drs" ]
+  sounds = [ "data/sounds.drs" ]
+  interface = [ "data/interfac.drs" ]
+  terrain = [ "data/terrain.drs" ]
+
+[AOE1DE]
+name = "Age of Empires 1: Definitive Edition (Steam)"
+game_edition_id = "AOE1DE"
+support = "nope"
+targetmod = [ "aoe1-base", "aoe1-base-graphics" ]
+expansions = [ ]
+
+  [AOE1DE.mediapaths]
+  datfile = [ "Data/empires.dat" ]
+  graphics = [ "Assets/SLP/" ]
+  palettes = [ "Assets/Palettes/" ]
+  sounds = [ "Assets/Sounds/" ]
+  interface = [ "Data/DRS/interfac.drs", "Data/DRS/interfac_x1.drs" ]
+
+[ROR]
+name = "Age of Empires 1: Rise of Rome"
+game_edition_id = "ROR"
+support = "yes"
+targetmod = [ "aoe1-base", "aoe1-base-graphics" ]
+expansions = [ ]
+
+  [ROR.mediapaths]
+  datfile = [ "data2/empires.dat" ]
+  graphics = [ "data/graphics.drs", "data2/graphics.drs" ]
+  palettes = [ "data/Interfac.drs", "data2/Interfac.drs" ]
+  sounds = [ "data/sounds.drs", "data2/sounds.drs" ]
+  interface = [ "data/Interfac.drs", "data2/Interfac.drs" ]
+  language = [ "language.dll", "languagex.dll" ]
+  terrain = [ "data/Terrain.drs" ]
+  border = [ "data/Border.drs" ]
+
+[HDEDITION]
+name = "Age of Empires 2: HD Edition"
+game_edition_id = "HDEDITION"
+support = "yes"
+targetmod = [ "aoe2-base", "aoe2-base-graphics" ]
+expansions = [ ]
+
+  [HDEDITION.mediapaths]
+  datfile = [ "resources/_common/dat/empires2_x1_p1.dat" ]
+  gamedata = [ "resources/_common/drs/gamedata_x1/" ]
+  graphics = [ "resources/_common/drs/graphics/" ]
+  palettes = [ "resources/_common/drs/interface/" ]
+  sounds = [ "resources/_common/drs/sounds/" ]
+  interface = [ "resources/_common/drs/interface/" ]
+  terrain = [ "resources/_common/drs/terrain/" ]
+
+[AOE2DE]
+name = "Age of Empires 2: Definitive Edition"
+game_edition_id = "AOE2DE"
+support = "yes"
+targetmod = [ "aoe2-base", "aoe2-base-graphics" ]
+expansions = [ ]
+
+  [AOE2DE.mediapaths]
+  datfile = [ "resources/_common/dat/empires2_x2_p1.dat" ]
+  gamedata = [ "resources/_common/drs/gamedata_x1/" ]
+  graphics = [ "resources/_common/drs/graphics/" ]
+  language = [
+  "resources/br/strings/key-value/key-value-strings-utf8.txt",
+  "resources/de/strings/key-value/key-value-strings-utf8.txt",
+  "resources/en/strings/key-value/key-value-strings-utf8.txt",
+  "resources/es/strings/key-value/key-value-strings-utf8.txt",
+  "resources/fr/strings/key-value/key-value-strings-utf8.txt",
+  "resources/hi/strings/key-value/key-value-strings-utf8.txt",
+  "resources/it/strings/key-value/key-value-strings-utf8.txt",
+  "resources/jp/strings/key-value/key-value-strings-utf8.txt",
+  "resources/ko/strings/key-value/key-value-strings-utf8.txt",
+  "resources/ms/strings/key-value/key-value-strings-utf8.txt",
+  "resources/mx/strings/key-value/key-value-strings-utf8.txt",
+  "resources/ru/strings/key-value/key-value-strings-utf8.txt",
+  "resources/tr/strings/key-value/key-value-strings-utf8.txt",
+  "resources/tw/strings/key-value/key-value-strings-utf8.txt",
+  "resources/vi/strings/key-value/key-value-strings-utf8.txt",
+  "resources/zh/strings/key-value/key-value-strings-utf8.txt"
+]
+  palettes = [ "resources/_common/palettes/" ]
+  sounds = [ "wwise/" ]
+  interface = [ "resources/_common/drs/interface/" ]
+  terrain = [ "resources/_common/terrain/textures/" ]
+
+[SWGB]
+name = "Star Wars: Galactic Battlegrounds"
+game_edition_id = "SWGB"
+support = "yes"
+targetmod = [ "swgb-base", "swgb-base-graphics" ]
+expansions = [ "SWGB_CC" ]
+
+  [SWGB.mediapaths]
+  datfile = [ "Game/Data/GENIE.DAT" ]
+  gamedata = [ "Game/Data/GAMEDATA.DRS" ]
+  graphics = [ "Game/Data/GRAPHICS.DRS" ]
+  language = [ "Game/language.dll" ]
+  palettes = [ "Game/Data/INTERFAC.DRS" ]
+  sounds = [ "Game/Data/SOUNDS.DRS" ]
+  interface = [ "Game/Data/INTERFAC.DRS" ]
+  terrain = [ "Game/Data/TERRAIN.DRS" ]
+  blend = [ "Game/Data/blendomatic.dat" ]

--- a/cfg/converter/games/game_expansions.toml
+++ b/cfg/converter/games/game_expansions.toml
@@ -1,0 +1,31 @@
+# game expansion config file for openage
+
+file_version = "1.0"
+
+[AFRI_KING]
+name = "African Kingdoms (HD)"
+game_edition_id = "AFRI_KING"
+support = "nope"
+targetmod = [ "aoe2-ak", "aoe2-ak-graphics" ]
+
+  [AFRI_KING.mediapaths]
+  graphics = [ "resources/_common/slp/" ]
+  sounds = [ "resources/_common/sound/" ]
+  interface = [ "resources/_common/drs/interface/" ]
+  terrain = [ "resources/_common/terrain/" ]
+
+[SWGB_CC]
+name = "Clone Campaigns"
+game_edition_id = "SWGB_CC"
+support = "yes"
+targetmod = [ "swgb-cc", "swgb-cc-graphics" ]
+
+  [SWGB_CC.mediapaths]
+  datfile = [ "Game/Data/genie_x1.dat" ]
+  gamedata = [ "Game/Data/genie_x1.dat" ]
+  graphics = [ "Game/Data/graphics_x1.drs" ]
+  language = [ "Game/language_x1.dll" ]
+  palettes = [ "Game/Data/interfac_x1.drs" ]
+  sounds = [ "Game/Data/sounds_x1.drs" ]
+  interface = [ "Game/Data/interfac_x1.drs" ]
+  terrain = [ "Game/Data/terrain_x1.drs" ]

--- a/cfg/converter/games/version-hashes/AFRI_KING.toml
+++ b/cfg/converter/games/version-hashes/AFRI_KING.toml
@@ -1,0 +1,10 @@
+# version hashes of African Kingdoms (HD)
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[empires2_x2_p1dat]
+path = "resources/_common/dat/empires2_x2_p1.dat"
+
+  [empires2_x2_p1dat.map]
+  b2a69980a1ef39e68de2be1771392858cb639a9f2797373ab1649acf = "5.8"

--- a/cfg/converter/games/version-hashes/AOC.toml
+++ b/cfg/converter/games/version-hashes/AOC.toml
@@ -1,0 +1,17 @@
+# version hashes of Age of Empires 2: The Conqueror's
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[age2_x1]
+path = "age2_x1/age2_x1.exe"
+
+  [age2_x1.map]
+  d02ef2f4935c5ef568eaa873442b4b2b547067ed8e3572758bbbbee8 = "1.0c"
+  4568f37f309c0a89fa9e84a0c0f6c61b0f394c28adc82c0b3f2203b3 = "1.0c"
+
+[empires2_x1_p1dat]
+path = "Data/empires2_x1_p1.dat"
+
+  [empires2_x1_p1dat.map]
+  6aab4c7468c3d319ec00f577835dc7799b70ffab1de6bfd25ac227b5 = "1.0c"

--- a/cfg/converter/games/version-hashes/AOE1DE.toml
+++ b/cfg/converter/games/version-hashes/AOE1DE.toml
@@ -1,0 +1,16 @@
+# version hashes of Age of Empires 1: Definitive Edition (Steam)
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[AoEDE_s]
+path = "AoEDE_s.exe"
+
+  [AoEDE_s.map]
+  3356c013f2cb732601e1acf286654e4360d7e7304a092bdbeaa63d48 = "steam"
+
+[empiresdat]
+path = "Data/empires.dat"
+
+  [empiresdat.map]
+  4d1f3cb7ce20074bfa23445c62755b95e4ec193b41507d5196921033 = "steam"

--- a/cfg/converter/games/version-hashes/AOE2DE.toml
+++ b/cfg/converter/games/version-hashes/AOE2DE.toml
@@ -1,0 +1,16 @@
+# version hashes of Age of Empires 2: Definitive Edition
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[AoE2DE_s]
+path = "AoE2DE_s.exe"
+
+  [AoE2DE_s.map]
+  01ff7cc7819e4f77be059c8efc6c07472dd1a58f429621e937328750 = "36906"
+
+[empires2_x2_p1dat]
+path = "resources/_common/dat/empires2_x2_p1.dat"
+
+  [empires2_x2_p1dat.map]
+  cf13c553c78df192da1af957d1519870db15c9dbca314b245a5abe6f = "36906"

--- a/cfg/converter/games/version-hashes/AOK.toml
+++ b/cfg/converter/games/version-hashes/AOK.toml
@@ -1,0 +1,16 @@
+# version hashes of Age of Empires 2: Age of Kings
+
+file_version = "1.0"
+hash_algo = "MD5"
+
+[empires2]
+path = "empires2.exe"
+
+  [empires2.map]
+  5f7ca6c7edeba075c7982714619bc66b = "2.0a"
+
+[empires2dat]
+path = "data/empires2.dat"
+
+  [empires2dat.map]
+  89ff818894b69040ebd1657d8029b068 = "2.0a"

--- a/cfg/converter/games/version-hashes/HDEDITION.toml
+++ b/cfg/converter/games/version-hashes/HDEDITION.toml
@@ -1,0 +1,16 @@
+# version hashes of Age of Empires 2: HD Edition
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+["AoK HD"]
+path = "AoK HD.exe"
+
+  ["AoK HD".map]
+  73a068f353efd50e058762ca090062600a7ca50e435fe55a6ca87efa = "5.8"
+
+[empires2_x1_p1dat]
+path = "resources/_common/dat/empires2_x1_p1.dat"
+
+  [empires2_x1_p1dat.map]
+  91f7370b75b2fadf238b25f6fdd2f43a88a1f01ea022cd6086e44f43 = "5.8"

--- a/cfg/converter/games/version-hashes/ROR.toml
+++ b/cfg/converter/games/version-hashes/ROR.toml
@@ -1,0 +1,16 @@
+# version hashes of Age of Empires 1: Rise of Rome
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[EMPIRESX]
+path = "EMPIRESX.EXE"
+
+  [EMPIRESX.map]
+  bd55a288136ea5457c61fbc794e3e4a4ac526b1d53809f1b16762119 = "1.0B"
+
+[empiresdat]
+path = "data2/empires.dat"
+
+  [empiresdat.map]
+  0376368ce4c78be31596dea7b76f592b2352f6b5c3aca222b7939b4a = "1.0B"

--- a/cfg/converter/games/version-hashes/SWGB.toml
+++ b/cfg/converter/games/version-hashes/SWGB.toml
@@ -1,0 +1,16 @@
+# version hashes of Star Wars: Galactic Battlegrounds
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[Battlegrounds]
+path = "Game/Battlegrounds.exe"
+
+  [Battlegrounds.map]
+  0a5e2b7828b5b0a45cb6dfbf52e3becb2021e97259ba23a5cee94230 = "GOG"
+
+[GENIE]
+path = "Game/Data/GENIE.DAT"
+
+  [GENIE.map]
+  f1f641f201dac9d7663df4cf1ece7a60a78770a09e70e202399505d9 = "GOG"

--- a/cfg/converter/games/version-hashes/SWGB_CC.toml
+++ b/cfg/converter/games/version-hashes/SWGB_CC.toml
@@ -1,0 +1,16 @@
+# version hashes of Clone Campaigns
+
+file_version = "1.0"
+hash_algo = "SHA3-256"
+
+[battlegrounds_x1]
+path = "Game/battlegrounds_x1.exe"
+
+  [battlegrounds_x1.map]
+  fb722624bae8a4626925926d5709e1397766dd3ee2dcd1df7849ad27 = "GOG"
+
+[genie_x1dat]
+path = "Game/Data/genie_x1.dat"
+
+  [genie_x1dat.map]
+  036a16aefd1a66f5bad121786e66b8cc9542cbe88b43c4eb8f73eadb = "GOG"

--- a/openage/convert/deprecated/struct_definition.py
+++ b/openage/convert/deprecated/struct_definition.py
@@ -5,6 +5,8 @@
 from collections import OrderedDict
 import re
 
+from openage.convert.value_object.init.game_version import GameEdition
+
 from ..value_object.read.member_access import SKIP, READ_GEN, NOREAD_EXPORT
 from ..value_object.read.read_members import IncludeMembers, StringMember,\
     CharArrayMember, NumberMember, ReadMember, RefMember, ArrayMember
@@ -57,7 +59,10 @@ class StructDefinition:
         self.inherited_members = list()
         self.parent_classes = list()
 
-        target_members = target.get_data_format(("AOC", []),
+        # dummy game edition that represents AoC
+        dummy = GameEdition("", "AoC", "yes", [], [], [], [])
+
+        target_members = target.get_data_format((dummy, []),
                                                 allowed_modes=(True, SKIP, READ_GEN, NOREAD_EXPORT),
                                                 flatten_includes=True
                                                 )
@@ -114,7 +119,7 @@ class StructDefinition:
             if is_parent:
                 self.inherited_members.append(member_name)
 
-        members = target.get_data_format(("AOC", []), flatten_includes=False)
+        members = target.get_data_format((dummy, []), flatten_includes=False)
         for _, _, _, _, member_type in members:
             if isinstance(member_type, IncludeMembers):
                 self.parent_classes.append(member_type.cls)

--- a/openage/convert/deprecated/struct_definition.py
+++ b/openage/convert/deprecated/struct_definition.py
@@ -5,7 +5,6 @@
 from collections import OrderedDict
 import re
 
-from ..value_object.init.game_version import GameEdition
 from ..value_object.read.member_access import SKIP, READ_GEN, NOREAD_EXPORT
 from ..value_object.read.read_members import IncludeMembers, StringMember,\
     CharArrayMember, NumberMember, ReadMember, RefMember, ArrayMember
@@ -58,7 +57,7 @@ class StructDefinition:
         self.inherited_members = list()
         self.parent_classes = list()
 
-        target_members = target.get_data_format((GameEdition.AOC, []),
+        target_members = target.get_data_format(("AOC", []),
                                                 allowed_modes=(True, SKIP, READ_GEN, NOREAD_EXPORT),
                                                 flatten_includes=True
                                                 )
@@ -115,7 +114,7 @@ class StructDefinition:
             if is_parent:
                 self.inherited_members.append(member_name)
 
-        members = target.get_data_format((GameEdition.AOC, []), flatten_includes=False)
+        members = target.get_data_format(("AOC", []), flatten_includes=False)
         for _, _, _, _, member_type in members:
             if isinstance(member_type, IncludeMembers):
                 self.parent_classes.append(member_type.cls)

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -6,6 +6,8 @@ import hashlib
 import math
 import struct
 
+from openage.convert.value_object.init.game_version import GameEdition
+
 from ....util.strings import decode_until_null
 from ...deprecated.struct_definition import (StructDefinition, vararray_match,
                                              integer_match)
@@ -501,13 +503,18 @@ class GenieStructure:
     def structs(cls):
         """
         create struct definitions for this class and its subdata references.
+
+        TODO: Remove from buildsystem
         """
 
         ret = list()
         self_member_count = 0
 
+        # dummy game edition that represents AoC
+        dummy = GameEdition("", "AoC", "yes", [], [], [], [])
+
         # acquire all struct members, including the included members
-        members = cls.get_data_format(("AOC", []),
+        members = cls.get_data_format((dummy, []),
                                       allowed_modes=(True, SKIP, READ_GEN, NOREAD_EXPORT),
                                       flatten_includes=False)
 

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -10,7 +10,6 @@ from ....util.strings import decode_until_null
 from ...deprecated.struct_definition import (StructDefinition, vararray_match,
                                              integer_match)
 from ...deprecated.util import struct_type_lookup
-from ...value_object.init.game_version import GameEdition
 from ...value_object.read.member_access import READ, READ_GEN, READ_UNKNOWN, NOREAD_EXPORT, SKIP
 from ...value_object.read.read_members import (IncludeMembers, ContinueReadMember,
                                                MultisubtypeMember, GroupMember, SubdataMember,
@@ -508,7 +507,7 @@ class GenieStructure:
         self_member_count = 0
 
         # acquire all struct members, including the included members
-        members = cls.get_data_format((GameEdition.AOC, []),
+        members = cls.get_data_format(("AOC", []),
                                       allowed_modes=(True, SKIP, READ_GEN, NOREAD_EXPORT),
                                       flatten_includes=False)
 

--- a/openage/convert/entity_object/export/media_export_request.py
+++ b/openage/convert/entity_object/export/media_export_request.py
@@ -11,7 +11,6 @@ should be a processor/service that saves the file based on the request.
 """
 
 from ....util.observer import Observable
-from ...value_object.init.game_version import GameEdition
 from ...value_object.read.media_types import MediaType
 from .texture import Texture
 
@@ -161,7 +160,7 @@ class TerrainMediaExportRequest(MediaExportRequest):
             # TODO: Implement
             pass
 
-        if game_version[0] in (GameEdition.AOC, GameEdition.SWGB):
+        if game_version[0].game_id in ("AOC", "SWGB"):
             from ...processor.export.texture_merge import merge_terrain
             texture = Texture(image, palettes, custom_merger=merge_terrain)
 

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -17,7 +17,7 @@ from .tool.subtool.acquire_sourcedir import acquire_conversion_source_dir, wanna
 from .tool.subtool.version_select import get_game_version
 
 
-def convert_assets(assets, cfg, args, srcdir=None, prev_source_dir_path=None):
+def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     """
     Perform asset conversion.
 
@@ -37,7 +37,7 @@ def convert_assets(assets, cfg, args, srcdir=None, prev_source_dir_path=None):
         srcdir = acquire_conversion_source_dir(prev_source_dir_path)
 
     # Initialize game versions data
-    auxiliary_files_dir = cfg / "converter" / "games"
+    auxiliary_files_dir = args.cfg_dir / "converter" / "games"
     args.avail_game_eds, args.avail_game_exps = create_version_objects(auxiliary_files_dir)
 
     # Acquire game version info
@@ -176,7 +176,8 @@ def main(args, error):
     from ..cvar.location import get_config_path
     from ..util.fslike.union import Union
     root = Union().root
-    root["cfg"].mount(get_config_path(args.cfg_dir))
+    root["cfg"].mount(get_config_path())
+    args.cfg_dir = root["cfg"]
 
     if args.interactive:
         interactive_browser(root["cfg"], srcdir)
@@ -187,7 +188,7 @@ def main(args, error):
     outdir = get_asset_path(args.output_dir)
 
     if args.force or wanna_convert() or conversion_required(outdir, args):
-        if not convert_assets(outdir, root["cfg"], args, srcdir):
+        if not convert_assets(outdir, args, srcdir):
             return 1
     else:
         print("assets are up to date; no conversion is required.")

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -92,7 +92,7 @@ def get_class_lookups(game_version):
     if game_edition.game_id == "ROR":
         return ror_internal.CLASS_ID_LOOKUPS
 
-    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
+    if game_edition.game_id in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.CLASS_ID_LOOKUPS
 
     if game_edition.game_id == "SWGB":
@@ -115,7 +115,7 @@ def get_command_lookups(game_version):
     if game_edition.game_id == "ROR":
         return ror_internal.COMMAND_TYPE_LOOKUPS
 
-    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
+    if game_edition.game_id in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.COMMAND_TYPE_LOOKUPS
 
     if game_edition.game_id == "SWGB":
@@ -206,7 +206,7 @@ def get_gather_lookups(game_version):
     if game_edition.game_id == "ROR":
         return ror_internal.GATHER_TASK_LOOKUPS
 
-    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
+    if game_edition.game_id in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.GATHER_TASK_LOOKUPS
 
     if game_edition.game_id == "SWGB":
@@ -262,7 +262,7 @@ def get_restock_lookups(game_version):
     if game_edition.game_id == "ROR":
         return None
 
-    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
+    if game_edition.game_id in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.RESTOCK_TARGET_LOOKUPS
 
     if game_edition.game_id == "SWGB":

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -11,7 +11,6 @@ import openage.convert.value_object.conversion.hd.fgt.internal_nyan_names as fgt
 import openage.convert.value_object.conversion.hd.raj.internal_nyan_names as raj_internal
 import openage.convert.value_object.conversion.ror.internal_nyan_names as ror_internal
 import openage.convert.value_object.conversion.swgb.internal_nyan_names as swgb_internal
-from ...value_object.init.game_version import GameEdition
 
 
 def get_armor_class_lookups(game_version):
@@ -24,13 +23,13 @@ def get_armor_class_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.ARMOR_CLASS_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.ARMOR_CLASS_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         armor_lookup_dict = {}
         armor_lookup_dict.update(aoc_internal.ARMOR_CLASS_LOOKUPS)
         armor_lookup_dict.update(fgt_internal.ARMOR_CLASS_LOOKUPS)
@@ -40,7 +39,7 @@ def get_armor_class_lookups(game_version):
 
         return armor_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.ARMOR_CLASS_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -57,13 +56,13 @@ def get_civ_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.CIV_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.CIV_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         civ_lookup_dict = {}
         civ_lookup_dict.update(aoc_internal.CIV_GROUP_LOOKUPS)
         civ_lookup_dict.update(fgt_internal.CIV_GROUP_LOOKUPS)
@@ -73,7 +72,7 @@ def get_civ_lookups(game_version):
 
         return civ_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.CIV_GROUP_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -90,13 +89,13 @@ def get_class_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.CLASS_ID_LOOKUPS
 
-    if game_edition in (GameEdition.AOC, GameEdition.HDEDITION, GameEdition.AOE2DE):
+    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.CLASS_ID_LOOKUPS
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.CLASS_ID_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -113,13 +112,13 @@ def get_command_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.COMMAND_TYPE_LOOKUPS
 
-    if game_edition in (GameEdition.AOC, GameEdition.HDEDITION, GameEdition.AOE2DE):
+    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.COMMAND_TYPE_LOOKUPS
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.COMMAND_TYPE_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -138,7 +137,7 @@ def get_entity_lookups(game_version):
 
     entity_lookup_dict = {}
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         entity_lookup_dict.update(ror_internal.UNIT_LINE_LOOKUPS)
         entity_lookup_dict.update(ror_internal.BUILDING_LINE_LOOKUPS)
         entity_lookup_dict.update(ror_internal.AMBIENT_GROUP_LOOKUPS)
@@ -146,7 +145,7 @@ def get_entity_lookups(game_version):
 
         return entity_lookup_dict
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         entity_lookup_dict.update(aoc_internal.UNIT_LINE_LOOKUPS)
         entity_lookup_dict.update(aoc_internal.BUILDING_LINE_LOOKUPS)
         entity_lookup_dict.update(aoc_internal.AMBIENT_GROUP_LOOKUPS)
@@ -154,7 +153,7 @@ def get_entity_lookups(game_version):
 
         return entity_lookup_dict
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         entity_lookup_dict.update(aoc_internal.UNIT_LINE_LOOKUPS)
         entity_lookup_dict.update(aoc_internal.BUILDING_LINE_LOOKUPS)
         entity_lookup_dict.update(aoc_internal.AMBIENT_GROUP_LOOKUPS)
@@ -182,7 +181,7 @@ def get_entity_lookups(game_version):
 
         return entity_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         entity_lookup_dict.update(swgb_internal.UNIT_LINE_LOOKUPS)
         entity_lookup_dict.update(swgb_internal.BUILDING_LINE_LOOKUPS)
         entity_lookup_dict.update(swgb_internal.AMBIENT_GROUP_LOOKUPS)
@@ -204,13 +203,13 @@ def get_gather_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.GATHER_TASK_LOOKUPS
 
-    if game_edition in (GameEdition.AOC, GameEdition.HDEDITION, GameEdition.AOE2DE):
+    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.GATHER_TASK_LOOKUPS
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.GATHER_TASK_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -227,13 +226,13 @@ def get_graphic_set_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.GRAPHICS_SET_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.GRAPHICS_SET_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         graphic_set_lookup_dict = {}
         graphic_set_lookup_dict.update(aoc_internal.GRAPHICS_SET_LOOKUPS)
         graphic_set_lookup_dict.update(fgt_internal.GRAPHICS_SET_LOOKUPS)
@@ -243,7 +242,7 @@ def get_graphic_set_lookups(game_version):
 
         return graphic_set_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.GRAPHICS_SET_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -260,13 +259,13 @@ def get_restock_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return None
 
-    if game_edition in (GameEdition.AOC, GameEdition.HDEDITION, GameEdition.AOE2DE):
+    if game_edition in ("AOC", "HDEDITION", "AOE2DE"):
         return aoc_internal.RESTOCK_TARGET_LOOKUPS
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.RESTOCK_TARGET_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -283,13 +282,13 @@ def get_tech_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.TECH_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.TECH_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         tech_lookup_dict = {}
         tech_lookup_dict.update(aoc_internal.TECH_GROUP_LOOKUPS)
         tech_lookup_dict.update(fgt_internal.TECH_GROUP_LOOKUPS)
@@ -299,7 +298,7 @@ def get_tech_lookups(game_version):
 
         return tech_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.TECH_GROUP_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -316,13 +315,13 @@ def get_terrain_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.TERRAIN_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.TERRAIN_GROUP_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         terrain_lookup_dict = {}
         terrain_lookup_dict.update(aoc_internal.TERRAIN_GROUP_LOOKUPS)
         terrain_lookup_dict.update(fgt_internal.TERRAIN_GROUP_LOOKUPS)
@@ -332,7 +331,7 @@ def get_terrain_lookups(game_version):
 
         return terrain_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.TERRAIN_GROUP_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"
@@ -349,13 +348,13 @@ def get_terrain_type_lookups(game_version):
     game_edition = game_version[0]
     # game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         return ror_internal.TERRAIN_TYPE_LOOKUPS
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         return aoc_internal.TERRAIN_TYPE_LOOKUPS
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         terrain_type_lookup_dict = {}
         terrain_type_lookup_dict.update(aoc_internal.TERRAIN_TYPE_LOOKUPS)
         terrain_type_lookup_dict.update(fgt_internal.TERRAIN_TYPE_LOOKUPS)
@@ -365,7 +364,7 @@ def get_terrain_type_lookups(game_version):
 
         return terrain_type_lookup_dict
 
-    if game_edition is GameEdition.SWGB:
+    if game_edition.game_id == "SWGB":
         return swgb_internal.TERRAIN_TYPE_LOOKUPS
 
     raise Exception("No lookup dict found for game version %s"

--- a/openage/convert/service/init/mount_asset_dirs.py
+++ b/openage/convert/service/init/mount_asset_dirs.py
@@ -24,7 +24,7 @@ def mount_asset_dirs(srcdir, game_version):
         """
 
         drspath = srcdir[filename]
-        result[target].mount(DRS(drspath.open('rb'), game_version).root)
+        result[target].mount(DRS(drspath.open('rb'), game_version[0].game_id).root)
 
     # Mount the media sources of the game edition
     for media_type, media_paths in game_version[0].media_paths.items():

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -66,27 +66,25 @@ def create_version_objects(srcdir):
     game_edition_list = []
 
     # initiliaze necessary paths
-    game_edition_path = srcdir.joinpath("game_edition.toml")
-    game_expansion_path = srcdir.joinpath("game_expansion.toml")
-    version_hashes_path = srcdir.joinpath("version_hashes")
+    game_edition_path = srcdir.joinpath("game_editions.toml")
+    game_expansion_path = srcdir.joinpath("game_expansions.toml")
+    version_hashes_path = srcdir.joinpath("version-hashes")
 
     # load toml config files to a dictionary variable
-    game_edition_dic = toml.load(game_edition_path)
-    game_expansion_dic = toml.load(game_expansion_path)
+    with game_edition_path.open() as game_edition_toml:
+        game_edition_dic = toml.loads(game_edition_toml.read())
+    with game_expansion_path.open() as game_expansion_toml:
+        game_expansion_dic = toml.loads(game_expansion_toml.read())
 
     # create and list GameEdition objects
+    game_edition_dic.pop("file_version")
     for game in game_edition_dic:
-        if game == 'file_version':
-            continue
-
         game_obj = create_game_obj(game_edition_dic[game], version_hashes_path)
         game_edition_list.append(game_obj)
 
     # create and list GameExpansion objects
+    game_expansion_dic.pop("file_version")
     for game in game_expansion_dic:
-        if game == 'file_version':
-            continue
-
         game_obj = create_game_obj(game_expansion_dic[game], version_hashes_path, True)
         game_expansion_list.append(game_obj)
 
@@ -110,12 +108,15 @@ def create_game_obj(game_dic, version_hashes_path, expansion=False):
         expansions = game_dic['expansions']
 
     # add version-hashes from the auxiliary file specific for the game
-    game_hash_dic = toml.load(version_hashes_path.joinpath(game_id + '.toml'))
+    game_hash_path = version_hashes_path.joinpath(game_id + '.toml')
+    with game_hash_path.open() as game_hash_toml:
+        game_hash_dic = toml.loads(game_hash_toml.read())
+
     game_hash_list = []
-    for item in game_hash_dic:
-        if item in ['file_version', 'hash_algo']:
+    for item in game_hash_dic.items():
+        if item[0] in ['file_version', 'hash_algo']:
             continue
-        game_hash_list.append((item['path'], item['map']))
+        game_hash_list.append((item[1]['path'], item[1]['map']))
 
     # add mediapaths for the game
     game_mediapaths_list = []

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -5,10 +5,12 @@
 Detects the base version of the game and installed expansions.
 """
 
-from ...value_object.init.game_version import GameEdition, Support
+import toml
+
+from ...value_object.init.game_version import GameEdition, GameExpansion, Support
 
 
-def iterate_game_versions(srcdir):
+def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
     """
     Determine what editions and expansions of a game are installed in srcdir
     by iterating through all versions the converter knows about.
@@ -16,7 +18,7 @@ def iterate_game_versions(srcdir):
     edition = None
     expansions = []
 
-    for game_edition in GameEdition:
+    for game_edition in avail_game_eds:
         for detection_hints in game_edition.game_file_versions:
             required_path = detection_hints.get_path()
             required_file = srcdir.joinpath(required_path)
@@ -36,6 +38,11 @@ def iterate_game_versions(srcdir):
         raise Exception("no valid game version found.")
 
     for game_expansion in edition.expansions:
+
+        for existing_game_expansion in avail_game_exps:
+            if game_expansion == existing_game_expansion.game_id:
+                game_expansion = existing_game_expansion
+
         for detection_hints in game_expansion.game_file_versions:
             required_path = detection_hints.get_path()
             required_file = srcdir.joinpath(required_path)
@@ -47,3 +54,77 @@ def iterate_game_versions(srcdir):
             expansions.append(game_expansion)
 
     return edition, expansions
+
+
+def create_version_objects(srcdir):
+    """
+    Create GameEdition and GameExpansion objects from auxiliary
+    config files.
+    """
+
+    game_expansion_list = []
+    game_edition_list = []
+
+    # initiliaze necessary paths
+    game_edition_path = srcdir.joinpath("game_edition.toml")
+    game_expansion_path = srcdir.joinpath("game_expansion.toml")
+    version_hashes_path = srcdir.joinpath("version_hashes")
+
+    # load toml config files to a dictionary variable
+    game_edition_dic = toml.load(game_edition_path)
+    game_expansion_dic = toml.load(game_expansion_path)
+
+    # create and list GameEdition objects
+    for game in game_edition_dic:
+        if game == 'file_version':
+            continue
+
+        game_obj = create_game_obj(game_edition_dic[game], version_hashes_path)
+        game_edition_list.append(game_obj)
+
+    # create and list GameExpansion objects
+    for game in game_expansion_dic:
+        if game == 'file_version':
+            continue
+
+        game_obj = create_game_obj(game_expansion_dic[game], version_hashes_path, True)
+        game_expansion_list.append(game_obj)
+
+    return game_edition_list, game_expansion_list
+
+
+def create_game_obj(game_dic, version_hashes_path, expansion=False):
+    """
+    Create a GameEdition or GameExpansion object with the help of
+    game_dic map and its version hash file.
+    Use expansion parameter to decide if a GameEdition object
+    is needed to be created or GameExpansion.
+    """
+
+    # initialize necessary parameters
+    game_name = game_dic['name']
+    game_id = game_dic['game_edition_id']
+    support = game_dic['support']
+    modpacks = game_dic['targetmod']
+    if not expansion:
+        expansions = game_dic['expansions']
+
+    # add version-hashes from the auxiliary file specific for the game
+    game_hash_dic = toml.load(version_hashes_path.joinpath(game_id + '.toml'))
+    game_hash_list = []
+    for item in game_hash_dic:
+        if item in ['file_version', 'hash_algo']:
+            continue
+        game_hash_list.append((item['path'], item['map']))
+
+    # add mediapaths for the game
+    game_mediapaths_list = []
+    for media_type in game_dic['mediapaths']:
+        game_mediapaths_list.append((media_type, game_dic['mediapaths'][media_type]))
+
+    if expansion:
+        return GameExpansion(game_name, game_id, support, game_hash_list,
+                             game_mediapaths_list, modpacks)
+
+    return GameEdition(game_name, game_id, support, game_hash_list,
+                       game_mediapaths_list, modpacks, expansions)

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -9,7 +9,6 @@ from tempfile import gettempdir
 from zlib import decompress
 
 from ....log import spam, dbg, info, warn
-from ...value_object.init.game_version import GameEdition, GameExpansion
 from ...value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
 from ...value_object.read.media_types import MediaType
 
@@ -18,11 +17,11 @@ def get_gamespec(srcdir, game_version, dont_pickle):
     """
     Reads empires.dat file.
     """
-    if game_version[0] in (GameEdition.ROR, GameEdition.AOC, GameEdition.AOE2DE):
+    if game_version[0] .game_id in ("ROR", "AOC", "AOE2DE"):
         filepath = srcdir.joinpath(game_version[0].media_paths[MediaType.DATFILE][0])
 
-    elif game_version[0] is GameEdition.SWGB:
-        if GameExpansion.SWGB_CC in game_version[1]:
+    elif game_version[0] .game_id == "SWGB":
+        if "SWGB_CC" in [expansion.game_id for expansion in game_version[1]]:
             filepath = srcdir.joinpath(game_version[1][0].media_paths[MediaType.DATFILE][0])
 
         else:

--- a/openage/convert/service/read/palette.py
+++ b/openage/convert/service/read/palette.py
@@ -3,7 +3,6 @@
 """
 Module for reading palette files.
 """
-from ...value_object.init.game_version import GameEdition
 from ...value_object.read.media.colortable import ColorTable
 from ...value_object.read.media_types import MediaType
 
@@ -16,7 +15,7 @@ def get_palettes(srcdir, game_version, index=None):
 
     palettes = {}
 
-    if game_edition in (GameEdition.ROR, GameEdition.AOC, GameEdition.SWGB, GameEdition.HDEDITION):
+    if game_edition.game_id in ("ROR", "AOC", "SWGB", "HDEDITION"):
         if index:
             palette_path = "%s/%s.bina" % (MediaType.PALETTES.value, str(index))
             palette_file = srcdir[palette_path]
@@ -35,11 +34,11 @@ def get_palettes(srcdir, game_version, index=None):
 
                     palettes[palette_id] = palette
 
-            if game_edition is GameEdition.HDEDITION:
+            if game_edition.game_id == "HDEDITION":
                 # TODO: HD edition has extra palettes in the dat folder
                 pass
 
-    elif game_edition in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+    elif game_edition.game_id in ("AOE1DE", "AOE2DE"):
         # Parse palettes.conf file and save the ids/paths
         conf_filepath = "%s/palettes.conf" % (MediaType.PALETTES.value)
         conf_file = srcdir[conf_filepath].open('rb')

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -6,7 +6,6 @@ Module for reading plaintext-based language files.
 
 from ....log import dbg
 from ...entity_object.conversion.stringresource import StringResource
-from ...value_object.init.game_version import GameEdition
 from ...value_object.read.media.langcodes import LANGCODES_DE2, LANGCODES_HD
 from ...value_object.read.media.pefile import PEFile
 from ...value_object.read.media_types import MediaType
@@ -23,15 +22,15 @@ def get_string_resources(args):
     language_files = game_edition.media_paths[MediaType.LANGUAGE]
 
     for language_file in language_files:
-        if game_edition in (GameEdition.ROR, GameEdition.AOC, GameEdition.SWGB):
+        if game_edition.game_id in ("ROR", "AOC", "SWGB"):
             # AoC/RoR use .DLL PE files for their string resources
             pefile = PEFile(srcdir[language_file].open('rb'))
             stringres.fill_from(pefile.resources().strings)
 
-        elif game_edition is GameEdition.HDEDITION:
+        elif game_edition.game_id == "HDEDITION":
             read_age2_hd_3x_stringresources(stringres, srcdir)
 
-        elif game_edition is GameEdition.AOE2DE:
+        elif game_edition.game_id == "AOE2DE":
             strings = read_de2_language_file(srcdir, language_file)
             stringres.fill_from(strings)
 

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -12,7 +12,6 @@ from ..service.read.gamedata import get_gamespec
 from ..service.read.palette import get_palettes
 from ..service.read.register_media import get_existing_graphics
 from ..service.read.string_resource import get_string_resources
-from ..value_object.init.game_version import GameEdition, GameExpansion
 from ..value_object.read.media.blendomatic import Blendomatic
 from ..value_object.read.media_types import MediaType
 
@@ -96,10 +95,10 @@ def convert_metadata(args):
     for modpack in modpacks:
         ModpackExporter.export(modpack, args)
 
-    if args.game_version[0] not in (GameEdition.ROR, GameEdition.AOE2DE):
+    if args.game_version[0].game_id not in ("ROR", "AOE2DE"):
         yield "blendomatic.dat"
 
-        if args.game_version[0] is GameEdition.SWGB:
+        if args.game_version[0].game_id == "SWGB":
             blend_mode_count = gamespec[0]["blend_mode_count_swgb"].get_value()
             blend_data = get_blendomatic_data(args, blend_mode_count)
 
@@ -137,20 +136,20 @@ def get_converter(game_version):
     game_edition = game_version[0]
     game_expansions = game_version[1]
 
-    if game_edition is GameEdition.ROR:
+    if game_edition.game_id == "ROR":
         from ..processor.conversion.ror.processor import RoRProcessor
         return RoRProcessor
 
-    if game_edition is GameEdition.AOC:
+    if game_edition.game_id == "AOC":
         from ..processor.conversion.aoc.processor import AoCProcessor
         return AoCProcessor
 
-    if game_edition is GameEdition.AOE2DE:
+    if game_edition.game_id == "AOE2DE":
         from ..processor.conversion.de2.processor import DE2Processor
         return DE2Processor
 
-    if game_edition is GameEdition.SWGB:
-        if GameExpansion.SWGB_CC in game_expansions:
+    if game_edition.game_id == "SWGB":
+        if "SWGB_CC" in [expansion.game_id for expansion in game_expansions]:
             from ..processor.conversion.swgbcc.processor import SWGBCCProcessor
             return SWGBCCProcessor
 

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -10,10 +10,11 @@ import readline  # pylint: disable=unused-import
 from ...log import warn, info
 from ...util.fslike.directory import Directory
 from ..service.init.mount_asset_dirs import mount_asset_dirs
+from ..service.init.version_detect import create_version_objects
 from .subtool.version_select import get_game_version
 
 
-def interactive_browser(srcdir=None):
+def interactive_browser(cfg, srcdir=None):
     """
     launch an interactive view for browsing the original
     archives.
@@ -25,7 +26,14 @@ def interactive_browser(srcdir=None):
 
     # the variables are actually used, in the interactive prompt.
     # pylint: disable=possibly-unused-variable
-    game_version = get_game_version(srcdir)
+
+    # Initialize game versions data
+
+    auxiliary_files_dir = cfg / "converter" / "games"
+    avail_game_eds, avail_game_exps = create_version_objects(auxiliary_files_dir)
+
+    # Acquire game version info
+    game_version = get_game_version(srcdir, avail_game_eds, avail_game_exps)
     data = mount_asset_dirs(srcdir, game_version)
 
     if not data:

--- a/openage/convert/tool/singlefile.py
+++ b/openage/convert/tool/singlefile.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from ...log import info
 from ...util.fslike.directory import Directory
 from ..entity_object.export.texture import Texture
-from ..value_object.init.game_version import GameEdition
 from ..value_object.read.media.colortable import ColorTable
 from ..value_object.read.media.drs import DRS
 
@@ -109,7 +108,7 @@ def read_palettes(palettes_path):
         # open from drs archive
         # TODO: Also allow SWGB's DRS files
         palette_file = Path(palettes_path).open("rb")
-        game_version = (GameEdition.AOC, [])
+        game_version = ("AOC", [])
         palette_dir = DRS(palette_file, game_version)
 
         info("parsing palette data...")
@@ -158,7 +157,7 @@ def read_slp_in_drs_file(drs, slp_path, output_path, palettes):
 
     # open from drs archive
     # TODO: Also allow SWGB's DRS files
-    game_version = (GameEdition.AOC, [])
+    game_version = ("AOC", [])
     drs_file = DRS(drs, game_version)
 
     info("opening slp in drs '%s:%s'...", drs.name, slp_path)
@@ -264,7 +263,7 @@ def read_wav_in_drs_file(drs, wav_path, output_path):
 
     # open from drs archive
     # TODO: Also allow SWGB's DRS files
-    game_version = (GameEdition.AOC, [])
+    game_version = ("AOC", [])
     drs_file = DRS(drs, game_version)
 
     info("opening wav in drs '%s:%s'...", drs.name, wav_path)

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -6,14 +6,14 @@ TODO: Version selection.
 """
 from ....log import warn, info
 from ...service.init.version_detect import iterate_game_versions
-from ...value_object.init.game_version import GameEdition, Support
+from ...value_object.init.game_version import Support
 
 
-def get_game_version(srcdir):
+def get_game_version(srcdir, avail_game_eds, avail_game_exps):
     """
     Mount the input folders for conversion.
     """
-    game_version = iterate_game_versions(srcdir)
+    game_version = iterate_game_versions(srcdir, avail_game_eds, avail_game_exps)
     if not game_version:
         warn("No valid game version(s) could not be detected in %s", srcdir)
 
@@ -42,7 +42,7 @@ def get_game_version(srcdir):
     # inform about supported versions
     if no_support:
         warn("You need at least one of:")
-        for edition in GameEdition:
+        for edition in avail_game_eds:
             if edition.support == Support.yes:
                 warn(" * \x1b[34m%s\x1b[m", edition)
 

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -2,8 +2,6 @@
 
 """
 Associate files or filepaths with hash values to determine the version of a game.
-
-TODO: This is unused at the moment.
 """
 
 

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -22,75 +22,89 @@ class Support(enum.Enum):
     breaks = "presence breaks conversion"
 
 
-@enum.unique
-class GameExpansion(enum.Enum):
+class GameBase:
+    """
+    Common base class for GameEdition and GameExpansion
+    """
+
+    def __init__(self, game_id, support, game_hashes, media_paths,
+                 modpacks, **flags):
+        """
+        :param game_id: Unique id for the given game.
+        :type_param: str
+        :param support: Whether the converter can read/convert
+                               the game to openage formats.
+        :type support: str
+        :param modpacks: List of modpacks.
+        :type modpacks: list
+        :param game_hashes: A list of tuples of GameFileVersion parameters
+        :type game_hashes: list[tuple]
+        :param media_paths: A list of tuples of media types and their
+                            paths
+        :type media_paths: list[tuple]
+        :param flags: Anything else specific to this version which is useful
+                      for the converter.
+        """
+        self.game_id = game_id
+        self.flags = flags
+        self.target_modpacks = modpacks
+        self.support_status = Support[support]
+
+        self.game_file_versions = []
+        self.media_paths = {}
+
+        for path, hash_map in game_hashes:
+            self.add_game_file_versions(path, hash_map)
+        for media_type, paths in media_paths:
+            self.add_media_paths(media_type, paths)
+
+    def add_game_file_versions(self, filepath, hashes):
+        """
+        Add a GameFileVersion object for files which are unique
+        to this version of the game.
+
+        :param filepath: Path of the specific file.
+        :type filepath: str
+        :param hashes: Hash value mapped to the file version.
+        :type hashes: dict
+        """
+        game_file_version_obj = GameFileVersion(filepath, hashes)
+        self.game_file_versions.append(game_file_version_obj)
+
+    def add_media_paths(self, media_type, paths):
+        """
+        Add a media type with the associated files.
+
+        :param media_type: The type of media file.
+        :type media_type: MediaType
+        :param paths: Paths to those media files.
+        :type paths: list
+        """
+        self.media_paths[MediaType[media_type.upper()]] = paths
+
+
+class GameExpansion(GameBase):
     """
     An optional expansion to a GameEdition.
     """
 
-    AFRI_KING = ("African Kingdoms (HD)",
-                 Support.nope,
-                 {GameFileVersion("resources/_common/dat/empires2_x2_p1.dat",
-                                  {"f2bf8b128b4bdac36ee36fafe139baf1": "1.0c"})},
-                 {
-                     MediaType.GRAPHICS: ["resources/_common/slp/"],
-                     MediaType.SOUNDS: ["resources/_common/sound/"],
-                     MediaType.INTERFACE: ["resources/_common/drs/interface/"],
-                     MediaType.TERRAIN: ["resources/_common/terrain/"]
-                 },
-                 ["aoe2-ak", "aoe2-ak-graphics"])
-
-    SWGB_CC = ("Clone Campaigns",
-               Support.yes,
-               {GameFileVersion('Game/battlegrounds_x1.exe',
-                                {"974f4d4404bb94451a9c27ae5c673243": "GOG"})},
-               {
-                   MediaType.DATFILE: ["Game/Data/genie_x1.dat"],
-                   MediaType.GAMEDATA: ["Game/Data/genie_x1.dat"],
-                   MediaType.GRAPHICS: ["Game/Data/graphics_x1.drs"],
-                   MediaType.LANGUAGE: ["Game/language_x1.dll"],
-                   MediaType.PALETTES: ["Game/Data/interfac_x1.drs"],
-                   MediaType.SOUNDS: ["Game/Data/sounds_x1.drs"],
-                   MediaType.INTERFACE: ["Game/Data/interfac_x1.drs"],
-                   MediaType.TERRAIN: ["Game/Data/terrain_x1.drs"],
-               },
-               ["swgb-cc", "swgb-cc-graphics"])
-
-    def __init__(self, name, support_status, game_file_versions,
-                 media_paths, target_modpacks, **flags):
+    def __init__(self, name, game_id, support, game_hashes, media_paths,
+                 modpacks, **flags):
         """
-        Create a new GameInfo instance.
+        Create a new GameExpansion instance.
 
         :param name: Name of the game.
         :type name: str
-        :param support_status: Whether the converter can read/convert
-                               the game to openage formats.
-        :type support_status: SupportStatus
-        :param game_file_versions: A set of files that is unique to this
-                                   version of the game.
-        :type game_file_versions: set
-        :param media_paths: A dictionary with MediaType as keys and
-                            (bool, [str]). bool denotes whether the path
-                            is a file that requires extraction. every str is
-                            a path to a file or folder.
-        :type media_paths: dict
-        :param target_modpacks: A list of tuples containing
-                                (modpack_name, uid, expected_manifest_hash).
-                                These modpacks will be created for this version.
-        :type target_modpacks: list
-        :param flags: Anything else specific to this version which is useful
-                      for the converter.
+        :param game_id: Unique id for the given game.
+        :type game_id: str
         """
+        super().__init__(game_id, support, game_hashes, media_paths,
+                         modpacks, **flags)
+
         self.expansion_name = name
-        self.support = support_status
-        self.game_file_versions = game_file_versions
-        self.media_paths = media_paths
-        self.target_modpacks = target_modpacks
-        self.flags = flags
 
 
-@enum.unique
-class GameEdition(enum.Enum):
+class GameEdition(GameBase):
     """
     Standalone/base version of a game. Multiple standalone versions
     may exist, e.g. AoC, HD, DE2 for AoE2.
@@ -100,206 +114,22 @@ class GameEdition(enum.Enum):
     The Conquerors are considered "downgrade" expansions.
     """
 
-    ROR = (
-        "Age of Empires 1: Rise of Rome",
-        Support.yes,
-        {
-            GameFileVersion('EMPIRESX.EXE',
-                            {"140bda90145182966acf582b28a4c8ef": "1.0B"}),
-            GameFileVersion('data2/empires.dat',
-                            {"3e567b2746653107cf80bae18c6962a7": "1.0B"}),
-        },
-        {
-            MediaType.DATFILE: ["data2/empires.dat"],
-            MediaType.GRAPHICS: ["data/graphics.drs", "data2/graphics.drs"],
-            MediaType.PALETTES: ["data/Interfac.drs", "data2/Interfac.drs"],
-            MediaType.SOUNDS: ["data/sounds.drs", "data2/sounds.drs"],
-            MediaType.INTERFACE: ["data/Interfac.drs", "data2/Interfac.drs"],
-            MediaType.LANGUAGE: ["language.dll", "languagex.dll"],
-            MediaType.TERRAIN: ["data/Terrain.drs"],
-            MediaType.BORDER: ["data/Border.drs"],
-        },
-        ["aoe1-base", "aoe1-base-graphics"],
-        []
-    )
-
-    AOE1DE = (
-        "Age of Empires 1: Definitive Edition (Steam)",
-        Support.nope,
-        {
-            GameFileVersion('AoEDE_s.exe',
-                            {"0b652f0821cc0796a6a104bffc69875e": "steam"}),
-            GameFileVersion('Data/empires.dat',
-                            {"0b652f0821cc0796a6a104bffc69875e": "steam"})},
-        {
-            MediaType.DATFILE: ["Data/empires.dat"],
-            MediaType.GRAPHICS: ["Assets/SLP/"],
-            MediaType.PALETTES: ["Assets/Palettes/"],
-            MediaType.SOUNDS: ["Assets/Sounds/"],
-            MediaType.INTERFACE: ["Data/DRS/interfac.drs", "Data/DRS/interfac_x1.drs"],
-        },
-        ["aoe1-base", "aoe1-base-graphics"],
-        []
-    )
-
-    AOK = (
-        "Age of Empires 2: Age of Kings",
-        Support.nope,
-        {
-            GameFileVersion('empires2.exe',
-                            {"5f7ca6c7edeba075c7982714619bc66b": "2.0a"}),
-            GameFileVersion('data/empires2.dat',
-                            {"89ff818894b69040ebd1657d8029b068": "2.0a"})},
-        {
-            MediaType.DATFILE: ["data/empires2.dat"],
-            MediaType.GAMEDATA: ["data/gamedata.drs"],
-            MediaType.GRAPHICS: ["data/graphics.drs"],
-            MediaType.PALETTES: ["data/interfac.drs"],
-            MediaType.SOUNDS: ["data/sounds.drs"],
-            MediaType.INTERFACE: ["data/interfac.drs"],
-            MediaType.TERRAIN: ["data/terrain.drs"],
-        },
-        [],
-        []
-    )
-
-    AOC = (
-        "Age of Empires 2: The Conqueror's",
-        Support.yes,
-        {
-            GameFileVersion('age2_x1/age2_x1.exe',
-                            {"f2bf8b128b4bdac36ee36fafe139baf1": "1.0c"}),
-            GameFileVersion('data/empires2_x1_p1.dat',
-                            {"8358c9e64ec0e70e7b13bd34d5a46296": "1.0c"})},
-        {
-            MediaType.DATFILE: ["data/empires2_x1_p1.dat"],
-            MediaType.GAMEDATA: ["data/gamedata_x1_p1.drs"],
-            MediaType.GRAPHICS: ["data/graphics.drs"],
-            MediaType.LANGUAGE: ["language.dll", "language_x1.dll", "language_x1_p1.dll"],
-            MediaType.PALETTES: ["data/interfac.drs"],
-            MediaType.SOUNDS: ["data/sounds.drs", "data/sounds_x1.drs"],
-            MediaType.INTERFACE: ["data/interfac.drs"],
-            MediaType.TERRAIN: ["data/terrain.drs"],
-            MediaType.BLEND: ["data/blendomatic.dat"],
-        },
-        ["aoe2-base", "aoe2-base-graphics"],
-        []
-    )
-
-    HDEDITION = (
-        "Age of Empires 2: HD Edition",
-        Support.yes,
-        {
-            GameFileVersion('AoK HD.exe',
-                            {"ca2d6c1e26e8900a9a3140ba2e12e4c9": "5.8"}),
-            GameFileVersion('resources/_common/dat/empires2_x1_p1.dat',
-                            {"6f5a83789ec3dc0fd92986294d03031f": "5.8"})},
-        {
-            MediaType.DATFILE: ["resources/_common/dat/empires2_x1_p1.dat"],
-            MediaType.GAMEDATA: ["resources/_common/drs/gamedata_x1/"],
-            MediaType.GRAPHICS: ["resources/_common/drs/graphics/"],
-            MediaType.PALETTES: ["resources/_common/drs/interface/"],
-            MediaType.SOUNDS: ["resources/_common/drs/sounds/"],
-            MediaType.INTERFACE: ["resources/_common/drs/interface/"],
-            MediaType.TERRAIN: ["resources/_common/drs/terrain/"],
-        },
-        ["aoe2-base", "aoe2-base-graphics"],
-        []
-    )
-
-    AOE2DE = (
-        "Age of Empires 2: Definitive Edition",
-        Support.yes,
-        {
-            GameFileVersion('AoE2DE_s.exe',
-                            {"8771d2380f8637efb407d09198167c12": "release"}),
-            GameFileVersion('resources/_common/dat/empires2_x2_p1.dat',
-                            {"1dd581c6b06e2615c1a0ed8069f5eb13": "release"})},
-        {
-            MediaType.DATFILE: ["resources/_common/dat/empires2_x2_p1.dat"],
-            MediaType.GAMEDATA: ["resources/_common/drs/gamedata_x1/"],
-            MediaType.GRAPHICS: ["resources/_common/drs/graphics/"],
-            MediaType.LANGUAGE: [
-                "resources/br/strings/key-value/key-value-strings-utf8.txt",
-                "resources/de/strings/key-value/key-value-strings-utf8.txt",
-                "resources/en/strings/key-value/key-value-strings-utf8.txt",
-                "resources/es/strings/key-value/key-value-strings-utf8.txt",
-                "resources/fr/strings/key-value/key-value-strings-utf8.txt",
-                "resources/hi/strings/key-value/key-value-strings-utf8.txt",
-                "resources/it/strings/key-value/key-value-strings-utf8.txt",
-                "resources/jp/strings/key-value/key-value-strings-utf8.txt",
-                "resources/ko/strings/key-value/key-value-strings-utf8.txt",
-                "resources/ms/strings/key-value/key-value-strings-utf8.txt",
-                "resources/mx/strings/key-value/key-value-strings-utf8.txt",
-                "resources/ru/strings/key-value/key-value-strings-utf8.txt",
-                "resources/tr/strings/key-value/key-value-strings-utf8.txt",
-                "resources/tw/strings/key-value/key-value-strings-utf8.txt",
-                "resources/vi/strings/key-value/key-value-strings-utf8.txt",
-                "resources/zh/strings/key-value/key-value-strings-utf8.txt",
-            ],
-            MediaType.PALETTES: ["resources/_common/palettes/"],
-            MediaType.SOUNDS: ["wwise/"],
-            MediaType.INTERFACE: ["resources/_common/drs/interface/"],
-            MediaType.TERRAIN: ["resources/_common/terrain/textures/"],
-        },
-        ["aoe2-base", "aoe2-base-graphics"],
-        []
-    )
-
-    SWGB = (
-        "Star Wars: Galactic Battlegrounds",
-        Support.yes,
-        {
-            GameFileVersion('Game/Battlegrounds.exe',
-                            {"6ad181133823a72f046c75a649cf8124": "GOG"}),
-            GameFileVersion('Game/Data/GENIE.DAT',
-                            {"2e2704e8fcf9e9fd0ee2147209ad6617": "GOG"})},
-        {
-            MediaType.DATFILE: ["Game/Data/GENIE.DAT"],
-            MediaType.GAMEDATA: ["Game/Data/GAMEDATA.DRS"],
-            MediaType.GRAPHICS: ["Game/Data/GRAPHICS.DRS"],
-            MediaType.LANGUAGE: ["Game/language.dll"],
-            MediaType.PALETTES: ["Game/Data/INTERFAC.DRS"],
-            MediaType.SOUNDS: ["Game/Data/SOUNDS.DRS"],
-            MediaType.INTERFACE: ["Game/Data/INTERFAC.DRS"],
-            MediaType.TERRAIN: ["Game/Data/TERRAIN.DRS"],
-            MediaType.BLEND: ["Game/Data/blendomatic.dat"],
-        },
-        ["swgb-base", "swgb-base-graphics"],
-        [GameExpansion.SWGB_CC]
-    )
-
-    def __init__(self, name, support_status, game_file_versions,
-                 media_paths, target_modpacks, expansions, **flags):
+    def __init__(self, name, game_id, support, game_hashes, media_paths,
+                 modpacks, expansions, **flags):
         """
-        Create a new GameEditionInfo instance.
+        Create a new GameEdition instance.
 
         :param name: Name of the game.
         :type name: str
-        :param support_status: Whether the converter can read/convert
-                               the game to openage formats.
-        :type support_status: SupportStatus
-        :param game_file_versions: A set of of files that is
-                               unique to this version of the game.
-        :type game_file_versions: set
-        :param media_paths: A dictionary with MediaType as keys and
-                            (bool, [str]). bool denotes whether the path
-                            is a file that requires extraction. every str is
-                            a path to a file or folder.
-        :type media_paths: dict
-        :param target_modpacks: A list of tuples containing
-                                (modpack_name, uid, expected_manifest_hash).
-                                These modpacks will be created for this version.
-        :type target_modpacks: list
-        :param expansions: A list of expansions available for this edition.
+        :param game_id: Unique id for the given game.
+        :type game_id: str
+        :param expansions: A list of expansions.
         :type expansion: list
         :param flags: Anything else specific to this version which is useful
                       for the converter.
         """
+        super().__init__(game_id, support, game_hashes, media_paths,
+                         modpacks, **flags)
+
         self.edition_name = name
-        self.support = support_status
-        self.game_file_versions = game_file_versions
-        self.media_paths = media_paths
-        self.target_modpacks = target_modpacks
         self.expansions = expansions
-        self.flags = flags

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -48,7 +48,7 @@ class GameBase:
         self.game_id = game_id
         self.flags = flags
         self.target_modpacks = modpacks
-        self.support_status = Support[support]
+        self.support = Support[support]
 
         self.game_file_versions = []
         self.media_paths = {}
@@ -103,6 +103,9 @@ class GameExpansion(GameBase):
 
         self.expansion_name = name
 
+    def __str__(self):
+        return self.expansion_name
+
 
 class GameEdition(GameBase):
     """
@@ -133,3 +136,6 @@ class GameEdition(GameBase):
 
         self.edition_name = name
         self.expansions = expansions
+
+    def __str__(self):
+        return self.edition_name

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 from . import unit
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import MultisubtypeMember, EnumLookupMember
 from ....read.value_members import MemberTypes as StorageType
@@ -24,7 +23,7 @@ class Civ(GenieStructure):
             (SKIP, "player_type", StorageType.INT_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -41,11 +40,11 @@ class Civ(GenieStructure):
             (READ_GEN, "tech_tree_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             # links to tech id as well
             data_format.append((READ_GEN, "team_bonus_id", StorageType.ID_MEMBER, "int16_t"))
 
-            if game_version[0] is GameEdition.SWGB:
+            if game_version[0].game_id == "SWGB":
                 data_format.extend([
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[20]"),
                     (READ_GEN, "unique_unit_techs", StorageType.ARRAY_ID, "int16_t[4]"),

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -12,7 +12,6 @@ from . import tech
 from . import terrain
 from . import unit
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP
 from ....read.read_members import SubdataMember
 from ....read.value_members import MemberTypes as StorageType
@@ -43,7 +42,7 @@ class EmpiresDat(GenieStructure):
         """
         data_format = [(READ_GEN, "versionstr", StorageType.STRING_MEMBER, "char[8]")]
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "civ_count_swgb", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
@@ -61,7 +60,7 @@ class EmpiresDat(GenieStructure):
             (READ, "float_ptr_terrain_tables", StorageType.ARRAY_ID, "int32_t[terrain_restriction_count]"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ, "terrain_pass_graphics_ptrs", StorageType.ARRAY_ID, "int32_t[terrain_restriction_count]"))
 
         data_format.extend([
@@ -110,27 +109,27 @@ class EmpiresDat(GenieStructure):
 
         # Stored terrain number is hardcoded.
         # Usually less terrains are used by the game
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=55,
             )))
-        elif game_version[0] is GameEdition.AOE2DE:
+        elif game_version[0].game_id == "AOE2DE":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=200,
             )))
-        elif game_version[0] is GameEdition.AOE1DE:
+        elif game_version[0].game_id == "AOE1DE":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=96,
             )))
-        elif game_version[0] is GameEdition.HDEDITION:
+        elif game_version[0].game_id == "HDEDITION":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=100,
             )))
-        elif game_version[0] is GameEdition.AOC:
+        elif game_version[0].game_id == "AOC":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=42,
@@ -141,7 +140,7 @@ class EmpiresDat(GenieStructure):
                 length=32,
             )))
 
-        if game_version[0] is not GameEdition.AOE2DE:
+        if game_version[0].game_id != "AOE2DE":
             data_format.extend([
                 (READ_GEN, "terrain_border", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=terrain.TerrainBorder,
@@ -150,7 +149,7 @@ class EmpiresDat(GenieStructure):
                 (SKIP, "map_row_offset", StorageType.INT_MEMBER, "int32_t"),
             ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "map_min_x", StorageType.FLOAT_MEMBER, "float"),
                 (SKIP, "map_min_y", StorageType.FLOAT_MEMBER, "float"),
@@ -177,7 +176,7 @@ class EmpiresDat(GenieStructure):
             (SKIP, "block_end_column", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "search_map_ptr", StorageType.INT_MEMBER, "int32_t"),
                 (SKIP, "search_map_rows_ptr", StorageType.INT_MEMBER, "int32_t"),
@@ -195,13 +194,13 @@ class EmpiresDat(GenieStructure):
             (SKIP, "fog_flag", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] is not GameEdition.AOE2DE:
-            if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id != "AOE2DE":
+            if game_version[0].game_id == "SWGB":
                 data_format.extend([
                     (READ_UNKNOWN, "terrain_blob0", StorageType.ARRAY_INT, "uint8_t[25]"),
                     (READ_UNKNOWN, "terrain_blob1", StorageType.ARRAY_INT, "uint32_t[157]"),
                 ])
-            elif game_version[0] in (GameEdition.ROR, GameEdition.AOE1DE):
+            elif game_version[0].game_id in ("ROR", "AOE1DE"):
                 data_format.extend([
                     (READ_UNKNOWN, "terrain_blob0", StorageType.ARRAY_INT, "uint8_t[2]"),
                     (READ_UNKNOWN, "terrain_blob1", StorageType.ARRAY_INT, "uint32_t[5]"),
@@ -233,7 +232,7 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ, "unit_line_count", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "unit_lines", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -243,7 +242,7 @@ class EmpiresDat(GenieStructure):
             ])
 
         # unit header data
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ, "unit_count", StorageType.INT_MEMBER, "uint32_t"),
                 (READ_GEN, "unit_headers", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -261,7 +260,7 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.append((READ_UNKNOWN, None, StorageType.INT_MEMBER, "int8_t"))
 
         # research data
@@ -273,10 +272,10 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.append((READ_UNKNOWN, None, StorageType.INT_MEMBER, "int8_t"))
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "time_slice", StorageType.INT_MEMBER, "int32_t"),
                 (SKIP, "unit_kill_rate", StorageType.INT_MEMBER, "int32_t"),
@@ -293,7 +292,7 @@ class EmpiresDat(GenieStructure):
                 (READ, "building_connection_count", StorageType.INT_MEMBER, "uint8_t"),
             ])
 
-            if game_version[0] is GameEdition.SWGB:
+            if game_version[0].game_id == "SWGB":
                 data_format.append((READ, "unit_connection_count", StorageType.INT_MEMBER, "uint16_t"))
 
             else:

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import MemberTypes as StorageType
@@ -85,7 +84,7 @@ class GraphicAttackSound(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format = [
                 (READ_GEN, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=DE2SoundProp,
@@ -117,7 +116,7 @@ class Graphic(GenieStructure):
         data_format = []
 
         # internal name: e.g. ARRG2NNE = archery range feudal Age north european
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -126,18 +125,18 @@ class Graphic(GenieStructure):
                 (READ, "filename_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[filename_len]"),
             ])
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (SKIP, "particle_effect_name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                     (READ, "particle_effect_name_len", StorageType.INT_MEMBER, "uint16_t"),
                     (READ_GEN, "particle_effect_name", StorageType.STRING_MEMBER, "char[particle_effect_name_len]"),
                 ])
-            if game_version[0] is GameEdition.AOE1DE:
+            if game_version[0].game_id == "AOE1DE":
                 data_format.extend([
                     (READ_GEN, "first_frame", StorageType.ID_MEMBER, "uint16_t"),
                 ])
 
-        elif game_version[0] is GameEdition.SWGB:
+        elif game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[25]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[25]"),
@@ -184,7 +183,7 @@ class Graphic(GenieStructure):
             (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_sound_id", StorageType.ID_MEMBER, "uint32_t"),
             ])
@@ -201,7 +200,7 @@ class Graphic(GenieStructure):
             (READ_GEN, "mirroring_mode", StorageType.ID_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             # sprite editor thing for AoK
             data_format.append((SKIP, "editor_flag", StorageType.BOOLEAN_MEMBER, "int8_t"))
 

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ_GEN
 from ....read.value_members import MemberTypes as StorageType
 
@@ -19,7 +18,7 @@ class PlayerColor(GenieStructure):
         Return the members in this struct.
         """
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format = [
                 (READ_GEN, "id", StorageType.ID_MEMBER, "int32_t"),
                 # palette index offset, where the 8 player colors start

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import MemberTypes as StorageType
@@ -263,7 +262,7 @@ class Tech(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format = [
                 # research ids of techs that are required for activating the possible research
                 (READ_GEN, "required_techs", StorageType.ARRAY_ID, "int16_t[6]"),
@@ -282,7 +281,7 @@ class Tech(GenieStructure):
             (READ_GEN, "required_tech_count", StorageType.INT_MEMBER, "int16_t"),       # a subset of the above required techs may be sufficient, this defines the minimum amount
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "civilization_id", StorageType.ID_MEMBER, "int16_t"),           # id of the civ that gets this technology
                 (READ_GEN, "full_tech_mode", StorageType.BOOLEAN_MEMBER, "int16_t"),       # 1: research is available when the full tech tree is activated on game start, 0: not
@@ -302,14 +301,14 @@ class Tech(GenieStructure):
             (READ_GEN, "hotkey", StorageType.ID_MEMBER, "int32_t"),                    # -1 for every tech
         ])
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_length_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "repeatable", StorageType.INT_MEMBER, "int8_t"),
                 ])
@@ -320,7 +319,7 @@ class Tech(GenieStructure):
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0] is GameEdition.SWGB:
+            if game_version[0].game_id == "SWGB":
                 data_format.extend([
                     (READ, "name2_length", StorageType.INT_MEMBER, "uint16_t"),
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ_GEN, READ, SKIP
 from ....read.read_members import SubdataMember
 from ....read.value_members import MemberTypes as StorageType
@@ -21,13 +20,13 @@ class SoundItem(GenieStructure):
         """
         data_format = []
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ])
-        elif game_version[0] is GameEdition.SWGB:
+        elif game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[27]"),
             ])
@@ -41,7 +40,7 @@ class SoundItem(GenieStructure):
             (READ_GEN, "probablilty", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "civilization_id", StorageType.ID_MEMBER, "int16_t"),
                 (READ_GEN, "icon_set", StorageType.ID_MEMBER, "int16_t"),
@@ -67,7 +66,7 @@ class Sound(GenieStructure):
             (SKIP, "cache_time", StorageType.INT_MEMBER, "int32_t"),                   # always 300000
         ]
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "total_probability", StorageType.ID_MEMBER, "int16_t"),
             ])

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import MemberTypes as StorageType
@@ -120,7 +119,7 @@ class EffectBundle(GenieStructure):  # also called techage in some other tools
         """
         Return the members in this struct.
         """
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format = [
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -190,7 +189,7 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "status", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] is not GameEdition.ROR:
+        if game_version[0].game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "buildings", StorageType.ARRAY_ID, "int32_t[building_count]"),
@@ -213,7 +212,7 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -221,7 +220,7 @@ class AgeTechTree(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0] is GameEdition.ROR:
+        elif game_version[0].game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -242,12 +241,12 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "building_level_count", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "buildings_per_zone", StorageType.ARRAY_INT, "int8_t[20]"),
                 (READ_GEN, "group_length_per_zone", StorageType.ARRAY_INT, "int8_t[20]"),
             ])
-        elif game_version[0] is GameEdition.ROR:
+        elif game_version[0].game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "buildings_per_zone", StorageType.ARRAY_INT, "int8_t[3]"),
                 (READ_GEN, "group_length_per_zone", StorageType.ARRAY_INT, "int8_t[3]"),
@@ -291,7 +290,7 @@ class BuildingConnection(GenieStructure):
             (READ, "status", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] is not GameEdition.ROR:
+        if game_version[0].game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 # new buildings available when this building was created
@@ -317,7 +316,7 @@ class BuildingConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -325,7 +324,7 @@ class BuildingConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0] is GameEdition.ROR:
+        elif game_version[0].game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -381,7 +380,7 @@ class UnitConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ]
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -389,7 +388,7 @@ class UnitConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0] is GameEdition.ROR:
+        elif game_version[0].game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -410,7 +409,7 @@ class UnitConnection(GenieStructure):
             (READ_GEN, "vertical_line", StorageType.ID_MEMBER, "int32_t"),
         ])
 
-        if game_version[0] is not GameEdition.ROR:
+        if game_version[0].game_id != "ROR":
             data_format.extend([
                 (READ, "unit_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "units", StorageType.ARRAY_ID, "int32_t[unit_count]"),
@@ -457,7 +456,7 @@ class ResearchConnection(GenieStructure):
             (READ_GEN, "upper_building", StorageType.ID_MEMBER, "int32_t"),
         ]
 
-        if game_version[0] is not GameEdition.ROR:
+        if game_version[0].game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "buildings", StorageType.ARRAY_ID, "int32_t[building_count]"),
@@ -480,7 +479,7 @@ class ResearchConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -488,7 +487,7 @@ class ResearchConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0] is GameEdition.ROR:
+        elif game_version[0].game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import ArrayMember, SubdataMember, IncludeMembers
 from ....read.value_members import MemberTypes as StorageType
@@ -45,7 +44,7 @@ class TerrainPassGraphic(GenieStructure):
             (READ_GEN, "slp_id_walk_tile", StorageType.ID_MEMBER, "int32_t"),
         ]
 
-        if game_version[0] is GameEdition.SWGB:
+        if game_version[0].game_id == "SWGB":
             data_format.append((READ_GEN, "walk_sprite_rate", StorageType.FLOAT_MEMBER, "float"))
         else:
             data_format.append((READ_GEN, "replication_amount", StorageType.INT_MEMBER, "int32_t"))
@@ -78,7 +77,7 @@ class TerrainRestriction(GenieStructure):
             (READ_GEN, "accessible_dmgmultiplier", StorageType.ARRAY_FLOAT, "float[terrain_count]")
         ]
 
-        if game_version[0] is not GameEdition.ROR:
+        if game_version[0].game_id != "ROR":
             data_format.append(
                 (READ_GEN, "pass_graphics", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=TerrainPassGraphic,
@@ -138,14 +137,14 @@ class Terrain(GenieStructure):
             (READ_GEN, "random", StorageType.INT_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "is_water", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "hide_in_editor", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "string_id", StorageType.ID_MEMBER, "int32_t"),
             ])
 
-            if game_version[0] is GameEdition.AOE1DE:
+            if game_version[0].game_id == "AOE1DE":
                 data_format.extend([
                     (READ_GEN, "blend_priority", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "blend_type", StorageType.ID_MEMBER, "int16_t"),
@@ -159,7 +158,7 @@ class Terrain(GenieStructure):
                 (READ, "filename_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[filename_len]"),
             ])
-        elif game_version[0] is GameEdition.SWGB:
+        elif game_version[0].game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "internal_name", StorageType.STRING_MEMBER, "char[17]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[17]"),
@@ -176,19 +175,19 @@ class Terrain(GenieStructure):
             (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int32_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_stop_sound_id", StorageType.ID_MEMBER, "uint32_t"),
             ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 # see doc/media/blendomatic.md for blending stuff
                 (READ_GEN, "blend_priority", StorageType.ID_MEMBER, "int32_t"),
                 (READ_GEN, "blend_mode", StorageType.ID_MEMBER, "int32_t"),
             ])
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (SKIP, "overlay_mask_name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                     (READ, "overlay_mask_name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -216,32 +215,32 @@ class Terrain(GenieStructure):
             (READ_GEN, "terrain_to_draw1", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.append(
                 (READ_GEN, "terrain_unit_masked_density", StorageType.ARRAY_INT, "int16_t[30]")
             )
-        elif game_version[0] is GameEdition.SWGB:
+        elif game_version[0].game_id == "SWGB":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     55
                 ))
             )
-        elif game_version[0] is GameEdition.AOE1DE:
+        elif game_version[0].game_id == "AOE1DE":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     96
                 ))
             )
-        elif game_version[0] is GameEdition.HDEDITION:
+        elif game_version[0].game_id == "HDEDITION":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     100
                 ))
             )
-        elif game_version[0] is GameEdition.AOC:
+        elif game_version[0].game_id == "AOC":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
@@ -267,7 +266,7 @@ class Terrain(GenieStructure):
             (READ_GEN, "terrain_units_used_count", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is not GameEdition.SWGB:
+        if game_version[0].game_id != "SWGB":
             data_format.append((READ, "phantom", StorageType.INT_MEMBER, "int16_t"))
 
         return data_format

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -3,7 +3,6 @@
 # TODO pylint: disable=C,R,too-many-lines
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....init.game_version import GameEdition
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import EnumLookupMember, ContinueReadMember, IncludeMembers, SubdataMember
 from ....read.value_members import MemberTypes as StorageType
@@ -132,7 +131,7 @@ class UnitCommand(GenieStructure):
             (READ_GEN, "resource_deposit_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ]
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_resource_gather_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 # sound to play on resource drop
@@ -583,7 +582,7 @@ class UnitObject(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0] not in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id not in ("AOE1DE", "AOE2DE"):
             data_format = [
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
             ]
@@ -594,7 +593,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "id0", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "language_dll_creation", StorageType.ID_MEMBER, "uint32_t"),
@@ -681,7 +680,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "idle_graphic0", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "idle_graphic1", StorageType.ID_MEMBER, "int16_t"),
             ])
@@ -703,7 +702,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "train_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "damage_sound_id", StorageType.ID_MEMBER, "int16_t"))
 
         data_format.extend([
@@ -711,7 +710,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "dead_unit_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "blood_unit_id", StorageType.ID_MEMBER, "int16_t"),
             ])
@@ -727,7 +726,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "enabled", StorageType.BOOLEAN_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ, "disabled", StorageType.BOOLEAN_MEMBER, "int8_t"))
 
         data_format.extend([
@@ -897,7 +896,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "resource_gather_drop", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             # bit 0 == 1 && val != 7: mask shown behind buildings,
             # bit 0 == 0 && val != {6, 10}: no mask displayed,
             # val == {-1, 7}: in open area mask is partially displayed
@@ -931,7 +930,7 @@ class UnitObject(GenieStructure):
                 # leftover from trait+civ variable
                 (SKIP, "attribute_piece", StorageType.INT_MEMBER, "int16_t"),
             ])
-        elif game_version[0] is GameEdition.AOE1DE:
+        elif game_version[0].game_id == "AOE1DE":
             data_format.extend([
                 (READ_GEN, "obstruction_type", StorageType.ID_MEMBER, EnumLookupMember(
                     raw_type="int8_t",
@@ -973,7 +972,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "selection_shape_z", StorageType.FLOAT_MEMBER, "float"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ, "scenario_trigger_data0", StorageType.ID_MEMBER, "uint32_t"),
                 (READ, "scenario_trigger_data1", StorageType.ID_MEMBER, "uint32_t"),
@@ -993,7 +992,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "dying_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_creation_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_damage_sound_id", StorageType.ID_MEMBER, "uint32_t"),
@@ -1016,7 +1015,7 @@ class UnitObject(GenieStructure):
             (SKIP, "convert_terrain", StorageType.INT_MEMBER, "int8_t"),        # leftover from alpha. would et units change terrain under them
         ])
 
-        if game_version[0] in (GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -1028,7 +1027,7 @@ class UnitObject(GenieStructure):
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0] is GameEdition.SWGB:
+            if game_version[0].game_id == "SWGB":
                 data_format.extend([
                     (READ, "name2_length", StorageType.INT_MEMBER, "uint16_t"),
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),
@@ -1038,9 +1037,9 @@ class UnitObject(GenieStructure):
 
         data_format.append((READ_GEN, "id1", StorageType.ID_MEMBER, "int16_t"))
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "id2", StorageType.ID_MEMBER, "int16_t"))
-        elif game_version[0] is GameEdition.AOE1DE:
+        elif game_version[0].game_id == "AOE1DE":
             data_format.append((READ_GEN, "telemetry_id", StorageType.ID_MEMBER, "int16_t"))
 
         return data_format
@@ -1142,7 +1141,7 @@ class MovingUnit(DoppelgangerUnit):
             (SKIP, "old_move_algorithm", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "turn_radius", StorageType.FLOAT_MEMBER, "float"),
                 (READ_GEN, "turn_radius_speed", StorageType.FLOAT_MEMBER, "float"),
@@ -1151,7 +1150,7 @@ class MovingUnit(DoppelgangerUnit):
                 (READ_GEN, "max_yaw_per_sec_stationary", StorageType.FLOAT_MEMBER, "float"),
             ])
 
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "min_collision_size_multiplier", StorageType.FLOAT_MEMBER, "float"),
                 ])
@@ -1185,7 +1184,7 @@ class ActionUnit(MovingUnit):
             (READ_GEN, "work_rate", StorageType.FLOAT_MEMBER, "float"),
         ]
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "drop_sites", StorageType.ARRAY_ID, "int16_t[3]"),
             ])
@@ -1208,7 +1207,7 @@ class ActionUnit(MovingUnit):
             (READ_GEN, "stop_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_command_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_stop_sound_id", StorageType.ID_MEMBER, "uint32_t"),
@@ -1219,7 +1218,7 @@ class ActionUnit(MovingUnit):
             (SKIP, "run_pattern", StorageType.ID_MEMBER, "int8_t"),
         ])
 
-        if game_version[0] in (GameEdition.ROR, GameEdition.AOE1DE, GameEdition.AOE2DE):
+        if game_version[0].game_id in ("ROR", "AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ, "unit_command_count", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "unit_commands", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -1250,7 +1249,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, None, None, IncludeMembers(cls=ActionUnit)),
         ]
 
-        if game_version[0] is GameEdition.ROR:
+        if game_version[0].game_id == "ROR":
             data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "uint8_t"))
         else:
             data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "int16_t"))
@@ -1307,7 +1306,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, "weapon_range_min", StorageType.FLOAT_MEMBER, "float"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "accuracy_dispersion", StorageType.FLOAT_MEMBER, "float"))
 
         data_format.extend([
@@ -1398,7 +1397,7 @@ class LivingUnit(ProjectileUnit):
             (READ, "creation_button_id", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "rear_attack_modifier", StorageType.FLOAT_MEMBER, "float"),
                 (SKIP, "flank_attack_modifier", StorageType.FLOAT_MEMBER, "float"),
@@ -1425,7 +1424,7 @@ class LivingUnit(ProjectileUnit):
                 # duplicated projectiles
             ])
 
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "spawn_graphic_id", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "upgrade_graphic_id", StorageType.ID_MEMBER, "int16_t"),
@@ -1483,10 +1482,10 @@ class BuildingUnit(LivingUnit):
             (READ_GEN, "construction_graphic_id", StorageType.ID_MEMBER, "int16_t"),
         ]
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "snow_graphic_id", StorageType.ID_MEMBER, "int16_t"))
 
-            if game_version[0] is GameEdition.AOE2DE:
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "destruction_graphic_id", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "destruction_rubble_graphic_id", StorageType.ID_MEMBER, "int16_t"),
@@ -1510,7 +1509,7 @@ class BuildingUnit(LivingUnit):
             (READ_GEN, "research_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "can_burn", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "building_annex", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -1526,8 +1525,8 @@ class BuildingUnit(LivingUnit):
 
         data_format.append((READ_GEN, "construction_sound_id", StorageType.ID_MEMBER, "int16_t"))
 
-        if game_version[0] not in (GameEdition.ROR, GameEdition.AOE1DE):
-            if game_version[0] is GameEdition.AOE2DE:
+        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+            if game_version[0].game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "wwise_construction_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                     (READ_GEN, "wwise_transform_sound_id", StorageType.ID_MEMBER, "uint32_t"),

--- a/openage/convert/value_object/read/media/drs.py
+++ b/openage/convert/value_object/read/media/drs.py
@@ -12,7 +12,6 @@ from .....util.filelike.stream import StreamFragment
 from .....util.fslike.filecollection import FileCollection
 from .....util.strings import decode_until_null
 from .....util.struct import NamedStruct
-from ...init.game_version import GameEdition
 
 
 # version of the drs files, hardcoded for now
@@ -92,7 +91,7 @@ class DRS(FileCollection):
         self.fileobj = fileobj
 
         # read header
-        if GameEdition.SWGB is game_version[0]:
+        if game_version == "SWGB":
             header = DRSHeaderLucasArts.read(fileobj)
 
         else:

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -65,7 +65,7 @@ def main(args, error):
                 prev_source_dir_path = file_obj.read().strip()
         except FileNotFoundError:
             prev_source_dir_path = None
-        used_asset_path = convert_assets(root["assets"], args,
+        used_asset_path = convert_assets(root["assets"], root["cfg"], args,
                                          prev_source_dir_path=prev_source_dir_path)
         if used_asset_path:
             # Remember the asset location


### PR DESCRIPTION
Fixes #1314 and #1312.

Things done so far:
- created version-hash toml files for game editions and expansions inside `version-hashes` directory
   - every game/expansion has a single toml file
   - remaining games with MD5 hashes were also created(not sure if this was needed to be done)
   - a directory was created to store the files
- created auxiliary files from `GameEdition` and `GameExpansion` enums
   - single files were created for both

@heinezen any changes or additions needs to be done?

Also `AOE1DE` enum in `game_version.py` has same MD5 hashes for both `AoEDE_s.exe` and `empires.dat`. Is that a coincidence? 