### PR TITLE
Bugfix: Correct the damage_modifier_2 bitmask

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -136,6 +136,7 @@ _the openage authors_ are:
 | David Heidelberg            | okias                       | david à ixit dawt cz                              |
 | Giacomo Frascarelli         | 0ro8lu                      | giacomo dawt frascarelli1 à gmail dawt com        |
 | Antonio M. R. Cunha         | Grubben                     | antoniomsprc à gmail dawt com                     |
+| Jens Nyman                  | nymanjens                   | nymanjens dawt nj à gmail dawt com                |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/value_object/read/media/smx.pyx
+++ b/openage/convert/value_object/read/media/smx.pyx
@@ -569,7 +569,7 @@ cdef class SMXMainLayer8to5(SMXLayer):
                         pixel_data.push_back(((pixel_data_odd_2 >> 2) | (pixel_data_odd_3 << 6)) & 0xF0)
 
                         # Damage mask 2. Described in byte[4] in bits 0-5.
-                        pixel_data.push_back((pixel_data_odd_3 >> 2) & 0x1F)
+                        pixel_data.push_back((pixel_data_odd_3 >> 2) & 0x3F)
 
                         row_data.push_back(pixel(color_standard,
                                                  pixel_data[0],
@@ -626,7 +626,7 @@ cdef class SMXMainLayer8to5(SMXLayer):
                         pixel_data.push_back(((pixel_data_odd_2 >> 2) | (pixel_data_odd_3 << 6)) & 0xF0)
 
                         # Damage modifier 2. Described in byte[4] in bits 0-5.
-                        pixel_data.push_back((pixel_data_odd_3 >> 2) & 0x1F)
+                        pixel_data.push_back((pixel_data_odd_3 >> 2) & 0x3F)
 
                         row_data.push_back(pixel(color_player,
                                                  pixel_data[0],


### PR DESCRIPTION
`damage_modifier_2` is 6 bits long, but the bitmask `0x1F` had only 5 bits (contrary to what the comment above it says). This PR fixes that.

This fix is also aligned with the SMX specification (https://github.com/SFTtech/openage/blob/master/doc/media/smx-files.md) in this project. I found this bug and validated the proposed fix when I was implementing my own SMX updater library in Python.