### PR TITLE
Add a Python argparse option to supply additional DLL search paths for Windows 

### DIFF
--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -56,6 +56,10 @@ def main(argv=None):
                             help=("upon throwing an exception a debug break is "
                                   "triggered. this will crash openage if no "
                                   "debugger is present"))
+    global_cli.add_argument(
+        "--add-dll-search-path", action='append', dest='dll_paths',
+        help="(Windows only) provide additional DLL search path")
+
     devmodes = global_cli.add_mutually_exclusive_group()
     devmodes.add_argument("--devmode", action="store_true",
                           help="force-enable development mode")

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -56,9 +56,10 @@ def main(argv=None):
                             help=("upon throwing an exception a debug break is "
                                   "triggered. this will crash openage if no "
                                   "debugger is present"))
-    global_cli.add_argument(
-        "--add-dll-search-path", action='append', dest='dll_paths',
-        help="(Windows only) provide additional DLL search path")
+    if sys.platform == 'win32':
+        global_cli.add_argument(
+            "--add-dll-search-path", action='append', dest='dll_paths',
+            help="(Windows only) provide additional DLL search path")
 
     devmodes = global_cli.add_mutually_exclusive_group()
     devmodes.add_argument("--devmode", action="store_true",

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -6,6 +6,7 @@
 Holds the game entry point for openage.
 """
 
+import sys
 from ..convert.tool.subtool.acquire_sourcedir import wanna_convert
 from ..log import err, info
 
@@ -31,7 +32,6 @@ def main(args, error):
     del error  # unused
 
     win_dll_path_handles = []
-    import sys
     if sys.platform == 'win32' and args.dll_paths is not None:
         import os
         for addtional_path in args.dll_paths:

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -30,6 +30,13 @@ def main(args, error):
     """
     del error  # unused
 
+    win_dll_path_handles = []
+    import sys
+    if sys.platform == 'win32' and args.dll_paths is not None:
+        import os
+        for addtional_path in args.dll_paths:
+            win_dll_path_handles.append(os.add_dll_directory(addtional_path))
+
     # we have to import stuff inside the function
     # as it depends on generated/compiled code
     from .main_cpp import run_game
@@ -39,6 +46,10 @@ def main(args, error):
     from ..cppinterface.setup import setup as cpp_interface_setup
     from ..cvar.location import get_config_path
     from ..util.fslike.union import Union
+
+    if sys.platform == 'win32':
+        for handle in win_dll_path_handles:
+            handle.close()
 
     # initialize libopenage
     cpp_interface_setup(args)
@@ -87,7 +98,6 @@ def main(args, error):
     info("Generated nyan assets are not yet compatible to the engine.")
     info("Please revert to release v0.4.1 if you want to test the previous working gamestate.")
     info("Exiting...")
-    import sys
     sys.exit()
 
     # start the game, continue in main_cpp.pyx!


### PR DESCRIPTION
As stated in https://docs.python.org/3/library/os.html#os.add_dll_directory, Python 3.8+ on Windows uses DLL paths added with `os.add_dll_directory`, and the PATH is not used.