### PR TITLE
util: include typeinfo header for typeid

### DIFF
--- a/buildsystem/codecompliance/pylint.py
+++ b/buildsystem/codecompliance/pylint.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Checks the Python modules with pylint.
@@ -27,7 +27,10 @@ def find_issues(check_files, dirnames):
     if check_files is None:
         invocation.extend(dirnames)
     else:
-        invocation.extend(filter_file_list(check_files, dirnames))
+        check_files = filter_file_list(check_files, dirnames)
+        if not check_files:
+            return
+        invocation.extend(check_files)
 
     try:
         lint.Run(invocation)

--- a/libopenage/error/error.cpp
+++ b/libopenage/error/error.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 the openage authors. See copying.md for legal info.
+// Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 #include "error.h"
 
@@ -76,7 +76,7 @@ const char *Error::what() const noexcept {
 
 
 std::string Error::type_name() const {
-	return util::demangle(typeid(*this).name());
+	return util::typestring(*this);
 }
 
 
@@ -96,7 +96,7 @@ std::ostream &operator <<(std::ostream &os, const Error &e) {
 	} catch (Error &cause) {
 		os << cause << std::endl;
 	} catch (std::exception &cause) {
-		os << util::demangle(typeid(cause).name()) << ": " << cause.what() << std::endl;
+		os << util::typestring(cause) << ": " << cause.what() << std::endl;
 	} catch (...) {
 		os << "unknown non std::exception cause!" << std::endl;
 	}

--- a/libopenage/error/handlers.cpp
+++ b/libopenage/error/handlers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 /*
  * This file holds handlers for std::terminate and SIGSEGV.
@@ -14,7 +14,6 @@
 
 #include <exception>
 #include <iostream>
-#include <typeinfo>
 #include <cstring>
 
 #ifdef _MSC_VER
@@ -83,7 +82,7 @@ util::OnDeInit restore_handlers([]() {
 		} catch (std::exception &exc) {
 			std::cout <<
 				"std::exception of type " <<
-				util::demangle(typeid(exc).name()) <<
+				util::typestring(exc) <<
 				": " << exc.what() << std::endl;
 		} catch (...) {
 			std::cout << "non-standard exception object" << std::endl;

--- a/libopenage/event/eventhandler.h
+++ b/libopenage/event/eventhandler.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 the openage authors. See copying.md for legal info.
+// Copyright 2017-2021 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,6 +8,7 @@
 #include <any>
 #include <memory>
 #include <string>
+#include <typeinfo>
 #include <unordered_map>
 
 

--- a/libopenage/gamestate/old/game_spec.cpp
+++ b/libopenage/gamestate/old/game_spec.cpp
@@ -67,7 +67,7 @@ bool GameSpec::initialize() {
 	catch (std::exception &exc) {
 		// unfortunately we have no idea of the std::exception backtrace
 		throw Error{ERR << "gamedata could not be loaded: "
-		                << util::demangle(typeid(exc).name())
+		                << util::typestring(exc)
 		                << ": "<< exc.what()};
 	}
 

--- a/libopenage/pyinterface/exctranslate_tests.cpp
+++ b/libopenage/pyinterface/exctranslate_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #include "exctranslate_tests.h"
 
@@ -84,13 +84,13 @@ void err_py_to_cpp() {
 				}
 
 			} catch (std::exception &cause) {
-				return "exc had cause of unexpected type " + util::demangle(typeid(cause).name());
+				return "exc had cause of unexpected type " + util::typestring(cause);
 			} catch (...) {
 				return "exc had cause of nonstandard type";
 			}
 
 		} catch (std::exception &cause) {
-			return "exc had unexpected type " + util::demangle(typeid(cause).name());
+			return "exc had unexpected type " + util::typestring(cause);
 		} catch (...) {
 			return "exc had nonstandard type";
 		}

--- a/libopenage/renderer/font/font.h
+++ b/libopenage/renderer/font/font.h
@@ -1,10 +1,10 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <memory>
 #include <string>
-#include <typeindex>
+#include <typeinfo>
 #include <vector>
 
 #include "../../util/hash.h"

--- a/libopenage/renderer/font/glyph_atlas.cpp
+++ b/libopenage/renderer/font/glyph_atlas.cpp
@@ -1,10 +1,11 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #include "glyph_atlas.h"
 
 #include <algorithm>
 #include <functional>
 #include <typeindex>
+#include <typeinfo>
 #include <cstring>
 #include <epoxy/gl.h>
 

--- a/libopenage/util/compiler.h
+++ b/libopenage/util/compiler.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,10 +8,12 @@
  *
  * May contain some platform-dependent code.
  */
-#include <ciso646>
 
+#include <ciso646>
 // pxd: from libcpp.string cimport string
 #include <string>
+#include <typeinfo>
+
 
 /**
  * DLL entry-point decorations.

--- a/libopenage/util/compiler.h
+++ b/libopenage/util/compiler.h
@@ -134,5 +134,13 @@ std::string typestring(const T *ptr) {
 	return demangle(typeid(*ptr).name());
 }
 
+/**
+ * Returns the string representation of type of given reference
+ */
+template <typename T>
+std::string typestring(const T &ref) {
+	return demangle(typeid(ref).name());
+}
+
 
 }} // openage::util

--- a/libopenage/util/enum.h
+++ b/libopenage/util/enum.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -82,7 +82,7 @@ public:
 	}
 
 	friend std::ostream &operator <<(std::ostream &os, const DerivedType &arg) {
-		os << util::demangle(typeid(DerivedType).name()) << "::" << arg.name;
+		os << util::typestring<DerivedType>() << "::" << arg.name;
 		return os;
 	}
 

--- a/libopenage/util/hash.h
+++ b/libopenage/util/hash.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <array>
 #include <typeindex>
+#include <typeinfo>
 
 namespace openage {
 namespace util {


### PR DESCRIPTION
"if the header is not included, every use of the keyword `typeid`
makes the program ill-formed".