### PR TITLE
Small improvements in macOS build instructions

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -135,6 +135,7 @@ _the openage authors_ are:
 | Ayxan Haqverdili            | Ayxan13                     | aykhanhagverdili à gmail dawt com                 |
 | David Heidelberg            | okias                       | david à ixit dawt cz                              |
 | Giacomo Frascarelli         | 0ro8lu                      | giacomo dawt frascarelli1 à gmail dawt com        |
+| Antonio M. R. Cunha         | Grubben                     | antoniomsprc à gmail dawt com                     |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/build_instructions/os_x_10.14_mojave.md
+++ b/doc/build_instructions/os_x_10.14_mojave.md
@@ -7,17 +7,26 @@
 ```
 brew update-reset && brew update
 brew tap homebrew/cask-fonts
-brew cask install font-dejavu-sans
+brew install --cask font-dejavu-sans
 brew install cmake python3 libepoxy freetype fontconfig harfbuzz sdl2 sdl2_image opus opusfile qt5 libogg libpng eigen
 brew install llvm
 pip3 install cython numpy jinja2 lz4 pillow pygments toml
 ```
+Install this **optionally** to later generate the documentation
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies:
 
 ```
 brew install flex make
 ```
+
+(For noobs
+## Clone the repository
+```
+git clone https://github.com/SFTtech/openage
+cd openage
+```
+)
 
 ## Building
 
@@ -30,3 +39,7 @@ make
 
 ## Running
 `make run` or `./bin/run` launches the game. Try `./bin/run --help`!
+
+## To create the documentation
+`make doc`
+For more options and details, refer to [doc/README.md][/doc/README.md]


### PR DESCRIPTION
Bettered the brew installation to avoid  warnings and added the fact one could generate docs. Only figured that out from scouring the docs.

Sorry if this is too little for a pull request. This is my first time contributing, but please do correct me so I learn!