### PR TITLE
Typo fix

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -43,10 +43,10 @@ jobs:
         run: brew update
       - name: Brew install DeJaVu fonts
         run: brew tap homebrew/cask-fonts && brew install --cask font-dejavu
-      - name: Install environment helpers with homebrew
-        run: brew install ccache
       - name: Remove python's 2to3 link so that 'brew link' does not fail
         run: rm '/usr/local/bin/2to3'
+      - name: Install environment helpers with homebrew
+        run: brew install ccache
       - name: Install dependencies with homebrew
         run: brew install libepoxy freetype fontconfig harfbuzz sdl2 sdl2_image opus opusfile qt5 libogg libpng eigen
       - name: Install nyan dependencies with homebrew

--- a/copying.md
+++ b/copying.md
@@ -134,6 +134,7 @@ _the openage authors_ are:
 | Tobias Feldballe            | Namabilis                   | tobias à osandweb dawt dk                         |
 | Ayxan Haqverdili            | Ayxan13                     | aykhanhagverdili à gmail dawt com                 |
 | David Heidelberg            | okias                       | david à ixit dawt cz                              |
+| Giacomo Frascarelli	      | 0ro8lu			    | giacomo dawt frascarelli1 à gmail dawt com	|
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/copying.md
+++ b/copying.md
@@ -134,7 +134,7 @@ _the openage authors_ are:
 | Tobias Feldballe            | Namabilis                   | tobias à osandweb dawt dk                         |
 | Ayxan Haqverdili            | Ayxan13                     | aykhanhagverdili à gmail dawt com                 |
 | David Heidelberg            | okias                       | david à ixit dawt cz                              |
-| Giacomo Frascarelli	      | 0ro8lu			    | giacomo dawt frascarelli1 à gmail dawt com	|
+| Giacomo Frascarelli         | 0ro8lu                      | giacomo dawt frascarelli1 à gmail dawt com        |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/code/converter/architecture_overview.md
+++ b/doc/code/converter/architecture_overview.md
@@ -31,7 +31,7 @@ Entity objects are used for structures that have a defined identity. An example 
 be one `Unit` object from AoE2 or a `GameEntity` instance from the openage API. Entity objects are mutable
 and can have any number of attributes assigned to them. In the converter, they are used to model the
 more complex structures from Genie games such as units, civilizations and techs. The transition to the nyan
-API objects is also done utilizing etntity objects.
+API objects is also done utilizing entity objects.
 
 ### Service
 


### PR DESCRIPTION
Fixed a typo in architecture_overview.md at line 34. Changed the work "etnity" to "entity"