### PR TITLE
Fix HD Edition's empires_x1 dat file conversion

### DIFF
--- a/cfg/converter/games/game_editions.toml
+++ b/cfg/converter/games/game_editions.toml
@@ -86,7 +86,20 @@ expansions = [ ]
   palettes = [ "resources/_common/drs/interface/" ]
   sounds = [ "resources/_common/drs/sounds/" ]
   interface = [ "resources/_common/drs/interface/" ]
-  terrain = [ "resources/_common/drs/terrain/" ]
+  language = [
+  "resources/br/strings/key-value/key-value-strings-utf8.txt",
+  "resources/de/strings/key-value/key-value-strings-utf8.txt",
+  "resources/en/strings/key-value/key-value-strings-utf8.txt",
+  "resources/es/strings/key-value/key-value-strings-utf8.txt",
+  "resources/fr/strings/key-value/key-value-strings-utf8.txt",
+  "resources/it/strings/key-value/key-value-strings-utf8.txt",
+  "resources/jp/strings/key-value/key-value-strings-utf8.txt",
+  "resources/ko/strings/key-value/key-value-strings-utf8.txt",
+  "resources/nl/strings/key-value/key-value-strings-utf8.txt",
+  "resources/ru/strings/key-value/key-value-strings-utf8.txt",
+  "resources/zh/strings/key-value/key-value-strings-utf8.txt"
+  ]
+  terrain = [ "resources/_common/terrain/textures/" ]
 
 [AOE2DE]
 name = "Age of Empires 2: Definitive Edition"
@@ -117,7 +130,7 @@ expansions = [ ]
   "resources/tw/strings/key-value/key-value-strings-utf8.txt",
   "resources/vi/strings/key-value/key-value-strings-utf8.txt",
   "resources/zh/strings/key-value/key-value-strings-utf8.txt"
-]
+  ]
   palettes = [ "resources/_common/palettes/" ]
   sounds = [ "wwise/" ]
   interface = [ "resources/_common/drs/interface/" ]

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2021 the openage authors. See copying.md for legal info.
 
 """
 Provides functions that retrieve name lookup dicts for internal nyan object
@@ -28,6 +28,14 @@ def get_armor_class_lookups(game_version):
 
     if game_edition.game_id == "AOC":
         return aoc_internal.ARMOR_CLASS_LOOKUPS
+
+    if game_edition.game_id == "HDEDITION":
+        armor_lookup_dict = {}
+        armor_lookup_dict.update(aoc_internal.ARMOR_CLASS_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return armor_lookup_dict
 
     if game_edition.game_id == "AOE2DE":
         armor_lookup_dict = {}
@@ -61,6 +69,14 @@ def get_civ_lookups(game_version):
 
     if game_edition.game_id == "AOC":
         return aoc_internal.CIV_GROUP_LOOKUPS
+
+    if game_edition.game_id == "HDEDITION":
+        civ_lookup_dict = {}
+        civ_lookup_dict.update(aoc_internal.CIV_GROUP_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return civ_lookup_dict
 
     if game_edition.game_id == "AOE2DE":
         civ_lookup_dict = {}
@@ -153,6 +169,16 @@ def get_entity_lookups(game_version):
 
         return entity_lookup_dict
 
+    if game_edition.game_id == "HDEDITION":
+        entity_lookup_dict.update(aoc_internal.UNIT_LINE_LOOKUPS)
+        entity_lookup_dict.update(aoc_internal.BUILDING_LINE_LOOKUPS)
+        entity_lookup_dict.update(aoc_internal.AMBIENT_GROUP_LOOKUPS)
+        entity_lookup_dict.update(aoc_internal.VARIANT_GROUP_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return entity_lookup_dict
+
     if game_edition.game_id == "AOE2DE":
         entity_lookup_dict.update(aoc_internal.UNIT_LINE_LOOKUPS)
         entity_lookup_dict.update(aoc_internal.BUILDING_LINE_LOOKUPS)
@@ -232,6 +258,14 @@ def get_graphic_set_lookups(game_version):
     if game_edition.game_id == "AOC":
         return aoc_internal.GRAPHICS_SET_LOOKUPS
 
+    if game_edition.game_id == "HDEDITION":
+        graphic_set_lookup_dict = {}
+        graphic_set_lookup_dict.update(aoc_internal.GRAPHICS_SET_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return graphic_set_lookup_dict
+
     if game_edition.game_id == "AOE2DE":
         graphic_set_lookup_dict = {}
         graphic_set_lookup_dict.update(aoc_internal.GRAPHICS_SET_LOOKUPS)
@@ -288,6 +322,14 @@ def get_tech_lookups(game_version):
     if game_edition.game_id == "AOC":
         return aoc_internal.TECH_GROUP_LOOKUPS
 
+    if game_edition.game_id == "HDEDITION":
+        tech_lookup_dict = {}
+        tech_lookup_dict.update(aoc_internal.TECH_GROUP_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return tech_lookup_dict
+
     if game_edition.game_id == "AOE2DE":
         tech_lookup_dict = {}
         tech_lookup_dict.update(aoc_internal.TECH_GROUP_LOOKUPS)
@@ -321,6 +363,14 @@ def get_terrain_lookups(game_version):
     if game_edition.game_id == "AOC":
         return aoc_internal.TERRAIN_GROUP_LOOKUPS
 
+    if game_edition.game_id == "HDEDITION":
+        terrain_lookup_dict = {}
+        terrain_lookup_dict.update(aoc_internal.TERRAIN_GROUP_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return terrain_lookup_dict
+
     if game_edition.game_id == "AOE2DE":
         terrain_lookup_dict = {}
         terrain_lookup_dict.update(aoc_internal.TERRAIN_GROUP_LOOKUPS)
@@ -353,6 +403,14 @@ def get_terrain_type_lookups(game_version):
 
     if game_edition.game_id == "AOC":
         return aoc_internal.TERRAIN_TYPE_LOOKUPS
+
+    if game_edition.game_id == "HDEDITION":
+        terrain_type_lookup_dict = {}
+        terrain_type_lookup_dict.update(aoc_internal.TERRAIN_TYPE_LOOKUPS)
+
+        # TODO: Include expansion lookups
+
+        return terrain_type_lookup_dict
 
     if game_edition.game_id == "AOE2DE":
         terrain_type_lookup_dict = {}

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -17,7 +17,7 @@ def get_gamespec(srcdir, game_version, dont_pickle):
     """
     Reads empires.dat file.
     """
-    if game_version[0] .game_id in ("ROR", "AOC", "AOE2DE"):
+    if game_version[0] .game_id in ("ROR", "AOC", "HDEDITION", "AOE2DE"):
         filepath = srcdir.joinpath(game_version[0].media_paths[MediaType.DATFILE][0])
 
     elif game_version[0] .game_id == "SWGB":

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -123,7 +123,7 @@ def get_converter(game_version):
         from ..processor.conversion.ror.processor import RoRProcessor
         return RoRProcessor
 
-    if game_edition.game_id == "AOC":
+    if game_edition.game_id in ("AOC", "HDEDITION"):
         from ..processor.conversion.aoc.processor import AoCProcessor
         return AoCProcessor
 

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -121,16 +121,24 @@ class EmpiresDat(GenieStructure):
                 length=96,
             )))
         elif game_version[0].game_id == "HDEDITION":
-            data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
-                ref_type=terrain.Terrain,
-                length=100,
-            )))
+            if len(game_version[1]) > 0:
+                data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
+                    ref_type=terrain.Terrain,
+                    length=100,
+                )))
+
+            else:
+                data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
+                    ref_type=terrain.Terrain,
+                    length=42,
+                )))
+
         elif game_version[0].game_id == "AOC":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=42,
             )))
-        else:
+        else:  # game_version[0].game_id == "ROR"
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=32,

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -218,12 +218,21 @@ class Terrain(GenieStructure):
                 ))
             )
         elif game_version[0].game_id == "HDEDITION":
-            data_format.append(
-                (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
-                    "int16_t",
-                    100
-                ))
-            )
+            if len(game_version[1]) > 0:
+                data_format.append(
+                    (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
+                        "int16_t",
+                        100
+                    ))
+                )
+            else:
+                data_format.append(
+                    (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
+                        "int16_t",
+                        42
+                    ))
+                )
+
         elif game_version[0].game_id == "AOC":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
@@ -231,7 +240,7 @@ class Terrain(GenieStructure):
                     42
                 ))
             )
-        else:
+        else:  # game_version[0].game_id == "ROR"
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",


### PR DESCRIPTION
The converter now uses the correct number of terrains for that file --> 42 like in AoC.

Language file support was also streamlined, so that the data conversion is successful. Media conversion still fails because of the non-existent terrain SLP files.