### PR TITLE
Improve user experience for python part

### DIFF
--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -77,6 +77,10 @@ def main(argv=None):
                             help=("upon throwing an exception a debug break is "
                                   "triggered. this will crash openage if no "
                                   "debugger is present"))
+    if sys.platform == 'win32':
+        global_cli.add_argument(
+            "--add-dll-search-path", action='append', dest='dll_paths',
+            help="(Windows only) provide additional DLL search path")
 
     devmodes = global_cli.add_mutually_exclusive_group()
     devmodes.add_argument("--devmode", action="store_true",

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -16,7 +16,7 @@ from ..service.init.version_detect import create_version_objects
 from .subtool.version_select import get_game_version
 
 
-def interactive_browser(cfg, srcdir=None):
+def interactive_browser(cfg, srcdir, game_version):
     """
     launch an interactive view for browsing the original
     archives.
@@ -29,13 +29,6 @@ def interactive_browser(cfg, srcdir=None):
     # the variables are actually used, in the interactive prompt.
     # pylint: disable=possibly-unused-variable
 
-    # Initialize game versions data
-
-    auxiliary_files_dir = cfg / "converter" / "games"
-    avail_game_eds, avail_game_exps = create_version_objects(auxiliary_files_dir)
-
-    # Acquire game version info
-    game_version = get_game_version(srcdir, avail_game_eds, avail_game_exps)
     if not game_version[0]:
         warn("cannot launch browser as no valid game version was found.")
         return

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -63,3 +63,19 @@ def get_game_version(srcdir, avail_game_eds, avail_game_exps):
             info(" * %s", expansion.expansion_name)
 
     return game_version
+
+def get_game_version_by_id(edition_name, expansion_names, avail_game_eds, avail_game_exps):
+    res_edition = None
+    for game_edition in avail_game_eds:
+        if game_edition.game_id == edition_name:
+            res_edition = game_edition
+
+    if res_edition is None:
+        return None, []
+
+    res_expansions = []
+    for game_expansion in avail_game_exps:
+        if game_expansion.game_id in res_edition.expansions and game_expansion.game_id in expansion_names:
+            res_expansions.append(game_expansion)
+
+    return res_edition, res_expansions


### PR DESCRIPTION
1. Add `--add-dll-search-path` to all subparsers.
2. Game version auto-detection often fails on Windows when the game is installed from MS Store, due to the special file permissions. Users normally know their installed game versions so I added some options to let them specify the version directly.

It would be nice if we can list all supported game editions / expansions but right now I haven't added this.