### PR TITLE
Add DE2 Dawn of the Dukes support + HD Edition fixes

### DIFF
--- a/cfg/converter/games/aoc/version_hashes.toml
+++ b/cfg/converter/games/aoc/version_hashes.toml
@@ -1,17 +1,17 @@
 # version hashes of Age of Empires 2: The Conqueror's
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [age2_x1]
-path = "age2_x1/age2_x1.exe"
+paths = ["age2_x1/age2_x1.exe"]
 
   [age2_x1.map]
   d02ef2f4935c5ef568eaa873442b4b2b547067ed8e3572758bbbbee8 = "1.0c"
   4568f37f309c0a89fa9e84a0c0f6c61b0f394c28adc82c0b3f2203b3 = "1.0c"
 
 [empires2_x1_p1dat]
-path = "Data/empires2_x1_p1.dat"
+paths = ["Data/empires2_x1_p1.dat"]
 
   [empires2_x1_p1dat.map]
   6aab4c7468c3d319ec00f577835dc7799b70ffab1de6bfd25ac227b5 = "1.0c"

--- a/cfg/converter/games/aok/version_hashes.toml
+++ b/cfg/converter/games/aok/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 2: Age of Kings
 
 file_version = "2.0"
-hash_algo = "MD5"
+hash_algo = "SHA3-256"
 
 [empires2]
 paths = ["empires2.exe"]
 
   [empires2.map]
-  5f7ca6c7edeba075c7982714619bc66b = "2.0a"
+  0425273b541b8405325775a4bae48d078db7444a94888943148b4e1a = "2.0a"
 
 [empires2dat]
 paths = ["data/empires2.dat"]
 
   [empires2dat.map]
-  89ff818894b69040ebd1657d8029b068 = "2.0a"
+  f7a9d214e16182747bd1c3e3302398740609413407aeffd32a0acdd8 = "2.0a"

--- a/cfg/converter/games/aok/version_hashes.toml
+++ b/cfg/converter/games/aok/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 2: Age of Kings
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "MD5"
 
 [empires2]
-path = "empires2.exe"
+paths = ["empires2.exe"]
 
   [empires2.map]
   5f7ca6c7edeba075c7982714619bc66b = "2.0a"
 
 [empires2dat]
-path = "data/empires2.dat"
+paths = ["data/empires2.dat"]
 
   [empires2dat.map]
   89ff818894b69040ebd1657d8029b068 = "2.0a"

--- a/cfg/converter/games/de1/version_hashes.toml
+++ b/cfg/converter/games/de1/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 1: Definitive Edition (Steam)
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [AoEDE_s]
-path = "AoEDE_s.exe"
+paths = ["AoEDE_s.exe", "AoEDE.exe"]
 
   [AoEDE_s.map]
   3356c013f2cb732601e1acf286654e4360d7e7304a092bdbeaa63d48 = "steam"
 
 [empiresdat]
-path = "Data/empires.dat"
+paths = ["Data/empires.dat"]
 
   [empiresdat.map]
   4d1f3cb7ce20074bfa23445c62755b95e4ec193b41507d5196921033 = "steam"

--- a/cfg/converter/games/de2/version_hashes.toml
+++ b/cfg/converter/games/de2/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 2: Definitive Edition
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [AoE2DE_s]
-path = "AoE2DE_s.exe"
+paths = ["AoE2DE_s.exe", "AoE2DE.exe"]
 
   [AoE2DE_s.map]
   01ff7cc7819e4f77be059c8efc6c07472dd1a58f429621e937328750 = "36906"
 
 [empires2_x2_p1dat]
-path = "resources/_common/dat/empires2_x2_p1.dat"
+paths = ["resources/_common/dat/empires2_x2_p1.dat"]
 
   [empires2_x2_p1dat.map]
   cf13c553c78df192da1af957d1519870db15c9dbca314b245a5abe6f = "36906"

--- a/cfg/converter/games/hd/version_hashes.toml
+++ b/cfg/converter/games/hd/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 2: HD Edition
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 ["AoK HD"]
-path = "AoK HD.exe"
+paths = ["AoK HD.exe"]
 
   ["AoK HD".map]
   73a068f353efd50e058762ca090062600a7ca50e435fe55a6ca87efa = "5.8"
 
 [empires2_x1_p1dat]
-path = "resources/_common/dat/empires2_x1_p1.dat"
+paths = ["resources/_common/dat/empires2_x1_p1.dat"]
 
   [empires2_x1_p1dat.map]
   91f7370b75b2fadf238b25f6fdd2f43a88a1f01ea022cd6086e44f43 = "5.8"

--- a/cfg/converter/games/hd_ak/version_hashes.toml
+++ b/cfg/converter/games/hd_ak/version_hashes.toml
@@ -1,10 +1,10 @@
 # version hashes of African Kingdoms (HD)
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [empires2_x2_p1dat]
-path = "resources/_common/dat/empires2_x2_p1.dat"
+paths = ["resources/_common/dat/empires2_x2_p1.dat"]
 
   [empires2_x2_p1dat.map]
   b2a69980a1ef39e68de2be1771392858cb639a9f2797373ab1649acf = "5.8"

--- a/cfg/converter/games/hd_fgt/version_hashes.toml
+++ b/cfg/converter/games/hd_fgt/version_hashes.toml
@@ -1,0 +1,10 @@
+# version hashes of Forgotten Empires (HD)
+
+file_version = "2.0"
+hash_algo = "SHA3-256"
+
+[empires2_x2_p1dat]
+paths = ["resources/_common/dat/empires2_x2_p1.dat"]
+
+  [empires2_x2_p1dat.map]
+  b2a69980a1ef39e68de2be1771392858cb639a9f2797373ab1649acf = "5.8"

--- a/cfg/converter/games/hd_raj/version_hashes.toml
+++ b/cfg/converter/games/hd_raj/version_hashes.toml
@@ -1,0 +1,10 @@
+# version hashes of Rise of the Rajas (HD)
+
+file_version = "2.0"
+hash_algo = "SHA3-256"
+
+[empires2_x2_p1dat]
+paths = ["resources/_common/dat/empires2_x2_p1.dat"]
+
+  [empires2_x2_p1dat.map]
+  b2a69980a1ef39e68de2be1771392858cb639a9f2797373ab1649acf = "5.8"

--- a/cfg/converter/games/ror/version_hashes.toml
+++ b/cfg/converter/games/ror/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Age of Empires 1: Rise of Rome
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [EMPIRESX]
-path = "EMPIRESX.EXE"
+paths = ["EMPIRESX.EXE"]
 
   [EMPIRESX.map]
   bd55a288136ea5457c61fbc794e3e4a4ac526b1d53809f1b16762119 = "1.0B"
 
 [empiresdat]
-path = "data2/empires.dat"
+paths = ["data2/empires.dat"]
 
   [empiresdat.map]
   0376368ce4c78be31596dea7b76f592b2352f6b5c3aca222b7939b4a = "1.0B"

--- a/cfg/converter/games/swgb/version_hashes.toml
+++ b/cfg/converter/games/swgb/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Star Wars: Galactic Battlegrounds
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [Battlegrounds]
-path = "Game/Battlegrounds.exe"
+paths = ["Game/Battlegrounds.exe"]
 
   [Battlegrounds.map]
   0a5e2b7828b5b0a45cb6dfbf52e3becb2021e97259ba23a5cee94230 = "GOG"
 
 [GENIE]
-path = "Game/Data/GENIE.DAT"
+paths = ["Game/Data/GENIE.DAT"]
 
   [GENIE.map]
   f1f641f201dac9d7663df4cf1ece7a60a78770a09e70e202399505d9 = "GOG"

--- a/cfg/converter/games/swgb_cc/version_hashes.toml
+++ b/cfg/converter/games/swgb_cc/version_hashes.toml
@@ -1,16 +1,16 @@
 # version hashes of Clone Campaigns
 
-file_version = "1.0"
+file_version = "2.0"
 hash_algo = "SHA3-256"
 
 [battlegrounds_x1]
-path = "Game/battlegrounds_x1.exe"
+paths = ["Game/battlegrounds_x1.exe"]
 
   [battlegrounds_x1.map]
   fb722624bae8a4626925926d5709e1397766dd3ee2dcd1df7849ad27 = "GOG"
 
 [genie_x1dat]
-path = "Game/Data/genie_x1.dat"
+paths = ["Game/Data/genie_x1.dat"]
 
   [genie_x1dat.map]
   036a16aefd1a66f5bad121786e66b8cc9542cbe88b43c4eb8f73eadb = "GOG"

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -681,8 +681,13 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
         """
         head_unit = self.get_head_unit()
         head_unit_id = head_unit["id0"].get_value()
-        head_unit_connection = self.data.building_connections[head_unit_id]
-        enabling_research_id = head_unit_connection["enabling_research"].get_value()
+        if head_unit_id in self.data.building_connections.keys():
+            head_unit_connection = self.data.building_connections[head_unit_id]
+            enabling_research_id = head_unit_connection["enabling_research"].get_value()
+
+        else:
+            # Assume it is avialable from the start
+            enabling_research_id = -1
 
         return enabling_research_id
 

--- a/openage/convert/entity_object/conversion/combined_terrain.py
+++ b/openage/convert/entity_object/conversion/combined_terrain.py
@@ -12,14 +12,14 @@ class CombinedTerrain:
     This will become a spritesheet texture with a terrain file.
     """
 
-    __slots__ = ('slp_id', 'filename', 'data', 'metadata', '_refs')
+    __slots__ = ('terrain_id', 'filename', 'data', 'metadata', '_refs')
 
-    def __init__(self, slp_id, filename, full_data_set):
+    def __init__(self, terrain_id, filename, full_data_set):
         """
-        Creates a new CombinedSprite instance.
+        Creates a new CombinedTerrain instance.
 
-        :param slp_id: The id of the SLP.
-        :type slp_id: int
+        :param terrain_id: The index of the terrain that references the sprite.
+        :type terrain_id: int
         :param filename: Name of the terrain and definition file.
         :type filename: str
         :param full_data_set: GenieObjectContainer instance that
@@ -28,7 +28,7 @@ class CombinedTerrain:
         :type full_data_set: class: ...dataformat.converter_object.ConverterObjectContainer
         """
 
-        self.slp_id = slp_id
+        self.terrain_id = terrain_id
         self.filename = filename
         self.data = full_data_set
 
@@ -53,15 +53,21 @@ class CombinedTerrain:
 
     def get_filename(self):
         """
-        Returns the desired filename of the terrain.
+        Returns the destination filename of the terrain.
         """
         return self.filename
 
+    def get_terrain(self):
+        """
+        Returns the terrain referenced by this terrain sprite.
+        """
+        return self.data.genie_terrains[self.terrain_id]
+
     def get_id(self):
         """
-        Returns the SLP id of the terrain.
+        Returns the terrain id of the terrain.
         """
-        return self.slp_id
+        return self.terrain_id
 
     def get_relative_terrain_location(self):
         """
@@ -96,4 +102,4 @@ class CombinedTerrain:
         return None
 
     def __repr__(self):
-        return f"CombinedTerrain<{self.slp_id}>"
+        return f"CombinedTerrain<{self.terrain_id}>"

--- a/openage/convert/entity_object/conversion/combined_terrain.py
+++ b/openage/convert/entity_object/conversion/combined_terrain.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2021 the openage authors. See copying.md for legal info.
 
 """
 References a graphic in the game that has to be converted.

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -6,7 +6,7 @@ Entry point for all of the asset conversion.
 """
 from datetime import datetime
 
-from ..log import info
+from ..log import info, err
 from ..util.fslike.directory import CaseIgnoringDirectory
 from ..util.fslike.wrapper import (DirectoryCreator,
                                    Synchronizer as AccessSynchronizer)
@@ -70,6 +70,9 @@ def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     # Acquire game version info
     args.game_version = get_game_version(srcdir, args.avail_game_eds, args.avail_game_exps)
     debug_game_version(args.debugdir, args.debug_info, args)
+
+    if not args.game_version[0]:
+        return None
 
     # Mount assets into conversion folder
     data_dir = mount_asset_dirs(srcdir, args.game_version)
@@ -220,7 +223,9 @@ def main(args, error):
 
     if args.force or wanna_convert() or conversion_required(outdir, args):
         if not convert_assets(outdir, args, srcdir):
+            err("game asset conversion failed")
             return 1
+
     else:
         print("assets are up to date; no conversion is required.")
         print("override with --force.")

--- a/openage/convert/processor/conversion/CMakeLists.txt
+++ b/openage/convert/processor/conversion/CMakeLists.txt
@@ -5,5 +5,6 @@ add_py_modules(
 add_subdirectory(aoc)
 add_subdirectory(de1)
 add_subdirectory(de2)
+add_subdirectory(hd)
 add_subdirectory(ror)
 add_subdirectory(swgbcc)

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -98,7 +98,7 @@ class AoCMediaSubprocessor:
 
         combined_terrains = full_data_set.combined_terrains.values()
         for texture in combined_terrains:
-            slp_id = texture.get_id()
+            slp_id = texture.get_terrain()["slp_id"].get_value()
 
             targetdir = texture.resolve_graphics_location()
             source_filename = f"{str(slp_id)}.slp"

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -1018,10 +1018,10 @@ class AoCNyanSubprocessor:
         # =======================================================================
         if terrain_group.has_subterrain():
             subterrain = terrain_group.get_subterrain()
-            slp_id = subterrain["slp_id"].get_value()
+            terrain_id = subterrain.get_id()
 
         else:
-            slp_id = terrain_group.get_terrain()["slp_id"].get_value()
+            terrain_id = terrain_group.get_id()
 
         # Create animation object
         graphic_name = f"{terrain_name}.TerrainTexture"
@@ -1031,11 +1031,11 @@ class AoCNyanSubprocessor:
         graphic_location = ForwardRef(terrain_group, terrain_name)
         graphic_raw_api_object.set_location(graphic_location)
 
-        if slp_id in dataset.combined_terrains.keys():
-            terrain_graphic = dataset.combined_terrains[slp_id]
+        if terrain_id in dataset.combined_terrains.keys():
+            terrain_graphic = dataset.combined_terrains[terrain_id]
 
         else:
-            terrain_graphic = CombinedTerrain(slp_id,
+            terrain_graphic = CombinedTerrain(terrain_id,
                                               f"texture_{terrain_lookup_dict[terrain_index][2]}",
                                               dataset)
             dataset.combined_terrains.update({terrain_graphic.get_id(): terrain_graphic})

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -8,6 +8,7 @@
 """
 Creates patches for technologies.
 """
+from openage.log import warn
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup,\
     CivTeamBonus, CivBonus
@@ -295,7 +296,13 @@ class AoCTechSubprocessor:
 
         line = dataset.unit_ref[upgrade_source_id]
         upgrade_source_pos = line.get_unit_position(upgrade_source_id)
-        upgrade_target_pos = line.get_unit_position(upgrade_target_id)
+        try:
+            upgrade_target_pos = line.get_unit_position(upgrade_target_id)
+
+        except KeyError:
+            # TODO: Implement branching line upgrades
+            warn(f"Could not create upgrade from unit {upgrade_source_id} to {upgrade_target_id}")
+            return patches
 
         if isinstance(line, GenieBuildingLineGroup):
             # Building upgrades always reference the head unit

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -348,6 +348,14 @@ class AoCUpgradeAttributeSubprocessor:
         elif value == 1:
             target_mode = dataset.nyan_api_objects["engine.util.target_mode.type.ExpectedPosition"]
 
+        elif value == 2:
+            # No Ballistics, only for Arambai
+            target_mode = dataset.nyan_api_objects["engine.util.target_mode.type.ExpectedPosition"]
+
+        elif value == 3:
+            # Ballistics, only for Arambai
+            target_mode = dataset.nyan_api_objects["engine.util.target_mode.type.ExpectedPosition"]
+
         obj_id = converter_group.get_id()
         if isinstance(converter_group, GenieTechEffectBundleGroup):
             tech_lookup_dict = internal_name_lookups.get_tech_lookups(dataset.game_version)

--- a/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
@@ -1101,6 +1101,26 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
+    def starting_stone_upgrade(converter_group, value, operator, team=False):
+        """
+        Creates a patch for the starting stone modify effect (ID: 93).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def starting_gold_upgrade(converter_group, value, operator, team=False):
         """
         Creates a patch for the starting gold modify effect (ID: 94).

--- a/openage/convert/processor/conversion/de2/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/civ_subprocessor.py
@@ -70,9 +70,14 @@ class DE2CivSubprocessor:
                         # This tech is usually unlocked by an age up
                         tech_id = civ_bonus.tech["required_techs"][1].get_value()
 
+                        if tech_id == 232:
+                            # Synergies with other civs (usually chinese farming bonus)
+                            # TODO: This must be solved in a better way than in the Genie dataset.
+                            continue
+
                         if tech_id not in dataset.tech_groups.keys():
                             # Circumvents a "funny" duplicate castle age up tech for Incas
-                            # The required tech of the dupicate is the age up we are looking for
+                            # The required tech of the duplicate is the age up we are looking for
                             tech_id = dataset.genie_techs[tech_id]["required_techs"][0].get_value()
 
                         if not dataset.tech_groups[tech_id].is_researchable():

--- a/openage/convert/processor/conversion/de2/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/media_subprocessor.py
@@ -1,6 +1,6 @@
 # Copyright 2020-2021 the openage authors. See copying.md for legal info.
 #
-# pylint: disable=too-many-locals,too-few-public-methods
+# pylint: disable=too-many-locals
 """
 Convert media information to metadata definitions and export
 requests. Subroutine of the main DE2 processor.

--- a/openage/convert/processor/conversion/de2/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/nyan_subprocessor.py
@@ -768,8 +768,7 @@ class DE2NyanSubprocessor:
         # =======================================================================
         # Graphic
         # =======================================================================
-        # DE2' SLP IDs are irrelevant, so we use the filename as ID
-        texture_id = terrain["filename"].get_value()
+        texture_id = terrain.get_id()
 
         # Create animation object
         graphic_name = f"{terrain_name}.TerrainTexture"

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -13,7 +13,7 @@ from .....log import info
 from .....util.ordered_set import OrderedSet
 from ....entity_object.conversion.aoc.genie_graphic import GenieGraphic
 from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
-from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup, GenieUnitLineGroup, GenieUnitObject, GenieAmbientGroup,\
+from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup, GenieUnitObject, GenieAmbientGroup,\
     GenieVariantGroup
 from ....service.debug_info import debug_converter_objects,\
     debug_converter_object_groups
@@ -207,7 +207,6 @@ class DE2Processor:
                                                 members=[])
                     unit.add_member(unit_commands)
 
-
     @staticmethod
     def extract_genie_graphics(gamespec, full_data_set):
         """
@@ -298,4 +297,3 @@ class DE2Processor:
             building_line.add_unit(full_data_set.genie_units[unit_id])
             full_data_set.building_lines.update({building_line.get_id(): building_line})
             full_data_set.unit_ref.update({unit_id: building_line})
-

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -88,6 +88,7 @@ class DE2TechSubprocessor:
         90: AoCUpgradeResourceSubprocessor.heal_range_upgrade,
         91: AoCUpgradeResourceSubprocessor.starting_food_upgrade,
         92: AoCUpgradeResourceSubprocessor.starting_wood_upgrade,
+        93: AoCUpgradeResourceSubprocessor.starting_stone_upgrade,
         94: AoCUpgradeResourceSubprocessor.starting_gold_upgrade,
         96: AoCUpgradeResourceSubprocessor.berserk_heal_rate_upgrade,
         97: AoCUpgradeResourceSubprocessor.herding_dominance_upgrade,
@@ -117,6 +118,10 @@ class DE2TechSubprocessor:
         220: DE2UpgradeResourceSubprocessor.relic_food_production_upgrade,
         234: DE2UpgradeResourceSubprocessor.first_crusade_upgrade,
         236: DE2UpgradeResourceSubprocessor.burgundian_vineyards_upgrade,
+        237: DE2UpgradeResourceSubprocessor.folwark_collect_upgrade,
+        238: DE2UpgradeResourceSubprocessor.folwark_flag_upgrade,
+        239: DE2UpgradeResourceSubprocessor.folwark_mill_id_upgrade,
+        241: DE2UpgradeResourceSubprocessor.stone_gold_gen_upgrade,
     }
 
     @classmethod

--- a/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
@@ -356,6 +356,72 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
+    def folwark_collect_upgrade(converter_group, value, operator, team=False):
+        """
+        Creates a patch for the folwark collect amount modify effect (ID: 237).
+
+        TODO: Move into AoC processor
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def folwark_flag_upgrade(converter_group, value, operator, team=False):
+        """
+        Creates a patch for the folwark flag effect (ID: 238).
+
+        TODO: Move into AoC processor
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def folwark_mill_id_upgrade(converter_group, value, operator, team=False):
+        """
+        Creates a patch for the folwark mill ID set effect (ID: 239).
+
+        TODO: Move into AoC processor
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def free_kipchaks_upgrade(converter_group, value, operator, team=False):
         """
         Creates a patch for the current gold amount modify effect (ID: 214).
@@ -421,6 +487,26 @@ class DE2UpgradeResourceSubprocessor:
     def sheep_food_amount_upgrade(converter_group, value, operator, team=False):
         """
         Creates a patch for the sheep food amount modify effect (ID: 216).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def stone_gold_gen_upgrade(converter_group, value, operator, team=False):
+        """
+        Creates a patch for the polish stone gold generation effect (ID: 241).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup

--- a/openage/convert/processor/conversion/hd/CMakeLists.txt
+++ b/openage/convert/processor/conversion/hd/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_py_modules(
+	__init__.py
+	media_subprocessor.py
+	modpack_subprocessor.py
+	processor.py
+)

--- a/openage/convert/processor/conversion/hd/__init__.py
+++ b/openage/convert/processor/conversion/hd/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+
+"""
+Drives the conversion process for AoE2: HD Edition.
+"""

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -1,4 +1,6 @@
 # Copyright 2021-2021 the openage authors. See copying.md for legal info.
+#
+# pylint: disable=too-many-locals
 
 """
 Convert media information to metadata definitions and export

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -1,0 +1,130 @@
+# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+
+"""
+Convert media information to metadata definitions and export
+requests. Subroutine of the main HD processor.
+"""
+from ....entity_object.export.formats.sprite_metadata import LayerMode
+from ....entity_object.export.media_export_request import MediaExportRequest
+from ....entity_object.export.metadata_export import SpriteMetadataExport
+from ....value_object.read.media_types import MediaType
+
+
+class HDMediaSubprocessor:
+    """
+    Creates the exports requests for media files from HD Edition.
+    """
+
+    @classmethod
+    def convert(cls, full_data_set):
+        """
+        Create all export requests for the dataset.
+        """
+        cls.create_graphics_requests(full_data_set)
+        cls.create_sound_requests(full_data_set)
+
+    @staticmethod
+    def create_graphics_requests(full_data_set):
+        """
+        Create export requests for graphics referenced by CombinedSprite objects.
+        """
+        combined_sprites = full_data_set.combined_sprites.values()
+        handled_graphic_ids = set()
+
+        for sprite in combined_sprites:
+            ref_graphics = sprite.get_graphics()
+            graphic_targetdirs = sprite.resolve_graphics_location()
+
+            metadata_filename = f"{sprite.get_filename()}.{'sprite'}"
+            metadata_export = SpriteMetadataExport(sprite.resolve_sprite_location(),
+                                                   metadata_filename)
+            full_data_set.metadata_exports.append(metadata_export)
+
+            for graphic in ref_graphics:
+                graphic_id = graphic.get_id()
+                if graphic_id in handled_graphic_ids:
+                    continue
+
+                targetdir = graphic_targetdirs[graphic_id]
+                source_filename = f"{str(graphic['slp_id'].get_value())}.slp"
+                target_filename = "%s_%s.png" % (sprite.get_filename(),
+                                                 str(graphic["slp_id"].get_value()))
+
+                export_request = MediaExportRequest(MediaType.GRAPHICS,
+                                                    targetdir,
+                                                    source_filename,
+                                                    target_filename)
+                full_data_set.graphics_exports.update({graphic_id: export_request})
+
+                # Metadata from graphics
+                sequence_type = graphic["sequence_type"].get_value()
+                if sequence_type == 0x00:
+                    layer_mode = LayerMode.OFF
+
+                elif sequence_type & 0x08:
+                    layer_mode = LayerMode.ONCE
+
+                else:
+                    layer_mode = LayerMode.LOOP
+
+                layer_pos = graphic["layer"].get_value()
+                frame_rate = round(graphic["frame_rate"].get_value(), ndigits=6)
+                if frame_rate < 0.000001:
+                    frame_rate = None
+
+                replay_delay = round(graphic["replay_delay"].get_value(), ndigits=6)
+                if replay_delay < 0.000001:
+                    replay_delay = None
+
+                frame_count = graphic["frame_count"].get_value()
+                angle_count = graphic["angle_count"].get_value()
+                mirror_mode = graphic["mirroring_mode"].get_value()
+                metadata_export.add_graphics_metadata(target_filename,
+                                                      layer_mode,
+                                                      layer_pos,
+                                                      frame_rate,
+                                                      replay_delay,
+                                                      frame_count,
+                                                      angle_count,
+                                                      mirror_mode)
+
+                # Notify metadata export about SLP metadata when the file is exported
+                export_request.add_observer(metadata_export)
+
+                handled_graphic_ids.add(graphic_id)
+
+        combined_terrains = full_data_set.combined_terrains.values()
+        for texture in combined_terrains:
+            slp_id = texture.get_terrain()["slp_id"].get_value()
+            srcfile_prefix = texture.get_terrain()["filename"].get_value()
+
+            targetdir = texture.resolve_graphics_location()
+            source_filename = f"{str(srcfile_prefix)}_00_color.png"
+            target_filename = f"{texture.get_filename()}.png"
+
+            export_request = MediaExportRequest(MediaType.TERRAIN,
+                                                targetdir,
+                                                source_filename,
+                                                target_filename)
+            full_data_set.graphics_exports.update({slp_id: export_request})
+
+    @staticmethod
+    def create_sound_requests(full_data_set):
+        """
+        Create export requests for sounds referenced by CombinedSound objects.
+        """
+        combined_sounds = full_data_set.combined_sounds.values()
+
+        for sound in combined_sounds:
+            sound_id = sound.get_file_id()
+
+            targetdir = sound.resolve_sound_location()
+            source_filename = f"{str(sound_id)}.wav"
+            target_filename = f"{sound.get_filename()}.opus"
+
+            export_request = MediaExportRequest(MediaType.SOUNDS,
+                                                targetdir,
+                                                source_filename,
+                                                target_filename)
+
+            full_data_set.sound_exports.update({sound_id: export_request})

--- a/openage/convert/processor/conversion/hd/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/modpack_subprocessor.py
@@ -1,0 +1,43 @@
+# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+#
+# pylint: disable=too-few-public-methods
+
+"""
+Organize export data (nyan objects, media, scripts, etc.)
+into modpacks.
+"""
+from ....entity_object.conversion.modpack import Modpack
+from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
+
+
+class HDModpackSubprocessor:
+    """
+    Creates the modpacks containing the nyan files and media from the HD conversion.
+    """
+
+    @classmethod
+    def get_modpacks(cls, gamedata):
+        """
+        Return all modpacks that can be created from the gamedata.
+        """
+        hd_base = cls._get_aoe2_base(gamedata)
+
+        return [hd_base]
+
+    @classmethod
+    def _get_aoe2_base(cls, gamedata):
+        """
+        Create the aoe2_base modpack.
+        """
+        modpack = Modpack("hd_base")
+
+        mod_def = modpack.get_info()
+
+        mod_def.set_info("hd_base", "5.8", repo="openage")
+
+        mod_def.add_include("data/*")
+
+        AoCModpackSubprocessor.organize_nyan_objects(modpack, gamedata)
+        AoCModpackSubprocessor.organize_media_objects(modpack, gamedata)
+
+        return modpack

--- a/openage/convert/processor/conversion/hd/processor.py
+++ b/openage/convert/processor/conversion/hd/processor.py
@@ -1,0 +1,149 @@
+# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+
+"""
+Convert data from AoE2:HD to openage formats.
+"""
+
+from .....log import info
+from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+from ....service.debug_info import debug_converter_objects,\
+    debug_converter_object_groups
+from ....service.read.nyan_api_loader import load_api
+from ..aoc.nyan_subprocessor import AoCNyanSubprocessor
+from ..aoc.pregen_processor import AoCPregenSubprocessor
+from ..aoc.processor import AoCProcessor
+from .media_subprocessor import HDMediaSubprocessor
+from .modpack_subprocessor import HDModpackSubprocessor
+
+
+class HDProcessor:
+    """
+    Main processor for converting data from HD Edition.
+    """
+
+    @classmethod
+    def convert(cls, gamespec, args, string_resources, existing_graphics):
+        """
+        Input game speification and media here and get a set of
+        modpacks back.
+
+        :param gamespec: Gamedata from empires.dat read in by the
+                         reader functions.
+        :type gamespec: ...dataformat.value_members.ArrayMember
+        :returns: A list of modpacks.
+        :rtype: list
+        """
+
+        info("Starting conversion...")
+
+        # Create a new container for the conversion process
+        dataset = cls._pre_processor(
+            gamespec,
+            args.game_version,
+            string_resources,
+            existing_graphics
+        )
+        debug_converter_objects(args.debugdir, args.debug_info, dataset)
+
+        # Create the custom openage formats (nyan, sprite, terrain, etc.)
+        dataset = cls._processor(dataset)
+        debug_converter_object_groups(args.debugdir, args.debug_info, dataset)
+
+        # Create modpack definitions
+        modpacks = cls._post_processor(dataset)
+
+        return modpacks
+
+    @classmethod
+    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+        """
+        Store data from the reader in a conversion container.
+
+        :param gamespec: Gamedata from empires.dat file.
+        :type gamespec: ...dataformat.value_members.ArrayMember
+        """
+        dataset = GenieObjectContainer()
+
+        dataset.game_version = game_version
+        dataset.nyan_api_objects = load_api()
+        dataset.strings = string_resources
+        dataset.existing_graphics = existing_graphics
+
+        info("Extracting Genie data...")
+
+        AoCProcessor.extract_genie_units(gamespec, dataset)
+        AoCProcessor.extract_genie_techs(gamespec, dataset)
+        AoCProcessor.extract_genie_effect_bundles(gamespec, dataset)
+        AoCProcessor.sanitize_effect_bundles(dataset)
+        AoCProcessor.extract_genie_civs(gamespec, dataset)
+        AoCProcessor.extract_age_connections(gamespec, dataset)
+        AoCProcessor.extract_building_connections(gamespec, dataset)
+        AoCProcessor.extract_unit_connections(gamespec, dataset)
+        AoCProcessor.extract_tech_connections(gamespec, dataset)
+        AoCProcessor.extract_genie_graphics(gamespec, dataset)
+        AoCProcessor.extract_genie_sounds(gamespec, dataset)
+        AoCProcessor.extract_genie_terrains(gamespec, dataset)
+
+        return dataset
+
+    @classmethod
+    def _processor(cls, full_data_set):
+        """
+        Transfer structures used in Genie games to more openage-friendly
+        Python objects.
+
+        :param full_data_set: GenieObjectContainer instance that
+                              contains all relevant data for the conversion
+                              process.
+        :type full_data_set: ...dataformat.aoc.genie_object_container.GenieObjectContainer
+        """
+
+        info("Creating API-like objects...")
+
+        AoCProcessor.create_unit_lines(full_data_set)
+        AoCProcessor.create_extra_unit_lines(full_data_set)
+        AoCProcessor.create_building_lines(full_data_set)
+        AoCProcessor.create_villager_groups(full_data_set)
+        AoCProcessor.create_ambient_groups(full_data_set)
+        AoCProcessor.create_variant_groups(full_data_set)
+        AoCProcessor.create_terrain_groups(full_data_set)
+        AoCProcessor.create_tech_groups(full_data_set)
+        AoCProcessor.create_civ_groups(full_data_set)
+
+        info("Linking API-like objects...")
+
+        AoCProcessor.link_building_upgrades(full_data_set)
+        AoCProcessor.link_creatables(full_data_set)
+        AoCProcessor.link_researchables(full_data_set)
+        AoCProcessor.link_civ_uniques(full_data_set)
+        AoCProcessor.link_gatherers_to_dropsites(full_data_set)
+        AoCProcessor.link_garrison(full_data_set)
+        AoCProcessor.link_trade_posts(full_data_set)
+        AoCProcessor.link_repairables(full_data_set)
+
+        info("Generating auxiliary objects...")
+
+        AoCPregenSubprocessor.generate(full_data_set)
+
+        return full_data_set
+
+    @classmethod
+    def _post_processor(cls, full_data_set):
+        """
+        Convert API-like Python objects to nyan.
+
+        :param full_data_set: GenieObjectContainer instance that
+                              contains all relevant data for the conversion
+                              process.
+        :type full_data_set: ...dataformat.aoc.genie_object_container.GenieObjectContainer
+        """
+
+        info("Creating nyan objects...")
+
+        AoCNyanSubprocessor.convert(full_data_set)
+
+        info("Creating requests for media export...")
+
+        HDMediaSubprocessor.convert(full_data_set)
+
+        return HDModpackSubprocessor.get_modpacks(full_data_set)

--- a/openage/convert/processor/conversion/hd/processor.py
+++ b/openage/convert/processor/conversion/hd/processor.py
@@ -1,4 +1,6 @@
 # Copyright 2021-2021 the openage authors. See copying.md for legal info.
+#
+# pylint: disable=too-few-public-methods
 
 """
 Convert data from AoE2:HD to openage formats.

--- a/openage/convert/processor/conversion/ror/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/nyan_subprocessor.py
@@ -810,10 +810,10 @@ class RoRNyanSubprocessor:
         # =======================================================================
         if terrain_group.has_subterrain():
             subterrain = terrain_group.get_subterrain()
-            slp_id = subterrain["slp_id"].get_value()
+            terrain_id = subterrain.get_id()
 
         else:
-            slp_id = terrain_group.get_terrain()["slp_id"].get_value()
+            terrain_id = terrain_group.get_id()
 
         # Create animation object
         graphic_name = f"{terrain_name}.TerrainTexture"
@@ -823,11 +823,11 @@ class RoRNyanSubprocessor:
         graphic_location = ForwardRef(terrain_group, terrain_name)
         graphic_raw_api_object.set_location(graphic_location)
 
-        if slp_id in dataset.combined_terrains.keys():
-            terrain_graphic = dataset.combined_terrains[slp_id]
+        if terrain_id in dataset.combined_terrains.keys():
+            terrain_graphic = dataset.combined_terrains[terrain_id]
 
         else:
-            terrain_graphic = CombinedTerrain(slp_id,
+            terrain_graphic = CombinedTerrain(terrain_id,
                                               f"texture_{terrain_lookup_dict[terrain_index][2]}",
                                               dataset)
             dataset.combined_terrains.update({terrain_graphic.get_id(): terrain_graphic})

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -304,7 +304,7 @@ class MediaExporter:
 
         else:
             raise Exception(f"Source file {source_file.name} has an unrecognized extension: "
-                            f"source_file.suffix.lower()")
+                            f"{source_file.suffix.lower()}")
 
         if game_version[0].game_id in ("AOC", "SWGB"):
             from .terrain_merge import merge_terrain

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -284,15 +284,27 @@ class MediaExporter:
             export_request.get_type().value,
             export_request.source_filename
         ]
-        media_file = source_file.open("rb")
 
         if source_file.suffix.lower() == ".slp":
             from ...value_object.read.media.slp import SLP
+            media_file = source_file.open("rb")
             image = SLP(media_file.read())
 
         elif source_file.suffix.lower() == ".dds":
             # TODO: Implement
             pass
+
+        elif source_file.suffix.lower() == ".png":
+            from shutil import copyfileobj
+            src_path = source_file.open('rb')
+            dst_path = exportdir[export_request.targetdir,
+                                 export_request.target_filename].open('wb')
+            copyfileobj(src_path, dst_path)
+            return
+
+        else:
+            raise Exception(f"Source file {source_file.name} has an unrecognized extension: "
+                            f"source_file.suffix.lower()")
 
         if game_version[0].game_id in ("AOC", "SWGB"):
             from .terrain_merge import merge_terrain

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -31,15 +31,15 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
                 required_file = srcdir.joinpath(required_path)
 
                 if required_file.is_file():
-                    hash = hash_file(required_file,
-                                     hash_algo=detection_hints.hash_algo)
+                    hash_val = hash_file(required_file,
+                                         hash_algo=detection_hints.hash_algo)
 
-                    if hash not in detection_hints.get_hashes():
+                    if hash_val not in detection_hints.get_hashes():
                         dbg(f"Found required file {required_file.resolve_native_path()} "
                             "but could not determine version number")
 
                     else:
-                        version_no = detection_hints.get_hashes()[hash]
+                        version_no = detection_hints.get_hashes()[hash_val]
                         dbg(f"Found required file {required_file.resolve_native_path()} "
                             f"for version {version_no}")
 
@@ -60,7 +60,7 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
                 # Continue to look for supported editions
                 continue
 
-            elif game_edition.support == Support.BREAKS:
+            if game_edition.support == Support.BREAKS:
                 dbg(f"Found broken game edition: {game_edition}")
 
                 if best_edition is None or best_edition.support == Support.NOPE:
@@ -106,7 +106,7 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
                 # Continue to look for supported expansions
                 continue
 
-            elif game_expansion.support == Support.BREAKS:
+            if game_expansion.support == Support.BREAKS:
                 info(f"Found broken game expansion: {best_edition}")
                 # Continue to look for supported expansions
                 continue

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -31,7 +31,7 @@ def get_gamespec(srcdir, game_version, dont_pickle):
         raise Exception("No service found for reading data file of version %s"
                         % game_version[0].game_id)
 
-    cache_file = os.path.join(gettempdir(), f"{filepath.name}.pickle")
+    cache_file = os.path.join(gettempdir(), f"{game_version[0].game_id}_{filepath.name}.pickle")
 
     with filepath.open('rb') as empiresdat_file:
         gamespec = load_gamespec(empiresdat_file,

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -225,7 +225,7 @@ def read_de1_language_file(srcdir, language_file):
             continue
 
         # Brilliant idea to split by command AND space!!
-        string_id, string = re.split(r"(,|\s)", line, maxsplit=1)
+        string_id, string = re.split(r",|\s", line, maxsplit=1)
 
         # strings that were added in the DE2 edition release have
         # UPPERCASE_STRINGS as names, instead of the numeric ID stuff

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -127,9 +127,13 @@ def get_converter(game_version):
         from ..processor.conversion.de1.processor import DE1Processor
         return DE1Processor
 
-    if game_edition.game_id in ("AOC", "HDEDITION"):
+    if game_edition.game_id == "AOC":
         from ..processor.conversion.aoc.processor import AoCProcessor
         return AoCProcessor
+
+    if game_edition.game_id == "HDEDITION":
+        from ..processor.conversion.hd.processor import HDProcessor
+        return HDProcessor
 
     if game_edition.game_id == "AOE2DE":
         from ..processor.conversion.de2.processor import DE2Processor

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -36,6 +36,10 @@ def interactive_browser(cfg, srcdir=None):
 
     # Acquire game version info
     game_version = get_game_version(srcdir, avail_game_eds, avail_game_exps)
+    if not game_version[0]:
+        warn("cannot launch browser as no valid game version was found.")
+        return
+
     data = mount_asset_dirs(srcdir, game_version)
 
     if not data:

--- a/openage/convert/tool/subtool/acquire_sourcedir.py
+++ b/openage/convert/tool/subtool/acquire_sourcedir.py
@@ -66,7 +66,8 @@ def wanna_use_wine():
     long_prompt = True
     while answer is None:
         if long_prompt:
-            print("  Should we call wine to determine an AOE installation? [Y/n]")
+            print(
+                "  Should we call wine to determine an AOE installation? [Y/n]")
             long_prompt = False
         else:
             # TODO: text-adventure here
@@ -122,7 +123,7 @@ def query_source_dir(proposals):
     """
 
     if proposals:
-        print("\nPlease select an Age of Kings installation directory.")
+        print("\nPlease select an Age of Empires installation directory.")
         print("Insert the index of one of the proposals, or any path:")
 
         proposals = sorted(proposals)
@@ -167,7 +168,8 @@ def acquire_conversion_source_dir(prev_source_dir_path=None):
             proposals = set()
 
             if prev_source_dir_path and Path(prev_source_dir_path).is_dir():
-                prev_source_dir = CaseIgnoringDirectory(prev_source_dir_path).root
+                prev_source_dir = CaseIgnoringDirectory(
+                    prev_source_dir_path).root
                 proposals.add(
                     prev_source_dir.resolve_native_path().decode('utf-8', errors='replace')
                 )

--- a/openage/convert/tool/subtool/acquire_sourcedir.py
+++ b/openage/convert/tool/subtool/acquire_sourcedir.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2021 the openage authors. See copying.md for legal info.
 
 """
 Acquire the sourcedir for the game that is supposed to be converted.

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -13,11 +13,15 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
     """
     Mount the input folders for conversion.
     """
+    info(f"Looking for compatible games to convert...")
     game_version = iterate_game_versions(
         srcdir, avail_game_eds, avail_game_exps)
 
     no_support = False
     if not game_version[0]:
+        warn("No valid game version(s) could not be detected "
+             f"in {srcdir.resolve_native_path()}")
+
         # no supported version was found
         no_support = True
 

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -13,7 +13,7 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
     """
     Mount the input folders for conversion.
     """
-    info(f"Looking for compatible games to convert...")
+    info("Looking for compatible games to convert...")
     game_version = iterate_game_versions(
         srcdir, avail_game_eds, avail_game_exps)
 

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -13,12 +13,11 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
     """
     Mount the input folders for conversion.
     """
-    game_version = iterate_game_versions(srcdir, avail_game_eds, avail_game_exps)
+    game_version = iterate_game_versions(
+        srcdir, avail_game_eds, avail_game_exps)
 
     no_support = False
     if not game_version[0]:
-        warn("No valid game version(s) could not be detected in %s", srcdir)
-
         # no supported version was found
         no_support = True
 

--- a/openage/convert/value_object/conversion/de2/internal_nyan_names.py
+++ b/openage/convert/value_object/conversion/de2/internal_nyan_names.py
@@ -30,6 +30,11 @@ UNIT_LINE_LOOKUPS = {
     1660: ("DSerjeant", "dserjeant"),           # Donjon Serjeant
     # 1663: ("FlemishMilitia", "flemish_militia"),
     1699: ("FlemishMilitia", "flemish_militia"),
+
+    # DOTD
+    1701: ("Obuch", "obuch"),
+    1704: ("HussiteWagon", "hussite_wagon"),
+    1709: ("Obuch", "obuch"),
 }
 
 # key: head unit id; value: (nyan object name, filename prefix)
@@ -39,6 +44,9 @@ BUILDING_LINE_LOOKUPS = {
 
     # LOTW
     1665: ("Donjon", "donjon"),
+
+    # DOTD
+    1734: ("Folwark", "folwark"),
 }
 
 # key: (head) unit id; value: (nyan object name, filename prefix)
@@ -78,6 +86,17 @@ TECH_GROUP_LOOKUPS = {
     755: ("FlemishRevolution", "flemish_revolution"),
     756: ("FirstCrusade", "first_crusade"),
     757: ("Scutage", "scutage"),
+
+    # DOTD
+    779: ("EliteObuch", "elite_obuch"),
+    781: ("EliteHussiteWagon", "elite_hussite_wagon"),
+    782: ("SzlachtaPriviledges", "slzachte_priviledges"),
+    783: ("LechiticLegacy", "lechitic_legacy"),
+    784: ("WagenburgTactics", "wagenburg_tactics"),
+    785: ("HussiteReforms", "hussite_reforms"),
+    786: ("WingedHussar", "winged_hussar"),
+    787: ("Houfnice", "houfnice"),
+    793: ("Folwark", "folwark"),
 }
 
 # key: civ index; value: (nyan object name, filename prefix)
@@ -91,6 +110,10 @@ CIV_GROUP_LOOKUPS = {
     # LOTW
     36: ("Burgundians", "burgundians"),
     37: ("Sicilians", "sicilians"),
+
+    # DOTD
+    38: ("Poles", "poles"),
+    39: ("Bohemians", "bohemians"),
 }
 
 # key: civ index; value: (civ ids, nyan object name, filename prefix)
@@ -98,6 +121,7 @@ CIV_GROUP_LOOKUPS = {
 GRAPHICS_SET_LOOKUPS = {
     0: ((0, 1, 2, 13, 14, 36), "WesternEuropean", "western_european"),
     4: ((7, 37), "Byzantine", "byzantine"),
+    8: ((22, 23, 32, 35, 38, 39), "EasternEuropean", "eastern_european"),
     11: ((33, 34), "CentralAsian", "central_asian"),
 }
 
@@ -118,4 +142,6 @@ TERRAIN_TYPE_LOOKUPS = {
 ARMOR_CLASS_LOOKUPS = {
     0: "Wonder",
     31: "AntiLetis",
+    36: "DE2Hero",
+    37: "HussiteWagon",
 }

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2021 the openage authors. See copying.md for legal info.
 
 """
 Associate files or filepaths with hash values to determine the exact version of a game.

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -10,6 +10,7 @@ class GameFileVersion:
     Associates a file hash with a specific version number.
     This can be used to pinpoint the exact version of a game.
     """
+    hash_algo = "SHA3-256"
 
     def __init__(self, filepaths, hashes):
         """

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -1,32 +1,42 @@
 # Copyright 2020-2020 the openage authors. See copying.md for legal info.
 
 """
-Associate files or filepaths with hash values to determine the version of a game.
+Associate files or filepaths with hash values to determine the exact version of a game.
 """
 
 
 class GameFileVersion:
     """
-    Can be used to associate a file hash with a specific version number.
+    Associates a file hash with a specific version number.
     This can be used to pinpoint the exact version of a game.
     """
 
-    def __init__(self, filepath, hashes):
+    def __init__(self, filepaths, hashes):
         """
         Create a new file hash to version association.
-        """
 
-        self.path = filepath
+        :param filepaths: Paths to the specified file. Only one of the paths
+                          needs to exist. The other paths are interpreted as
+                          alternatives, e.g. if the game is released on different
+                          platforms with different names for the same file.
+        :type filepaths: list
+        :param hashes: Maps hashes to a version number string.
+        :type hashes: dict
+        """
+        self.paths = filepaths
+        if len(self.paths) < 1:
+            raise Exception(f"{self}: List of paths cannot be empty.")
+
         self.hashes = hashes
 
-    def get_path(self):
+    def get_paths(self):
         """
-        Return the path of the file.
+        Return all known paths to the file.
         """
-        return self.path
+        return self.paths
 
     def get_hashes(self):
         """
-        Return the hash-version association for the file.
+        Return the hash-version association for the file paths.
         """
         return self.hashes

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -27,7 +27,7 @@ class GameBase:
     Common base class for GameEdition and GameExpansion
     """
 
-    def __init__(self, game_id, support, game_hashes, media_paths,
+    def __init__(self, game_id, support, game_version_info, media_paths,
                  modpacks, **flags):
         """
         :param game_id: Unique id for the given game.
@@ -37,10 +37,9 @@ class GameBase:
         :type support: str
         :param modpacks: List of modpacks.
         :type modpacks: list
-        :param game_hashes: A list of tuples of GameFileVersion parameters
-        :type game_hashes: list[tuple]
-        :param media_paths: A list of tuples of media types and their
-                            paths
+        :param game_version_info: Versioning information about the game.
+        :type game_version_info: list[tuple]
+        :param media_paths: Media types and their paths
         :type media_paths: list[tuple]
         :param flags: Anything else specific to this version which is useful
                       for the converter.
@@ -57,23 +56,26 @@ class GameBase:
         if "media_cache" in flags.keys():
             self.media_cache = flags["media_cache"]
 
-        for path, hash_map in game_hashes:
+        for path, hash_map in game_version_info:
             self.add_game_file_versions(path, hash_map)
+
         for media_type, paths in media_paths:
             self.add_media_paths(media_type, paths)
 
-    def add_game_file_versions(self, filepath, hashes):
+    def add_game_file_versions(self, filepaths, hashes):
         """
         Add a GameFileVersion object for files which are unique
         to this version of the game.
 
-        :param filepath: Path of the specific file.
-        :type filepath: str
-        :param hashes: Hash value mapped to the file version.
+        :param filepaths: Paths to the specified file. Only one of the paths
+                          needs to exist. The other paths are interpreted as
+                          alternatives, e.g. if the game is released on different
+                          platforms with different names for the same file.
+        :type filepaths: list
+        :param hashes: Hash value mapped to a file version.
         :type hashes: dict
         """
-        game_file_version_obj = GameFileVersion(filepath, hashes)
-        self.game_file_versions.append(game_file_version_obj)
+        self.game_file_versions.append(GameFileVersion(filepaths, hashes))
 
     def add_media_paths(self, media_type, paths):
         """

--- a/openage/convert/value_object/read/media/datfile/lookup_dicts.py
+++ b/openage/convert/value_object/read/media/datfile/lookup_dicts.py
@@ -494,6 +494,7 @@ ARMOR_CLASS = {
     34: "DE2_UNKOWN_34",
     35: "DE2_UNKOWN_35",
     36: "DE2_UNKOWN_36",
+    37: "DE2_UNKOWN_36",
 }
 
 UNIT_CLASSES = {
@@ -714,6 +715,10 @@ BLAST_OFFENSE_TYPES = {
     2: "NEARBY_UNITS",
     3: "TARGET_ONLY",
     6: "UNKNOWN_6",
+    10: "UNKNOWN_10",
+    18: "UNKNOWN_18",
+    34: "UNKNOWN_34",
+    66: "UNKNOWN_66",
 }
 
 CREATABLE_TYPES = {


### PR DESCRIPTION
Introduces a few improvements for the asset converter.

* Allow alternative paths/filenames for required files used in the version detection (This allows us to use the same game definition for Steam and MS Store distributions)
* Check file hashes in version detection (only for debugging)
* Use game edition ID for naming .dat cache files
* **DE2: Dawn of the Dukes support**
* Terrain textures are now referenced by index instead of SLP ID 
    * HD Edition terrain textures are now exported by copying the original file