### PR TITLE
Re-implemented how PYTHON_MIN_VERSION_HEX is computed

### DIFF
--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -48,9 +48,9 @@ endif()
 # use cmake's FindPython3 to locate library and interpreter
 find_package(Python3 ${PYTHON_MIN_VERSION} ${need_exact_version} COMPONENTS Interpreter Development NumPy)
 
-
 # python version string to cpython api test in modules/FindPython_test.cpp
-set(PYTHON_MIN_VERSION_HEX "0x0${Python3_VERSION_MAJOR}0${Python3_VERSION_MINOR}0000")
+math(EXPR BIT_SHIFT_HEX "${Python3_VERSION_MAJOR} << 24 | ${Python3_VERSION_MINOR} << 16" OUTPUT_FORMAT HEXADECIMAL)
+set(PYTHON_MIN_VERSION_HEX "${BIT_SHIFT_HEX}")
 
 # there's a static_assert that tests the Python version.
 # that way, we verify the interpreter and the library version.

--- a/copying.md
+++ b/copying.md
@@ -139,6 +139,7 @@ _the openage authors_ are:
 | Jens Nyman                  | nymanjens                   | nymanjens dawt nj à gmail dawt com                |
 | Deepak Dinesh               | deepak                      | d.deepakdinesh13 à gmail dawt com                 |
 | Damien Lejay                | dlejay                      | lejay à paracompact dawt space                    |
+| Talha Aamir                | sarcxd                      | sarcxd à gmail dawt com                    |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
* Removed old implementation
* Using Cmake Math function
* Bit shifting python versions to create PYTHON_MIN_VERSION_HEX  

This PR Fixes #1438