### PR TITLE
Fix Windows build failures

### DIFF
--- a/libopenage/gui/guisys/public/gui_property_map.cpp
+++ b/libopenage/gui/guisys/public/gui_property_map.cpp
@@ -1,10 +1,11 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 #include "gui_property_map.h"
 
 #include <algorithm>
 #include <typeinfo>
 #include <cassert>
+#include <stdexcept>
 
 #include <QVariant>
 #include <QRegExp>

--- a/libopenage/main/tests.cpp
+++ b/libopenage/main/tests.cpp
@@ -1,6 +1,7 @@
-// Copyright 2018-2019 the openage authors. See copying.md for legal info.
+// Copyright 2018-2021 the openage authors. See copying.md for legal info.
 
 #include "tests/pong.h"
+#include "tests.h"
 
 
 namespace openage::main::tests {

--- a/libopenage/main/tests.h
+++ b/libopenage/main/tests.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "../util/compiler.h"
 // pxd: from libopenage.util.path cimport Path
 #include "../util/path.h"
 
@@ -9,6 +10,6 @@
 namespace openage::main::tests {
 
 // pxd: void engine_demo(int demo_id, Path path) except +
-void engine_demo(int demo_id, const util::Path &path);
+OAAPI void engine_demo(int demo_id, const util::Path &path);
 
 } // openage::main::tests


### PR DESCRIPTION
1. Add missing header <stdexcept>.
2. Add missing OAAPI macro, which generates `__declspec(dllexport)` / `__declspec(dllimport)` on Windows.