### PR TITLE
Adding a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update && apt-get install \
+    cmake \
+    cython3 \
+    flex \
+    git \
+    libeigen3-dev \
+    libepoxy-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libharfbuzz-dev \
+    libogg-dev \
+    libopus-dev \
+    libopusfile-dev \
+    libpng-dev \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    make \
+    python3-dev \
+    python3-jinja2 \
+    python3-numpy \
+    python3-pil \
+    python3-pip \
+    python3-pygments \
+    qml-module-qtquick-controls \
+    qtdeclarative5-dev \
+    -y && apt-get clean
+
+RUN pip3 install \ 
+    cython \
+    numpy \
+    jinja2 \
+    lz4 \
+    pillow \ 
+    pygments \
+    toml
+
+WORKDIR /tmp
+COPY . .
+
+
+RUN ./configure --download-nyan --mode=release --prefix=/usr/local && \
+    make && \
+    make install


### PR DESCRIPTION
Hey all — this PR aims to dockerize compilation and release building. 
The application is configuring and compiling, but when I go to run the application from the command line I get this error: 
```
root@258b6ac02169:/tmp# openage
Traceback (most recent call last):
  File "/usr/local/bin/openage", line 14, in <module>
    from openage.__main__ import main
ModuleNotFoundError: No module named 'openage'
```
Steps to reproduce:
- Clone the repository
- `cd openage`
- `docker build -t openage:ubuntu`
- `docker run -it openage:ubuntu`
- `root@257bcac02168:/tmp# openage`

I was itching to play but couldn't get the application to configure on my machine (2013 MacBook Pro) so I started to tinker with a dockerfile.
My goal is to get the release building and running in an ubuntu container and eventually use Xquartz to forward the video along
