### PR TITLE
Flatpak support

### DIFF
--- a/flatpak/eigen.json
+++ b/flatpak/eigen.json
@@ -1,0 +1,16 @@
+{
+    "name": "eigen",
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
+    "config-opts" : [
+        "-DBUILD_TESTING=OFF"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz",
+            "sha256": "7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f"
+        }
+    ]
+}
+

--- a/flatpak/lol.sfttech.openage.json
+++ b/flatpak/lol.sfttech.openage.json
@@ -1,0 +1,49 @@
+{
+    "app-id" : "lol.sfttech.openage",
+    "runtime" : "org.kde.Platform",
+    "runtime-version" : "5.15",
+    "sdk" : "org.kde.Sdk",
+    "tags" : [
+        "nightly"
+    ],
+    "command" : "openage",
+    "_comment" : "many dangerous permissions are enabled, when gameplay can be tested, they must be dropped!",
+    "finish-args" : [
+        "--device=dri",
+        "--share=ipc",
+        "--share=network",
+        "--socket=system-bus",
+        "--socket=session-bus",
+        "--socket=pulseaudio",
+        "--socket=x11",
+        "--filesystem=xdg-run/gvfs",
+        "--filesystem=home",
+        "--filesystem=/tmp",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*"
+    ],
+    "modules" : [
+        "python3-cython.json",
+        "python3-pillow.json",
+        "python3-numpy.json",
+        "python3-jinja2.json",
+        "python3-lz4.json",
+        "python3-toml.json",
+        "eigen.json",
+        "nyan.json",
+        {
+            "name" : "openage",
+            "buildsystem" : "cmake",
+            "builddir" : true,
+            "config-opts" : [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/SFTtech/openage.git"
+                }
+            ]
+        }
+    ]
+}

--- a/flatpak/nyan.json
+++ b/flatpak/nyan.json
@@ -1,0 +1,11 @@
+{
+    "name" : "nyan",
+    "buildsystem" : "cmake",
+    "builddir" : true,
+    "sources" : [
+        {
+            "type" : "git",
+            "url" : "https://github.com/SFTtech/nyan.git"
+        }
+    ]
+}

--- a/flatpak/python3-cython.json
+++ b/flatpak/python3-cython.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-cython",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} cython"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz",
+            "sha256": "e57acb89bd55943c8d8bf813763d20b9099cc7165c0f16b707631a7654be9cad"
+        }
+    ]
+}

--- a/flatpak/python3-jinja2.json
+++ b/flatpak/python3-jinja2.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-jinja2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"jinja2\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
+            "sha256": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/64/a7/45e11eebf2f15bf987c3bc11d37dcc838d9dc81250e67e4c5968f6008b6c/Jinja2-2.11.2.tar.gz",
+            "sha256": "89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"
+        }
+    ]
+}

--- a/flatpak/python3-lz4.json
+++ b/flatpak/python3-lz4.json
@@ -1,0 +1,18 @@
+{
+    "name": "python3-lz4",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"lz4\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1b/d7/ce69a9e1ec81ca3e14018d9db7c0d05b4f9a0c58a089d8e6c2e6c2c67a2f/lz4-3.1.1.tar.gz",
+            "sha256": "1ac354804cb2d5fb3d213857a6bf8590a301ef051cc16fbb4938bd2d6e524bda"
+        }
+    ],
+    "modules": [
+        "python3-pkgconfig.json",
+        "python3-setuptools-scm.json"
+    ]
+}

--- a/flatpak/python3-numpy.json
+++ b/flatpak/python3-numpy.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-numpy",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-build-isolation --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/c5/63/a48648ebc57711348420670bb074998f79828291f68aebfff1642be212ec/numpy-1.19.4.zip",
+            "sha256": "141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"
+        }
+    ]
+}

--- a/flatpak/python3-pillow.json
+++ b/flatpak/python3-pillow.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pillow",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/2b/06/93bf1626ef36815010e971a5ce90f49919d84ab5d2fa310329f843a74bc1/Pillow-8.0.1.tar.gz",
+            "sha256": "11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e"
+        }
+    ]
+}

--- a/flatpak/python3-pkgconfig.json
+++ b/flatpak/python3-pkgconfig.json
@@ -1,0 +1,15 @@
+{
+    "name": "python3-pkgconfig",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pkgconfig\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+	    "_comment": "do not upgrade over 1.4.x, it brings many dependencies starting from poetry",
+            "url": "https://files.pythonhosted.org/packages/17/b7/b6e2b5798eeadb6bfbebf6c332c8989463166769815f74d6e87ed9951f61/pkgconfig-1.4.0.tar.gz",
+            "sha256": "048c3b457da7b6f686b647ab10bf09e2250e4c50acfe6f215398a8b5e6fcdb52"
+        }
+    ]
+}

--- a/flatpak/python3-setuptools-scm.json
+++ b/flatpak/python3-setuptools-scm.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-setuptools-scm",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools-scm\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/af/df/f8aa8a78d4d29e0cffa4512e9bc223ed02f24893fe1837c6cee2749ebd67/setuptools_scm-5.0.1.tar.gz",
+            "sha256": "c85b6b46d0edd40d2301038cdea96bb6adc14d62ef943e75afb08b3e7bcf142a"
+        }
+    ]
+}

--- a/flatpak/python3-toml.json
+++ b/flatpak/python3-toml.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-toml",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"toml\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+            "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+        }
+    ]
+}


### PR DESCRIPTION
Flatpak uses KDE Runtime and SDK (since it has Qt libs).

Wayland has to be disabled due to #1300

There is currently enabled too many permission, when game starts working
properly, it needs to be tightened to required minimum.

Cleanup phase should be implemented in future (for headers and other
stuff which remains after libraries).

Closes: #1050

Signed-off-by: David Heidelberg <david@ixit.cz>