### PR TITLE
buildsystem: install all files into prefix on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 the openage authors. See copying.md for legal info.
+# Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 cmake_minimum_required(VERSION 3.16)
 
@@ -115,7 +115,7 @@ if(NOT DEFINED GLOBAL_CONFIG_DIR)
 	if(MSVC)
 		set(GLOBAL_CONFIG_DIR "${CONFIG_DIR}")
 	else()
-		set(GLOBAL_CONFIG_DIR "/${CONFIG_DIR}")
+		set(GLOBAL_CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/${CONFIG_DIR}")
 	endif()
 endif()
 

--- a/buildsystem/HandlePythonOptions.cmake
+++ b/buildsystem/HandlePythonOptions.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 # finds the python interpreter, install destination and extension flags.
 
@@ -45,7 +45,7 @@ if(NOT CMAKE_PY_INSTALL_PREFIX)
 	if(MSVC)
 		set(CMAKE_PY_INSTALL_PREFIX "python")
 	else()
-		py_exec("from distutils.sysconfig import get_python_lib; print(get_python_lib())" PREFIX)
+		py_exec("from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))" PREFIX)
 		set(CMAKE_PY_INSTALL_PREFIX "${PREFIX}")
 	endif()
 endif()

--- a/copying.md
+++ b/copying.md
@@ -133,6 +133,7 @@ _the openage authors_ are:
 | Martin Matějek              | mmtj                        | martin dawt matejek à gmx dawt com                |
 | Tobias Feldballe            | Namabilis                   | tobias à osandweb dawt dk                         |
 | Ayxan Haqverdili            | Ayxan13                     | aykhanhagverdili à gmail dawt com                 |
+| David Heidelberg            | okias                       | david à ixit dawt cz                              |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
Prequisite for Linux Flatpak support without ugly hacks.

Signed-off-by: David Heidelberg <david@ixit.cz>