### PR TITLE
Fix the condition for pygments 2.10.0

### DIFF
--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -265,7 +265,7 @@ class PXDGenerator:
 
         for token, val in self.tokenize():
             # ignore whitespaces
-            if token == Token.Text and not val.strip():
+            if token in Token.Text and not val.strip():
                 continue
 
             try:


### PR DESCRIPTION
In pygments 2.10.0 the whitespace is tagged with Token.Text.Whitespace, which could cause build breaks like https://github.com/duanqn/openage/runs/3383662608?check_suite_focus=true