### PR TITLE
More informative KeyError messages in converter

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -132,6 +132,7 @@ _the openage authors_ are:
 | D R Siddhartha              | drs-11                      | siddharthadr11 à gmail dawt com                   |
 | Martin Matějek              | mmtj                        | martin dawt matejek à gmx dawt com                |
 | Tobias Feldballe            | Namabilis                   | tobias à osandweb dawt dk                         |
+| Ayxan Haqverdili            | Ayxan13                     | aykhanhagverdili à gmail dawt com                 |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -71,7 +71,7 @@ class ConverterObject:
         try:
             return self.members[name]
         except KeyError as err:
-            raise KeyError(f"{self} has no attribute: {key}") from err
+            raise KeyError(f"{self} has no attribute: {name}") from err
 
     def has_member(self, name):
         """

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -68,7 +68,10 @@ class ConverterObject:
         """
         Returns a member of the object.
         """
-        return self.members[name]
+        try:
+            return self.members[name]
+        except KeyError as err:
+            raise KeyError(f"{self} has no attribute: {key}") from err
 
     def has_member(self, name):
         """


### PR DESCRIPTION
Added a try...catch to `get_member(self, name)` method of `ConverterObject`.