### PR TITLE
Update macOS instructions

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Brew update
         run: brew update
       - name: Brew install DeJaVu fonts
-        run: brew tap homebrew/cask-fonts && brew install --cask font-dejavu
+        run: brew tap homebrew/cask-fonts && brew install font-dejavu
       - name: Remove python's 2to3 link so that 'brew link' does not fail
         run: rm '/usr/local/bin/2to3'
       - name: Install environment helpers with homebrew

--- a/copying.md
+++ b/copying.md
@@ -16,7 +16,7 @@ _the openage authors_ are:
 | Sascha Vincent Kurowski     | svkurowski                  | svkurowski à gmail dawt com                       |
 | James Mintram               | JimmyJazz                   | jamesmintram à gmail dawt com                     |
 | Martin McGrath              | MartinMcGrath               | mcgrath dawt martin à gmail dawt com              |
-| Renée Kooi                  | goto-bus-stop               | renee à kooi dawt me                               |
+| Renée Kooi                  | goto-bus-stop               | renee à kooi dawt me                              |
 | Markus Elfring              | elfring                     | elfring à users dawt sourceforge dawt net         |
 | Jimmy Berry                 | boombatower                 | jimmy à boombatower dawt com                      |
 | João Roque                  | joaoroque                   | joaoroque à gmail dawt com                        |
@@ -138,6 +138,7 @@ _the openage authors_ are:
 | Antonio M. R. Cunha         | Grubben                     | antoniomsprc à gmail dawt com                     |
 | Jens Nyman                  | nymanjens                   | nymanjens dawt nj à gmail dawt com                |
 | Deepak Dinesh               | deepak                      | d.deepakdinesh13 à gmail dawt com                 |
+| Damien Lejay                | dlejay                      | lejay à paracompact dawt space                    |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/doc/build_instructions/macos.md
+++ b/doc/build_instructions/macos.md
@@ -7,13 +7,13 @@
 ```
 brew update-reset && brew update
 brew tap homebrew/cask-fonts
-brew install --cask font-dejavu-sans
+brew install font-dejavu
 brew install cmake python3 libepoxy freetype fontconfig harfbuzz sdl2 sdl2_image opus opusfile qt5 libogg libpng eigen
 brew install llvm
 pip3 install cython numpy jinja2 lz4 pillow pygments toml
 
 # optional, for documentation generation
-brew install --cask doxygen
+brew install doxygen
 ```
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies:


### PR DESCRIPTION
Cask `fonts-dejavu-sans` no longer exists,
the dejavu-sans fonts are now included
in the cask `fonts-dejavu`.

Aslo `brew --cask` is no longer needed with
newer versions of homebrew.

fix #1436