### PR TITLE
Address pylint >2.7 issues

### DIFF
--- a/buildsystem/check_py_file_list.py
+++ b/buildsystem/check_py_file_list.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Tests whether the files listed via add_py_module are consistent with the
@@ -27,7 +27,7 @@ def main():
     openage_dir = os.path.realpath(args.py_module_dir)
 
     listed = set()
-    with open(args.py_file_list) as fileobj:
+    with open(args.py_file_list, encoding='utf8') as fileobj:
         for filename in fileobj.read().strip().split(';'):
             filepath = os.path.realpath(os.path.normpath(filename))
             if filepath.startswith(openage_dir):

--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -150,7 +150,7 @@ def main(args):
     else:
         check_files = None
 
-    auto_fixes = list()
+    auto_fixes = []
     fixes_possible = False
 
     issues_count = 0

--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -194,7 +194,7 @@ def main(args):
                         remainfound=remainfound))
 
         if not args.fix and fixes_possible:
-            print("When invoked with --fix, I can try"
+            print("When invoked with --fix, I can try "
                   "to automatically resolve some of the issues.\n")
 
     return issues_count == 0

--- a/buildsystem/codecompliance/authors.py
+++ b/buildsystem/codecompliance/authors.py
@@ -33,7 +33,7 @@ def get_author_emails_copying_md():
 
     |     name     |    nick    |    email    |
     """
-    with open("copying.md") as fobj:
+    with open("copying.md", encoding='utf8') as fobj:
         for line in fobj:
             match = re.match("^.*\\|[^|]*\\|[^|]*\\|([^|]*)\\|.*$", line)
             if not match:

--- a/buildsystem/codecompliance/authors.py
+++ b/buildsystem/codecompliance/authors.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 the openage authors. See copying.md for legal info.
+# Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 """
 Checks whether all authors are properly listed in copying.md.
@@ -64,7 +64,8 @@ def get_author_emails_git_shortlog(exts):
         invocation.append(f"*{ext}.in")
         invocation.append(f"*{ext}.template")
 
-    output = Popen(invocation, stdout=PIPE).communicate()[0]
+    with Popen(invocation, stdout=PIPE) as invoc:
+        output = invoc.communicate()[0]
 
     for line in output.decode('utf-8', errors='replace').split('\n'):
         match = re.match("^ +[0-9]+\t[^<]*\\<(.*)\\>$", line)

--- a/buildsystem/codecompliance/legal.py
+++ b/buildsystem/codecompliance/legal.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 the openage authors. See copying.md for legal info.
+# Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 """
 Checks the legal headers of all files.
@@ -65,12 +65,12 @@ def get_git_change_year(filename):
         filename
     ]
 
-    proc = Popen(invocation, stdout=PIPE)
-    output = proc.communicate()[0].decode('utf-8', errors='ignore').strip()
+    with Popen(invocation, stdout=PIPE) as proc:
+        output = proc.communicate()[0].decode('utf-8', errors='ignore').strip()
 
-    if proc.returncode != 0 or not output:
-        # git doesn't know about the file
-        return None
+        if proc.returncode != 0 or not output:
+            # git doesn't know about the file
+            return None
 
     return int(output[:4])
 
@@ -133,8 +133,9 @@ def test_headers(check_files, paths, git_change_years, third_party_files):
 
     # determine all uncommited files from git.
     # those definitely need the current year in the copyright message.
-    proc = Popen(['git', 'diff', '--name-only', 'HEAD'], stdout=PIPE)
-    uncommited = set(proc.communicate()[0].decode('ascii').strip().split('\n'))
+    with Popen(['git', 'diff', '--name-only', 'HEAD'], stdout=PIPE) as proc:
+        uncommited = set(proc.communicate()[0].decode('ascii').strip().split('\n'))
+
     current_calendar_year = date.today().year
 
     for filename in findfiles(paths, EXTENSIONS_REQUIRING_LEGAL_HEADERS):

--- a/buildsystem/codecompliance/pylint.py
+++ b/buildsystem/codecompliance/pylint.py
@@ -6,8 +6,8 @@ Checks the Python modules with pylint.
 
 from pylint import lint
 
-from .util import findfiles
 from .pystyle import filter_file_list
+from .util import findfiles
 
 
 def find_pyx_modules(dirnames):
@@ -22,7 +22,7 @@ def find_issues(check_files, dirnames):
     invocation = ['--rcfile=etc/pylintrc', '--reports=n']
 
     from multiprocessing import cpu_count
-    invocation.append("--jobs={:d}".format(cpu_count()))
+    invocation.append(f"--jobs={cpu_count():d}")
 
     if check_files is None:
         invocation.extend(dirnames)
@@ -35,10 +35,10 @@ def find_issues(check_files, dirnames):
     try:
         lint.Run(invocation)
     except SystemExit as exc:
-        errorcode = exc.args[0]
-        if errorcode != 0:
+        error_count = exc.args[0]
+        if error_count != 0:
             if check_files is None:
-                msg = "python code is noncompliant: %d" % errorcode
+                msg = f"python code is noncompliant: {error_count:d}"
             else:
                 msg = ("false positives may result from not checking the "
                        "entire codebase")

--- a/buildsystem/codecompliance/util.py
+++ b/buildsystem/codecompliance/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 the openage authors. See copying.md for legal info.
+# Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 """
 Some utilities.
@@ -56,7 +56,7 @@ def writefile(filename, new_content):
     if filename in BADUTF8FILES:
         raise Exception(f"{filename}: cannot write due to utf8-errors.")
 
-    with open(filename, 'w') as fileobj:
+    with open(filename, 'w', encoding='utf8') as fileobj:
         fileobj.write(new_content)
 
     FILECACHE[filename] = new_content

--- a/buildsystem/compilepy.py
+++ b/buildsystem/compilepy.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Compiles python modules with cpython to pyc/pyo files.
@@ -64,7 +64,7 @@ def main():
     ))
     args = cli.parse_args()
 
-    with open(args.pymodule_list_file) as fileobj:
+    with open(args.pymodule_list_file, encoding='utf8') as fileobj:
         modules = fileobj.read().strip().split(';')
         if modules == ['']:
             modules = []

--- a/buildsystem/cythonize.py
+++ b/buildsystem/cythonize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Runs Cython on all modules that were listed via add_cython_module.
@@ -60,7 +60,7 @@ class CythonFilter(LineFilter):
 
 def read_list_from_file(filename):
     """ Reads a semicolon-separated list of file entires """
-    with open(filename) as fileobj:
+    with open(filename, encoding='utf8') as fileobj:
         data = fileobj.read().strip()
 
     return [Path(filename).resolve() for filename in data.split(';')]

--- a/buildsystem/inplacemodules.py
+++ b/buildsystem/inplacemodules.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Installs the Python extension modules that were created in the configuration
@@ -29,7 +29,7 @@ def main():
     ))
     args = cli.parse_args()
 
-    with open(args.module_list_file) as fileobj:
+    with open(args.module_list_file, encoding='utf8') as fileobj:
         modules = fileobj.read().strip().split(';')
         if modules == ['']:
             modules = []

--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -74,7 +74,7 @@ class PXDGenerator:
 
         lexer = get_lexer_for_filename('.cpp')
 
-        with open(self.filename) as infile:
+        with open(self.filename, encoding='utf8') as infile:
             code = infile.read()
 
         for token, val in lexer.get_tokens(code):
@@ -376,12 +376,12 @@ class PXDGenerator:
         result = "\n".join(self.get_pxd_lines())
 
         if os.path.exists(pxdfile):
-            with open(pxdfile) as outfile:
+            with open(pxdfile, encoding='utf8') as outfile:
                 if outfile.read() == result:
                     # don't write the file if the content is up to date
                     return False
 
-        with open(pxdfile, 'w') as outfile:
+        with open(pxdfile, 'w', encoding='utf8') as outfile:
             print("\x1b[36mpxdgen: generate %s\x1b[0m" % os.path.relpath(pxdfile, CWD))
             outfile.write(result)
 
@@ -417,7 +417,7 @@ def parse_args():
     args = cli.parse_args()
 
     if args.file_list:
-        with open(args.file_list) as flist:
+        with open(args.file_list, encoding='utf8') as flist:
             file_list = flist.read().strip().split(';')
     else:
         file_list = []

--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -417,7 +417,8 @@ def parse_args():
     args = cli.parse_args()
 
     if args.file_list:
-        file_list = open(args.file_list).read().strip().split(';')
+        with open(args.file_list) as flist:
+            file_list = flist.read().strip().split(';')
     else:
         file_list = []
 

--- a/doc/ide/vscode.md
+++ b/doc/ide/vscode.md
@@ -41,7 +41,7 @@ You should add these entries to the list of directories that are not watched:
 
 These directories contain generated build files, binaries created from builds and media assets converted from the original games. Hence, there is no need to watch these files for changes during development. If you do not add these entries, vscode will likely complain that there are too many files for it to index.
 
-**C_Cpp> Default: Include Path**
+**C_Cpp > Default: Include Path**
 
 If you use a C/C++ language support extension, you need to add the path to the *nyan* directory to your workspace's include path. Otherwise, vscode will not be able to find the nyan header files.
 
@@ -62,6 +62,19 @@ If you use a C/C++ language support extension, you need to add the path to the *
     "${workspaceFolder}/../nyan/**"
 ]
 ```
+
+**Python > Formatting: Autopep8 Args**
+
+If you use a Python language support extension with `autopep8` formatting, you should add these settings to get the openage Python code style. Add these entries to the list of passed arguments:
+
+* `--ignore E221,E241,E251,E501`
+
+Ignoring the `E221,E241,E251` errors allows placing multiple spaces around commas and before comments for alignment, while ignoring `E501` disables auto-formatting of overlong lines.
+
+If you don't want to ignore `E501`, you should add this argument which increases the maximum line length to 100:
+
+* `--line-length 100`
+
 
 ## Add openage configure and build tasks
 

--- a/etc/pylintrc
+++ b/etc/pylintrc
@@ -78,7 +78,7 @@ confidence=
 # if cython modules are not yet build, they can't be imported.
 #
 # TODO: enable cyclic-import, once those issues have been fixed.
-disable=locally-disabled, cyclic-import, file-ignored, import-error, no-name-in-module, import-outside-toplevel
+disable=locally-disabled, cyclic-import, file-ignored, import-error, no-name-in-module, import-outside-toplevel, duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/openage/cabextract/test.py
+++ b/openage/cabextract/test.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 """
 Downloads the SFT test cab archive and uses it to test the cabextract code.
 """
@@ -51,7 +51,8 @@ def open_test_archive():
         pass
 
     with open(TEST_ARCHIVE_FILENAME, 'wb') as test_arc:
-        test_arc.write(urlopen(TEST_ARCHIVE_URL).read())
+        with urlopen(TEST_ARCHIVE_URL) as url:
+            test_arc.write(url.read())
 
     return open_cached_test_archive()
 

--- a/openage/codegen/codegen.py
+++ b/openage/codegen/codegen.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2020 the openage authors. See copying.md for legal info.
+# Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 """
 Utility and driver module for C++ code generation.
@@ -28,13 +28,13 @@ class CodegenMode(Enum):
     # pylint: disable=too-few-public-methods
 
     # source files are created regularily
-    codegen = "codegen"
+    CODEGEN = "codegen"
 
     # caches are updated, but no source files are created
-    dryrun = "dryrun"
+    DRYRUN = "dryrun"
 
     # files are deleted
-    clean = "clean"
+    CLEAN = "clean"
 
 
 class WriteCatcher(FIFO):
@@ -135,7 +135,7 @@ def codegen(mode, input_dir, output_dir):
 
         data = postprocess_write(parts, data)
 
-        if mode == CodegenMode.codegen:
+        if mode == CodegenMode.CODEGEN:
             # skip writing if the file already has that exact content
             try:
                 with wpath.open('rb') as outfile:
@@ -150,11 +150,11 @@ def codegen(mode, input_dir, output_dir):
                 print("\x1b[36mcodegen: %s\x1b[0m" % b'/'.join(parts).decode(errors='replace'))
                 outfile.write(data)
 
-        elif mode == CodegenMode.dryrun:
+        elif mode == CodegenMode.DRYRUN:
             # no-op
             pass
 
-        elif mode == CodegenMode.clean:
+        elif mode == CodegenMode.CLEAN:
             if wpath.is_file():
                 print(b'/'.join(parts).decode(errors='replace'))
                 wpath.unlink()

--- a/openage/codegen/coord.py
+++ b/openage/codegen/coord.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2016 the openage authors. See copying.md for legal info.
+# Copyright 2016-2021 the openage authors. See copying.md for legal info.
 
 """
 Generates libopenage/coord/coord_{xy, xyz, ne_se, ne_se_up}.{h, cpp}
@@ -13,6 +13,7 @@ def generate_coord_basetypes(projectdir):
 
     projectdir is a util.fslike.path.Path.
     """
+    # pylint: disable=cell-var-from-loop
     # this list contains all required member lists.
     member_lists = [
         ["x", "y"],

--- a/openage/codegen/main.py
+++ b/openage/codegen/main.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2018 the openage authors. See copying.md for legal info.
+# Copyright 2014-2021 the openage authors. See copying.md for legal info.
 
 """
 Codegen interface to the build system.
@@ -116,7 +116,7 @@ def main(args, error):
         If the file doesn't exist, a warning is printed.
         """
         try:
-            with open(filename) as fileobj:
+            with open(filename, encoding='utf8') as fileobj:
                 for line in fileobj:
                     line = line.strip()
                     if line:
@@ -152,10 +152,10 @@ def main(args, error):
     print_set_differences(old_generated, generated, "generated files")
     print_set_differences(old_depends, depends, "dependencies")
 
-    with open(args.generated_list_file, 'w') as fileobj:
+    with open(args.generated_list_file, 'w', encoding='utf8') as fileobj:
         fileobj.write('\n'.join(generated))
 
-    with open(args.depend_list_file, 'w') as fileobj:
+    with open(args.depend_list_file, 'w', encoding='utf8') as fileobj:
         fileobj.write('\n'.join(depends))
 
     if args.file_to_touch:

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2021 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-public-methods,too-many-instance-attributes,consider-iterating-dictionary
 
@@ -127,16 +127,16 @@ class GenieGameEntityGroup(ConverterObjectGroup):
             if position > -1:
                 insert_index = position
 
-                for unit in self.line_positions.keys():
-                    if self.line_positions[unit] >= insert_index:
+                for unit, line_pos in self.line_positions.items():
+                    if line_pos >= insert_index:
                         self.line_positions[unit] += 1
 
             elif after:
                 if self.contains_entity(after):
                     insert_index = self.line_positions[after] + 1
 
-                    for unit in self.line_positions.keys():
-                        if self.line_positions[unit] >= insert_index:
+                    for unit, line_pos in self.line_positions.items():
+                        if line_pos >= insert_index:
                             self.line_positions[unit] += 1
 
             self.line_positions.update({genie_unit.get_id(): insert_index})

--- a/openage/convert/entity_object/conversion/stringresource.py
+++ b/openage/convert/entity_object/conversion/stringresource.py
@@ -28,7 +28,7 @@ class StringResource(GenieStructure):
         return self.strings
 
     def dump(self, filename):
-        data = list()
+        data = []
 
         for lang, langstrings in self.strings.items():
             for idx, text in langstrings.items():

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -427,8 +427,8 @@ class AoCCivSubprocessor:
 
         civ_name = civ_lookup_dict[civ_id][0]
 
-        disabled_techs = dict()
-        disabled_entities = dict()
+        disabled_techs = {}
+        disabled_entities = {}
 
         tech_tree = civ_group.get_tech_tree_effects()
         for effect in tech_tree:

--- a/openage/convert/service/export/opus/demo.py
+++ b/openage/convert/service/export/opus/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 the openage authors. See copying.md for legal info.
+# Copyright 2018-2021 the openage authors. See copying.md for legal info.
 """
 Demo for the opusenc module.
 """
@@ -22,7 +22,9 @@ def convert(args):
 
     wavname = args.input
     info("Reading %s...", wavname)
-    wav = open(wavname, mode='rb').read()
+
+    with open(wavname, mode='rb') as wav_file:
+        wav = wav_file.read()
 
     info("Encoding...")
 

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -30,7 +30,7 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
         else:
             edition = game_edition
 
-            if edition.support == Support.nope:
+            if edition.support == Support.NOPE:
                 info(f"Found unsupported game edition: {edition}")
                 continue
 
@@ -53,7 +53,7 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
                 break
 
         else:
-            if game_expansion.support == Support.nope:
+            if game_expansion.support == Support.NOPE:
                 info(f"Found unsupported game expansion: {game_expansion}")
                 continue
 

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -24,7 +24,7 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
 
     else:
         # Check for broken edition
-        broken_edition = game_version[0].support == Support.breaks
+        broken_edition = game_version[0].support == Support.BREAKS
 
         # a broken edition is installed
         if broken_edition:
@@ -34,7 +34,7 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
 
         broken_expansions = []
         for expansion in game_version[1]:
-            if expansion.support == Support.breaks:
+            if expansion.support == Support.BREAKS:
                 broken_expansions.append(expansion)
 
         # a broken expansion is installed
@@ -47,7 +47,7 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
     if no_support:
         warn("You need at least one of:")
         for edition in avail_game_eds:
-            if edition.support == Support.yes:
+            if edition.support == Support.YES:
                 warn(" * \x1b[34m%s\x1b[m", edition)
 
         return (False, set())

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -17,9 +17,9 @@ class Support(enum.Enum):
     """
     Support state of a game version
     """
-    nope = "not supported"
-    yes = "supported"
-    breaks = "presence breaks conversion"
+    NOPE = "not supported"
+    YES = "supported"
+    BREAKS = "presence breaks conversion"
 
 
 class GameBase:

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -48,7 +48,7 @@ class GameBase:
         self.game_id = game_id
         self.flags = flags
         self.target_modpacks = modpacks
-        self.support = Support[support]
+        self.support = Support[support.upper()]
 
         self.game_file_versions = []
         self.media_paths = {}

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -37,10 +37,10 @@ class BlendingTile:
 
         import numpy
 
-        tile_rows = list()
+        tile_rows = []
 
         for picture_row in self.row_data:
-            tile_row_data = list()
+            tile_row_data = []
 
             for alpha_data in picture_row:
 
@@ -110,7 +110,7 @@ class BlendingMode:
                                       data_file.read(self.pxcount * 4))
 
         # list of alpha-mask tiles
-        self.alphamasks = list()
+        self.alphamasks = []
 
         # draw mask tiles for this blending mode
         for _ in range(tile_count):
@@ -118,7 +118,7 @@ class BlendingMode:
                                  data_file.read(self.pxcount))
             self.alphamasks.append(self.get_tile_from_data(pixels))
 
-        bitvalues = list()
+        bitvalues = []
         for i in alpha_masks_raw:
             for b_id in range(7, -1, -1):
                 # bitmask from 0b00000001 to 0b10000000
@@ -126,7 +126,7 @@ class BlendingMode:
                 bitvalues.append(i & bit_mask)
 
         # list of bit-mask tiles
-        self.bitmasks = list()
+        self.bitmasks = []
 
         # TODO: is 32 really hardcoded?
         for i in range(32):
@@ -153,7 +153,7 @@ class BlendingMode:
 
         read_so_far = 0
         max_width = 0
-        tilerows = list()
+        tilerows = []
 
         for y_pos in range(self.row_count):
             if y_pos < half_row_count:
@@ -235,7 +235,7 @@ class Blendomatic(GenieStructure):
 
         blending_mode = Struct("< I %dB" % (tile_count))
 
-        self.blending_modes = list()
+        self.blending_modes = []
 
         for i in range(blending_mode_count):
             header_data = fileobj.read(blending_mode.size)

--- a/openage/util/fslike/directory.py
+++ b/openage/util/fslike/directory.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 FSLikeObjects that represent actual file system paths:
@@ -86,7 +86,8 @@ class Directory(FSLikeObject):
         try:
             os.utime(self.resolve(parts))
         except FileNotFoundError:
-            open(self.resolve(parts), 'ab').close()
+            with open(self.resolve(parts), 'ab') as directory:
+                directory.close()
 
     def rename(self, srcparts, tgtparts):
         return os.rename(self.resolve(srcparts), self.resolve(tgtparts))

--- a/openage/util/system.py
+++ b/openage/util/system.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 """
 Various OS utilities
@@ -22,7 +22,7 @@ def free_memory():
 
     if platform.startswith('linux'):
         pattern = re.compile('^MemAvailable: +([0-9]+) kB\n$')
-        with open('/proc/meminfo') as meminfo:
+        with open('/proc/meminfo', encoding='utf8') as meminfo:
             for line in meminfo:
                 match = pattern.match(line)
                 if match:


### PR DESCRIPTION
Our CI now uses a newer version of `pylint` with more complaints. This PR addresses the issues raised.

* Disable pylint code `R0801` (duplicate code check)
* Fix a few missing uppercases for enums
* Add `with` statements where it makes sense
* `autopep8` settings for IDEs