### PR TITLE
Fix running the converter from './run' executable

### DIFF
--- a/cfg/CMakeLists.txt
+++ b/cfg/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 the openage authors. See copying.md for legal info.
+# Copyright 2017-2021 the openage authors. See copying.md for legal info.
 
 install(FILES
 	"${CMAKE_CURRENT_SOURCE_DIR}/keybinds.oac"
@@ -6,6 +6,6 @@ install(FILES
 )
 
 install(DIRECTORY
-	"${CMAKE_CURRENT_SOURCE_DIR}/converter/"
+	"${CMAKE_CURRENT_SOURCE_DIR}/converter"
 	DESTINATION "${GLOBAL_CONFIG_DIR}/"
 )

--- a/cfg/CMakeLists.txt
+++ b/cfg/CMakeLists.txt
@@ -1,6 +1,11 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2020 the openage authors. See copying.md for legal info.
 
 install(FILES
 	"${CMAKE_CURRENT_SOURCE_DIR}/keybinds.oac"
 	DESTINATION "${GLOBAL_CONFIG_DIR}"
+)
+
+install(DIRECTORY
+	"${CMAKE_CURRENT_SOURCE_DIR}/converter/"
+	DESTINATION "${GLOBAL_CONFIG_DIR}/"
 )

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -43,6 +43,18 @@ def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     converted_path.mkdirs()
     targetdir = DirectoryCreator(converted_path).root
 
+    # Set compression level for media output if it was not set
+    if "compression_level" not in vars(args):
+        args.compression_level = 1
+
+    # Set verbosity for debug output
+    if "debug_info" not in vars(args):
+        if args.devmode:
+            args.debug_info = 3
+
+        else:
+            args.debug_info = 0
+
     # add a dir for debug info
     debug_log_path = converted_path / "debug" / datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     debugdir = DirectoryCreator(debug_log_path).root
@@ -190,14 +202,6 @@ def main(args, error):
         srcdir = CaseIgnoringDirectory(args.source_dir).root
     else:
         srcdir = None
-
-    # Set verbosity for debug output
-    if not args.debug_info:
-        if args.devmode:
-            args.debug_info = 3
-
-        else:
-            args.debug_info = 0
 
     # mount the config folder at "cfg/"
     from ..cvar.location import get_config_path

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -55,6 +55,7 @@ def main(args, error):
 
     # mount the config folder at "cfg/"
     root["cfg"].mount(get_config_path(args.cfg_dir))
+    args.cfg_dir = root["cfg"]
 
     # ensure that the assets have been converted
     if wanna_convert() or conversion_required(root["assets"], args):
@@ -65,7 +66,7 @@ def main(args, error):
                 prev_source_dir_path = file_obj.read().strip()
         except FileNotFoundError:
             prev_source_dir_path = None
-        used_asset_path = convert_assets(root["assets"], root["cfg"], args,
+        used_asset_path = convert_assets(root["assets"], args,
                                          prev_source_dir_path=prev_source_dir_path)
         if used_asset_path:
             # Remember the asset location

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -66,8 +66,12 @@ def main(args, error):
                 prev_source_dir_path = file_obj.read().strip()
         except FileNotFoundError:
             prev_source_dir_path = None
-        used_asset_path = convert_assets(root["assets"], args,
-                                         prev_source_dir_path=prev_source_dir_path)
+        used_asset_path = convert_assets(
+            root["assets"],
+            args,
+            prev_source_dir_path=prev_source_dir_path
+        )
+
         if used_asset_path:
             # Remember the asset location
             with asset_location_path.open("wb") as file_obj:
@@ -75,6 +79,13 @@ def main(args, error):
         else:
             err("game asset conversion failed")
             return 1
+
+    # Exit here with an explanation because the converted assets are incompatible!
+    # Remove this when the gamestate works again
+    info("Generated nyan assets are not yet compatible to the engine.")
+    info("Please revert to release v0.4.1 if you want to test the previous working gamestate.")
+    info("Exiting...")
+    exit()
 
     # start the game, continue in main_cpp.pyx!
     return run_game(args, root)

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -1,4 +1,6 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+#
+# pylint: disable=too-many-locals
 
 """
 Holds the game entry point for openage.
@@ -85,7 +87,8 @@ def main(args, error):
     info("Generated nyan assets are not yet compatible to the engine.")
     info("Please revert to release v0.4.1 if you want to test the previous working gamestate.")
     info("Exiting...")
-    exit()
+    import sys
+    sys.exit()
 
     # start the game, continue in main_cpp.pyx!
     return run_game(args, root)


### PR DESCRIPTION
Fixes https://github.com/SFTtech/openage/issues/1350

Also adds an explanation for why the engine can't use the new asset formats and exits before starting the game. 