### PR TITLE
Output summary of converter run for debugging

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Brew update
         run: brew update
       - name: Brew install DeJaVu fonts
-        run: brew tap homebrew/cask-fonts && brew cask install font-dejavu
+        run: brew tap homebrew/cask-fonts && brew install --cask font-dejavu
       - name: Install environment helpers with homebrew
         run: brew install ccache
       - name: Install dependencies with homebrew

--- a/doc/code/converter/README.md
+++ b/doc/code/converter/README.md
@@ -1,0 +1,22 @@
+# Converter
+
+The converter transforms the old and janky Genie Engine formats
+into new and shiny openage formats.
+
+The major parts are implemented in Python 3. Where speed is important
+or external libraries are used, we use Cython.
+
+
+## Architecture
+
+[Architecture](architecture_overview.md)
+
+This document gives you an overview of the paradigms used in the code.
+
+
+## Workflow
+
+[Workflow](workflow.md)
+
+Here you can find out about the workflow of a converter run and what
+happens in the individual stages of conversion.

--- a/doc/code/converter/workflow.md
+++ b/doc/code/converter/workflow.md
@@ -1,11 +1,10 @@
 # Workflow
 
-- Converter has a general workflow
-- Workflow is the same for every game edition
-- Workflow should stay consistent if changes are made
+The converter has a general workflow that is the same for every game edition.
+This workflow should stay consistent if changes are made.
 
-- Converter is built to support multiple games
-- Keep that in mind when adding features
+Our converter is built to support multiple games. Keep in mind that you
+must test with all supported version when you add a feature.
 
 ![workflow structogram](images/workflow.svg)
 

--- a/doc/convert/debugger.md
+++ b/doc/convert/debugger.md
@@ -1,0 +1,43 @@
+# Converter Semantic Debugger
+
+The converter can generate debug info for a run. This provides
+information about the contents of converter parameters
+during conversion. It can help to find *semantic errors* in
+the code that would be hard to discover otherwise. Syntax and
+runtime errors are handled by the general logger.
+
+## Loglevels
+
+There are 4 loglevel to choose from. They can be manually specified using
+the `--debug-info [0, 1, 2, 3]` CLI parameter when starting a run. Otherwise
+the converter will use its default loglevels. These are 0 when started in `no-devmode`
+and 3 when started in `devmode`.
+
+* Level 0
+    * No output
+    * Default for `--no-devmode`
+
+* Level 1
+    * Converter CLI args
+    * Generated info file
+    * Generated manifest file
+    * Logfile
+
+* Level 2
+    * Info from Level 1
+    * Summaries of all stages (init, read, processor, export)
+        * Game version (init)
+        * Mount points (init)
+        * Used `.dat` file data format (read)
+        * Found languages (read)
+        * Found graphic files (read)
+        * Number of `ConverterObject`s and `ConverterObjectGroup`s by type (processor)
+        * Number of generated data, media and metadata files by type (export)
+
+* Level 3
+    * Info from Level 2
+    * Summaries for every `ConverterObjectGroup`
+        * Output of helper functions (`is_XYZ()` or `get_XYZ()`)
+        * Content of parameters
+        * Nyan object name (if available)
+    * Default for `--devmode`

--- a/openage/convert/entity_object/conversion/aoc/genie_civ.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_civ.py
@@ -102,7 +102,7 @@ class GenieCivilizationGroup(ConverterObjectGroup):
         """
         Adds a unique unit to the civilization.
         """
-        self.unique_entities.update({entity_group.get_id(): entity_group})
+        self.unique_entities.update({entity_group.get_head_unit_id(): entity_group})
 
     def add_unique_tech(self, tech_group):
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_tech.py
@@ -232,7 +232,7 @@ class UnitLineUpgrade(GenieTechEffectBundleGroup):
 
     def get_upgraded_line(self):
         """
-        Returns the line id of the upgraded line.
+        Returns the line that is upgraded.
         """
         return self.data.unit_lines_vertical_ref[self.unit_line_id]
 
@@ -487,17 +487,17 @@ class CivTeamBonus(ConverterObjectGroup):
         self.civ_id = civ_id
         self.effects = self.data.genie_effect_bundles[effect_bundle_id]
 
-    def get_effects(self):
-        """
-        Returns the associated effects.
-        """
-        return self.effects.get_effects()
-
     def get_civilization(self):
         """
         Returns ID of the civilization that has this bonus.
         """
         return self.civ_id
+
+    def get_effects(self):
+        """
+        Returns the associated effects.
+        """
+        return self.effects.get_effects()
 
     def __repr__(self):
         return f"CivTeamBonus<{self.get_id()}>"
@@ -534,6 +534,12 @@ class CivTechTree(ConverterObjectGroup):
         else:
             self.effects = None
 
+    def get_civilization(self):
+        """
+        Returns ID of the civilization that has this tech tree.
+        """
+        return self.civ_id
+
     def get_effects(self):
         """
         Returns the associated effects.
@@ -542,12 +548,6 @@ class CivTechTree(ConverterObjectGroup):
             return self.effects.get_effects()
 
         return []
-
-    def get_civilization(self):
-        """
-        Returns ID of the civilization that has this tech tree.
-        """
-        return self.civ_id
 
     def __repr__(self):
         return f"CivTechTree<{self.get_id()}>"

--- a/openage/convert/entity_object/conversion/aoc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_tech.py
@@ -277,6 +277,12 @@ class BuildingLineUpgrade(GenieTechEffectBundleGroup):
         """
         return self.building_line_id
 
+    def get_upgraded_line(self):
+        """
+        Returns the line that is upgraded.
+        """
+        return self.data.building_lines[self.building_line_id]
+
     def get_upgrade_target_id(self):
         """
         Returns the target unit that is upgraded to.

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -914,7 +914,22 @@ class GenieAmbientGroup(GenieGameEntityGroup):
         """
         return self.contains_entity(ambient_id)
 
+    def is_creatable(self, civ_id=-1):
+        return False
+
+    def is_gatherer(self, civ_id=-1):
+        return False
+
+    def is_melee(self, civ_id=-1):
+        return False
+
+    def is_ranged(self, civ_id=-1):
+        return False
+
     def is_projectile_shooter(self, civ_id=-1):
+        return False
+
+    def is_unique(self):
         return False
 
     def __repr__(self):
@@ -934,6 +949,21 @@ class GenieVariantGroup(GenieGameEntityGroup):
         Returns True if a unit with unit_id is part of the group.
         """
         return self.contains_entity(object_id)
+
+    def is_creatable(self, civ_id=-1):
+        return False
+
+    def is_gatherer(self, civ_id=-1):
+        return False
+
+    def is_melee(self, civ_id=-1):
+        return False
+
+    def is_ranged(self, civ_id=-1):
+        return False
+
+    def is_unique(self):
+        return False
 
     def __repr__(self):
         return f"GenieVariantGroup<{self.get_id()}>"

--- a/openage/convert/entity_object/conversion/ror/genie_tech.py
+++ b/openage/convert/entity_object/conversion/ror/genie_tech.py
@@ -39,6 +39,9 @@ class RoRUnitLineUpgrade(UnitLineUpgrade):
     Upgrades a unit in a line.
     """
 
+    def get_upgraded_line(self):
+        return self.data.unit_lines[self.unit_line_id]
+
     def is_unique(self):
         return False
 

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -4,6 +4,8 @@
 """
 Entry point for all of the asset conversion.
 """
+from datetime import datetime
+
 from ..log import info
 from ..util.fslike.directory import CaseIgnoringDirectory
 from ..util.fslike.wrapper import (DirectoryCreator,
@@ -59,6 +61,11 @@ def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     # make srcdir and targetdir safe for threaded conversion
     args.srcdir = AccessSynchronizer(data_dir).root
     args.targetdir = AccessSynchronizer(targetdir).root
+
+    # add a dir for debug logs
+    debug_log_path = converted_path / "debug" / datetime.now().isoformat(timespec='seconds')
+    debugdir = DirectoryCreator(debug_log_path).root
+    args.debugdir = AccessSynchronizer(debugdir).root
 
     def flag(name):
         """
@@ -160,6 +167,10 @@ def init_subparser(cli):
     cli.add_argument(
         "--compression-level", type=int, default=1, choices=[0, 1, 2, 3],
         help="set PNG compression level")
+
+    cli.add_argument(
+        "--debug-log", type=int, default=3, choices=[0, 1, 2, 3, 4, 5, 6],
+        help="create a debug log for the converter run; verbosity level 0-6")
 
 
 def main(args, error):

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -169,8 +169,8 @@ def init_subparser(cli):
         help="set PNG compression level")
 
     cli.add_argument(
-        "--debug-log", type=int, default=3, choices=[0, 1, 2, 3, 4, 5, 6],
-        help="create a debug log for the converter run; verbosity level 0-6")
+        "--debug-info", type=int, choices=[0, 1, 2, 3],
+        help="create debug output for the converter run; verbosity levels 0-3")
 
 
 def main(args, error):
@@ -186,6 +186,14 @@ def main(args, error):
         srcdir = CaseIgnoringDirectory(args.source_dir).root
     else:
         srcdir = None
+
+    # Set verbosity for debug output
+    if not args.debug_info:
+        if args.devmode:
+            args.debug_info = 3
+
+        else:
+            args.debug_info = 0
 
     # mount the config folder at "cfg/"
     from ..cvar.location import get_config_path

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -62,8 +62,8 @@ def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     args.srcdir = AccessSynchronizer(data_dir).root
     args.targetdir = AccessSynchronizer(targetdir).root
 
-    # add a dir for debug logs
-    debug_log_path = converted_path / "debug" / datetime.now().isoformat(timespec='seconds')
+    # add a dir for debug info
+    debug_log_path = converted_path / "debug" / datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     debugdir = DirectoryCreator(debug_log_path).root
     args.debugdir = AccessSynchronizer(debugdir).root
 

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -2,11 +2,9 @@
 #
 # pylint: disable=too-many-lines,too-many-branches,too-many-statements
 # pylint: disable=too-many-locals,too-many-public-methods
-
 """
 Convert data from AoC to openage formats.
 """
-
 from .....log import info
 from ....entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
 from ....entity_object.conversion.aoc.genie_civ import GenieCivilizationObject
@@ -35,6 +33,8 @@ from ....entity_object.conversion.aoc.genie_unit import GenieUnitObject
 from ....entity_object.conversion.aoc.genie_unit import GenieUnitTaskGroup,\
     GenieVillagerGroup
 from ....entity_object.conversion.aoc.genie_unit import GenieVariantGroup
+from ....service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 from ....service.read.nyan_api_loader import load_api
 from ....value_object.conversion.aoc.internal_nyan_names import AMBIENT_GROUP_LOOKUPS,\
     VARIANT_GROUP_LOOKUPS
@@ -50,7 +50,7 @@ class AoCProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, game_version, string_resources, existing_graphics):
+    def convert(cls, gamespec, args, string_resources, existing_graphics):
         """
         Input game speification and media here and get a set of
         modpacks back.
@@ -65,13 +65,15 @@ class AoCProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        data_set = cls._pre_processor(gamespec, game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        debug_converter_objects(args.debugdir, dataset, args.debug_log)
 
         # Create the custom openae formats (nyan, sprite, terrain)
-        data_set = cls._processor(data_set)
+        dataset = cls._processor(dataset)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
 
         # Create modpack definitions
-        modpacks = cls._post_processor(data_set)
+        modpacks = cls._post_processor(dataset)
 
         return modpacks
 

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -66,11 +66,11 @@ class AoCProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_log)
+        debug_converter_objects(args.debugdir, dataset, args.debug_info)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -451,6 +451,9 @@ class AoCProcessor:
         """
         Sort units into lines, based on information in the unit connections.
 
+        TODO: Use the head unit id as the line id because the latter is pretty
+        useless.
+
         :param full_data_set: GenieObjectContainer instance that
                               contains all relevant data for the conversion
                               process.

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -66,11 +66,11 @@ class AoCProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_info)
+        debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
+        debug_converter_object_groups(args.debugdir, args.debug_info, dataset)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -65,7 +65,12 @@ class AoCProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(
+            gamespec,
+            args.game_version,
+            string_resources,
+            existing_graphics
+        )
         debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -4,7 +4,8 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-
+from openage.convert.service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 """
 Convert data from DE2 to openage formats.
 """
@@ -31,7 +32,7 @@ class DE2Processor:
     """
 
     @classmethod
-    def convert(cls, gamespec, game_version, string_resources, existing_graphics):
+    def convert(cls, gamespec, args, string_resources, existing_graphics):
         """
         Input game speification and media here and get a set of
         modpacks back.
@@ -46,13 +47,15 @@ class DE2Processor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        data_set = cls._pre_processor(gamespec, game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        debug_converter_objects(args.debugdir, dataset, args.debug_log)
 
         # Create the custom openae formats (nyan, sprite, terrain)
-        data_set = cls._processor(data_set)
+        dataset = cls._processor(dataset)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
 
         # Create modpack definitions
-        modpacks = cls._post_processor(data_set)
+        modpacks = cls._post_processor(dataset)
 
         return modpacks
 

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -4,8 +4,6 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-from openage.convert.service.debug_info import debug_converter_objects,\
-    debug_converter_object_groups
 """
 Convert data from DE2 to openage formats.
 """
@@ -18,6 +16,8 @@ from .....util.ordered_set import OrderedSet
 from ....entity_object.conversion.aoc.genie_graphic import GenieGraphic
 from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 from ....entity_object.conversion.aoc.genie_unit import GenieUnitObject, GenieAmbientGroup, GenieVariantGroup
+from ....service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 from ....service.read.nyan_api_loader import load_api
 from ..aoc.pregen_processor import AoCPregenSubprocessor
 from ..aoc.processor import AoCProcessor
@@ -47,7 +47,12 @@ class DE2Processor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(
+            gamespec,
+            args.game_version,
+            string_resources,
+            existing_graphics
+        )
         debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -48,11 +48,11 @@ class DE2Processor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_log)
+        debug_converter_objects(args.debugdir, dataset, args.debug_info)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -48,11 +48,11 @@ class DE2Processor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_info)
+        debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
+        debug_converter_object_groups(args.debugdir, args.debug_info, dataset)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -5,7 +5,7 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-
+from openage.convert.service.debug_info import debug_converter_object_groups
 """
 Convert data from RoR to openage formats.
 """
@@ -21,6 +21,7 @@ from ....entity_object.conversion.ror.genie_tech import RoRStatUpgrade,\
 from ....entity_object.conversion.ror.genie_unit import RoRUnitTaskGroup,\
     RoRUnitLineGroup, RoRBuildingLineGroup, RoRVillagerGroup, RoRAmbientGroup,\
     RoRVariantGroup
+from ....service.debug_info import debug_converter_objects
 from ....service.read.nyan_api_loader import load_api
 from ....value_object.conversion.ror.internal_nyan_names import AMBIENT_GROUP_LOOKUPS,\
     VARIANT_GROUP_LOOKUPS
@@ -37,7 +38,7 @@ class RoRProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, game_version, string_resources, existing_graphics):
+    def convert(cls, gamespec, args, string_resources, existing_graphics):
         """
         Input game specification and media here and get a set of
         modpacks back.
@@ -52,13 +53,15 @@ class RoRProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        data_set = cls._pre_processor(gamespec, game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        debug_converter_objects(args.debugdir, dataset, args.debug_log)
 
         # Create the custom openae formats (nyan, sprite, terrain)
-        data_set = cls._processor(gamespec, data_set)
+        dataset = cls._processor(gamespec, dataset)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
 
         # Create modpack definitions
-        modpacks = cls._post_processor(data_set)
+        modpacks = cls._post_processor(dataset)
 
         return modpacks
 

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -54,11 +54,11 @@ class RoRProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_log)
+        debug_converter_objects(args.debugdir, dataset, args.debug_info)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(gamespec, dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -5,11 +5,9 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-from openage.convert.service.debug_info import debug_converter_object_groups
 """
 Convert data from RoR to openage formats.
 """
-
 from .....log import info
 from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 from ....entity_object.conversion.aoc.genie_tech import InitiatedTech
@@ -21,7 +19,8 @@ from ....entity_object.conversion.ror.genie_tech import RoRStatUpgrade,\
 from ....entity_object.conversion.ror.genie_unit import RoRUnitTaskGroup,\
     RoRUnitLineGroup, RoRBuildingLineGroup, RoRVillagerGroup, RoRAmbientGroup,\
     RoRVariantGroup
-from ....service.debug_info import debug_converter_objects
+from ....service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 from ....service.read.nyan_api_loader import load_api
 from ....value_object.conversion.ror.internal_nyan_names import AMBIENT_GROUP_LOOKUPS,\
     VARIANT_GROUP_LOOKUPS
@@ -53,7 +52,12 @@ class RoRProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(
+            gamespec,
+            args.game_version,
+            string_resources,
+            existing_graphics
+        )
         debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -54,11 +54,11 @@ class RoRProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_info)
+        debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(gamespec, dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
+        debug_converter_object_groups(args.debugdir, args.debug_info, dataset)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -4,7 +4,8 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-
+from openage.convert.service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 """
 Convert data from SWGB:CC to openage formats.
 """
@@ -37,7 +38,7 @@ class SWGBCCProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, game_version, string_resources, existing_graphics):
+    def convert(cls, gamespec, args, string_resources, existing_graphics):
         """
         Input game specification and media here and get a set of
         modpacks back.
@@ -52,13 +53,15 @@ class SWGBCCProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        data_set = cls._pre_processor(gamespec, game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        debug_converter_objects(args.debugdir, dataset, args.debug_log)
 
         # Create the custom openae formats (nyan, sprite, terrain)
-        data_set = cls._processor(data_set)
+        dataset = cls._processor(dataset)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
 
         # Create modpack definitions
-        modpacks = cls._post_processor(data_set)
+        modpacks = cls._post_processor(dataset)
 
         return modpacks
 

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -54,11 +54,11 @@ class SWGBCCProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_info)
+        debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
+        debug_converter_object_groups(args.debugdir, args.debug_info, dataset)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -54,11 +54,11 @@ class SWGBCCProcessor:
 
         # Create a new container for the conversion process
         dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
-        debug_converter_objects(args.debugdir, dataset, args.debug_log)
+        debug_converter_objects(args.debugdir, dataset, args.debug_info)
 
         # Create the custom openae formats (nyan, sprite, terrain)
         dataset = cls._processor(dataset)
-        debug_converter_object_groups(args.debugdir, dataset, args.debug_log)
+        debug_converter_object_groups(args.debugdir, dataset, args.debug_info)
 
         # Create modpack definitions
         modpacks = cls._post_processor(dataset)

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -4,8 +4,6 @@
 #
 # TODO:
 # pylint: disable=line-too-long
-from openage.convert.service.debug_info import debug_converter_objects,\
-    debug_converter_object_groups
 """
 Convert data from SWGB:CC to openage formats.
 """
@@ -21,6 +19,8 @@ from ....entity_object.conversion.swgbcc.genie_tech import SWGBUnitUnlock,\
     SWGBUnitLineUpgrade
 from ....entity_object.conversion.swgbcc.genie_unit import SWGBUnitTransformGroup,\
     SWGBMonkGroup, SWGBUnitLineGroup, SWGBStackBuildingGroup
+from ....service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
 from ....service.read.nyan_api_loader import load_api
 from ....value_object.conversion.swgb.internal_nyan_names import MONK_GROUP_ASSOCS,\
     CIV_LINE_ASSOCS, AMBIENT_GROUP_LOOKUPS, VARIANT_GROUP_LOOKUPS,\
@@ -53,7 +53,12 @@ class SWGBCCProcessor:
         info("Starting conversion...")
 
         # Create a new container for the conversion process
-        dataset = cls._pre_processor(gamespec, args.game_version, string_resources, existing_graphics)
+        dataset = cls._pre_processor(
+            gamespec,
+            args.game_version,
+            string_resources,
+            existing_graphics
+        )
         debug_converter_objects(args.debugdir, args.debug_info, dataset)
 
         # Create the custom openae formats (nyan, sprite, terrain)

--- a/openage/convert/service/CMakeLists.txt
+++ b/openage/convert/service/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_py_modules(
 	__init__.py
+	debug_info.py
 )
 
 add_subdirectory(conversion)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -5,8 +5,43 @@
 Creates debug output from data in a conversion run.
 """
 from openage.convert.value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
-from openage.convert.value_object.read.read_members import SubdataMember,\
-    IncludeMembers, MultisubtypeMember
+from openage.convert.value_object.read.read_members import IncludeMembers, MultisubtypeMember
+
+
+def debug_init(debugdir, args):
+    """
+    Log the converter settings.
+    """
+    logfile = debugdir["args"]
+    logtext = ""
+
+    # Get CLI args
+    arg_dict = {}
+    for name, arg in vars(args).items():
+        if name == "entrypoint":
+            # args after entrypoint are not from CLI
+            break
+
+        arg_dict.update({name: arg})
+
+    # Sort by name
+    arg_dict = dict(sorted(arg_dict.items(), key=lambda item: item[0]))
+
+    for name, arg in arg_dict.items():
+        logtext += f"{name}: {arg}\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)
+
+    # Log game version
+    logfile = debugdir.joinpath("init/")["game_version"]
+    logtext = ""
+
+    logtext += f"game edition: {args.game_version[0]}\n"
+    logtext += f"game expansions: {args.game_version[1]}\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)
 
 
 def debug_gamedata_format(debugdir, game_version, loglevel):

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -4,6 +4,11 @@
 """
 Creates debug output from data in a conversion run.
 """
+from openage.convert.entity_object.conversion.aoc.genie_tech import AgeUpgrade,\
+    UnitLineUpgrade, BuildingLineUpgrade, UnitUnlock, BuildingUnlock
+from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
+    GenieBuildingLineGroup, GenieStackBuildingGroup, GenieUnitTransformGroup,\
+    GenieMonkGroup
 from openage.convert.value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
 from openage.convert.value_object.read.read_members import IncludeMembers, MultisubtypeMember
 from openage.util.fslike.filecollection import FileCollectionPath
@@ -190,3 +195,201 @@ def debug_registered_graphics(debugdir, existing_graphics, loglevel):
 
     with logfile.open("w") as log:
         log.write(logtext)
+
+
+def debug_converter_objects(debugdir, dataset, loglevel):
+    """
+    Create debug output for ConverterObject instances from the
+    conversion preprocessor.
+    """
+    logfile = debugdir.joinpath("conversion/")["preprocessor_objects"]
+    logtext = ""
+
+    logtext += (
+        f"unit objects count: {len(dataset.genie_units)}\n"
+        f"tech objects count: {len(dataset.genie_techs)}\n"
+        f"civ objects count: {len(dataset.genie_civs)}\n"
+        f"effect bundles count: {len(dataset.genie_effect_bundles)}\n"
+        f"age connections count: {len(dataset.age_connections)}\n"
+        f"building connections count: {len(dataset.building_connections)}\n"
+        f"unit connections count: {len(dataset.unit_connections)}\n"
+        f"tech connections count: {len(dataset.tech_connections)}\n"
+        f"graphics objects count: {len(dataset.genie_graphics)}\n"
+        f"sound objects count: {len(dataset.genie_sounds)}\n"
+        f"terrain objects count: {len(dataset.genie_terrains)}\n"
+    )
+
+    with logfile.open("w") as log:
+        log.write(logtext)
+
+
+def debug_converter_object_groups(debugdir, dataset, loglevel):
+    """
+    Create debug output for ConverterObjectGroup instances from the
+    conversion preprocessor.
+    """
+    enitity_groups = {}
+    enitity_groups.update(dataset.unit_lines)
+    enitity_groups.update(dataset.building_lines)
+    enitity_groups.update(dataset.ambient_groups)
+    enitity_groups.update(dataset.variant_groups)
+
+    for key, line in enitity_groups.items():
+        logfile = debugdir.joinpath("conversion/entity_groups/")[str(key)]
+        logtext = ""
+
+        logtext += f"repr: {line}\n"
+
+        logtext += f"is_creatable: {line.is_creatable()}\n"
+        logtext += f"is_harvestable: {line.is_harvestable()}\n"
+        logtext += f"is_garrison: {line.is_garrison()}\n"
+        logtext += f"is_gatherer: {line.is_gatherer()}\n"
+        logtext += f"is_passable: {line.is_passable()}\n"
+        logtext += f"is_projectile_shooter: {line.is_projectile_shooter()}\n"
+        logtext += f"is_ranged: {line.is_ranged()}\n"
+        logtext += f"is_melee: {line.is_melee()}\n"
+        logtext += f"is_repairable: {line.is_repairable()}\n"
+        logtext += f"is_unique: {line.is_unique()}\n"
+
+        logtext += f"class id: {line.get_class_id()}\n"
+        logtext += f"garrison mode: {line.get_garrison_mode()}\n"
+        logtext += f"head unit: {line.get_head_unit()}\n"
+        logtext += f"train location id: {line.get_train_location_id()}\n"
+
+        logtext += "line:\n"
+        for unit in line.line:
+            logtext += f"    - {unit}\n"
+
+        if len(line.creates) > 0:
+            logtext += "creates:\n"
+            for unit in line.creates:
+                logtext += f"    - {unit}\n"
+
+        else:
+            logtext += "creates: nothing\n"
+
+        if len(line.researches) > 0:
+            logtext += "researches:\n"
+            for tech in line.researches:
+                logtext += f"    - {tech}\n"
+
+        else:
+            logtext += "researches: nothing\n"
+
+        if len(line.garrison_entities) > 0:
+            logtext += "garrisons units:\n"
+            for unit in line.garrison_entities:
+                logtext += f"    - {unit}\n"
+
+        else:
+            logtext += "garrisons units: nothing\n"
+
+        if len(line.garrison_locations) > 0:
+            logtext += "garrisons in:\n"
+            for unit in line.garrison_locations:
+                logtext += f"    - {unit}\n"
+
+        else:
+            logtext += "garrisons in: nothing\n"
+
+        if isinstance(line, GenieUnitLineGroup):
+            logtext += "\n"
+            logtext += f"civ id: {line.get_civ_id()}\n"
+            logtext += f"enabling research id: {line.get_enabling_research_id()}\n"
+
+        if isinstance(line, GenieBuildingLineGroup):
+            logtext += "\n"
+            logtext += f"has_foundation: {line.has_foundation()}\n"
+            logtext += f"is_dropsite: {line.is_dropsite()}\n"
+            logtext += f"is_trade_post {line.is_trade_post()}\n"
+            logtext += f"enabling research id: {line.get_enabling_research_id()}\n"
+            logtext += f"dropoff gatherer ids: {line.get_gatherer_ids()}\n"
+
+        if isinstance(line, GenieStackBuildingGroup):
+            logtext += "\n"
+            logtext += f"is_gate: {line.is_gate()}\n"
+            logtext += f"stack unit: {line.get_stack_unit()}\n"
+
+        if isinstance(line, GenieUnitTransformGroup):
+            logtext += "\n"
+            logtext += f"transform unit: {line.get_transform_unit()}\n"
+
+        if isinstance(line, GenieMonkGroup):
+            logtext += "\n"
+            logtext += f"switch unit: {line.get_switch_unit()}\n"
+
+        with logfile.open("w") as log:
+            log.write(logtext)
+
+    for key, civ in dataset.civ_groups.items():
+        logfile = debugdir.joinpath("conversion/civ_groups/")[str(key)]
+        logtext = ""
+
+        logtext += f"repr: {civ}\n"
+        logtext += f"team bonus: {civ.team_bonus}\n"
+        logtext += f"tech tree: {civ.tech_tree}\n"
+
+        logtext += "civ bonus ids:\n"
+        for bonus in civ.civ_boni:
+            logtext += f"    - {bonus}\n"
+
+        logtext += "unique unit ids:\n"
+        for unit in civ.unique_entities:
+            logtext += f"    - {unit}\n"
+
+        logtext += "unique tech ids:\n"
+        for tech in civ.unique_techs:
+            logtext += f"    - {tech}\n"
+
+        with logfile.open("w") as log:
+            log.write(logtext)
+
+    for key, tech in dataset.tech_groups.items():
+        logfile = debugdir.joinpath("conversion/tech_groups/")[str(key)]
+        logtext = ""
+
+        logtext += f"repr: {tech}\n"
+        logtext += f"is_researchable: {tech.is_researchable()}\n"
+        logtext += f"is_unique: {tech.is_unique()}\n"
+        logtext += f"research location id: {tech.get_research_location_id()}\n"
+
+        logtext += f"required tech count: {tech.get_required_tech_count()}\n"
+        logtext += "required techs:\n"
+        for req_tech in tech.get_required_techs():
+            logtext += f"    - {req_tech}\n"
+
+        if isinstance(tech, AgeUpgrade):
+            logtext += "\n"
+            logtext += f"researched age id: {tech.age_id}\n"
+
+        if isinstance(tech, UnitLineUpgrade):
+            logtext += "\n"
+            logtext += f"upgraded line id: {tech.get_line_id()}\n"
+            logtext += f"upgraded line: {tech.get_upgraded_line()}\n"
+            logtext += f"upgrade target id: {tech.get_upgrade_target_id()}\n"
+
+        if isinstance(tech, BuildingLineUpgrade):
+            logtext += "\n"
+            logtext += f"upgraded line id: {tech.get_line_id()}\n"
+            logtext += f"upgrade target id: {tech.get_upgrade_target_id()}\n"
+
+        if isinstance(tech, UnitUnlock):
+            logtext += "\n"
+            logtext += f"unlocked line: {tech.get_unlocked_line()}\n"
+
+        if isinstance(tech, BuildingUnlock):
+            logtext += "\n"
+            logtext += f"unlocked line: {tech.get_unlocked_line()}\n"
+
+        with logfile.open("w") as log:
+            log.write(logtext)
+
+    for key, terrain in dataset.terrain_groups.items():
+        logfile = debugdir.joinpath("conversion/terrain_groups/")[str(key)]
+        logtext = ""
+
+        logtext += f"repr: {terrain}\n"
+        logtext += f"has_subterrain: {terrain.has_subterrain()}\n"
+
+        with logfile.open("w") as log:
+            log.write(logtext)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -6,7 +6,6 @@ Creates debug output from data in a conversion run.
 """
 from openage.convert.value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
 from openage.convert.value_object.read.read_members import IncludeMembers, MultisubtypeMember
-from openage.util.fslike.directory import Directory
 from openage.util.fslike.filecollection import FileCollectionPath
 from openage.util.fslike.path import Path
 
@@ -154,6 +153,40 @@ def debug_gamedata_format(debugdir, game_version, loglevel):
 
         handled_structs.add(struct)
         logtext += "\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)
+
+
+def debug_string_resources(debugdir, string_resources, loglevel):
+    """
+    Create debug output for found string resources.
+    """
+    logfile = debugdir.joinpath("read/")["string_resources"]
+    logtext = ""
+
+    logtext += "found languages: "
+    logtext += ", ".join(string_resources.get_tables().keys())
+    logtext += "\n\n"
+
+    for language, strings in string_resources.get_tables().items():
+        logtext += f"{language}: {len(strings)} IDs\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)
+
+
+def debug_registered_graphics(debugdir, existing_graphics, loglevel):
+    """
+    Create debug output for found graphics files.
+    """
+    logfile = debugdir.joinpath("read/")["existing_graphics"]
+    logtext = ""
+
+    logtext += f"file count: {len(existing_graphics)}\n\n"
+
+    sorted_graphics = list(sorted(existing_graphics))
+    logtext += "\n".join(sorted_graphics)
 
     with logfile.open("w") as log:
         log.write(logtext)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -1,0 +1,61 @@
+# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+
+# TODO pylint: disable=C,R
+"""
+Creates debug output from data in a conversion run.
+"""
+from openage.convert.value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
+from openage.convert.value_object.read.read_members import SubdataMember,\
+    IncludeMembers, MultisubtypeMember
+
+
+def debug_gamedata_format(debugdir, game_version, loglevel):
+    """
+    Logs the data format of a .dat file of a specific a game version.
+    """
+    logfile = debugdir.joinpath("read/")["data_format"]
+    logtext = ""
+
+    discovered_structs = {EmpiresDatWrapper}
+    handled_structs = set()
+
+    while discovered_structs:
+        struct = discovered_structs.pop()
+
+        if struct in handled_structs:
+            continue
+
+        members = struct.get_data_format_members(game_version)
+        logtext += f"struct name: {struct.name_struct}\n"
+        logtext += f"total member count: {len(members)}\n"
+
+        max_name_width = 1
+        max_vmemb_width = 1
+        for member in members:
+            # Find out width of columns for table formatting
+            if len(str(member[1])) > max_name_width:
+                max_name_width = len(str(member[1]))
+
+            if len(str(member[2])) > max_vmemb_width:
+                max_vmemb_width = len(str(member[2]))
+
+            # Search for sub-structs
+            if isinstance(member[3], IncludeMembers):
+                discovered_structs.add(member[3].cls)
+
+            elif isinstance(member[3], MultisubtypeMember):
+                discovered_structs.update(member[3].class_lookup.values())
+
+        for member in members:
+            logtext += (
+                f"{str(member[0].value):8}  "
+                f"{str(member[1]):{max_name_width}}  "
+                f"{str(member[2]):{max_vmemb_width}}  "
+                f"{str(member[3])}\n"
+            )
+
+        handled_structs.add(struct)
+        logtext += "\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -20,6 +20,13 @@ from openage.util.fslike.path import Path
 def debug_cli_args(debugdir, loglevel, args):
     """
     Create debug output for the converter CLI args.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param args: CLI arguments.
+    :type args: Namespace
     """
     if loglevel < 1:
         return
@@ -45,6 +52,13 @@ def debug_cli_args(debugdir, loglevel, args):
 def debug_game_version(debugdir, loglevel, args):
     """
     Create debug output for the detected game version.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param args: CLI arguments.
+    :type args: Namespace
     """
     if loglevel < 2:
         return
@@ -73,6 +87,13 @@ def debug_game_version(debugdir, loglevel, args):
 def debug_mounts(debugdir, loglevel, args):
     """
     Create debug output for the mounted files and folders.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param args: CLI arguments.
+    :type args: Namespace
     """
     if loglevel < 2:
         return
@@ -131,6 +152,13 @@ def debug_mounts(debugdir, loglevel, args):
 def debug_gamedata_format(debugdir, loglevel, game_version):
     """
     Create debug output for the converted .dat format.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param game_version: Game version the .dat file comes with.
+    :type game_version: tuple
     """
     if loglevel < 2:
         return
@@ -186,6 +214,13 @@ def debug_gamedata_format(debugdir, loglevel, game_version):
 def debug_string_resources(debugdir, loglevel, string_resources):
     """
     Create debug output for found string resources.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param string_resources: Language and string information.
+    :type string_resources: StringResource
     """
     if loglevel < 2:
         return
@@ -207,6 +242,13 @@ def debug_string_resources(debugdir, loglevel, string_resources):
 def debug_registered_graphics(debugdir, loglevel, existing_graphics):
     """
     Create debug output for found graphics files.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param existing_graphics: List of graphic ids of graphic files.
+    :type existing_graphics: list
     """
     if loglevel < 2:
         return
@@ -227,6 +269,13 @@ def debug_converter_objects(debugdir, loglevel, dataset):
     """
     Create debug output for ConverterObject instances from the
     conversion preprocessor.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param dataset: Dataset containing converter objects from pre-processing.
+    :type dataset: GenieObjectContainer
     """
     if loglevel < 2:
         return
@@ -256,6 +305,13 @@ def debug_converter_object_groups(debugdir, loglevel, dataset):
     """
     Create debug output for ConverterObjectGroup instances from the
     conversion preprocessor.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param dataset: Dataset containing converter object groups from processing.
+    :type dataset: GenieObjectContainer
     """
     if loglevel < 3:
         return
@@ -503,6 +559,13 @@ def debug_converter_object_groups(debugdir, loglevel, dataset):
 def debug_modpack(debugdir, loglevel, modpack):
     """
     Create debug output for a modpack.
+
+    :param debugdir: Output directory for the debug info.
+    :type debugdir: Directory
+    :param loglevel: Determines how detailed the output is.
+    :type loglevel: int
+    :param modpack: Modpack container.
+    :type modpack: Modpack
     """
     if loglevel < 1:
         return

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -97,7 +97,7 @@ def debug_mounts(debugdir, loglevel, args):
     # Format mounts
     for mountpoint, resources in mount_dict.items():
         if len(mountpoint) == 0:
-            logtext += f"mountpoint: ${{srcdir}}/\n"
+            logtext += "mountpoint: ${srcdir}/\n"
 
         else:
             logtext += f"mountpoint: ${{srcdir}}/{mountpoint[0].decode()}/\n"
@@ -122,7 +122,7 @@ def debug_mounts(debugdir, loglevel, args):
             if resource_type == "file collection":
                 logtext += f"    file count: {file_count}\n"
 
-            logtext += f"    ----\n"
+            logtext += "    ----\n"
 
     with logfile.open("w") as log:
         log.write(logtext)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -15,20 +15,19 @@ from openage.util.fslike.filecollection import FileCollectionPath
 from openage.util.fslike.path import Path
 
 
-def debug_init(debugdir, args, loglevel):
+def debug_cli_args(debugdir, loglevel, args):
     """
-    Log the converter settings.
+    Create debug output for the converter CLI args.
     """
+    if loglevel < 1:
+        return
+
     logfile = debugdir["args"]
     logtext = ""
 
     # Get CLI args
     arg_dict = {}
     for name, arg in vars(args).items():
-        if name == "entrypoint":
-            # args after entrypoint are not from CLI
-            break
-
         arg_dict.update({name: arg})
 
     # Sort by name
@@ -39,6 +38,14 @@ def debug_init(debugdir, args, loglevel):
 
     with logfile.open("w") as log:
         log.write(logtext)
+
+
+def debug_game_version(debugdir, loglevel, args):
+    """
+    Create debug output for the detected game version.
+    """
+    if loglevel < 2:
+        return
 
     # Log game version
     logfile = debugdir.joinpath("init/")["game_version"]
@@ -59,6 +66,14 @@ def debug_init(debugdir, args, loglevel):
 
     with logfile.open("w") as log:
         log.write(logtext)
+
+
+def debug_mounts(debugdir, loglevel, args):
+    """
+    Create debug output for the mounted files and folders.
+    """
+    if loglevel < 2:
+        return
 
     # Log mounts
     logfile = debugdir.joinpath("init/")["mounts"]
@@ -111,10 +126,13 @@ def debug_init(debugdir, args, loglevel):
         log.write(logtext)
 
 
-def debug_gamedata_format(debugdir, game_version, loglevel):
+def debug_gamedata_format(debugdir, loglevel, game_version):
     """
-    Logs the data format of a .dat file of a specific a game version.
+    Create debug output for the converted .dat format.
     """
+    if loglevel < 2:
+        return
+
     logfile = debugdir.joinpath("read/")["data_format"]
     logtext = ""
 
@@ -163,10 +181,13 @@ def debug_gamedata_format(debugdir, game_version, loglevel):
         log.write(logtext)
 
 
-def debug_string_resources(debugdir, string_resources, loglevel):
+def debug_string_resources(debugdir, loglevel, string_resources):
     """
     Create debug output for found string resources.
     """
+    if loglevel < 2:
+        return
+
     logfile = debugdir.joinpath("read/")["string_resources"]
     logtext = ""
 
@@ -181,10 +202,13 @@ def debug_string_resources(debugdir, string_resources, loglevel):
         log.write(logtext)
 
 
-def debug_registered_graphics(debugdir, existing_graphics, loglevel):
+def debug_registered_graphics(debugdir, loglevel, existing_graphics):
     """
     Create debug output for found graphics files.
     """
+    if loglevel < 2:
+        return
+
     logfile = debugdir.joinpath("read/")["existing_graphics"]
     logtext = ""
 
@@ -197,11 +221,14 @@ def debug_registered_graphics(debugdir, existing_graphics, loglevel):
         log.write(logtext)
 
 
-def debug_converter_objects(debugdir, dataset, loglevel):
+def debug_converter_objects(debugdir, loglevel, dataset):
     """
     Create debug output for ConverterObject instances from the
     conversion preprocessor.
     """
+    if loglevel < 2:
+        return
+
     logfile = debugdir.joinpath("conversion/")["preprocessor_objects"]
     logtext = ""
 
@@ -223,11 +250,14 @@ def debug_converter_objects(debugdir, dataset, loglevel):
         log.write(logtext)
 
 
-def debug_converter_object_groups(debugdir, dataset, loglevel):
+def debug_converter_object_groups(debugdir, loglevel, dataset):
     """
     Create debug output for ConverterObjectGroup instances from the
     conversion preprocessor.
     """
+    if loglevel < 3:
+        return
+
     enitity_groups = {}
     enitity_groups.update(dataset.unit_lines)
     enitity_groups.update(dataset.building_lines)
@@ -395,10 +425,21 @@ def debug_converter_object_groups(debugdir, dataset, loglevel):
             log.write(logtext)
 
 
-def debug_modpack(debugdir, modpack, loglevel):
+def debug_modpack(debugdir, loglevel, modpack):
     """
     Create debug output for a modpack.
     """
+    if loglevel < 1:
+        return
+
+    # Export info and manifest file
+    logdir = debugdir.joinpath(f"export/{modpack.name}")
+    modpack.info.save(logdir)
+    modpack.manifest.save(logdir)
+
+    if loglevel < 2:
+        return
+
     logfile = debugdir.joinpath(f"export/{modpack.name}")["summary"]
     logtext = ""
 
@@ -428,8 +469,3 @@ def debug_modpack(debugdir, modpack, loglevel):
 
     with logfile.open("w") as log:
         log.write(logtext)
-
-    # Export info and manifest file
-    logdir = debugdir.joinpath(f"export/{modpack.name}")
-    modpack.info.save(logdir)
-    modpack.manifest.save(logdir)

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -393,3 +393,43 @@ def debug_converter_object_groups(debugdir, dataset, loglevel):
 
         with logfile.open("w") as log:
             log.write(logtext)
+
+
+def debug_modpack(debugdir, modpack, loglevel):
+    """
+    Create debug output for a modpack.
+    """
+    logfile = debugdir.joinpath(f"export/{modpack.name}")["summary"]
+    logtext = ""
+
+    logtext += f"name: {modpack.name}\n"
+
+    file_count = (
+        len(modpack.get_data_files()) +
+        len(modpack.get_media_files()) +
+        len(modpack.get_metadata_files())
+    )
+    logtext += f"file count: {file_count}\n"
+    logtext += f"    data: {len(modpack.get_data_files())}\n"
+    logtext += f"    media: {len(modpack.get_media_files())}\n"
+
+    # Count the files by type
+    media_dict = {}
+    for media_type, files in modpack.get_media_files().items():
+        media_dict[media_type.value] = len(files)
+
+    # Sort by type name
+    media_dict = dict(sorted(media_dict.items(), key=lambda item: item[0]))
+
+    for media_type, file_count in media_dict.items():
+        logtext += f"        {media_type}: {file_count}\n"
+
+    logtext += f"    metadata: {len(modpack.get_metadata_files())}\n"
+
+    with logfile.open("w") as log:
+        log.write(logtext)
+
+    # Export info and manifest file
+    logdir = debugdir.joinpath(f"export/{modpack.name}")
+    modpack.info.save(logdir)
+    modpack.manifest.save(logdir)

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -78,7 +78,7 @@ def convert_metadata(args):
         gamedata_path.removerecursive()
 
     args.converter = get_converter(args.game_version)
-    debug_init(args.debugdir, args)
+    debug_init(args.debugdir, args, args.debug_log)
 
     # Read .dat
     yield "empires.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -96,7 +96,7 @@ def convert_metadata(args):
 
     # Convert
     modpacks = args.converter.convert(gamespec,
-                                      args.game_version,
+                                      args,
                                       string_resources,
                                       existing_graphics)
 

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -5,6 +5,8 @@ Receives cleaned-up srcdir and targetdir objects from .main, and drives the
 actual conversion process.
 """
 
+from openage.convert.service.debug_info import debug_init
+
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
 from ..service.debug_info import debug_gamedata_format
@@ -76,6 +78,7 @@ def convert_metadata(args):
         gamedata_path.removerecursive()
 
     args.converter = get_converter(args.game_version)
+    debug_init(args.debugdir, args)
 
     # Read .dat
     yield "empires.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -5,7 +5,8 @@ Receives cleaned-up srcdir and targetdir objects from .main, and drives the
 actual conversion process.
 """
 
-from openage.convert.service.debug_info import debug_init
+from openage.convert.service.debug_info import debug_init,\
+    debug_string_resources, debug_registered_graphics
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
@@ -87,9 +88,11 @@ def convert_metadata(args):
 
     # Read strings
     string_resources = get_string_resources(args)
+    debug_string_resources(args.debugdir, string_resources, args.debug_log)
 
     # Existing graphic IDs/filenames
     existing_graphics = get_existing_graphics(args)
+    debug_registered_graphics(args.debugdir, existing_graphics, args.debug_log)
 
     # Convert
     modpacks = args.converter.convert(gamespec,

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -7,6 +7,7 @@ actual conversion process.
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
+from ..service.debug_info import debug_gamedata_format
 from ..service.init.changelog import (ASSET_VERSION)
 from ..service.read.gamedata import get_gamespec
 from ..service.read.palette import get_palettes
@@ -78,6 +79,7 @@ def convert_metadata(args):
 
     # Read .dat
     yield "empires.dat"
+    debug_gamedata_format(args.debugdir, args.game_version, args.debug_log)
     gamespec = get_gamespec(args.srcdir, args.game_version, args.flag("no_pickle_cache"))
 
     # Read strings

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -5,8 +5,8 @@ Receives cleaned-up srcdir and targetdir objects from .main, and drives the
 actual conversion process.
 """
 
-from openage.convert.service.debug_info import debug_init,\
-    debug_string_resources, debug_registered_graphics, debug_modpack
+from openage.convert.service.debug_info import debug_string_resources,\
+    debug_registered_graphics, debug_modpack, debug_cli_args
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
@@ -79,20 +79,20 @@ def convert_metadata(args):
         gamedata_path.removerecursive()
 
     args.converter = get_converter(args.game_version)
-    debug_init(args.debugdir, args, args.debug_info)
+    debug_cli_args(args.debugdir, args.debug_info, args)
 
     # Read .dat
     yield "empires.dat"
-    debug_gamedata_format(args.debugdir, args.game_version, args.debug_info)
+    debug_gamedata_format(args.debugdir, args.debug_info, args.game_version)
     gamespec = get_gamespec(args.srcdir, args.game_version, args.flag("no_pickle_cache"))
 
     # Read strings
     string_resources = get_string_resources(args)
-    debug_string_resources(args.debugdir, string_resources, args.debug_info)
+    debug_string_resources(args.debugdir, args.debug_info, string_resources)
 
     # Existing graphic IDs/filenames
     existing_graphics = get_existing_graphics(args)
-    debug_registered_graphics(args.debugdir, existing_graphics, args.debug_info)
+    debug_registered_graphics(args.debugdir, args.debug_info, existing_graphics)
 
     # Convert
     modpacks = args.converter.convert(gamespec,
@@ -102,7 +102,7 @@ def convert_metadata(args):
 
     for modpack in modpacks:
         ModpackExporter.export(modpack, args)
-        debug_modpack(args.debugdir, modpack, args.debug_info)
+        debug_modpack(args.debugdir, args.debug_info, modpack)
 
     if args.game_version[0].game_id not in ("ROR", "AOE2DE"):
         yield "blendomatic.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -5,13 +5,11 @@ Receives cleaned-up srcdir and targetdir objects from .main, and drives the
 actual conversion process.
 """
 
-from openage.convert.service.debug_info import debug_string_resources,\
-    debug_registered_graphics, debug_modpack, debug_cli_args, debug_game_version,\
-    debug_mounts
-
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
 from ..service.debug_info import debug_gamedata_format
+from ..service.debug_info import debug_string_resources,\
+    debug_registered_graphics, debug_modpack
 from ..service.init.changelog import (ASSET_VERSION)
 from ..service.read.gamedata import get_gamespec
 from ..service.read.palette import get_palettes
@@ -80,9 +78,6 @@ def convert_metadata(args):
         gamedata_path.removerecursive()
 
     args.converter = get_converter(args.game_version)
-    debug_cli_args(args.debugdir, args.debug_info, args)
-    debug_game_version(args.debugdir, args.debug_info, args)
-    debug_mounts(args.debugdir, args.debug_info, args)
 
     # Read .dat
     yield "empires.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -6,7 +6,8 @@ actual conversion process.
 """
 
 from openage.convert.service.debug_info import debug_string_resources,\
-    debug_registered_graphics, debug_modpack, debug_cli_args
+    debug_registered_graphics, debug_modpack, debug_cli_args, debug_game_version,\
+    debug_mounts
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
@@ -80,6 +81,8 @@ def convert_metadata(args):
 
     args.converter = get_converter(args.game_version)
     debug_cli_args(args.debugdir, args.debug_info, args)
+    debug_game_version(args.debugdir, args.debug_info, args)
+    debug_mounts(args.debugdir, args.debug_info, args)
 
     # Read .dat
     yield "empires.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -6,7 +6,7 @@ actual conversion process.
 """
 
 from openage.convert.service.debug_info import debug_init,\
-    debug_string_resources, debug_registered_graphics
+    debug_string_resources, debug_registered_graphics, debug_modpack
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
@@ -102,6 +102,7 @@ def convert_metadata(args):
 
     for modpack in modpacks:
         ModpackExporter.export(modpack, args)
+        debug_modpack(args.debugdir, modpack, args.debug_log)
 
     if args.game_version[0].game_id not in ("ROR", "AOE2DE"):
         yield "blendomatic.dat"

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -79,20 +79,20 @@ def convert_metadata(args):
         gamedata_path.removerecursive()
 
     args.converter = get_converter(args.game_version)
-    debug_init(args.debugdir, args, args.debug_log)
+    debug_init(args.debugdir, args, args.debug_info)
 
     # Read .dat
     yield "empires.dat"
-    debug_gamedata_format(args.debugdir, args.game_version, args.debug_log)
+    debug_gamedata_format(args.debugdir, args.game_version, args.debug_info)
     gamespec = get_gamespec(args.srcdir, args.game_version, args.flag("no_pickle_cache"))
 
     # Read strings
     string_resources = get_string_resources(args)
-    debug_string_resources(args.debugdir, string_resources, args.debug_log)
+    debug_string_resources(args.debugdir, string_resources, args.debug_info)
 
     # Existing graphic IDs/filenames
     existing_graphics = get_existing_graphics(args)
-    debug_registered_graphics(args.debugdir, existing_graphics, args.debug_log)
+    debug_registered_graphics(args.debugdir, existing_graphics, args.debug_info)
 
     # Convert
     modpacks = args.converter.convert(gamespec,
@@ -102,7 +102,7 @@ def convert_metadata(args):
 
     for modpack in modpacks:
         ModpackExporter.export(modpack, args)
-        debug_modpack(args.debugdir, modpack, args.debug_log)
+        debug_modpack(args.debugdir, modpack, args.debug_info)
 
     if args.game_version[0].game_id not in ("ROR", "AOE2DE"):
         yield "blendomatic.dat"

--- a/openage/convert/value_object/read/member_access.py
+++ b/openage/convert/value_object/read/member_access.py
@@ -10,11 +10,11 @@ class MemberAccess(Enum):
     # pylint doesn't understand that this Enum doesn't need any members.
     # pylint: disable=too-few-public-methods
 
-    READ          = "binary-read_member"
-    READ_GEN      = "binary-read_gen_member"
-    NOREAD_EXPORT = "noread-export_member"
-    READ_UNKNOWN  = "read-unknown_member"
-    SKIP          = "skip-member"
+    READ          = "READ"
+    READ_GEN      = "READ_GEN"
+    NOREAD_EXPORT = "NOREAD_EXPORT"
+    READ_UNKNOWN  = "READ_UNKNOWN"
+    SKIP          = "SKIP"
 
 
 # TODO those values are made available in the module's global namespace


### PR DESCRIPTION
Implements the current ideas from https://github.com/SFTtech/openage/issues/1343 in a new dubug service.

  * [x] Init
    * [x] CLI args
    * [x] Game version
    * [x] Mounted folders
  * [x] Reader
    * [x] The .dat format that is read (because it depends the game version)
    * [x] Total number of string resources; maybe also list filenames
    * [x] Total number of media files (by type); maybe also list filenames
  * [x] Processor
    * [x] ~~for each `ConverterObject`: ID + helper function return value (where possible)~~ summary of different converter object types
    * [x] for each `ConverterObjectGroup`: ID + members + helper function return value (where possible)
    * [x] nyan object names
  * [x] Export
    * [x] for each modpack:
      * [x] modpack name
      * [x] info file
      * [x] manifest
      * [x] number of data files
      * [x] number of media files by type + list of converted files

Extra improvements:
* ~~Use a data definition format for output (probably toml) instead of a pure plaintext dumps~~
* [x] Document the debug outputs in `/docs`
* [x] Verbosity levels?