### PR TITLE
Python type hints

### DIFF
--- a/.github/workflows/windows-server-2019.yml
+++ b/.github/workflows/windows-server-2019.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies [Python]
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade Cython wheel numpy lz4 toml pillow pygments Jinja2
+        python -m pip install --upgrade Cython wheel numpy lz4 toml pillow pygments pyreadline3 Jinja2
       shell: pwsh
     - name: Build
       run: |

--- a/.github/workflows/windows-server-2022.yml
+++ b/.github/workflows/windows-server-2022.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies [Python]
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade Cython wheel numpy lz4 toml pillow pygments Jinja2
+        python -m pip install --upgrade Cython wheel numpy lz4 toml pillow pygments pyreadline3 Jinja2
       shell: pwsh
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Python and Cython requirements
-set(PYTHON_MIN_VERSION 3.6)
+set(PYTHON_MIN_VERSION 3.9)
 set(CYTHON_MIN_VERSION 0.25)
 
 # CMake policies

--- a/buildsystem/scripts/EmbedPython.cmake
+++ b/buildsystem/scripts/EmbedPython.cmake
@@ -25,6 +25,6 @@ execute_process(COMMAND
 
 execute_process(COMMAND
 	"${PYTHON}" "${buildsystem_dir}/scripts/copy_modules.py"
-	numpy PIL readline
+	numpy PIL pyreadline3 readline
 	"${CMAKE_INSTALL_PREFIX}/${py_install_prefix}"
 )

--- a/doc/build_instructions/fedora.md
+++ b/doc/build_instructions/fedora.md
@@ -1,4 +1,4 @@
-# Prerequisite steps for Fedora users (Fedora >= 33)
+# Prerequisite steps for Fedora users (Fedora >= 34)
 
 Run the following command:
 

--- a/doc/build_instructions/opensuse.md
+++ b/doc/build_instructions/opensuse.md
@@ -1,5 +1,13 @@
 # Prerequisite steps for openSUSE users (openSUSE Tumbleweed)
 
- - `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel python3-Cython python3-Jinja2 python3-lz4 python3-Pillow python3-Pygments python3-toml python3-devel`
+- `zypper install --no-recommends cmake doxygen eigen3-devel fontconfig-devel gcc-c graphviz++ harfbuzz-devel libSDL2-devel libSDL2_image-devel libepoxy-devel libfreetype6 libogg-devel libopus-devel libpng-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols opusfile-devel python3-Cython python3-Jinja2 python3-lz4 python3-Pillow python3-Pygments python3-toml python3-devel`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.
+
+# Troubleshooting
+
+## CMake Warning: We need a Python interpreter >= 3.9 that is shipped with libpython and header files
+
+Tumbleweed's default Python packages may not contain Python version 3.9. To upgrade to Python 3.9, install the `python39` package and corresponding modules with the following command:
+
+- `zypper install python39 python39-Cython python39-Jinja2 python39-lz4 python39-Pillow python39-Pygments python39-toml python39-devel`

--- a/doc/build_instructions/ubuntu.md
+++ b/doc/build_instructions/ubuntu.md
@@ -1,8 +1,20 @@
 # Prerequisite steps for Ubuntu users
 
-You need at least Ubuntu 20.04 for `gcc >= 10`.
+You need at least Ubuntu 20.04 for `gcc >= 10` and Python 3.9.
+
+## Ubuntu >=21.04
 
  - `sudo apt-get update`
  - `sudo apt-get install g++-10 cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3-dev python3-jinja2 python3-numpy python3-lz4 python3-pil python3-pip python3-pygments python3-toml qml-module-qtquick-controls qtdeclarative5-dev`
+
+You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.
+
+
+## Ubuntu 20.04 LTS
+
+On Ubuntu 20.04 you need to install Python 3.9 manually as the default version provided is too old.
+
+ - `sudo apt-get update`
+ - `sudo apt-get install g++-10 cmake cython3 libeigen3-dev libepoxy-dev libfontconfig1-dev libfreetype6-dev libharfbuzz-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsdl2-image-dev python3.9 python3.9-dev python3.9-jinja2 python3.9-numpy python3.9-lz4 python3.9-pil python3.9-pip python3.9-pygments python3.9-toml qml-module-qtquick-controls qtdeclarative5-dev`
 
 You will also need [nyan](https://github.com/SFTtech/nyan/blob/master/doc/building.md) and its dependencies.

--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -34,7 +34,7 @@ __NOTE:__ You need to manually make sure and doublecheck if the system you are b
 ### Python Modules
  Open a command prompt at `<Python 3 installation directory>/Scripts`
 
-    pip install cython numpy lz4 toml pillow pygments Jinja2
+    pip install cython numpy lz4 toml pillow pygments pyreadline3 Jinja2
 
 _Note:_ Make sure the Python 3 instance you're installing these scripts for is the one you call `python` in CMD
 _Note:_ Also ensure that `python` and `python3` both point to the correct and the same version of Python 3

--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -29,8 +29,6 @@ __NOTE:__ You need to manually make sure and doublecheck if the system you are b
    - If in doubt, run the installer again and choose "Modify".
    - You are going to need the 64-bit version of python if you are planning to build the 64-bit version of openage, and vice versa.
 
-    __Note:__ You need to install Python 3.7.x currently, because 3.8 deals with finding DLLs differently (see [#1201](https://github.com/SFTtech/openage/issues/1201)) which would result in errors down the line
-
  - [CMake](https://cmake.org/download/)
 
 ### Python Modules
@@ -87,10 +85,6 @@ _Note:_ If you want to download and build Nyan automatically add `-DDOWNLOAD_NYA
     - `nyan.dll` (The location depends on the procedure chosen to get nyan.)
     - DLLs from vcpkg-installed dependencies. Normally, these DLLs should be copied to `<openage directory>\build\libopenage\<config built>` during the build process. If they are not, you can find them in `<vcpkg directory>\installed\<relevant config>\bin`.
       - If prebuilt QT5 was installed, the original location of QT5 DLLs is `<QT5 directory>\bin`.
-
-    You need to ensure Python can locate these DLL files.
-    Up to Python 3.7, this can be done by adding the paths into the global system variables `PATH` (not the user-specific `PATH`).
-    For Python 3.8+, you should use the `--add-dll-search-path` option when running the `openage` module.
 
   - Now, to run the openage:
     - Open a CMD window in `<openage directory>\build\` and run `python -m openage game`

--- a/doc/building.md
+++ b/doc/building.md
@@ -28,7 +28,7 @@ Dependencies are needed for:
 Dependency list:
 
     C     gcc >=10 or clang >=10
-    CRA   python >=3.6
+    CRA   python >=3.9
     C     cython >=0.25
     C     cmake >=3.16
       A   numpy

--- a/openage/assets.py
+++ b/openage/assets.py
@@ -1,9 +1,12 @@
-# Copyright 2014-2017 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Code for locating the game assets.
 """
+from __future__ import annotations
 
+
+import typing
 import os
 from pathlib import Path
 
@@ -14,8 +17,11 @@ from .util.fslike.wrapper import WriteBlocker
 from . import config
 from . import default_dirs
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.directory import Directory
 
-def get_asset_path(custom_asset_dir=None):
+
+def get_asset_path(custom_asset_dir: str = None) -> Directory:
     """
     Returns a Path object for the game assets.
 

--- a/openage/cabextract/lzxdstream.py
+++ b/openage/cabextract/lzxdstream.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Wraps the LZXDecompressor in a file-like, read-only stream object.
@@ -6,6 +6,7 @@ Wraps the LZXDecompressor in a file-like, read-only stream object.
 
 import os
 from io import UnsupportedOperation
+from typing import NoReturn
 
 from ..util.filelike.readonly import ReadOnlyFileLikeObject
 from ..util.bytequeue import ByteQueue
@@ -51,7 +52,7 @@ class LZXDStream(ReadOnlyFileLikeObject):
 
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         """
         Resets the decompressor back to the start of the file.
         """
@@ -64,7 +65,7 @@ class LZXDStream(ReadOnlyFileLikeObject):
         self.pos = 0
         self.buf = ByteQueue()
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         if size < 0:
             size = INF
 
@@ -78,22 +79,22 @@ class LZXDStream(ReadOnlyFileLikeObject):
 
         return self.buf.popleft(size)
 
-    def get_size(self):
+    def get_size(self) -> int:
         del self  # unused
         # size is unknown in advance
         return -1
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset: int, whence=os.SEEK_SET) -> NoReturn:
         del offset, whence  # unused
         raise UnsupportedOperation("Cannot seek in LZXDStream.")
 
-    def seekable(self):
+    def seekable(self) -> bool:
         return False
 
-    def tell(self):
+    def tell(self) -> int:
         return self.pos
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         del self.decompressor
         del self.sourcestream

--- a/openage/cabextract/test.py
+++ b/openage/cabextract/test.py
@@ -1,7 +1,9 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 """
 Downloads the SFT test cab archive and uses it to test the cabextract code.
 """
+from __future__ import annotations
+import typing
 
 import os
 from tempfile import gettempdir
@@ -9,6 +11,9 @@ from hashlib import md5
 from urllib.request import urlopen
 
 from .cab import CABFile
+
+if typing.TYPE_CHECKING:
+    from io import BufferedReader
 
 # the test archive file has been generated using ./gen_test_arc.sh
 
@@ -41,7 +46,7 @@ def open_cached_test_archive():
     return open(TEST_ARCHIVE_FILENAME, 'rb')
 
 
-def open_test_archive():
+def open_test_archive() -> BufferedReader:
     """
     Opens the cached test archive file, or downloads it if necessary.
     """

--- a/openage/codegen/codegen.py
+++ b/openage/codegen/codegen.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Utility and driver module for C++ code generation.
@@ -11,6 +11,7 @@ from itertools import chain
 import os
 from sys import modules
 import sys
+from typing import Generator
 
 from ..log import err
 from ..util.filelike.fifo import FIFO
@@ -43,10 +44,10 @@ class WriteCatcher(FIFO):
     and read() fails if eof is not set.
     """
 
-    def close(self):
+    def close(self) -> None:
         self.eof = True
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         if not self.eof:
             raise UnsupportedOperation(
                 "can not read from WriteCatcher while not closed for writing")
@@ -80,7 +81,7 @@ class CodegenDirWrapper(Wrapper):
         self.writes.append((parts, intercept_obj))
         return intercept_obj
 
-    def get_reads(self):
+    def get_reads(self) -> None:
         """
         Returns an iterable of all path component tuples for files that have
         been read.
@@ -90,7 +91,7 @@ class CodegenDirWrapper(Wrapper):
 
         self.reads.clear()
 
-    def get_writes(self):
+    def get_writes(self) -> None:
         """
         Returns an iterable of all (path components, data_written) tuples for
         files that have been written.
@@ -104,7 +105,7 @@ class CodegenDirWrapper(Wrapper):
         return f"CodegenDirWrapper({repr(self.obj)})"
 
 
-def codegen(mode, input_dir, output_dir):
+def codegen(mode: CodegenMode, input_dir: str, output_dir: str) -> tuple[list[str], list[str]]:
     """
     Calls .listing.generate_all(), and post-processes the generated
     data, checking them and adding a header.
@@ -190,7 +191,7 @@ def depend_module_blacklist():
         pass
 
 
-def get_codegen_depends(outputwrapper):
+def get_codegen_depends(outputwrapper: CodegenDirWrapper) -> Generator[str, None, None]:
     """
     Yields all codegen dependencies.
 
@@ -238,7 +239,7 @@ def get_codegen_depends(outputwrapper):
         yield filename
 
 
-def get_header_lines():
+def get_header_lines() -> Generator[str, None, None]:
     """
     Yields the lines for the automatically-added file header.
     """
@@ -254,7 +255,7 @@ def get_header_lines():
     yield ""
 
 
-def postprocess_write(parts, data):
+def postprocess_write(parts, data: str) -> str:
     """
     Post-processes a single write operation, as intercepted during codegen.
     """

--- a/openage/codegen/main.py
+++ b/openage/codegen/main.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Codegen interface to the build system.
@@ -47,13 +47,19 @@ depending on the specified invocation commands,
 - cmake re-builds are triggered if a cache has changed
 """
 
+from __future__ import annotations
+import typing
+
 import os
 import sys
 
 from .codegen import CodegenMode, codegen
 
+if typing.TYPE_CHECKING:
+    from argparse import ArgumentParser
 
-def init_subparser(cli):
+
+def init_subparser(cli: ArgumentParser):
     """ Codegen-specific CLI. """
     cli.set_defaults(entrypoint=main)
 

--- a/openage/convert/entity_object/conversion/aoc/genie_civ.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_civ.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for civilization from AoC.
@@ -12,7 +12,8 @@ from .genie_tech import CivTeamBonus, CivTechTree
 
 if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.entity_object.conversion.aoc.genie_tech import CivBonus, GenieTechObject
     from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
     from openage.convert.value_object.read.value_members import ValueMember

--- a/openage/convert/entity_object/conversion/aoc/genie_connection.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_connection.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for connections from AoC.
@@ -11,7 +11,8 @@ import typing
 from ..converter_object import ConverterObject
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.value_object.read.value_members import ValueMember
 
 

--- a/openage/convert/entity_object/conversion/aoc/genie_connection.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_connection.py
@@ -4,8 +4,15 @@
 Contains structures and API-like objects for connections from AoC.
 """
 
+from __future__ import annotations
+import typing
+
 
 from ..converter_object import ConverterObject
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieAgeConnection(ConverterObject):
@@ -15,7 +22,12 @@ class GenieAgeConnection(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, age_id, full_data_set, members=None):
+    def __init__(
+        self,
+        age_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie age connection.
 
@@ -41,7 +53,12 @@ class GenieBuildingConnection(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, building_id, full_data_set, members=None):
+    def __init__(
+        self,
+        building_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie building connection.
 
@@ -67,7 +84,12 @@ class GenieTechConnection(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, tech_id, full_data_set, members=None):
+    def __init__(
+        self,
+        tech_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie tech connection.
 
@@ -93,7 +115,12 @@ class GenieUnitConnection(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, unit_id, full_data_set, members=None):
+    def __init__(
+        self,
+        unit_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie unit connection.
 

--- a/openage/convert/entity_object/conversion/aoc/genie_effect.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_effect.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for effects from AoC.
@@ -10,7 +10,8 @@ import typing
 from ..converter_object import ConverterObject
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.value_object.read.value_members import ValueMember
 
 

--- a/openage/convert/entity_object/conversion/aoc/genie_effect.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_effect.py
@@ -4,7 +4,14 @@
 Contains structures and API-like objects for effects from AoC.
 """
 
+from __future__ import annotations
+import typing
+
 from ..converter_object import ConverterObject
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieEffectObject(ConverterObject):
@@ -14,7 +21,13 @@ class GenieEffectObject(ConverterObject):
 
     __slots__ = ('bundle_id', 'data')
 
-    def __init__(self, effect_id, bundle_id, full_data_set, members=None):
+    def __init__(
+        self,
+        effect_id: int,
+        bundle_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie effect object.
 
@@ -32,7 +45,7 @@ class GenieEffectObject(ConverterObject):
         self.bundle_id = bundle_id
         self.data = full_data_set
 
-    def get_type(self):
+    def get_type(self) -> int:
         """
         Returns the effect's type.
         """
@@ -49,7 +62,13 @@ class GenieEffectBundle(ConverterObject):
 
     __slots__ = ('effects', 'sanitized', 'data')
 
-    def __init__(self, bundle_id, effects, full_data_set, members=None):
+    def __init__(
+        self,
+        bundle_id: int,
+        effects: list[GenieEffectObject],
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie effect bundle.
 
@@ -70,11 +89,11 @@ class GenieEffectBundle(ConverterObject):
         #     - effects that do nothing
         #     - effects without a type        #
         # Processors should set this to True, once the bundle is sanitized.
-        self.sanitized = False
+        self.sanitized: bool = False
 
         self.data = full_data_set
 
-    def get_effects(self, effect_type=None):
+    def get_effects(self, effect_type: int = None) -> list[GenieEffectObject]:
         """
         Returns the effects in the bundle, optionally only effects with a specific
         type.
@@ -94,7 +113,7 @@ class GenieEffectBundle(ConverterObject):
 
         return list(self.effects.values())
 
-    def is_sanitized(self):
+    def is_sanitized(self) -> bool:
         """
         Returns whether the effect bundle has been sanitized.
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_graphic.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_graphic.py
@@ -3,8 +3,14 @@
 """
 Contains structures and API-like objects for graphics from AoC.
 """
+from __future__ import annotations
+import typing
 
 from ..converter_object import ConverterObject
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieGraphic(ConverterObject):
@@ -14,7 +20,12 @@ class GenieGraphic(ConverterObject):
 
     __slots__ = ('exists', 'subgraphics', '_refs', 'data')
 
-    def __init__(self, graphic_id, full_data_set, members=None):
+    def __init__(
+        self,
+        graphic_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie graphic object.
 
@@ -36,18 +47,18 @@ class GenieGraphic(ConverterObject):
         self.exists = True
 
         # Direct subgraphics (deltas) of this graphic
-        self.subgraphics = []
+        self.subgraphics: list[GenieGraphic] = []
 
         # Other graphics that have this graphic as a subgraphic (delta)
-        self._refs = []
+        self._refs: list[GenieGraphic] = []
 
-    def add_reference(self, referer):
+    def add_reference(self, referer: GenieGraphic) -> None:
         """
         Add another graphic that is referencing this sprite.
         """
         self._refs.append(referer)
 
-    def detect_subgraphics(self):
+    def detect_subgraphics(self) -> None:
         """
         Add references for the direct subgraphics to this object.
         """
@@ -65,27 +76,27 @@ class GenieGraphic(ConverterObject):
             self.subgraphics.append(graphic)
             graphic.add_reference(self)
 
-    def get_animation_length(self):
+    def get_animation_length(self) -> float:
         """
         Returns the time taken to display all frames in this graphic.
         """
         head_graphic = self.data.genie_graphics[self.get_id()]
         return head_graphic["frame_rate"].get_value() * head_graphic["frame_count"].get_value()
 
-    def get_subgraphics(self):
+    def get_subgraphics(self) -> list[GenieGraphic]:
         """
         Return the subgraphics of this graphic
         """
         return self.subgraphics
 
-    def get_frame_rate(self):
+    def get_frame_rate(self) -> float:
         """
         Returns the time taken to display a single frame in this graphic.
         """
         head_graphic = self.data.genie_graphics[self.get_id()]
         return head_graphic["frame_rate"].get_value()
 
-    def is_shared(self):
+    def is_shared(self) -> bool:
         """
         Return True if the number of references to this graphic is >1.
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_graphic.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_graphic.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for graphics from AoC.
@@ -9,7 +9,8 @@ import typing
 from ..converter_object import ConverterObject
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.value_object.read.value_members import ValueMember
 
 

--- a/openage/convert/entity_object/conversion/aoc/genie_object_container.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_object_container.py
@@ -5,8 +5,35 @@
 """
 Object for comparing and passing around data from a dataset.
 """
+from __future__ import annotations
+import typing
 
 from ..converter_object import ConverterObjectContainer
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.nyan.nyan_structs import NyanObject
+    from openage.convert.entity_object.conversion.combined_sound import CombinedSound
+    from openage.convert.entity_object.conversion.combined_sprite import CombinedSprite
+    from openage.convert.entity_object.conversion.combined_terrain import CombinedTerrain
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationObject,\
+        GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_connection import GenieAgeConnection,\
+        GenieBuildingConnection, GenieTechConnection, GenieUnitConnection
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectBundle
+    from openage.convert.entity_object.conversion.aoc.genie_graphic import GenieGraphic
+    from openage.convert.entity_object.conversion.aoc.genie_sound import GenieSound
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechObject,\
+        AgeUpgrade, BuildingLineUpgrade, BuildingUnlock, CivBonus, GenieTechEffectBundleGroup,\
+        InitiatedTech, StatUpgrade, UnitLineUpgrade, UnitUnlock
+    from openage.convert.entity_object.conversion.aoc.genie_terrain import GenieTerrainObject,\
+        GenieTerrainGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitObject,\
+        GenieAmbientGroup, GenieBuildingLineGroup, GenieMonkGroup, GenieUnitLineGroup,\
+        GenieUnitTaskGroup, GenieUnitTransformGroup, GenieVariantGroup, GenieVillagerGroup,\
+        GenieGameEntityGroup
+    from openage.convert.entity_object.export.media_export_request import MediaExportRequest
+    from openage.convert.entity_object.export.metadata_export import MetadataExport
 
 
 class GenieObjectContainer(ConverterObjectContainer):
@@ -18,76 +45,78 @@ class GenieObjectContainer(ConverterObjectContainer):
     def __init__(self):
 
         # Game version
-        self.game_version = None
+        self.game_version: tuple[GameEdition, list[GameExpansion]] = None
 
         # API reference
-        self.nyan_api_objects = None
+        self.nyan_api_objects: dict[str, NyanObject] = None
 
         # Things that don't exist in the game, e.g. Attributes
         # saved as RawAPIObjects
-        self.pregen_nyan_objects = {}
+        self.pregen_nyan_objects: dict[str, NyanObject] = {}
 
         # Auxiliary
-        self.strings = None
-        self.existing_graphics = None
+        self.strings: dict[str, dict[str, str]] = None
+        self.existing_graphics: list[str] = None
 
         # Phase 1: Genie-like objects
         # ConverterObject types (the data from the game)
         # key: obj_id; value: ConverterObject instance
-        self.genie_units = {}
-        self.genie_techs = {}
-        self.genie_effect_bundles = {}
-        self.genie_civs = {}
-        self.age_connections = {}
-        self.building_connections = {}
-        self.unit_connections = {}
-        self.tech_connections = {}
-        self.genie_graphics = {}
-        self.genie_sounds = {}
-        self.genie_terrains = {}
+        self.genie_units: dict[int, GenieUnitObject] = {}
+        self.genie_techs: dict[int, GenieTechObject]  = {}
+        self.genie_effect_bundles: dict[int, GenieEffectBundle]  = {}
+        self.genie_civs: dict[int, GenieCivilizationObject]  = {}
+        self.age_connections: dict[int, GenieAgeConnection]  = {}
+        self.building_connections: dict[int, GenieBuildingConnection]  = {}
+        self.tech_connections: dict[int, GenieTechConnection]  = {}
+        self.unit_connections: dict[int, GenieUnitConnection]  = {}
+        self.genie_graphics: dict[int, GenieGraphic]  = {}
+        self.genie_sounds: dict[int, GenieSound]  = {}
+        self.genie_terrains: dict[int, GenieTerrainObject]  = {}
 
         # Phase 2: API-like objects
         # ConverterObjectGroup types (things that will become
         # nyan objects)
         # key: group_id; value: ConverterObjectGroup instance
-        self.unit_lines = {}                        # Keys are the ID of the first unit in line
-        self.unit_lines_vertical_ref = {}           # Keys are the line ID of the unit connection
-        self.building_lines = {}
-        self.task_groups = {}
-        self.transform_groups = {}
-        self.villager_groups = {}
-        self.monk_groups = {}
-        self.ambient_groups = {}
-        self.variant_groups = {}
 
-        self.civ_groups = {}
+        # Keys are the ID of the first unit in line
+        self.unit_lines: dict[int, GenieUnitLineGroup] = {}
+        # Keys are the line ID of the unit connection
+        self.unit_lines_vertical_ref: dict[int, GenieUnitLineGroup] = {}
+        self.building_lines: dict[int, GenieBuildingLineGroup] = {}
+        self.task_groups: dict[int, GenieUnitTaskGroup] = {}
+        self.transform_groups: dict[int, GenieUnitTransformGroup] = {}
+        self.villager_groups: dict[int, GenieVillagerGroup] = {}
+        self.monk_groups: dict[int, GenieMonkGroup] = {}
+        self.ambient_groups: dict[int, GenieAmbientGroup] = {}
+        self.variant_groups: dict[int, GenieVariantGroup] = {}
 
-        self.tech_groups = {}
-        self.age_upgrades = {}
-        self.unit_upgrades = {}
-        self.building_upgrades = {}
-        self.stat_upgrades = {}
-        self.unit_unlocks = {}
-        self.building_unlocks = {}
-        self.civ_boni = {}
-        self.initiated_techs = {}
-        self.node_techs = {}
+        self.civ_groups: dict[int, GenieCivilizationGroup]  = {}
 
-        self.terrain_groups = {}
+        self.tech_groups: dict[int, GenieTechEffectBundleGroup]  = {}
+        self.age_upgrades: dict[int, AgeUpgrade]  = {}
+        self.unit_upgrades: dict[int, UnitLineUpgrade]  = {}
+        self.building_upgrades: dict[int, BuildingLineUpgrade] = {}
+        self.stat_upgrades: dict[int, StatUpgrade] = {}
+        self.unit_unlocks: dict[int, UnitUnlock] = {}
+        self.building_unlocks: dict[int, BuildingUnlock] = {}
+        self.civ_boni: dict[int, CivBonus] = {}
+        self.initiated_techs: dict[int, InitiatedTech] = {}
+
+        self.terrain_groups: dict[int, GenieTerrainGroup] = {}
 
         # Stores which line a unit is part of
-        # key: unit id; value: ConverterObjectGroup
-        self.unit_ref = {}
+        self.unit_ref: dict[int, GenieGameEntityGroup] = {}
 
         # Phase 3: sprites, sounds
-        self.combined_sprites = {}          # Animation or Terrain graphics
-        self.combined_sounds = {}
-        self.combined_terrains = {}
+        # Animation or Terrain graphics
+        self.combined_sprites: dict[int, CombinedSprite] = {}
+        self.combined_sounds: dict[int, CombinedSound] = {}
+        self.combined_terrains: dict[int, CombinedTerrain] = {}
 
-        self.graphics_exports = {}
-        self.blend_exports = {}
-        self.sound_exports = {}
-        self.metadata_exports = []
+        self.graphics_exports: dict[int, MediaExportRequest] = {}
+        self.blend_exports: dict[int, MediaExportRequest] = {}
+        self.sound_exports: dict[int, MediaExportRequest] = {}
+        self.metadata_exports: list[MetadataExport] = []
 
     def __repr__(self):
         return "GenieObjectContainer"

--- a/openage/convert/entity_object/conversion/aoc/genie_object_container.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_object_container.py
@@ -35,7 +35,7 @@ if typing.TYPE_CHECKING:
         GenieGameEntityGroup
     from openage.convert.entity_object.export.media_export_request import MediaExportRequest
     from openage.convert.entity_object.export.metadata_export import MetadataExport
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
     from openage.nyan.nyan_structs import NyanObject
 
 
@@ -48,7 +48,7 @@ class GenieObjectContainer(ConverterObjectContainer):
     def __init__(self):
 
         # Game version
-        self.game_version: tuple[GameEdition, list[GameExpansion]] = None
+        self.game_version: GameVersion = None
 
         # API reference
         self.nyan_api_objects: dict[str, NyanObject] = None

--- a/openage/convert/entity_object/conversion/aoc/genie_object_container.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_object_container.py
@@ -8,14 +8,15 @@ Object for comparing and passing around data from a dataset.
 from __future__ import annotations
 import typing
 
+
 from ..converter_object import ConverterObjectContainer
 
 if typing.TYPE_CHECKING:
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
-    from openage.nyan.nyan_structs import NyanObject
+    from openage.convert.entity_object.conversion.converter_object import RawAPIObject
     from openage.convert.entity_object.conversion.combined_sound import CombinedSound
     from openage.convert.entity_object.conversion.combined_sprite import CombinedSprite
     from openage.convert.entity_object.conversion.combined_terrain import CombinedTerrain
+    from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationObject,\
         GenieCivilizationGroup
     from openage.convert.entity_object.conversion.aoc.genie_connection import GenieAgeConnection,\
@@ -34,6 +35,8 @@ if typing.TYPE_CHECKING:
         GenieGameEntityGroup
     from openage.convert.entity_object.export.media_export_request import MediaExportRequest
     from openage.convert.entity_object.export.metadata_export import MetadataExport
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.nyan.nyan_structs import NyanObject
 
 
 class GenieObjectContainer(ConverterObjectContainer):
@@ -52,10 +55,10 @@ class GenieObjectContainer(ConverterObjectContainer):
 
         # Things that don't exist in the game, e.g. Attributes
         # saved as RawAPIObjects
-        self.pregen_nyan_objects: dict[str, NyanObject] = {}
+        self.pregen_nyan_objects: dict[str, RawAPIObject] = {}
 
         # Auxiliary
-        self.strings: dict[str, dict[str, str]] = None
+        self.strings: StringResource = None
         self.existing_graphics: list[str] = None
 
         # Phase 1: Genie-like objects

--- a/openage/convert/entity_object/conversion/aoc/genie_object_container.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_object_container.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-instance-attributes,too-few-public-methods
 

--- a/openage/convert/entity_object/conversion/aoc/genie_sound.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_sound.py
@@ -3,8 +3,14 @@
 """
 Contains structures and API-like objects for sounds from AoC.
 """
+from __future__ import annotations
+import typing
 
 from ..converter_object import ConverterObject
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieSound(ConverterObject):
@@ -14,7 +20,12 @@ class GenieSound(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, sound_id, full_data_set, members=None):
+    def __init__(
+        self,
+        sound_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie sound object.
 
@@ -29,7 +40,7 @@ class GenieSound(ConverterObject):
 
         self.data = full_data_set
 
-    def get_sounds(self, civ_id=-1):
+    def get_sounds(self, civ_id: int = -1) -> list[int]:
         """
         Return sound resource ids for the associated DRS file.
 

--- a/openage/convert/entity_object/conversion/aoc/genie_sound.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_sound.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for sounds from AoC.
@@ -9,7 +9,8 @@ import typing
 from ..converter_object import ConverterObject
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.value_object.read.value_members import ValueMember
 
 

--- a/openage/convert/entity_object/conversion/aoc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_tech.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for techs from AoC.
@@ -9,9 +9,12 @@ import typing
 from ..converter_object import ConverterObject, ConverterObjectGroup
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject, GenieEffectBundle
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
-    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup, GenieBuildingLineGroup
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject,\
+        GenieEffectBundle
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
+        GenieBuildingLineGroup
     from openage.convert.value_object.read.value_members import ValueMember
 
 
@@ -487,6 +490,9 @@ class CivBonus(GenieTechEffectBundleGroup):
         self.civ_id = civ_id
 
     def get_civilization_id(self) -> int:
+        """
+        Get the ID of the civilization that receives the bonus.
+        """
         return self.civ_id
 
     def replaces_researchable_tech(self) -> typing.Union[GenieTechEffectBundleGroup, None]:

--- a/openage/convert/entity_object/conversion/aoc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_tech.py
@@ -3,9 +3,16 @@
 """
 Contains structures and API-like objects for techs from AoC.
 """
-
+from __future__ import annotations
+import typing
 
 from ..converter_object import ConverterObject, ConverterObjectGroup
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject, GenieEffectBundle
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup, GenieBuildingLineGroup
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieTechObject(ConverterObject):
@@ -19,7 +26,12 @@ class GenieTechObject(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, tech_id, full_data_set, members=None):
+    def __init__(
+        self,
+        tech_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie tech object.
 
@@ -45,7 +57,11 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
     __slots__ = ('data', 'tech', 'effects')
 
-    def __init__(self, tech_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -63,15 +79,13 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         self.tech = self.data.genie_techs[tech_id]
 
         # Effects of the tech
-        effect_bundle_id = self.tech["tech_effect_id"].get_value()
+        effect_bundle_id: int = self.tech["tech_effect_id"].get_value()
 
+        self.effects: GenieEffectBundle = None
         if effect_bundle_id > -1:
             self.effects = self.data.genie_effect_bundles[effect_bundle_id]
 
-        else:
-            self.effects = None
-
-    def is_researchable(self):
+    def is_researchable(self) -> bool:
         """
         Techs are researchable if they are associated with an ingame tech.
         This is the case if the research time is greater than 0 and the research
@@ -85,7 +99,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         return research_time > 0 and research_location_id > -1
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Techs are unique if they belong to a specific civ.
 
@@ -96,7 +110,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         # -1 = no train location
         return civilization_id > -1
 
-    def get_civilization(self):
+    def get_civilization(self) -> typing.Union[int, None]:
         """
         Returns the civilization id if the tech is unique, otherwise return None.
         """
@@ -105,7 +119,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         return None
 
-    def get_effects(self, effect_type=None):
+    def get_effects(self, effect_type: int = None) -> list[GenieEffectObject]:
         """
         Returns the associated effects.
         """
@@ -114,7 +128,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         return []
 
-    def get_required_techs(self):
+    def get_required_techs(self) -> list[GenieTechObject]:
         """
         Returns the techs that are required for this tech.
         """
@@ -131,13 +145,13 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         return required_techs
 
-    def get_required_tech_count(self):
+    def get_required_tech_count(self) -> int:
         """
         Returns the number of required techs necessary to unlock this  tech.
         """
         return self.tech["required_tech_count"].get_value()
 
-    def get_research_location_id(self):
+    def get_research_location_id(self) -> int:
         """
         Returns the group_id for a building line if the tech is
         researchable, otherwise return None.
@@ -147,7 +161,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         return None
 
-    def has_effect(self):
+    def has_effect(self) -> bool:
         """
         Returns True if the techology's effects do anything.
         """
@@ -181,7 +195,12 @@ class AgeUpgrade(GenieTechEffectBundleGroup):
 
     __slots__ = ('age_id',)
 
-    def __init__(self, tech_id, age_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        age_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -208,7 +227,13 @@ class UnitLineUpgrade(GenieTechEffectBundleGroup):
 
     __slots__ = ('unit_line_id', 'upgrade_target_id')
 
-    def __init__(self, tech_id, unit_line_id, upgrade_target_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        unit_line_id: int,
+        upgrade_target_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie line upgrade object.
 
@@ -224,19 +249,19 @@ class UnitLineUpgrade(GenieTechEffectBundleGroup):
         self.unit_line_id = unit_line_id
         self.upgrade_target_id = upgrade_target_id
 
-    def get_line_id(self):
+    def get_line_id(self) -> int:
         """
         Returns the line id of the upgraded line.
         """
         return self.unit_line_id
 
-    def get_upgraded_line(self):
+    def get_upgraded_line(self) -> GenieUnitLineGroup:
         """
         Returns the line that is upgraded.
         """
         return self.data.unit_lines[self.unit_line_id]
 
-    def get_upgrade_target_id(self):
+    def get_upgrade_target_id(self) -> int:
         """
         Returns the target unit that is upgraded to.
         """
@@ -255,7 +280,13 @@ class BuildingLineUpgrade(GenieTechEffectBundleGroup):
 
     __slots__ = ('building_line_id', 'upgrade_target_id')
 
-    def __init__(self, tech_id, building_line_id, upgrade_target_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        building_line_id: int,
+        upgrade_target_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie line upgrade object.
 
@@ -271,19 +302,19 @@ class BuildingLineUpgrade(GenieTechEffectBundleGroup):
         self.building_line_id = building_line_id
         self.upgrade_target_id = upgrade_target_id
 
-    def get_line_id(self):
+    def get_line_id(self) -> int:
         """
         Returns the line id of the upgraded line.
         """
         return self.building_line_id
 
-    def get_upgraded_line(self):
+    def get_upgraded_line(self) -> GenieBuildingLineGroup:
         """
         Returns the line that is upgraded.
         """
         return self.data.building_lines[self.building_line_id]
 
-    def get_upgrade_target_id(self):
+    def get_upgrade_target_id(self) -> int:
         """
         Returns the target unit that is upgraded to.
         """
@@ -304,7 +335,12 @@ class UnitUnlock(GenieTechEffectBundleGroup):
 
     __slots__ = ('line_id',)
 
-    def __init__(self, tech_id, line_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        line_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -319,13 +355,13 @@ class UnitUnlock(GenieTechEffectBundleGroup):
 
         self.line_id = line_id
 
-    def get_line_id(self):
+    def get_line_id(self) -> int:
         """
         Returns the ID of the line that is unlocked by this tech.
         """
         return self.line_id
 
-    def get_unlocked_line(self):
+    def get_unlocked_line(self) -> GenieUnitLineGroup:
         """
         Returns the line that is unlocked by this tech.
         """
@@ -346,7 +382,12 @@ class BuildingUnlock(GenieTechEffectBundleGroup):
 
     __slots__ = ('head_unit_id',)
 
-    def __init__(self, tech_id, head_unit_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        head_unit_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -361,13 +402,13 @@ class BuildingUnlock(GenieTechEffectBundleGroup):
 
         self.head_unit_id = head_unit_id
 
-    def get_line_id(self):
+    def get_line_id(self) -> int:
         """
         Returns the ID of the line that is unlocked by this tech.
         """
         return self.head_unit_id
 
-    def get_unlocked_line(self):
+    def get_unlocked_line(self) -> GenieBuildingLineGroup:
         """
         Returns the line that is unlocked by this tech.
         """
@@ -386,7 +427,12 @@ class InitiatedTech(GenieTechEffectBundleGroup):
 
     __slots__ = ('building_id',)
 
-    def __init__(self, tech_id, building_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        building_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -401,7 +447,7 @@ class InitiatedTech(GenieTechEffectBundleGroup):
 
         self.building_id = building_id
 
-    def get_building_id(self):
+    def get_building_id(self) -> int:
         """
         Returns the ID of the building intiating this tech.
         """
@@ -420,7 +466,12 @@ class CivBonus(GenieTechEffectBundleGroup):
 
     __slots__ = ('civ_id',)
 
-    def __init__(self, tech_id, civ_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        civ_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -435,10 +486,10 @@ class CivBonus(GenieTechEffectBundleGroup):
 
         self.civ_id = civ_id
 
-    def get_civilization(self):
+    def get_civilization_id(self) -> int:
         return self.civ_id
 
-    def replaces_researchable_tech(self):
+    def replaces_researchable_tech(self) -> typing.Union[GenieTechEffectBundleGroup, None]:
         """
         Checks if this bonus replaces a researchable Tech and returns the tech group
         if thats the case. Otherwise None is returned.
@@ -466,7 +517,13 @@ class CivTeamBonus(ConverterObjectGroup):
 
     __slots__ = ('tech_id', 'data', 'civ_id', 'effects')
 
-    def __init__(self, tech_id, civ_id, effect_bundle_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        civ_id: int,
+        effect_bundle_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -483,13 +540,13 @@ class CivTeamBonus(ConverterObjectGroup):
         self.civ_id = civ_id
         self.effects = self.data.genie_effect_bundles[effect_bundle_id]
 
-    def get_civilization(self):
+    def get_civilization_id(self) -> int:
         """
         Returns ID of the civilization that has this bonus.
         """
         return self.civ_id
 
-    def get_effects(self):
+    def get_effects(self) -> list[GenieEffectObject]:
         """
         Returns the associated effects.
         """
@@ -508,7 +565,13 @@ class CivTechTree(ConverterObjectGroup):
 
     __slots__ = ('tech_id', 'data', 'civ_id', 'effects')
 
-    def __init__(self, tech_id, civ_id, effect_bundle_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        civ_id: int,
+        effect_bundle_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -524,19 +587,17 @@ class CivTechTree(ConverterObjectGroup):
         self.data = full_data_set
         self.civ_id = civ_id
 
+        self.effects: GenieEffectBundle = None
         if effect_bundle_id > -1:
             self.effects = self.data.genie_effect_bundles[effect_bundle_id]
 
-        else:
-            self.effects = None
-
-    def get_civilization(self):
+    def get_civilization_id(self):
         """
         Returns ID of the civilization that has this tech tree.
         """
         return self.civ_id
 
-    def get_effects(self):
+    def get_effects(self) -> list[GenieEffectObject]:
         """
         Returns the associated effects.
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_terrain.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_terrain.py
@@ -3,9 +3,14 @@
 """
 Contains structures and API-like objects for terrain from AoC.
 """
-
+from __future__ import annotations
+import typing
 
 from ..converter_object import ConverterObject, ConverterObjectGroup
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieTerrainObject(ConverterObject):
@@ -15,7 +20,12 @@ class GenieTerrainObject(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, terrain_id, full_data_set, members=None):
+    def __init__(
+        self,
+        terrain_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie terrain object.
 
@@ -42,7 +52,11 @@ class GenieTerrainGroup(ConverterObjectGroup):
 
     __slots__ = ('data', 'terrain')
 
-    def __init__(self, terrain_id, full_data_set):
+    def __init__(
+        self,
+        terrain_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie tech group object.
 
@@ -59,19 +73,19 @@ class GenieTerrainGroup(ConverterObjectGroup):
         # The terrain that belongs to the index
         self.terrain = self.data.genie_terrains[terrain_id]
 
-    def has_subterrain(self):
+    def has_subterrain(self) -> bool:
         """
         Checks if this terrain uses a subterrain for its graphics.
         """
         return self.terrain["terrain_replacement_id"].get_value() > -1
 
-    def get_subterrain(self):
+    def get_subterrain(self) -> GenieTerrainObject:
         """
         Return the subterrain used for the graphics.
         """
         return self.data.genie_terrains[self.terrain["terrain_replacement_id"].get_value()]
 
-    def get_terrain(self):
+    def get_terrain(self) -> GenieTerrainObject:
         """
         Return the subterrain used for the graphics.
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_terrain.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_terrain.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for terrain from AoC.
@@ -9,7 +9,8 @@ import typing
 from ..converter_object import ConverterObject, ConverterObjectGroup
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.value_object.read.value_members import ValueMember
 
 

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -5,10 +5,17 @@
 """
 Contains structures and API-like objects for game entities from AoC.
 """
+from __future__ import annotations
+import typing
 
 from enum import Enum
 
 from ..converter_object import ConverterObject, ConverterObjectGroup
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+    from openage.convert.value_object.read.value_members import ValueMember
 
 
 class GenieUnitObject(ConverterObject):
@@ -18,7 +25,12 @@ class GenieUnitObject(ConverterObject):
 
     __slots__ = ('data',)
 
-    def __init__(self, unit_id, full_data_set, members=None):
+    def __init__(
+        self,
+        unit_id: int,
+        full_data_set: GenieObjectContainer,
+        members: dict[str, ValueMember] = None
+    ):
         """
         Creates a new Genie unit object.
 
@@ -47,10 +59,22 @@ class GenieGameEntityGroup(ConverterObjectGroup):
     be patches to that GameEntity applied by Techs.
     """
 
-    __slots__ = ('data', 'line', 'line_positions', 'creates', 'researches',
-                 'garrison_entities', 'garrison_locations', 'repairable')
+    __slots__ = (
+        'data',
+        'line',
+        'line_positions',
+        'creates',
+        'researches',
+        'garrison_entities',
+        'garrison_locations',
+        'repairable'
+    )
 
-    def __init__(self, line_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie game entity line.
 
@@ -66,28 +90,28 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         self.data = full_data_set
 
         # The line is stored as an ordered list of GenieUnitObjects.
-        self.line = []
+        self.line: list[GenieUnitObject] = []
 
         # This dict stores unit ids and their repective position in the
         # unit line for quick referencing and searching
-        self.line_positions = {}
+        self.line_positions: dict[int, int] = {}
 
         # List of units/buildings that the line can create
-        self.creates = []
+        self.creates: list[GenieGameEntityGroup] = []
 
         # List of GenieTechEffectBundleGroup objects
-        self.researches = []
+        self.researches: list[GenieTechEffectBundleGroup] = []
 
         # List of units that the line can garrison
-        self.garrison_entities = []
+        self.garrison_entities: list[GenieGameEntityGroup] = []
 
         # List of units/buildings where the line can garrison
-        self.garrison_locations = []
+        self.garrison_locations: list[GenieGameEntityGroup] = []
 
         # Can be repaired by villagers
         self.repairable = False
 
-    def add_creatable(self, line):
+    def add_creatable(self, line: GenieGameEntityGroup) -> None:
         """
         Adds another line to the list of creatables.
 
@@ -96,7 +120,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if not self.contains_creatable(line.get_head_unit_id()):
             self.creates.append(line)
 
-    def add_researchable(self, tech_group):
+    def add_researchable(self, tech_group: GenieTechEffectBundleGroup) -> None:
         """
         Adds a tech group to the list of researchables.
 
@@ -105,7 +129,12 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if not self.contains_researchable(tech_group.get_id()):
             self.researches.append(tech_group)
 
-    def add_unit(self, genie_unit, position=-1, after=None):
+    def add_unit(
+        self,
+        genie_unit: GenieUnitObject,
+        position: int = -1,
+        after: GenieUnitObject = None
+    ) -> None:
         """
         Adds a unit/building to the line.
 
@@ -142,7 +171,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
             self.line_positions.update({genie_unit.get_id(): insert_index})
             self.line.insert(insert_index, genie_unit)
 
-    def contains_creatable(self, line_id):
+    def contains_creatable(self, line_id: int) -> bool:
         """
         Returns True if a line with line_id is a creatable of
         this unit.
@@ -155,13 +184,13 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return line in self.creates
 
-    def contains_entity(self, unit_id):
+    def contains_entity(self, unit_id: int) -> bool:
         """
         Returns True if a entity with unit_id is part of the line.
         """
         return unit_id in self.line_positions.keys()
 
-    def contains_researchable(self, line_id):
+    def contains_researchable(self, line_id: int) -> bool:
         """
         Returns True if a tech line with line_id is researchable
         in this building.
@@ -170,7 +199,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return tech_line in self.researches
 
-    def has_armor(self, armor_class):
+    def has_armor(self, armor_class: int) -> bool:
         """
         Checks if units in the line have a specific armor class.
 
@@ -188,7 +217,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return False
 
-    def has_attack(self, armor_class):
+    def has_attack(self, armor_class: int) -> bool:
         """
         Checks if units in the line can execute a specific command.
 
@@ -206,7 +235,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return False
 
-    def has_command(self, command_id, civ_id=-1):
+    def has_command(self, command_id: int, civ_id: int = -1) -> bool:
         """
         Checks if units in the line can execute a specific command.
 
@@ -230,7 +259,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return False
 
-    def has_projectile(self, projectile_id, civ_id=-1):
+    def has_projectile(self, projectile_id: int, civ_id: int = -1) -> bool:
         """
         Checks if units shoot a projectile with this ID.
 
@@ -252,7 +281,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return projectile_id in (projectile_id_0, projectile_id_1)
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         """
         Units/Buildings are creatable if they have a valid train location.
 
@@ -271,7 +300,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         # -1 = no train location
         return train_location_id > -1
 
-    def is_harvestable(self, civ_id=-1):
+    def is_harvestable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group holds any of the 4 main resources Food,
         Wood, Gold and Stone.
@@ -293,7 +322,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return False
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group can garrison other entities. This covers
         all of these garrisons:
@@ -334,7 +363,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return False
 
-    def is_gatherer(self, civ_id=-1):
+    def is_gatherer(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has any gather abilities.
 
@@ -345,7 +374,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         return self.has_command(5, civ_id=civ_id)
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -360,7 +389,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return head_unit["obstruction_type"].get_value() == 0
 
-    def is_projectile_shooter(self, civ_id=-1):
+    def is_projectile_shooter(self, civ_id: int = -1) -> bool:
         """
         Units/Buildings are projectile shooters if they have assigned a projectile ID.
 
@@ -387,7 +416,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         # -1 -> no projectile
         return projectile_id_0 > -1 or projectile_id_1 > -1
 
-    def is_ranged(self, civ_id=-1):
+    def is_ranged(self, civ_id: int = -1) -> bool:
         """
         Groups are ranged if their maximum range is greater than 0.
 
@@ -402,7 +431,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return head_unit["weapon_range_max"].get_value() > 0
 
-    def is_melee(self, civ_id=-1):
+    def is_melee(self, civ_id: int = -1) -> bool:
         """
         Groups are melee if they have a Combat ability and are not ranged units.
 
@@ -413,7 +442,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         return self.has_command(7, civ_id=civ_id)
 
-    def is_repairable(self):
+    def is_repairable(self) -> bool:
         """
         Only certain lines and classes are repairable.
 
@@ -421,7 +450,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         return self.repairable
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Groups are unique if they belong to a specific civ.
 
@@ -460,13 +489,13 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         # Enabling tech has no specific civ -> not unique
         return enabling_civ_id > -1
 
-    def get_class_id(self):
+    def get_class_id(self) -> int:
         """
         Return the class ID for units in the group.
         """
         return self.get_head_unit()["unit_class"].get_value()
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> GenieGarrisonMode:
         """
         Returns the mode the garrison operates in. This is used by the
         converter to determine which storage abilities the line will get.
@@ -505,26 +534,26 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         return None
 
-    def get_head_unit_id(self):
+    def get_head_unit_id(self) -> int:
         """
         Return the obj_id of the first unit in the line.
         """
         head_unit = self.get_head_unit()
         return head_unit["id0"].get_value()
 
-    def get_head_unit(self):
+    def get_head_unit(self) -> GenieUnitObject:
         """
         Return the first unit in the line.
         """
         return self.line[0]
 
-    def get_unit_position(self, unit_id):
+    def get_unit_position(self, unit_id: int) -> int:
         """
         Return the position of a unit in the line.
         """
         return self.line_positions[unit_id]
 
-    def get_train_location_id(self):
+    def get_train_location_id(self) -> typing.Union[int, None]:
         """
         Returns the group_id for building line if the unit is
         creatable, otherwise return None.
@@ -550,13 +579,13 @@ class GenieUnitLineGroup(GenieGameEntityGroup):
     be patches to that GameEntity applied by Techs.
     """
 
-    def contains_unit(self, unit_id):
+    def contains_unit(self, unit_id: int) -> bool:
         """
         Returns True if a unit with unit_id is part of the line.
         """
         return self.contains_entity(unit_id)
 
-    def get_civ_id(self):
+    def get_civ_id(self) -> typing.Union[int, None]:
         """
         Returns the enabling civ obj_id if the unit is unique,
         otherwise return None.
@@ -572,7 +601,7 @@ class GenieUnitLineGroup(GenieGameEntityGroup):
 
         return None
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         """
         Returns the enabling tech id of the unit
 
@@ -616,16 +645,20 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
 
     __slots__ = ('gatherer_ids', 'trades_with')
 
-    def __init__(self, line_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         super().__init__(line_id, full_data_set)
 
         # IDs of gatherers that drop off resources here
-        self.gatherer_ids = set()
+        self.gatherer_ids: set[int] = set()
 
         # Unit lines that this building trades with
-        self.trades_with = []
+        self.trades_with: set[GenieGameEntityGroup] = []
 
-    def add_gatherer_id(self, unit_id):
+    def add_gatherer_id(self, unit_id: int) -> None:
         """
         Adds Id of gatherers that drop off resources at this building.
 
@@ -633,7 +666,7 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
         """
         self.gatherer_ids.add(unit_id)
 
-    def add_trading_line(self, unit_line):
+    def add_trading_line(self, unit_line: GenieGameEntityGroup) -> None:
         """
         Adds a reference to a line that trades with this building.
 
@@ -641,41 +674,41 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
         """
         self.trades_with.append(unit_line)
 
-    def contains_unit(self, building_id):
+    def contains_unit(self, building_id: int) -> bool:
         """
         Returns True if a building with building_id is part of the line.
         """
         return self.contains_entity(building_id)
 
-    def has_foundation(self):
+    def has_foundation(self) -> bool:
         """
         Returns True if the building has a foundation terrain.
         """
         head_unit = self.get_head_unit()
         return head_unit["foundation_terrain_id"].get_value() > -1
 
-    def is_dropsite(self):
+    def is_dropsite(self) -> bool:
         """
         Returns True if the building accepts resources.
         """
         return len(self.gatherer_ids) > 0
 
-    def is_repairable(self):
+    def is_repairable(self) -> bool:
         return True
 
-    def is_trade_post(self):
+    def is_trade_post(self) -> bool:
         """
         Returns True if the building is traded with.
         """
         return len(self.trades_with) > 0
 
-    def get_gatherer_ids(self):
+    def get_gatherer_ids(self) -> set[int]:
         """
         Returns gatherer unit IDs that drop off resources at this building.
         """
         return self.gatherer_ids
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         """
         Returns the enabling tech id of the unit
         """
@@ -708,7 +741,12 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
 
     __slots__ = ('head', 'stack')
 
-    def __init__(self, stack_unit_id, head_building_id, full_data_set):
+    def __init__(
+        self,
+        stack_unit_id: int,
+        head_building_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie building line.
 
@@ -723,7 +761,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
         self.head = self.data.genie_units[head_building_id]
         self.stack = self.data.genie_units[stack_unit_id]
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         """
         Stack buildings are created through their head building. We have to
         lookup its values.
@@ -738,7 +776,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
 
         return True
 
-    def is_gate(self):
+    def is_gate(self) -> bool:
         """
         Checks if the building has gate properties.
 
@@ -747,31 +785,31 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
         head_unit = self.get_head_unit()
         return head_unit["obstruction_class"].get_value() == 4
 
-    def get_head_unit(self):
+    def get_head_unit(self) -> GenieUnitObject:
         """
         Return the first unit in the line.
         """
         return self.head
 
-    def get_stack_unit(self):
+    def get_stack_unit(self) -> GenieUnitObject:
         """
         Returns the unit that is stacked on this building after construction.
         """
         return self.stack
 
-    def get_head_unit_id(self):
+    def get_head_unit_id(self) -> int:
         """
         Returns the stack unit ID because that is the unit that is referenced by other entities.
         """
         return self.get_stack_unit_id()
 
-    def get_stack_unit_id(self):
+    def get_stack_unit_id(self) -> int:
         """
         Returns the stack unit ID.
         """
         return self.stack["id0"].get_value()
 
-    def get_train_location_id(self):
+    def get_train_location_id(self) -> int:
         """
         Stack buildings are creatable when their head building is creatable.
 
@@ -797,7 +835,12 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
 
     __slots__ = ('head_unit', 'transform_unit')
 
-    def __init__(self, line_id, head_unit_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        head_unit_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie transform group.
 
@@ -815,7 +858,7 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
         transform_id = self.head_unit["transform_unit_id"].get_value()
         self.transform_unit = self.data.genie_units[transform_id]
 
-    def is_projectile_shooter(self, civ_id=-1):
+    def is_projectile_shooter(self, civ_id: int = -1) -> int:
         """
         Transform groups are projectile shooters if their head or transform units
         have assigned a projectile ID.
@@ -831,25 +874,25 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
         return (projectile_id_0 > -1 or projectile_id_1 > -1
                 or projectile_id_2 > -1 or projectile_id_3 > -1)
 
-    def get_head_unit_id(self):
+    def get_head_unit_id(self) -> int:
         """
         Returns the ID of the head unit.
         """
         return self.head_unit["id0"].get_value()
 
-    def get_head_unit(self):
+    def get_head_unit(self) -> GenieUnitObject:
         """
         Returns the head unit.
         """
         return self.head_unit
 
-    def get_transform_unit_id(self):
+    def get_transform_unit_id(self) -> int:
         """
         Returns the ID of the transform unit.
         """
         return self.transform_unit["id0"].get_value()
 
-    def get_transform_unit(self):
+    def get_transform_unit(self) -> GenieUnitObject:
         """
         Returns the transform unit.
         """
@@ -871,7 +914,13 @@ class GenieMonkGroup(GenieUnitLineGroup):
 
     __slots__ = ('head_unit', 'switch_unit')
 
-    def __init__(self, line_id, head_unit_id, switch_unit_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        head_unit_id: int,
+        switch_unit_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie monk group.
 
@@ -888,13 +937,13 @@ class GenieMonkGroup(GenieUnitLineGroup):
         self.head_unit = self.data.genie_units[head_unit_id]
         self.switch_unit = self.data.genie_units[switch_unit_id]
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         return True
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id=-1) -> GenieGarrisonMode:
         return GenieGarrisonMode.MONK
 
-    def get_switch_unit(self):
+    def get_switch_unit(self) -> GenieUnitObject:
         """
         Returns the unit that is switched to when picking up something.
         """
@@ -913,28 +962,28 @@ class GenieAmbientGroup(GenieGameEntityGroup):
     Example: Trees, Gold mines, Sign
     """
 
-    def contains_unit(self, ambient_id):
+    def contains_unit(self, ambient_id: int) -> bool:
         """
         Returns True if the ambient object with ambient_id is in this group.
         """
         return self.contains_entity(ambient_id)
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_gatherer(self, civ_id=-1):
+    def is_gatherer(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_melee(self, civ_id=-1):
+    def is_melee(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_ranged(self, civ_id=-1):
+    def is_ranged(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_projectile_shooter(self, civ_id=-1):
+    def is_projectile_shooter(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -949,25 +998,25 @@ class GenieVariantGroup(GenieGameEntityGroup):
     Example: Cliffs, flowers, mountains
     """
 
-    def contains_unit(self, object_id):
+    def contains_unit(self, object_id: int) -> bool:
         """
         Returns True if a unit with unit_id is part of the group.
         """
         return self.contains_entity(object_id)
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_gatherer(self, civ_id=-1):
+    def is_gatherer(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_melee(self, civ_id=-1):
+    def is_melee(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_ranged(self, civ_id=-1):
+    def is_ranged(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -992,7 +1041,12 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
     # Female villagers have no line obj_id, so we use the combat unit
     female_line_id = 293  # female villager (with combat task)
 
-    def __init__(self, line_id, task_group_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        task_group_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie task group.
 
@@ -1007,7 +1061,12 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
 
         self.task_group_id = task_group_id
 
-    def add_unit(self, genie_unit, position=-1, after=None):
+    def add_unit(
+        self,
+        genie_unit: GenieUnitObject,
+        position: int = -1,
+        after: GenieUnitObject = None
+    ) -> None:
         # Force the idle/combat units at the beginning of the line
         if genie_unit["id0"].get_value() in (GenieUnitTaskGroup.male_line_id,
                                              GenieUnitTaskGroup.female_line_id):
@@ -1016,7 +1075,7 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
         else:
             super().add_unit(genie_unit, position, after)
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         """
         Task groups are creatable if any unit in the group is creatable.
 
@@ -1030,7 +1089,7 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
 
         return False
 
-    def get_train_location_id(self):
+    def get_train_location_id(self) -> int:
         """
         Returns the group_id for building line if the task group is
         creatable, otherwise return None.
@@ -1065,7 +1124,12 @@ class GenieVillagerGroup(GenieUnitLineGroup):
         110: "HUNT",    # Kill first, then gather
     }
 
-    def __init__(self, group_id, task_group_ids, full_data_set):
+    def __init__(
+        self,
+        group_id: int,
+        task_group_ids: list[int],
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie villager group.
 
@@ -1082,22 +1146,22 @@ class GenieVillagerGroup(GenieUnitLineGroup):
         self.data = full_data_set
 
         # Reference to the variant task groups
-        self.variants = []
+        self.variants: list[GenieUnitTaskGroup] = []
         for task_group_id in task_group_ids:
             task_group = self.data.task_groups[task_group_id]
             self.variants.append(task_group)
 
         # List of buildings that units can create
-        self.creates = []
+        self.creates: list[GenieGameEntityGroup] = []
 
-    def contains_entity(self, unit_id):
+    def contains_entity(self, unit_id: int) -> bool:
         for task_group in self.variants:
             if task_group.contains_entity(unit_id):
                 return True
 
         return False
 
-    def has_command(self, command_id, civ_id=-1):
+    def has_command(self, command_id: int, civ_id: int = -1) -> bool:
         for variant in self.variants:
             for genie_unit in variant.line:
                 commands = genie_unit["unit_commands"].get_value()
@@ -1110,7 +1174,7 @@ class GenieVillagerGroup(GenieUnitLineGroup):
 
         return False
 
-    def is_creatable(self, civ_id=-1):
+    def is_creatable(self, civ_id: int = -1) -> bool:
         """
         Villagers are creatable if any of their variant task groups are creatable.
 
@@ -1122,41 +1186,41 @@ class GenieVillagerGroup(GenieUnitLineGroup):
 
         return False
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_gatherer(self, civ_id=-1):
+    def is_gatherer(self, civ_id: int = -1) -> bool:
         return True
 
     @classmethod
-    def is_hunter(cls):
+    def is_hunter(cls) -> bool:
         """
         Returns True if the unit hunts animals.
         """
         return True
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
-    def is_projectile_shooter(self, civ_id=-1):
+    def is_projectile_shooter(self, civ_id: int = -1) -> bool:
         return False
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> bool:
         return None
 
-    def get_head_unit_id(self):
+    def get_head_unit_id(self) -> int:
         """
         For villagers, this returns the group obj_id.
         """
         return self.get_id()
 
-    def get_head_unit(self):
+    def get_head_unit(self) -> GenieUnitObject:
         """
         For villagers, this returns the group obj_id.
         """
         return self.variants[0].line[0]
 
-    def get_units_with_command(self, command_id):
+    def get_units_with_command(self, command_id: int) -> GenieUnitObject:
         """
         Returns all genie units which have the specified command.
         """
@@ -1174,7 +1238,7 @@ class GenieVillagerGroup(GenieUnitLineGroup):
 
         return matching_units
 
-    def get_train_location_id(self):
+    def get_train_location_id(self) -> int:
         """
         Returns the group_id for building line if the task group is
         creatable, otherwise return None.
@@ -1201,7 +1265,9 @@ class GenieGarrisonMode(Enum):
     # The negative integers at the start of the tupe prevent Python from creating
     # aliases for the enums.
     NATURAL       = (-1, 1, 2, 3, 5, 6)  # enter/exit/remove; rally point
-    UNIT_GARRISON = (-2, 1, 2, 5)        # enter/exit/remove; no cavalry/monks; speedboost for infantry; no rally point
+    # enter/exit/remove; no cavalry/monks; speedboost for infantry; no rally point
+    UNIT_GARRISON = (-2, 1, 2, 5)
     TRANSPORT     = (-3, 1, 2, 3, 5, 6)  # enter/exit/remove; no rally point
-    SELF_PRODUCED = (-4, 1, 2, 3, 5, 6)  # enter only with OwnStorage; exit/remove; only produced units; rally point
+    # enter only with OwnStorage; exit/remove; only produced units; rally point
+    SELF_PRODUCED = (-4, 1, 2, 3, 5, 6)
     MONK          = (-5, 4,)             # remove/collect/transfer; only relics; no rally point

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-public-methods,too-many-instance-attributes,consider-iterating-dictionary
 
@@ -13,7 +13,8 @@ from enum import Enum
 from ..converter_object import ConverterObject, ConverterObjectGroup
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
     from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
     from openage.convert.value_object.read.value_members import ValueMember
 

--- a/openage/convert/entity_object/conversion/combined_sound.py
+++ b/openage/convert/entity_object/conversion/combined_sound.py
@@ -4,6 +4,15 @@
 References a sound in the game that has to be converted.
 """
 
+from __future__ import annotations
+
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectContainer
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject
+
 
 class CombinedSound:
     """
@@ -12,7 +21,13 @@ class CombinedSound:
 
     __slots__ = ('head_sound_id', 'file_id', 'filename', 'data', 'genie_sound', '_refs')
 
-    def __init__(self, head_sound_id, file_id, filename, full_data_set):
+    def __init__(
+        self,
+        head_sound_id: int,
+        file_id: int,
+        filename: str,
+        full_data_set: ConverterObjectContainer
+    ):
         """
         Creates a new CombinedSound instance.
 
@@ -22,7 +37,7 @@ class CombinedSound:
         :type file_id: int
         :param filename: Name of the sound file.
         :type filename: str
-        :param full_data_set: GenieObjectContainer instance that
+        :param full_data_set: ConverterObjectContainer instance that
                               contains all relevant data for the conversion
                               process.
         :type full_data_set: class: ...dataformat.converter_object.ConverterObjectContainer
@@ -41,31 +56,31 @@ class CombinedSound:
         # >1 = store in 'shared' resources;
         self._refs = []
 
-    def add_reference(self, referer):
+    def add_reference(self, referer: ConverterObject) -> None:
         """
         Add an object that is referencing this sound.
         """
         self._refs.append(referer)
 
-    def get_filename(self):
+    def get_filename(self) -> str:
         """
         Returns the desired filename of the sprite.
         """
         return self.filename
 
-    def get_file_id(self):
+    def get_file_id(self) -> int:
         """
         Returns the ID of the sound file in the game folder.
         """
         return self.file_id
 
-    def get_id(self):
+    def get_id(self) -> int:
         """
         Returns the ID of the sound object in the .dat.
         """
         return self.head_sound_id
 
-    def get_relative_file_location(self):
+    def get_relative_file_location(self) -> str:
         """
         Return the sound file location relative to where the file
         is expected to be in the modpack.
@@ -78,7 +93,7 @@ class CombinedSound:
 
         return None
 
-    def resolve_sound_location(self):
+    def resolve_sound_location(self) -> str:
         """
         Returns the planned location of the sound file in the modpack.
         """
@@ -90,7 +105,7 @@ class CombinedSound:
 
         return None
 
-    def remove_reference(self, referer):
+    def remove_reference(self, referer: ConverterObject) -> None:
         """
         Remove an object that is referencing this sound.
         """

--- a/openage/convert/entity_object/conversion/combined_sound.py
+++ b/openage/convert/entity_object/conversion/combined_sound.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 References a sound in the game that has to be converted.

--- a/openage/convert/entity_object/conversion/combined_sprite.py
+++ b/openage/convert/entity_object/conversion/combined_sprite.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 References a graphic in the game that has to be converted.

--- a/openage/convert/entity_object/conversion/combined_sprite.py
+++ b/openage/convert/entity_object/conversion/combined_sprite.py
@@ -4,6 +4,16 @@
 References a graphic in the game that has to be converted.
 """
 
+from __future__ import annotations
+
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectContainer
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject
+    from openage.convert.entity_object.conversion.aoc.genie_graphic import GenieGraphic
+
 
 class CombinedSprite:
     """
@@ -14,7 +24,12 @@ class CombinedSprite:
 
     __slots__ = ('head_sprite_id', 'filename', 'data', 'metadata', '_refs')
 
-    def __init__(self, head_sprite_id, filename, full_data_set):
+    def __init__(
+        self,
+        head_sprite_id: int,
+        filename: str,
+        full_data_set: ConverterObjectContainer
+    ):
         """
         Creates a new CombinedSprite instance.
 
@@ -22,7 +37,7 @@ class CombinedSprite:
         :type head_sprite_id: int
         :param filename: Name of the sprite and definition file.
         :type filename: str
-        :param full_data_set: GenieObjectContainer instance that
+        :param full_data_set: ConverterObjectContainer instance that
                               contains all relevant data for the conversion
                               process.
         :type full_data_set: class: ...dataformat.converter_object.ConverterObjectContainer
@@ -40,25 +55,19 @@ class CombinedSprite:
         # >1 = store in 'shared' resources;
         self._refs = []
 
-    def add_reference(self, referer):
+    def add_reference(self, referer: ConverterObject) -> None:
         """
         Add an object that is referencing this sprite.
         """
         self._refs.append(referer)
 
-    def add_metadata(self, metadata):
-        """
-        Add a metadata file to the sprite.
-        """
-        self.metadata = metadata
-
-    def get_filename(self):
+    def get_filename(self) -> str:
         """
         Returns the desired filename of the sprite.
         """
         return self.filename
 
-    def get_graphics(self):
+    def get_graphics(self) -> list[GenieGraphic]:
         """
         Return all graphics referenced by this sprite.
         """
@@ -73,13 +82,13 @@ class CombinedSprite:
 
         return existing_graphics
 
-    def get_id(self):
+    def get_id(self) -> int:
         """
         Returns the head sprite ID of the sprite.
         """
         return self.head_sprite_id
 
-    def get_relative_sprite_location(self):
+    def get_relative_sprite_location(self) -> str:
         """
         Return the sprite file location relative to where the file
         is expected to be in the modpack.
@@ -92,13 +101,13 @@ class CombinedSprite:
 
         return None
 
-    def remove_reference(self, referer):
+    def remove_reference(self, referer: ConverterObject) -> None:
         """
         Remove an object that is referencing this sprite.
         """
         self._refs.remove(referer)
 
-    def resolve_graphics_location(self):
+    def resolve_graphics_location(self) -> str:
         """
         Returns the planned location in the modpack of all image files
         referenced by the sprite.
@@ -114,7 +123,7 @@ class CombinedSprite:
 
         return location_dict
 
-    def resolve_sprite_location(self):
+    def resolve_sprite_location(self) -> str:
         """
         Returns the planned location of the definition file in the modpack.
         """

--- a/openage/convert/entity_object/conversion/combined_terrain.py
+++ b/openage/convert/entity_object/conversion/combined_terrain.py
@@ -4,6 +4,16 @@
 References a graphic in the game that has to be converted.
 """
 
+from __future__ import annotations
+
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectContainer
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject
+    from openage.convert.entity_object.conversion.aoc.genie_terrain import GenieTerrainObject
+
 
 class CombinedTerrain:
     """
@@ -14,7 +24,12 @@ class CombinedTerrain:
 
     __slots__ = ('terrain_id', 'filename', 'data', 'metadata', '_refs')
 
-    def __init__(self, terrain_id, filename, full_data_set):
+    def __init__(
+        self,
+        terrain_id: int,
+        filename: str,
+        full_data_set: ConverterObjectContainer
+    ):
         """
         Creates a new CombinedTerrain instance.
 
@@ -39,37 +54,31 @@ class CombinedTerrain:
         # >=1 = store with first occuring Terrain;
         self._refs = []
 
-    def add_reference(self, referer):
+    def add_reference(self, referer: ConverterObject) -> None:
         """
         Add an object that is referencing this terrain.
         """
         self._refs.append(referer)
 
-    def add_metadata(self, metadata):
-        """
-        Add a metadata file to the terrain.
-        """
-        self.metadata = metadata
-
-    def get_filename(self):
+    def get_filename(self) -> str:
         """
         Returns the destination filename of the terrain.
         """
         return self.filename
 
-    def get_terrain(self):
+    def get_terrain(self) -> GenieTerrainObject:
         """
         Returns the terrain referenced by this terrain sprite.
         """
         return self.data.genie_terrains[self.terrain_id]
 
-    def get_id(self):
+    def get_id(self) -> int:
         """
         Returns the terrain id of the terrain.
         """
         return self.terrain_id
 
-    def get_relative_terrain_location(self):
+    def get_relative_terrain_location(self) -> str:
         """
         Return the terrain file location relative to where the file
         is expected to be in the modpack.
@@ -79,20 +88,20 @@ class CombinedTerrain:
 
         return None
 
-    def remove_reference(self, referer):
+    def remove_reference(self, referer: ConverterObject) -> None:
         """
         Remove an object that is referencing this sprite.
         """
         self._refs.remove(referer)
 
-    def resolve_graphics_location(self):
+    def resolve_graphics_location(self) -> str:
         """
         Returns the planned location in the modpack of the image file
         referenced by the terrain file.
         """
         return self.resolve_terrain_location()
 
-    def resolve_terrain_location(self):
+    def resolve_terrain_location(self) -> str:
         """
         Returns the planned location of the definition file in the modpack.
         """

--- a/openage/convert/entity_object/conversion/combined_terrain.py
+++ b/openage/convert/entity_object/conversion/combined_terrain.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 References a graphic in the game that has to be converted.

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 # pylint: disable=too-many-instance-attributes,too-many-branches,too-few-public-methods
 

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -3,6 +3,7 @@
 # TODO pylint: disable=C,R
 
 from __future__ import annotations
+import typing
 
 import math
 import re
@@ -17,6 +18,9 @@ from ...value_object.read.read_members import (IncludeMembers, ContinueReadMembe
 from ...value_object.read.value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
     StringMember, BooleanMember, IDMember, BitfieldMember, ValueMember
 from ...value_object.read.value_members import MemberTypes as StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class GenieStructure:
@@ -64,7 +68,7 @@ class GenieStructure:
         self,
         raw: bytes,
         offset: int,
-        game_version: tuple,
+        game_version: GameVersion,
         cls: GenieStructure = None,
         members: tuple = None
     ) -> tuple[int, list[ValueMember]]:
@@ -515,7 +519,7 @@ class GenieStructure:
     @classmethod
     def get_data_format(
         cls,
-        game_version: tuple,
+        game_version: GameVersion,
         allowed_modes: tuple[MemberAccess] = None,
         flatten_includes: bool = False,
         is_parent: bool = False
@@ -556,7 +560,7 @@ class GenieStructure:
             yield member_entry
 
     @classmethod
-    def get_data_format_members(cls, game_version: tuple):
+    def get_data_format_members(cls, game_version: GameVersion):
         """
         Return the members in this struct.
 

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -17,7 +17,7 @@ from ...value_object.read.read_members import (IncludeMembers, ContinueReadMembe
                                                EnumLookupMember)
 from ...value_object.read.value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
     StringMember, BooleanMember, IDMember, BitfieldMember, ValueMember
-from ...value_object.read.value_members import MemberTypes as StorageType
+from ...value_object.read.value_members import StorageType
 
 if typing.TYPE_CHECKING:
     from openage.convert.value_object.init.game_version import GameVersion
@@ -504,7 +504,7 @@ class GenieStructure:
                     if is_custom_member:
                         result = var_type.entry_hook(result)
 
-                        if result == ContinueReadMember.Result.ABORT:
+                        if result == ContinueReadMember.result.ABORT:
                             # don't go through all other members of this class!
                             stop_reading_members = True
 
@@ -560,7 +560,10 @@ class GenieStructure:
             yield member_entry
 
     @classmethod
-    def get_data_format_members(cls, game_version: GameVersion):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
 
@@ -573,7 +576,7 @@ class GenieStructure:
         var_name: The stored name of the extracted variable.
                   Must be unique for each ConverterObject
         storage_type: ValueMember type for storage
-                      (see value_members.MemberTypes)
+                      (see value_members.StorageType)
         read_type: ReadMember type for reading the values from bytes
                    (see read_members.py)
         ===========================================================

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -2,18 +2,20 @@
 
 # TODO pylint: disable=C,R
 
+from __future__ import annotations
+
 import math
 import re
 import struct
 
 from ....util.strings import decode_until_null
-from ...value_object.read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP
+from ...value_object.read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP, MemberAccess
 from ...value_object.read.read_members import (IncludeMembers, ContinueReadMember,
                                                MultisubtypeMember, GroupMember, SubdataMember,
                                                ReadMember,
                                                EnumLookupMember)
 from ...value_object.read.value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
-    StringMember, BooleanMember, IDMember, BitfieldMember
+    StringMember, BooleanMember, IDMember, BitfieldMember, ValueMember
 from ...value_object.read.value_members import MemberTypes as StorageType
 
 
@@ -58,7 +60,14 @@ class GenieStructure:
         # store passed arguments as members
         self.__dict__.update(args)
 
-    def read(self, raw, offset, game_version, cls=None, members=None):
+    def read(
+        self,
+        raw: bytes,
+        offset: int,
+        game_version: tuple,
+        cls: GenieStructure = None,
+        members: tuple = None
+    ) -> tuple[int, list[ValueMember]]:
         """
         recursively read defined binary data from raw at given offset.
 
@@ -504,8 +513,13 @@ class GenieStructure:
         return offset, generated_value_members
 
     @classmethod
-    def get_data_format(cls, game_version, allowed_modes=False,
-                        flatten_includes=False, is_parent=False):
+    def get_data_format(
+        cls,
+        game_version: tuple,
+        allowed_modes: tuple[MemberAccess] = None,
+        flatten_includes: bool = False,
+        is_parent: bool = False
+    ):
         """
         return all members of this exportable (a struct.)
 
@@ -542,7 +556,7 @@ class GenieStructure:
             yield member_entry
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(cls, game_version: tuple):
         """
         Return the members in this struct.
 

--- a/openage/convert/entity_object/conversion/modpack.py
+++ b/openage/convert/entity_object/conversion/modpack.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Defines a modpack that can be exported.

--- a/openage/convert/entity_object/conversion/modpack.py
+++ b/openage/convert/entity_object/conversion/modpack.py
@@ -4,6 +4,8 @@
 Defines a modpack that can be exported.
 """
 
+from __future__ import annotations
+
 from ..export.data_definition import DataDefinition
 from ..export.formats.modpack_info import ModpackInfo
 from ..export.formats.modpack_manifest import ManifestFile
@@ -16,7 +18,7 @@ class Modpack:
     A collection of data and media files.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str):
 
         self.name = name
 
@@ -27,11 +29,11 @@ class Modpack:
         self.manifest = ManifestFile("", "manifest.toml")
 
         # Data/media export
-        self.data_export_files = []
-        self.media_export_files = {}
-        self.metadata_files = []
+        self.data_export_files: list[DataDefinition] = []
+        self.media_export_files: list[MediaExportRequest] = {}
+        self.metadata_files: list[MetadataExport] = []
 
-    def add_data_export(self, export_file):
+    def add_data_export(self, export_file: DataDefinition) -> None:
         """
         Add a data file to the modpack for exporting.
         """
@@ -41,7 +43,7 @@ class Modpack:
 
         self.data_export_files.append(export_file)
 
-    def add_media_export(self, export_request):
+    def add_media_export(self, export_request: MediaExportRequest) -> None:
         """
         Add a media export request to the modpack.
         """
@@ -55,7 +57,7 @@ class Modpack:
         else:
             self.media_export_files[export_request.get_type()] = [export_request]
 
-    def add_metadata_export(self, export_file):
+    def add_metadata_export(self, export_file: MetadataExport) -> None:
         """
         Add a metadata file to the modpack for exporting.
         """
@@ -65,25 +67,25 @@ class Modpack:
 
         self.metadata_files.append(export_file)
 
-    def get_info(self):
+    def get_info(self) -> ModpackInfo:
         """
         Return the modpack definition file.
         """
         return self.info
 
-    def get_data_files(self):
+    def get_data_files(self) -> list[DataDefinition]:
         """
         Returns the data files for exporting.
         """
         return self.data_export_files
 
-    def get_media_files(self):
+    def get_media_files(self) -> list[MediaExportRequest]:
         """
         Returns the media requests for exporting.
         """
         return self.media_export_files
 
-    def get_metadata_files(self):
+    def get_metadata_files(self) -> list[MetadataExport]:
         """
         Returns the metadata exports.
         """

--- a/openage/convert/entity_object/conversion/ror/genie_sound.py
+++ b/openage/convert/entity_object/conversion/ror/genie_sound.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for sounds from RoR.

--- a/openage/convert/entity_object/conversion/ror/genie_sound.py
+++ b/openage/convert/entity_object/conversion/ror/genie_sound.py
@@ -5,6 +5,8 @@ Contains structures and API-like objects for sounds from RoR.
 
 Based on the classes from the AoC converter.
 """
+from __future__ import annotations
+
 
 from ..aoc.genie_sound import GenieSound
 
@@ -15,7 +17,7 @@ class RoRSound(GenieSound):
     have all features from AoE2.
     """
 
-    def get_sounds(self, civ_id=-1):
+    def get_sounds(self, civ_id: int = -1) -> list[int]:
         """
         Does not search for the civ id because RoR does not have
         a .dat entry for that.

--- a/openage/convert/entity_object/conversion/ror/genie_tech.py
+++ b/openage/convert/entity_object/conversion/ror/genie_tech.py
@@ -5,9 +5,14 @@ Contains structures and API-like objects for techs from RoR.
 
 Based on the classes from the AoC converter.
 """
+from __future__ import annotations
+import typing
 
 from ..aoc.genie_tech import StatUpgrade, AgeUpgrade, UnitLineUpgrade,\
     BuildingLineUpgrade, UnitUnlock, BuildingUnlock
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.ror.genie_unit import RoRUnitLineGroup
 
 
 class RoRStatUpgrade(StatUpgrade):
@@ -15,7 +20,7 @@ class RoRStatUpgrade(StatUpgrade):
     Upgrades attributes of units/buildings or other stats in the game.
     """
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -27,7 +32,7 @@ class RoRAgeUpgrade(AgeUpgrade):
     Researches a new Age.
     """
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -39,10 +44,10 @@ class RoRUnitLineUpgrade(UnitLineUpgrade):
     Upgrades a unit in a line.
     """
 
-    def get_upgraded_line(self):
+    def get_upgraded_line(self) -> RoRUnitLineGroup:
         return self.data.unit_lines[self.unit_line_id]
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -54,7 +59,7 @@ class RoRBuildingLineUpgrade(BuildingLineUpgrade):
     Upgrades a building in a line.
     """
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):
@@ -66,10 +71,10 @@ class RoRUnitUnlock(UnitUnlock):
     Unlocks units.
     """
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
-    def get_unlocked_line(self):
+    def get_unlocked_line(self) -> RoRUnitLineGroup:
         """
         Returns the line that is unlocked by this tech.
         """
@@ -84,7 +89,7 @@ class RoRBuildingUnlock(BuildingUnlock):
     Unlocks buildings.
     """
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         return False
 
     def __repr__(self):

--- a/openage/convert/entity_object/conversion/ror/genie_tech.py
+++ b/openage/convert/entity_object/conversion/ror/genie_tech.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for techs from RoR.

--- a/openage/convert/entity_object/conversion/ror/genie_unit.py
+++ b/openage/convert/entity_object/conversion/ror/genie_unit.py
@@ -5,10 +5,16 @@ Contains structures and API-like objects for game entities from RoR.
 
 Based on the classes from the AoC converter.
 """
+from __future__ import annotations
+import typing
 
 from ..aoc.genie_unit import GenieUnitLineGroup, GenieBuildingLineGroup,\
-    GenieAmbientGroup, GenieVariantGroup, GenieGarrisonMode, GenieUnitTaskGroup,\
+    GenieAmbientGroup, GenieVariantGroup, GenieUnitTaskGroup,\
     GenieVillagerGroup
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGarrisonMode
 
 
 class RoRUnitLineGroup(GenieUnitLineGroup):
@@ -22,7 +28,12 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
 
     __slots__ = ('enabling_research_id',)
 
-    def __init__(self, line_id, enabling_research_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        enabling_research_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new RoR game entity line.
 
@@ -37,7 +48,7 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
         # Saved for RoR because there's no easy way to detect it with a connection
         self.enabling_research_id = enabling_research_id
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         """
         Only transport shis can garrison in RoR.
 
@@ -45,7 +56,7 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
         """
         return self.has_command(12)
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -54,7 +65,7 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
         head_unit = self.get_head_unit()
         return head_unit["unit_class"].get_value() == 10
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> typing.Union[GenieGarrisonMode, None]:
         """
         Checks only for transport boat commands.
 
@@ -66,7 +77,7 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
 
         return None
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         return self.enabling_research_id
 
     def __repr__(self):
@@ -84,7 +95,12 @@ class RoRBuildingLineGroup(GenieBuildingLineGroup):
 
     __slots__ = ('enabling_research_id',)
 
-    def __init__(self, line_id, enabling_research_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        enabling_research_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new RoR game entity line.
 
@@ -99,10 +115,10 @@ class RoRBuildingLineGroup(GenieBuildingLineGroup):
         # Saved for RoR because there's no easy way to detect it with a connection
         self.enabling_research_id = enabling_research_id
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -111,10 +127,10 @@ class RoRBuildingLineGroup(GenieBuildingLineGroup):
         head_unit = self.get_head_unit()
         return head_unit["unit_class"].get_value() == 10
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         return self.enabling_research_id
 
     def __repr__(self):
@@ -130,10 +146,10 @@ class RoRAmbientGroup(GenieAmbientGroup):
     Example: Trees, Gold mines, Sign
     """
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -142,7 +158,7 @@ class RoRAmbientGroup(GenieAmbientGroup):
         head_unit = self.get_head_unit()
         return head_unit["unit_class"].get_value() == 10
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
 
     def __repr__(self):
@@ -157,10 +173,10 @@ class RoRVariantGroup(GenieVariantGroup):
     Example: Cliffs, flowers, mountains
     """
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         return False
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -169,7 +185,7 @@ class RoRVariantGroup(GenieVariantGroup):
         head_unit = self.get_head_unit()
         return head_unit["unit_class"].get_value() == 10
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
 
     def __repr__(self):
@@ -189,7 +205,13 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
 
     __slots__ = ('enabling_research_id',)
 
-    def __init__(self, line_id, task_group_id, enabling_research_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        task_group_id: int,
+        enabling_research_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new RoR task group.
 
@@ -205,7 +227,7 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
         # Saved for RoR because there's no easy way to detect it with a connection
         self.enabling_research_id = enabling_research_id
 
-    def is_garrison(self, civ_id=-1):
+    def is_garrison(self, civ_id: int = -1) -> bool:
         """
         Only transport shis can garrison in RoR.
 
@@ -213,7 +235,7 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
         """
         return self.has_command(12)
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         """
         Checks whether the group has a passable hitbox.
 
@@ -222,7 +244,7 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
         head_unit = self.get_head_unit()
         return head_unit["unit_class"].get_value() == 10
 
-    def get_garrison_mode(self, civ_id=-1):
+    def get_garrison_mode(self, civ_id: int = -1) -> typing.Union[GenieGarrisonMode, None]:
         """
         Checks only for transport boat commands.
 
@@ -234,7 +256,7 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
 
         return None
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         return self.enabling_research_id
 
     def __repr__(self):
@@ -247,10 +269,10 @@ class RoRVillagerGroup(GenieVillagerGroup):
     configurations for RoR.
     """
 
-    def is_passable(self, civ_id=-1):
+    def is_passable(self, civ_id: int = -1) -> bool:
         return False
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         return -1
 
     def __repr__(self):

--- a/openage/convert/entity_object/conversion/ror/genie_unit.py
+++ b/openage/convert/entity_object/conversion/ror/genie_unit.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Contains structures and API-like objects for game entities from RoR.
@@ -13,7 +13,8 @@ from ..aoc.genie_unit import GenieUnitLineGroup, GenieBuildingLineGroup,\
     GenieVillagerGroup, GenieGarrisonMode
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class RoRUnitLineGroup(GenieUnitLineGroup):

--- a/openage/convert/entity_object/conversion/ror/genie_unit.py
+++ b/openage/convert/entity_object/conversion/ror/genie_unit.py
@@ -10,11 +10,10 @@ import typing
 
 from ..aoc.genie_unit import GenieUnitLineGroup, GenieBuildingLineGroup,\
     GenieAmbientGroup, GenieVariantGroup, GenieUnitTaskGroup,\
-    GenieVillagerGroup
+    GenieVillagerGroup, GenieGarrisonMode
 
 if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
-    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGarrisonMode
 
 
 class RoRUnitLineGroup(GenieUnitLineGroup):

--- a/openage/convert/entity_object/conversion/stringresource.py
+++ b/openage/convert/entity_object/conversion/stringresource.py
@@ -13,21 +13,21 @@ class StringResource(GenieStructure):
         super().__init__()
         self.strings = defaultdict(lambda: {})
 
-    def fill_from(self, stringtable):
+    def fill_from(self, stringtable: dict[str, dict[str, str]]) -> None:
         """
         stringtable is a dict {langcode: {id: string}}
         """
         for lang, langstrings in stringtable.items():
             self.strings[lang].update(langstrings)
 
-    def get_tables(self):
+    def get_tables(self) -> dict[str, dict[str, str]]:
         """
         Returns the stringtable.
         """
         return self.strings
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(cls, game_version: tuple) -> tuple:
         """
         Return the members in this struct.
         """

--- a/openage/convert/entity_object/conversion/stringresource.py
+++ b/openage/convert/entity_object/conversion/stringresource.py
@@ -2,9 +2,15 @@
 
 # TODO pylint: disable=C,too-many-function-args
 
+from __future__ import annotations
+import typing
+
 from collections import defaultdict
 
 from ...entity_object.conversion.genie_structure import GenieStructure
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class StringResource(GenieStructure):
@@ -27,7 +33,7 @@ class StringResource(GenieStructure):
         return self.strings
 
     @classmethod
-    def get_data_format_members(cls, game_version: tuple) -> tuple:
+    def get_data_format_members(cls, game_version: GameVersion) -> tuple:
         """
         Return the members in this struct.
         """

--- a/openage/convert/entity_object/conversion/stringresource.py
+++ b/openage/convert/entity_object/conversion/stringresource.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,too-many-function-args
 

--- a/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 SWGB tech objects. These extend the normal Genie techs to reflect
@@ -10,7 +10,8 @@ import typing
 from ..aoc.genie_tech import UnitUnlock, UnitLineUpgrade
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class SWGBUnitLineUpgrade(UnitLineUpgrade):

--- a/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
@@ -4,8 +4,13 @@
 SWGB tech objects. These extend the normal Genie techs to reflect
 that SWGB techs can have unique variants for every civilization.
 """
+from __future__ import annotations
+import typing
 
 from ..aoc.genie_tech import UnitUnlock, UnitLineUpgrade
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class SWGBUnitLineUpgrade(UnitLineUpgrade):
@@ -15,7 +20,13 @@ class SWGBUnitLineUpgrade(UnitLineUpgrade):
 
     __slots__ = ('civ_unlocks',)
 
-    def __init__(self, tech_id, unit_line_id, upgrade_target_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        unit_line_id: int,
+        upgrade_target_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new SWGB unit upgrade object.
 
@@ -30,9 +41,9 @@ class SWGBUnitLineUpgrade(UnitLineUpgrade):
         super().__init__(tech_id, unit_line_id, upgrade_target_id, full_data_set)
 
         # Unlocks for other civs
-        self.civ_unlocks = {}
+        self.civ_unlocks: dict[int, SWGBUnitUnlock] = {}
 
-    def add_civ_upgrade(self, other_unlock):
+    def add_civ_upgrade(self, other_unlock: SWGBUnitUnlock) -> None:
         """
         Adds a reference to an alternative unlock tech for another civ
         to this tech group.
@@ -40,7 +51,7 @@ class SWGBUnitLineUpgrade(UnitLineUpgrade):
         other_civ_id = other_unlock.tech["civilization_id"].get_value()
         self.civ_unlocks[other_civ_id] = other_unlock
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Techs are unique if they belong to a specific civ.
 
@@ -56,7 +67,12 @@ class SWGBUnitUnlock(UnitUnlock):
 
     __slots__ = ('civ_unlocks',)
 
-    def __init__(self, tech_id, line_id, full_data_set):
+    def __init__(
+        self,
+        tech_id: int,
+        line_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new SWGB unit unlock object.
 
@@ -70,9 +86,9 @@ class SWGBUnitUnlock(UnitUnlock):
         super().__init__(tech_id, line_id, full_data_set)
 
         # Unlocks for other civs
-        self.civ_unlocks = {}
+        self.civ_unlocks: dict[int, SWGBUnitUnlock] = {}
 
-    def add_civ_unlock(self, other_unlock):
+    def add_civ_unlock(self, other_unlock: SWGBUnitUnlock) -> None:
         """
         Adds a reference to an alternative unlock tech for another civ
         to this tech group.
@@ -80,7 +96,7 @@ class SWGBUnitUnlock(UnitUnlock):
         other_civ_id = other_unlock.tech["civilization_id"].get_value()
         self.civ_unlocks[other_civ_id] = other_unlock
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Techs are unique if they belong to a specific civ.
 

--- a/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Converter objects for SWGB. Reimplements the ConverterObjectGroup
@@ -11,7 +11,8 @@ from ..aoc.genie_unit import GenieUnitLineGroup, GenieUnitTransformGroup,\
     GenieMonkGroup, GenieStackBuildingGroup
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class SWGBUnitLineGroup(GenieUnitLineGroup):

--- a/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
@@ -4,9 +4,14 @@
 Converter objects for SWGB. Reimplements the ConverterObjectGroup
 instances from AoC.
 """
+from __future__ import annotations
+import typing
 
 from ..aoc.genie_unit import GenieUnitLineGroup, GenieUnitTransformGroup,\
     GenieMonkGroup, GenieStackBuildingGroup
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class SWGBUnitLineGroup(GenieUnitLineGroup):
@@ -23,7 +28,11 @@ class SWGBUnitLineGroup(GenieUnitLineGroup):
 
     __slots__ = ('civ_lines',)
 
-    def __init__(self, line_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new SWGBUnitLineGroup.
 
@@ -35,9 +44,9 @@ class SWGBUnitLineGroup(GenieUnitLineGroup):
         super().__init__(line_id, full_data_set)
 
         # References to alternative lines from other civs
-        self.civ_lines = {}
+        self.civ_lines: dict[int, SWGBUnitLineGroup] = {}
 
-    def add_civ_line(self, other_line):
+    def add_civ_line(self, other_line: SWGBUnitLineGroup) -> None:
         """
         Adds a reference to an alternative line from another civ
         to this line.
@@ -45,14 +54,14 @@ class SWGBUnitLineGroup(GenieUnitLineGroup):
         other_civ_id = other_line.get_civ_id()
         self.civ_lines[other_civ_id] = other_line
 
-    def get_civ_id(self):
+    def get_civ_id(self) -> int:
         """
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
         return head_unit["civilization_id"].get_value()
 
-    def is_civ_unique(self):
+    def is_civ_unique(self) -> bool:
         """
         Groups are civ unique if there are alternative lines for this unit line..
 
@@ -60,7 +69,7 @@ class SWGBUnitLineGroup(GenieUnitLineGroup):
         """
         return len(self.civ_lines) > 0
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Groups are unique if they belong to a specific civ.
 
@@ -83,7 +92,7 @@ class SWGBStackBuildingGroup(GenieStackBuildingGroup):
     Examples: Gate, Command Center
     """
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         """
         Returns the enabling tech id of the unit
         """
@@ -111,7 +120,12 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
 
     __slots__ = ('civ_lines',)
 
-    def __init__(self, line_id, head_unit_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        head_unit_id: int,
+        full_data_set: GenieObjectContainer
+    ):
         """
         Creates a new SWGB transform group.
 
@@ -124,9 +138,9 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         super().__init__(line_id, head_unit_id, full_data_set)
 
         # References to alternative lines from other civs
-        self.civ_lines = {}
+        self.civ_lines: dict[int, SWGBUnitTransformGroup] = {}
 
-    def add_civ_line(self, other_line):
+    def add_civ_line(self, other_line: SWGBUnitLineGroup) -> None:
         """
         Adds a reference to an alternative line from another civ
         to this line.
@@ -134,14 +148,14 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         other_civ_id = other_line.get_civ_id()
         self.civ_lines[other_civ_id] = other_line
 
-    def get_civ_id(self):
+    def get_civ_id(self) -> int:
         """
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
         return head_unit["civilization_id"].get_value()
 
-    def is_civ_unique(self):
+    def is_civ_unique(self) -> bool:
         """
         Groups are civ unique if there are alternative lines for this unit line..
 
@@ -149,7 +163,7 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         """
         return len(self.civ_lines) > 0
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Groups are unique if they belong to a specific civ.
 
@@ -158,7 +172,7 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         """
         return False
 
-    def get_enabling_research_id(self):
+    def get_enabling_research_id(self) -> int:
         """
         Returns the enabling tech id of the unit
         """
@@ -182,7 +196,13 @@ class SWGBMonkGroup(GenieMonkGroup):
 
     __slots__ = ('civ_lines',)
 
-    def __init__(self, line_id, head_unit_id, switch_unit_id, full_data_set):
+    def __init__(
+        self,
+        line_id: int,
+        head_unit_id: int,
+        switch_unit_id: int,
+        full_data_set: GenieObjectContainer,
+    ):
         """
         Creates a new Genie monk group.
 
@@ -197,9 +217,9 @@ class SWGBMonkGroup(GenieMonkGroup):
         super().__init__(line_id, head_unit_id, switch_unit_id, full_data_set)
 
         # References to alternative lines from other civs
-        self.civ_lines = {}
+        self.civ_lines: dict[int, SWGBMonkGroup] = {}
 
-    def add_civ_line(self, other_line):
+    def add_civ_line(self, other_line: SWGBMonkGroup) -> None:
         """
         Adds a reference to an alternative line from another civ
         to this line.
@@ -207,14 +227,14 @@ class SWGBMonkGroup(GenieMonkGroup):
         other_civ_id = other_line.get_civ_id()
         self.civ_lines[other_civ_id] = other_line
 
-    def get_civ_id(self):
+    def get_civ_id(self) -> int:
         """
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
         return head_unit["civilization_id"].get_value()
 
-    def is_civ_unique(self):
+    def is_civ_unique(self) -> bool:
         """
         Groups are civ unique if there are alternative lines for this unit line..
 
@@ -222,7 +242,7 @@ class SWGBMonkGroup(GenieMonkGroup):
         """
         return len(self.civ_lines) > 0
 
-    def is_unique(self):
+    def is_unique(self) -> bool:
         """
         Groups are unique if they belong to a specific civ.
 

--- a/openage/convert/entity_object/export/data_definition.py
+++ b/openage/convert/entity_object/export/data_definition.py
@@ -4,6 +4,9 @@
 Output format specification for data to write.
 """
 
+from __future__ import annotations
+import typing
+
 
 class DataDefinition:
     """
@@ -11,7 +14,7 @@ class DataDefinition:
     formatted to an arbitrary output file.
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         """
         Creates a new data definition.
 
@@ -20,23 +23,16 @@ class DataDefinition:
         :param filename: Filename of the resulting file.
         :type filename: str
         """
-        if not isinstance(targetdir, str):
-            raise ValueError("str expected as targetdir")
-
         self.targetdir = targetdir
-
-        if not isinstance(filename, str):
-            raise ValueError(f"str expected as filename, not {type(filename)}")
-
         self.filename = filename
 
-    def dump(self):
+    def dump(self) -> typing.NoReturn:
         """
         Creates a human-readable string that can be written to a file.
         """
         raise NotImplementedError(f"{type(self)} has not implemented dump() method")
 
-    def set_filename(self, filename):
+    def set_filename(self, filename: str) -> None:
         """
         Sets the filename for the file.
 
@@ -48,7 +44,7 @@ class DataDefinition:
 
         self.filename = filename
 
-    def set_targetdir(self, targetdir):
+    def set_targetdir(self, targetdir: str) -> None:
         """
         Sets the target directory for the file.
 

--- a/openage/convert/entity_object/export/data_definition.py
+++ b/openage/convert/entity_object/export/data_definition.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Output format specification for data to write.

--- a/openage/convert/entity_object/export/formats/blmask_metadata.py
+++ b/openage/convert/entity_object/export/formats/blmask_metadata.py
@@ -5,6 +5,8 @@
 """
 Blendmask definition file.
 """
+from __future__ import annotations
+import typing
 
 from ..data_definition import DataDefinition
 
@@ -17,14 +19,14 @@ class BlendmaskMetadata(DataDefinition):
     as a .blmask custom format
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.image_files = {}
-        self.scalefactor = 1
-        self.masks = {}
+        self.image_files: dict[int, dict[str, typing.Any]] = {}
+        self.scalefactor = 1.0
+        self.masks: dict[int, dict[str, int]] = {}
 
-    def add_image(self, img_id, filename):
+    def add_image(self, img_id: int, filename: str) -> None:
         """
         Add an image and the relative file name.
 
@@ -38,7 +40,15 @@ class BlendmaskMetadata(DataDefinition):
             "filename": filename,
         }
 
-    def add_mask(self, directions, img_id, xpos, ypos, xsize, ysize):
+    def add_mask(
+        self,
+        directions: int,
+        img_id: int,
+        xpos: int,
+        ypos: int,
+        xsize: int,
+        ysize: int
+    ) -> None:
         """
         Add a mask for directions.
 
@@ -64,7 +74,7 @@ class BlendmaskMetadata(DataDefinition):
             "ysize": ysize,
         }
 
-    def set_scalefactor(self, factor):
+    def set_scalefactor(self, factor: typing.Union[int, float]) -> None:
         """
         Set the scale factor of the animation.
 
@@ -73,7 +83,7 @@ class BlendmaskMetadata(DataDefinition):
         """
         self.scalefactor = float(factor)
 
-    def dump(self):
+    def dump(self) -> str:
         output_str = ""
 
         # header

--- a/openage/convert/entity_object/export/formats/blmask_metadata.py
+++ b/openage/convert/entity_object/export/formats/blmask_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments
 

--- a/openage/convert/entity_object/export/formats/bltable_metadata.py
+++ b/openage/convert/entity_object/export/formats/bltable_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Blendtable definition file.

--- a/openage/convert/entity_object/export/formats/bltable_metadata.py
+++ b/openage/convert/entity_object/export/formats/bltable_metadata.py
@@ -3,6 +3,8 @@
 """
 Blendtable definition file.
 """
+from __future__ import annotations
+import typing
 
 from ..data_definition import DataDefinition
 
@@ -15,13 +17,13 @@ class BlendtableMetadata(DataDefinition):
     as a .bltable custom format
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.blendtable = None
-        self.patterns = {}
+        self.blendtable: tuple = None
+        self.patterns: dict[int, dict[str, typing.Any]] = {}
 
-    def add_pattern(self, pattern_id, filename):
+    def add_pattern(self, pattern_id: int, filename: str) -> None:
         """
         Define a pattern in the table.
 
@@ -35,7 +37,7 @@ class BlendtableMetadata(DataDefinition):
             "filename": filename
         }
 
-    def set_blendtabe(self, table):
+    def set_blendtabe(self, table: tuple) -> None:
         """
         Set the blendtable. This expects a tuple of integers with nxn entries.
 
@@ -46,7 +48,7 @@ class BlendtableMetadata(DataDefinition):
 
         self._check_table()
 
-    def dump(self):
+    def dump(self) -> str:
         output_str = ""
 
         # header
@@ -59,7 +61,7 @@ class BlendtableMetadata(DataDefinition):
         output_str += "blendtable [\n"
 
         # table entries
-        table_width = self._get_table_with()
+        table_width = self._get_table_width()
         for idx in range(table_width):
             row_entries = self.blendtable[idx * table_width:(idx + 1) * table_width]
             output_str += f'{" ".join(row_entries)}\n'
@@ -74,7 +76,7 @@ class BlendtableMetadata(DataDefinition):
 
         return output_str
 
-    def _get_table_with(self):
+    def _get_table_width(self) -> int:
         """
         Get the width of the blending table.
         """
@@ -89,11 +91,11 @@ class BlendtableMetadata(DataDefinition):
 
         return left
 
-    def _check_table(self):
+    def _check_table(self) -> typing.Union[None, typing.NoReturn]:
         """
         Check if the blending table is a nxn matrix.
         """
-        table_width = self._get_table_with()
+        table_width = self._get_table_width()
 
         if table_width * table_width != len(self.blendtable):
             raise Exception(f"blendtable entries malformed: "

--- a/openage/convert/entity_object/export/formats/media_cache.py
+++ b/openage/convert/entity_object/export/formats/media_cache.py
@@ -5,6 +5,8 @@
 """
 Create a media cache file for a game version.
 """
+from __future__ import annotations
+import typing
 
 import toml
 
@@ -12,24 +14,26 @@ from ..data_definition import DataDefinition
 
 FILE_VERSION = "1.0"
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.read.media_types import MediaType
+
 
 class MediaCacheFile(DataDefinition):
     """
     Used for creating a media cache file.
     """
 
-    def __init__(self, targetdir, filename, game_version):
+    def __init__(self, targetdir: str, filename: str, game_version: tuple):
         super().__init__(targetdir, filename)
 
         self.game_version = game_version
-        self.hash_func = None
+        self.hash_func: str = None
         self.cache = {}
 
-    def dump(self):
+    def dump(self) -> str:
         """
         Returns the media cache file content in TOML format.
         """
-
         output_dict = {}
 
         output_dict["file_version"] = FILE_VERSION
@@ -52,7 +56,14 @@ class MediaCacheFile(DataDefinition):
 
         return output_str
 
-    def add_cache_data(self, media_type, filepath, filehash, compr_settings, packer_settings):
+    def add_cache_data(
+        self,
+        media_type: MediaType,
+        filepath: str,
+        filehash: str,
+        compr_settings: tuple,
+        packer_settings: tuple
+    ) -> None:
         """
         Add cache data for a file.
 
@@ -66,7 +77,7 @@ class MediaCacheFile(DataDefinition):
         :param compr_settings: Settings for the PNG compression.
         :type compr_settings: tuple
         :param packer_settings: Settings for the packing algorithm.
-        :type packer_settings: ruple
+        :type packer_settings: tuple
         """
         if media_type not in self.cache.keys():
             self.cache[media_type] = []
@@ -75,7 +86,7 @@ class MediaCacheFile(DataDefinition):
             (filepath, filehash, compr_settings, packer_settings)
         )
 
-    def set_hash_func(self, hash_func):
+    def set_hash_func(self, hash_func: str) -> None:
         """
         Set the hash function used for generating
         hash values for the graphic files.

--- a/openage/convert/entity_object/export/formats/media_cache.py
+++ b/openage/convert/entity_object/export/formats/media_cache.py
@@ -16,6 +16,7 @@ FILE_VERSION = "1.0"
 
 if typing.TYPE_CHECKING:
     from openage.convert.value_object.read.media_types import MediaType
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class MediaCacheFile(DataDefinition):
@@ -23,7 +24,7 @@ class MediaCacheFile(DataDefinition):
     Used for creating a media cache file.
     """
 
-    def __init__(self, targetdir: str, filename: str, game_version: tuple):
+    def __init__(self, targetdir: str, filename: str, game_version: GameVersion):
         super().__init__(targetdir, filename)
 
         self.game_version = game_version

--- a/openage/convert/entity_object/export/formats/media_cache.py
+++ b/openage/convert/entity_object/export/formats/media_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments
 

--- a/openage/convert/entity_object/export/formats/modpack_info.py
+++ b/openage/convert/entity_object/export/formats/modpack_info.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 

--- a/openage/convert/entity_object/export/formats/modpack_info.py
+++ b/openage/convert/entity_object/export/formats/modpack_info.py
@@ -19,31 +19,39 @@ class ModpackInfo(DataDefinition):
     and about the creators of the modpack.
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
         # Info
-        self.packagename = None
-        self.version = None
-        self.extra_info = {}
+        self.packagename: str = None
+        self.version: str = None
+        self.extra_info: dict[str, str] = {}
 
         # Assets
-        self.includes = []
-        self.excludes = []
+        self.includes: list[str] = []
+        self.excludes: list[str] = []
 
         # Dependency
-        self.requires = []
+        self.requires: list[str] = []
 
         # Conflict
-        self.conflicts = []
+        self.conflicts: list[str] = []
 
         # Authors
-        self.authors = {}
+        self.authors: dict[str, str] = {}
 
         # Author groups
-        self.author_groups = {}
+        self.author_groups: dict[str, str] = {}
 
-    def add_author(self, name, fullname=None, since=None, until=None, roles=None, contact=None):
+    def add_author(
+        self,
+        name: str,
+        fullname: str = None,
+        since: str = None,
+        until: str = None,
+        roles: str = None,
+        contact: str = None
+    ) -> None:
         """
         Adds an author with optional contact info.
 
@@ -80,7 +88,12 @@ class ModpackInfo(DataDefinition):
 
         self.authors[name] = author
 
-    def add_author_group(self, name, authors, description=None):
+    def add_author_group(
+        self,
+        name: str,
+        authors: list[str],
+        description: str = None
+    ) -> None:
         """
         Adds an author with optional contact info.
 
@@ -100,7 +113,7 @@ class ModpackInfo(DataDefinition):
 
         self.author_groups[name] = author_group
 
-    def add_include(self, path):
+    def add_include(self, path: str) -> None:
         """
         Add a path to an asset that is loaded by the modpack.
 
@@ -109,7 +122,7 @@ class ModpackInfo(DataDefinition):
         """
         self.includes.append(path)
 
-    def add_exclude(self, path):
+    def add_exclude(self, path: str) -> None:
         """
         Add a path to an asset that excluded from loading.
 
@@ -118,7 +131,7 @@ class ModpackInfo(DataDefinition):
         """
         self.excludes.append(path)
 
-    def add_conflict(self, modpack_id):
+    def add_conflict(self, modpack_id: str) -> None:
         """
         Add an identifier of another modpack that has a conflict with this modpack.
 
@@ -127,7 +140,7 @@ class ModpackInfo(DataDefinition):
         """
         self.conflicts.append(modpack_id)
 
-    def add_dependency(self, modpack_id):
+    def add_dependency(self, modpack_id: str) -> None:
         """
         Add an identifier of another modpack that is a dependency of this modpack.
 
@@ -136,8 +149,18 @@ class ModpackInfo(DataDefinition):
         """
         self.requires.append(modpack_id)
 
-    def set_info(self, packagename, version, repo=None, alias=None, title=None,
-                 description=None, long_description=None, url=None, licenses=None):
+    def set_info(
+        self,
+        packagename: str,
+        version: str,
+        repo: str = None,
+        alias: str = None,
+        title: str = None,
+        description: str = None,
+        long_description: str = None,
+        url: str = None,
+        licenses: str = None
+    ) -> None:
         """
         Set the general information about the modpack.
 
@@ -184,7 +207,7 @@ class ModpackInfo(DataDefinition):
         if licenses:
             self.extra_info["licenses"] = licenses
 
-    def dump(self):
+    def dump(self) -> str:
         """
         Outputs the modpack info to the TOML output format.
         """

--- a/openage/convert/entity_object/export/formats/modpack_manifest.py
+++ b/openage/convert/entity_object/export/formats/modpack_manifest.py
@@ -14,17 +14,16 @@ class ManifestFile(DataDefinition):
     Used for creating a manifest file for a modpack.
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.hash_values = []
-        self.hashing_func = None
+        self.hash_values: list[tuple[str, str]] = []
+        self.hashing_func: str = None
 
-    def dump(self):
+    def dump(self) -> str:
         """
         Returns the manifest file content in TOML format.
         """
-
         output_dict = {}
 
         info_table = {"info": {}}
@@ -46,7 +45,7 @@ class ManifestFile(DataDefinition):
 
         return output_str
 
-    def add_hash_value(self, hash_val, item_path):
+    def add_hash_value(self, hash_val: str, item_path: str) -> None:
         """
         Add the item path and its hash value to the instances
         hash_values list.
@@ -58,7 +57,7 @@ class ManifestFile(DataDefinition):
         """
         self.hash_values.append((hash_val, item_path,))
 
-    def set_hashing_func(self, hashing_func):
+    def set_hashing_func(self, hashing_func: str) -> None:
         """
         Add the hashing function used for generating
         hash values for modpack files

--- a/openage/convert/entity_object/export/formats/modpack_manifest.py
+++ b/openage/convert/entity_object/export/formats/modpack_manifest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Create a manifest file for a modpack

--- a/openage/convert/entity_object/export/formats/nyan_file.py
+++ b/openage/convert/entity_object/export/formats/nyan_file.py
@@ -4,10 +4,15 @@
 Nyan file struct that stores a bunch of objects and
 manages imports.
 """
+from __future__ import annotations
+import typing
 
 from .....nyan.nyan_structs import NyanObject
 from .....util.ordered_set import OrderedSet
 from ..data_definition import DataDefinition
+
+if typing.TYPE_CHECKING:
+    from openage.nyan.import_tree import ImportTree
 
 
 FILE_VERSION = "0.1.0"
@@ -19,7 +24,13 @@ class NyanFile(DataDefinition):
     and dumping all objects into a human-readable .nyan file.
     """
 
-    def __init__(self, targetdir, filename, modpack_name, nyan_objects=None):
+    def __init__(
+        self,
+        targetdir: str,
+        filename: str,
+        modpack_name: str,
+        nyan_objects: typing.Collection = None
+    ):
         super().__init__(targetdir, filename)
 
         self.modpack_name = modpack_name
@@ -35,7 +46,7 @@ class NyanFile(DataDefinition):
                      *self.targetdir.replace("/", ".")[:-1].split("."),
                      self.filename.split(".")[0])
 
-    def add_nyan_object(self, new_object):
+    def add_nyan_object(self, new_object: NyanObject) -> None:
         """
         Adds a nyan object to the file.
         """
@@ -47,7 +58,7 @@ class NyanFile(DataDefinition):
         new_fqon = (*self.fqon, new_object.get_name())
         new_object.set_fqon(new_fqon)
 
-    def dump(self):
+    def dump(self) -> str:
         """
         Returns the string that represents the nyan file.
         """
@@ -77,39 +88,39 @@ class NyanFile(DataDefinition):
 
         return output_str
 
-    def get_fqon(self):
+    def get_fqon(self) -> str:
         """
         Return the fqon of the nyan file
         """
         return self.fqon
 
-    def get_relative_file_path(self):
+    def get_relative_file_path(self) -> str:
         """
         Relative path of the nyan file in the modpack.
         """
         return f"{self.modpack_name}/{self.targetdir}{self.filename}"
 
-    def set_import_tree(self, import_tree):
+    def set_import_tree(self, import_tree: ImportTree) -> None:
         """
         Sets the import tree of the file.
         """
         self.import_tree = import_tree
 
-    def set_filename(self, filename):
+    def set_filename(self, filename: str):
         super().set_filename(filename)
         self._reset_fqons()
 
-    def set_modpack_name(self, modpack_name):
+    def set_modpack_name(self, modpack_name: str) -> None:
         """
         Set the name of the modpack, the file is contained in.
         """
         self.modpack_name = modpack_name
 
-    def set_targetdir(self, targetdir):
+    def set_targetdir(self, targetdir: str) -> None:
         super().set_targetdir(targetdir)
         self._reset_fqons()
 
-    def _reset_fqons(self):
+    def _reset_fqons(self) -> None:
         """
         Resets fqons, depending on the modpack name,
         target directory and filename.

--- a/openage/convert/entity_object/export/formats/nyan_file.py
+++ b/openage/convert/entity_object/export/formats/nyan_file.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Nyan file struct that stores a bunch of objects and

--- a/openage/convert/entity_object/export/formats/palette_metadata.py
+++ b/openage/convert/entity_object/export/formats/palette_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Palette definition file.

--- a/openage/convert/entity_object/export/formats/palette_metadata.py
+++ b/openage/convert/entity_object/export/formats/palette_metadata.py
@@ -15,12 +15,12 @@ class PaletteMetadata(DataDefinition):
     as a .opal custom format
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.colours = []
+        self.colours: list[tuple] = []
 
-    def add_colour(self, colour):
+    def add_colour(self, colour: tuple) -> None:
         """
         Add a RGBA colour to the end of the palette.
 
@@ -29,7 +29,7 @@ class PaletteMetadata(DataDefinition):
         """
         self.colours.append(colour)
 
-    def add_colours(self, colours):
+    def add_colours(self, colours: list[tuple]) -> None:
         """
         Add a collection of RGBA colours to the end of the palette.
 
@@ -38,7 +38,7 @@ class PaletteMetadata(DataDefinition):
         """
         self.colours.extend(colours)
 
-    def dump(self):
+    def dump(self) -> str:
         output_str = ""
 
         # header

--- a/openage/convert/entity_object/export/formats/sprite_metadata.py
+++ b/openage/convert/entity_object/export/formats/sprite_metadata.py
@@ -5,6 +5,8 @@
 """
 Sprite definition file.
 """
+from __future__ import annotations
+import typing
 
 from enum import Enum
 
@@ -28,16 +30,16 @@ class SpriteMetadata(DataDefinition):
     as a .sprite custom format
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.image_files = {}
-        self.scalefactor = 1
-        self.layers = {}
-        self.angles = {}
-        self.frames = []
+        self.image_files: dict[int, dict[str, typing.Any]] = {}
+        self.scalefactor = 1.0
+        self.layers: dict[int, dict[str, typing.Any]] = {}
+        self.angles: dict[int, dict[str, int]] = {}
+        self.frames: list[dict[str, int]] = []
 
-    def add_image(self, img_id, filename):
+    def add_image(self, img_id: int, filename: str) -> None:
         """
         Add an image and the relative file name.
 
@@ -51,7 +53,14 @@ class SpriteMetadata(DataDefinition):
             "filename": filename,
         }
 
-    def add_layer(self, layer_id, mode=None, position=None, time_per_frame=None, replay_delay=None):
+    def add_layer(
+        self,
+        layer_id: int,
+        mode: LayerMode = None,
+        position: int = None,
+        time_per_frame: float = None,
+        replay_delay: float = None
+    ) -> None:
         """
         Define a layer for the rendered sprite.
 
@@ -74,7 +83,7 @@ class SpriteMetadata(DataDefinition):
             "replay_delay": replay_delay,
         }
 
-    def add_angle(self, degree, mirror_from=None):
+    def add_angle(self, degree: int, mirror_from: int = None) -> None:
         """
         Specifies an angle that frames can get assigned to.
 
@@ -88,8 +97,19 @@ class SpriteMetadata(DataDefinition):
             "mirror_from": mirror_from,
         }
 
-    def add_frame(self, frame_idx, angle, layer_id, img_id, xpos, ypos,
-                  xsize, ysize, xhotspot, yhotspot):
+    def add_frame(
+        self,
+        frame_idx: int,
+        angle: int,
+        layer_id: int,
+        img_id: int,
+        xpos: int,
+        ypos: int,
+        xsize: int,
+        ysize: int,
+        xhotspot: int,
+        yhotspot: int
+    ) -> None:
         """
         Add frame with all its spacial information.
 
@@ -129,7 +149,7 @@ class SpriteMetadata(DataDefinition):
             }
         )
 
-    def set_scalefactor(self, factor):
+    def set_scalefactor(self, factor: typing.Union[int, float]) -> None:
         """
         Set the scale factor of the animation.
 
@@ -138,7 +158,7 @@ class SpriteMetadata(DataDefinition):
         """
         self.scalefactor = float(factor)
 
-    def dump(self):
+    def dump(self) -> str:
         output_str = ""
 
         # header

--- a/openage/convert/entity_object/export/formats/sprite_metadata.py
+++ b/openage/convert/entity_object/export/formats/sprite_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments
 

--- a/openage/convert/entity_object/export/formats/terrain_metadata.py
+++ b/openage/convert/entity_object/export/formats/terrain_metadata.py
@@ -5,6 +5,9 @@
 """
 Terrain definition file.
 """
+from __future__ import annotations
+import typing
+
 
 from enum import Enum
 
@@ -27,16 +30,16 @@ class TerrainMetadata(DataDefinition):
     as a .terrain custom format
     """
 
-    def __init__(self, targetdir, filename):
+    def __init__(self, targetdir: str, filename: str):
         super().__init__(targetdir, filename)
 
-        self.scalefactor = 1
-        self.image_files = {}
-        self.blendtable = None
-        self.layers = {}
-        self.frames = []
+        self.scalefactor = 1.0
+        self.image_files: dict[int, dict[str, typing.Any]] = {}
+        self.blendtable: dict[str, typing.Any] = None
+        self.layers: dict[int, dict[str, typing.Any]] = {}
+        self.frames: list[dict[str, int]] = []
 
-    def add_image(self, img_id, filename):
+    def add_image(self, img_id: int, filename: str) -> None:
         """
         Add an image and the relative file name.
 
@@ -50,7 +53,14 @@ class TerrainMetadata(DataDefinition):
             "filename": filename,
         }
 
-    def add_layer(self, layer_id, mode, position=None, time_per_frame=None, replay_delay=None):
+    def add_layer(
+        self,
+        layer_id: int,
+        mode: LayerMode = None,
+        position: int = None,
+        time_per_frame: float = None,
+        replay_delay: float = None
+    ) -> None:
         """
         Define a layer for the rendered texture.
 
@@ -73,8 +83,18 @@ class TerrainMetadata(DataDefinition):
             "replay_delay": replay_delay,
         }
 
-    def add_frame(self, frame_idx, layer_id, img_id, xpos, ypos, xsize, ysize,
-                  priority=None, blend_mode=None):
+    def add_frame(
+        self,
+        frame_idx: int,
+        layer_id: int,
+        img_id: int,
+        xpos: int,
+        ypos: int,
+        xsize: int,
+        ysize: int,
+        priority: int,
+        blend_mode: int
+    ) -> None:
         """
         Add frame with all its spacial information.
 
@@ -111,7 +131,7 @@ class TerrainMetadata(DataDefinition):
             }
         )
 
-    def set_blendtable(self, table_id, filename):
+    def set_blendtable(self, table_id: int, filename: str) -> None:
         """
         Set the blendtable and the relative filename.
 
@@ -125,7 +145,7 @@ class TerrainMetadata(DataDefinition):
             "filename": filename,
         }
 
-    def set_scalefactor(self, factor):
+    def set_scalefactor(self, factor: typing.Union[int, float]) -> None:
         """
         Set the scale factor of the texture.
 
@@ -134,7 +154,7 @@ class TerrainMetadata(DataDefinition):
         """
         self.scalefactor = float(factor)
 
-    def dump(self):
+    def dump(self) -> str:
         output_str = ""
 
         # header

--- a/openage/convert/entity_object/export/formats/terrain_metadata.py
+++ b/openage/convert/entity_object/export/formats/terrain_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments
 

--- a/openage/convert/entity_object/export/media_export_request.py
+++ b/openage/convert/entity_object/export/media_export_request.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,arguments-differ
 """

--- a/openage/convert/entity_object/export/media_export_request.py
+++ b/openage/convert/entity_object/export/media_export_request.py
@@ -5,8 +5,13 @@
 Specifies a request for a media resource that should be
 converted and exported into a modpack.
 """
+from __future__ import annotations
+import typing
 
 from ....util.observer import Observable
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.read.media_types import MediaType
 
 
 class MediaExportRequest(Observable):
@@ -16,7 +21,13 @@ class MediaExportRequest(Observable):
 
     __slots__ = ("media_type", "targetdir", "source_filename", "target_filename")
 
-    def __init__(self, media_type, targetdir, source_filename, target_filename):
+    def __init__(
+        self,
+        media_type: MediaType,
+        targetdir: str,
+        source_filename: str,
+        target_filename: str
+    ):
         """
         Create a request for a media file.
 
@@ -32,17 +43,17 @@ class MediaExportRequest(Observable):
         super().__init__()
 
         self.media_type = media_type
-        self.set_targetdir(targetdir)
-        self.set_source_filename(source_filename)
-        self.set_target_filename(target_filename)
+        self.targetdir = targetdir
+        self.source_filename = source_filename
+        self.target_filename = target_filename
 
-    def get_type(self):
+    def get_type(self) -> MediaType:
         """
         Return the media type.
         """
         return self.media_type
 
-    def set_source_filename(self, filename):
+    def set_source_filename(self, filename: str) -> None:
         """
         Sets the filename for the source file.
 
@@ -54,7 +65,7 @@ class MediaExportRequest(Observable):
 
         self.source_filename = filename
 
-    def set_target_filename(self, filename):
+    def set_target_filename(self, filename: str) -> None:
         """
         Sets the filename for the target file.
 
@@ -66,7 +77,7 @@ class MediaExportRequest(Observable):
 
         self.target_filename = filename
 
-    def set_targetdir(self, targetdir):
+    def set_targetdir(self, targetdir: str) -> None:
         """
         Sets the target directory for the file.
 

--- a/openage/convert/entity_object/export/metadata_export.py
+++ b/openage/convert/entity_object/export/metadata_export.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments,too-many-locals
 

--- a/openage/convert/entity_object/export/metadata_export.py
+++ b/openage/convert/entity_object/export/metadata_export.py
@@ -5,9 +5,16 @@
 """
 Export requests for media metadata.
 """
+from __future__ import annotations
+import typing
+
 
 from ....util.observer import Observer
 from .formats.sprite_metadata import SpriteMetadata
+
+if typing.TYPE_CHECKING:
+    from openage.util.observer import Observable
+    from openage.convert.entity_object.export.formats.sprite_metadata import LayerMode
 
 
 class MetadataExport(Observer):
@@ -16,13 +23,13 @@ class MetadataExport(Observer):
     observers so they can receive data from media conversion.
     """
 
-    def __init__(self, targetdir, target_filename):
+    def __init__(self, targetdir: str, target_filename: str):
 
         self.targetdir = targetdir
         self.filename = target_filename
 
-    def update(self, observable, message=None):
-        return NotImplemented
+    def update(self, observable: Observable, message=None):
+        return NotImplementedError("Interface does not implement update()")
 
     def __repr__(self):
         return f"MetadataExport<{type(self)}>"
@@ -36,12 +43,20 @@ class SpriteMetadataExport(MetadataExport):
     def __init__(self, targetdir, target_filename):
         super().__init__(targetdir, target_filename)
 
-        self.graphics_metadata = {}
-        self.frame_metadata = {}
+        self.graphics_metadata: dict[int, tuple] = {}
+        self.frame_metadata: dict[int, tuple] = {}
 
-    def add_graphics_metadata(self, img_filename, layer_mode,
-                              layer_pos, frame_rate, replay_delay,
-                              frame_count, angle_count, mirror_mode):
+    def add_graphics_metadata(
+        self,
+        img_filename: str,
+        layer_mode: LayerMode,
+        layer_pos: int,
+        frame_rate: float,
+        replay_delay: float,
+        frame_count: int,
+        angle_count: int,
+        mirror_mode: int
+    ):
         """
         Add metadata from the GenieGraphic object.
 
@@ -50,7 +65,7 @@ class SpriteMetadataExport(MetadataExport):
         self.graphics_metadata[img_filename] = (layer_mode, layer_pos, frame_rate, replay_delay,
                                                 frame_count, angle_count, mirror_mode)
 
-    def dump(self):
+    def dump(self) -> str:
         """
         Creates a human-readable string that can be written to a file.
         """
@@ -101,7 +116,7 @@ class SpriteMetadataExport(MetadataExport):
 
         return sprite_file.dump()
 
-    def update(self, observable, message=None):
+    def update(self, observable: Observable, message: dict = None):
         """
         Receive metdata from the graphics file export.
 

--- a/openage/convert/entity_object/export/texture.py
+++ b/openage/convert/entity_object/export/texture.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """ Routines for texture generation etc """
 

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -1,10 +1,13 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-branches
 """
 Entry point for all of the asset conversion.
 """
+from __future__ import annotations
+
 from datetime import datetime
+import typing
 
 from ..log import info, err
 from ..util.fslike.directory import CaseIgnoringDirectory
@@ -19,8 +22,17 @@ from .tool.interactive import interactive_browser
 from .tool.subtool.acquire_sourcedir import acquire_conversion_source_dir, wanna_convert
 from .tool.subtool.version_select import get_game_version
 
+if typing.TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+    from openage.util.fslike.directory import Directory
 
-def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
+
+def convert_assets(
+    assets: Directory,
+    args: Namespace,
+    srcdir: Directory = None,
+    prev_source_dir_path: str = None
+) -> str:
     """
     Perform asset conversion.
 
@@ -123,7 +135,7 @@ def convert_assets(assets, args, srcdir=None, prev_source_dir_path=None):
     return data_dir.resolve_native_path()
 
 
-def init_subparser(cli):
+def init_subparser(cli: ArgumentParser):
     """ Initializes the parser for convert-specific args. """
     cli.set_defaults(entrypoint=main)
 

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -83,7 +83,7 @@ def convert_assets(
     args.game_version = get_game_version(srcdir, args.avail_game_eds, args.avail_game_exps)
     debug_game_version(args.debugdir, args.debug_info, args)
 
-    if not args.game_version[0]:
+    if not args.game_version.edition:
         return None
 
     # Mount assets into conversion folder

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -11,14 +11,17 @@
 Derives and adds abilities to lines. Subroutine of the
 nyan subprocessor.
 """
+from __future__ import annotations
+import typing
+
 from math import degrees
+
 
 from .....nyan.nyan_structs import MemberSpecialValue, MemberOperator
 from .....util.ordered_set import OrderedSet
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup,\
     GenieAmbientGroup, GenieGarrisonMode, GenieStackBuildingGroup,\
-    GenieUnitLineGroup, GenieMonkGroup
-from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup
+    GenieUnitLineGroup, GenieMonkGroup, GenieVillagerGroup
 from ....entity_object.conversion.combined_sound import CombinedSound
 from ....entity_object.conversion.combined_sprite import CombinedSprite
 from ....entity_object.conversion.converter_object import RawAPIObject
@@ -27,6 +30,10 @@ from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from .effect_subprocessor import AoCEffectSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+
 
 class AoCAbilitySubprocessor:
     """
@@ -34,7 +41,7 @@ class AoCAbilitySubprocessor:
     """
 
     @staticmethod
-    def active_transform_to_ability(line):
+    def active_transform_to_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ActiveTransformTo ability to a line.
 
@@ -47,7 +54,11 @@ class AoCAbilitySubprocessor:
         return None
 
     @staticmethod
-    def apply_continuous_effect_ability(line, command_id, ranged=False):
+    def apply_continuous_effect_ability(
+        line: GenieGameEntityGroup,
+        command_id: int,
+        ranged: bool = False
+    ) -> ForwardRef:
         """
         Adds the ApplyContinuousEffect ability to a line.
 
@@ -243,7 +254,8 @@ class AoCAbilitySubprocessor:
             # Construct
             effects = AoCEffectSubprocessor.get_construct_effects(line, ability_ref)
             allowed_types = [
-                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+                )
             ]
 
         elif command_id == 105:
@@ -257,7 +269,8 @@ class AoCAbilitySubprocessor:
             # Repair
             effects = AoCEffectSubprocessor.get_repair_effects(line, ability_ref)
             allowed_types = [
-                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+                )
             ]
 
         ability_raw_api_object.add_raw_member("effects",
@@ -286,7 +299,12 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def apply_discrete_effect_ability(line, command_id, ranged=False, projectile=-1):
+    def apply_discrete_effect_ability(
+        line: GenieGameEntityGroup,
+        command_id: int,
+        ranged: bool = False,
+        projectile: int = -1
+    ) -> ForwardRef:
         """
         Adds the ApplyDiscreteEffect ability to a line.
 
@@ -336,7 +354,8 @@ class AoCAbilitySubprocessor:
             ability_ref = "%s.ShootProjectile.Projectile%s.%s" % (game_entity_name,
                                                                   str(projectile),
                                                                   ability_name)
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
             ability_location = ForwardRef(line,
                                           "%s.ShootProjectile.Projectile%s"
@@ -556,7 +575,8 @@ class AoCAbilitySubprocessor:
         else:
             allowed_types = [
                 dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+                )
             ]
 
         ability_raw_api_object.add_raw_member("allowed_types",
@@ -589,7 +609,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def attribute_change_tracker_ability(line):
+    def attribute_change_tracker_ability(line) -> ForwardRef:
         """
         Adds the AttributeChangeTracker ability to a line.
 
@@ -665,7 +685,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "AnimationOverlay",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.AnimationOverlay")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.AnimationOverlay")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -705,7 +726,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def collect_storage_ability(line):
+    def collect_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the CollectStorage ability to a line.
 
@@ -755,7 +776,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def constructable_ability(line):
+    def constructable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Constructable ability to a line.
 
@@ -774,7 +795,8 @@ class AoCAbilitySubprocessor:
         game_entity_name = name_lookup_dict[current_unit_id][0]
 
         ability_ref = f"{game_entity_name}.Constructable"
-        ability_raw_api_object = RawAPIObject(ability_ref, "Constructable", dataset.nyan_api_objects)
+        ability_raw_api_object = RawAPIObject(
+            ability_ref, "Constructable", dataset.nyan_api_objects)
         ability_raw_api_object.add_raw_parent("engine.ability.type.Constructable")
         ability_location = ForwardRef(line, game_entity_name)
         ability_raw_api_object.set_location(ability_location)
@@ -825,7 +847,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1000,7 +1023,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1167,7 +1191,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1246,7 +1271,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1327,7 +1353,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1338,7 +1365,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -1536,7 +1564,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1547,7 +1576,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -1736,7 +1766,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1747,7 +1778,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -1849,7 +1881,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1860,7 +1893,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -1962,7 +1996,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1973,7 +2008,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, progress_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -2051,7 +2087,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def create_ability(line):
+    def create_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Create ability to a line.
 
@@ -2125,7 +2161,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def death_ability(line):
+    def death_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds a PassiveTransformTo ability to a line that is used to make entities die.
 
@@ -2224,7 +2260,8 @@ class AoCAbilitySubprocessor:
 
         # Death condition
         death_condition = [
-            dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object()
+            dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object(
+            )
         ]
         ability_raw_api_object.add_raw_member("condition",
                                               death_condition,
@@ -2406,7 +2443,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def delete_ability(line):
+    def delete_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds a PassiveTransformTo ability to a line that is used to make entities die.
 
@@ -2517,7 +2554,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def despawn_ability(line):
+    def despawn_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Despawn ability to a line.
 
@@ -2634,7 +2671,8 @@ class AoCAbilitySubprocessor:
         # Activation condition
         # Uses the death condition of the units
         activation_condition = [
-            dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object()
+            dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object(
+            )
         ]
         ability_raw_api_object.add_raw_member("activation_condition",
                                               activation_condition,
@@ -2667,7 +2705,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def drop_resources_ability(line):
+    def drop_resources_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the DropResources ability to a line.
 
@@ -2774,7 +2812,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def drop_site_ability(line):
+    def drop_site_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the DropSite ability to a line.
 
@@ -2851,7 +2889,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def enter_container_ability(line):
+    def enter_container_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the EnterContainer ability to a line.
 
@@ -2918,7 +2956,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def exchange_resources_ability(line):
+    def exchange_resources_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ExchangeResources ability to a line.
 
@@ -2940,7 +2978,8 @@ class AoCAbilitySubprocessor:
         for resource_name in resource_names:
             ability_name = f"MarketExchange{resource_name}"
             ability_ref = f"{game_entity_name}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent("engine.ability.type.ExchangeResources")
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
@@ -2948,7 +2987,8 @@ class AoCAbilitySubprocessor:
             line.add_raw_api_object(ability_raw_api_object)
 
             # Resource that is exchanged (resource A)
-            resource_a = dataset.pregen_nyan_objects[f"util.resource.types.{resource_name}"].get_nyan_object()
+            resource_a = dataset.pregen_nyan_objects[f"util.resource.types.{resource_name}"].get_nyan_object(
+            )
             ability_raw_api_object.add_raw_member("resource_a",
                                                   resource_a,
                                                   "engine.ability.type.ExchangeResources")
@@ -2968,8 +3008,10 @@ class AoCAbilitySubprocessor:
 
             # Exchange modes
             exchange_modes = [
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(),
+                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(
+                ),
+                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(
+                ),
             ]
             ability_raw_api_object.add_raw_member("exchange_modes",
                                                   exchange_modes,
@@ -2981,7 +3023,7 @@ class AoCAbilitySubprocessor:
         return abilities
 
     @staticmethod
-    def exit_container_ability(line):
+    def exit_container_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ExitContainer ability to a line.
 
@@ -3035,7 +3077,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def game_entity_stance_ability(line):
+    def game_entity_stance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the GameEntityStance ability to a line.
 
@@ -3122,7 +3164,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def formation_ability(line):
+    def formation_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Formation ability to a line.
 
@@ -3146,19 +3188,24 @@ class AoCAbilitySubprocessor:
 
         # Formation definitions
         if line.get_class_id() in (6,):
-            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Infantry"].get_nyan_object()
+            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Infantry"].get_nyan_object(
+            )
 
         elif line.get_class_id() in (12, 47):
-            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Cavalry"].get_nyan_object()
+            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Cavalry"].get_nyan_object(
+            )
 
         elif line.get_class_id() in (0, 23, 36, 44, 55):
-            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Ranged"].get_nyan_object()
+            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Ranged"].get_nyan_object(
+            )
 
         elif line.get_class_id() in (2, 13, 18, 20, 35, 43, 51, 59):
-            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Siege"].get_nyan_object()
+            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Siege"].get_nyan_object(
+            )
 
         else:
-            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Support"].get_nyan_object()
+            subformation = dataset.pregen_nyan_objects["util.formation.subformation.types.Support"].get_nyan_object(
+            )
 
         formation_names = ["Line", "Staggered", "Box", "Flank"]
 
@@ -3168,7 +3215,8 @@ class AoCAbilitySubprocessor:
             ge_formation_raw_api_object = RawAPIObject(ge_formation_ref,
                                                        formation_name,
                                                        dataset.nyan_api_objects)
-            ge_formation_raw_api_object.add_raw_parent("engine.util.game_entity_formation.GameEntityFormation")
+            ge_formation_raw_api_object.add_raw_parent(
+                "engine.util.game_entity_formation.GameEntityFormation")
             ge_formation_location = ForwardRef(line, ability_ref)
             ge_formation_raw_api_object.set_location(ge_formation_location)
 
@@ -3199,7 +3247,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def foundation_ability(line, terrain_id=-1):
+    def foundation_ability(line: GenieGameEntityGroup, terrain_id: int = -1) -> ForwardRef:
         """
         Adds the Foundation abilities to a line. Optionally chooses the specified
         terrain ID.
@@ -3243,7 +3291,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def gather_ability(line):
+    def gather_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Gather abilities to a line. Unlike the other methods, this
         creates multiple abilities.
@@ -3299,16 +3347,20 @@ class AoCAbilitySubprocessor:
                     resource_id = command["resource_in"].get_value()
 
                 if resource_id == 0:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
+                    )
 
                 elif resource_id == 1:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Wood"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Wood"].get_nyan_object(
+                    )
 
                 elif resource_id == 2:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object(
+                    )
 
                 elif resource_id == 3:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object(
+                    )
 
                 else:
                     continue
@@ -3351,7 +3403,8 @@ class AoCAbilitySubprocessor:
             ability_name = gather_lookup_dict[gatherer_unit_id][0]
 
             ability_ref = f"{game_entity_name}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent("engine.ability.type.Gather")
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
@@ -3400,7 +3453,8 @@ class AoCAbilitySubprocessor:
 
             line.add_raw_api_object(property_raw_api_object)
 
-            diplomatic_stances = [dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"]]
+            diplomatic_stances = [
+                dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"]]
             property_raw_api_object.add_raw_member("stances", diplomatic_stances,
                                                    "engine.ability.property.type.Diplomatic")
 
@@ -3430,10 +3484,12 @@ class AoCAbilitySubprocessor:
             rate_location = ForwardRef(line, ability_ref)
             rate_raw_api_object.set_location(rate_location)
 
-            rate_raw_api_object.add_raw_member("type", resource, "engine.util.resource.ResourceRate")
+            rate_raw_api_object.add_raw_member(
+                "type", resource, "engine.util.resource.ResourceRate")
 
             gather_rate = gatherer["work_rate"].get_value()
-            rate_raw_api_object.add_raw_member("rate", gather_rate, "engine.util.resource.ResourceRate")
+            rate_raw_api_object.add_raw_member(
+                "rate", gather_rate, "engine.util.resource.ResourceRate")
 
             line.add_raw_api_object(rate_raw_api_object)
 
@@ -3472,7 +3528,7 @@ class AoCAbilitySubprocessor:
         return abilities
 
     @staticmethod
-    def harvestable_ability(line):
+    def harvestable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Harvestable ability to a line.
 
@@ -3510,7 +3566,8 @@ class AoCAbilitySubprocessor:
                 resource = dataset.pregen_nyan_objects["util.resource.types.Wood"].get_nyan_object()
 
             elif resource_id == 2:
-                resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object(
+                )
 
             elif resource_id == 3:
                 resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object()
@@ -3610,7 +3667,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -3691,7 +3749,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -3771,7 +3830,8 @@ class AoCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -3849,7 +3909,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def herd_ability(line):
+    def herd_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Herd ability to a line.
 
@@ -3901,7 +3961,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def herdable_ability(line):
+    def herdable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Herdable ability to a line.
 
@@ -3941,7 +4001,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def hitbox_ability(line):
+    def hitbox_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Hitbox ability to a line.
 
@@ -4000,7 +4060,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def idle_ability(line):
+    def idle_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Idle ability to a line.
 
@@ -4105,7 +4165,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def live_ability(line):
+    def live_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Live ability to a line.
 
@@ -4138,7 +4198,8 @@ class AoCAbilitySubprocessor:
         health_location = ForwardRef(line, ability_ref)
         health_raw_api_object.set_location(health_location)
 
-        attribute_value = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object()
+        attribute_value = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object(
+        )
         health_raw_api_object.add_raw_member("attribute",
                                              attribute_value,
                                              "engine.util.attribute.AttributeSetting")
@@ -4177,7 +4238,8 @@ class AoCAbilitySubprocessor:
             faith_location = ForwardRef(line, ability_ref)
             faith_raw_api_object.set_location(faith_location)
 
-            attribute_value = dataset.pregen_nyan_objects["util.attribute.types.Faith"].get_nyan_object()
+            attribute_value = dataset.pregen_nyan_objects["util.attribute.types.Faith"].get_nyan_object(
+            )
             faith_raw_api_object.add_raw_member("attribute", attribute_value,
                                                 "engine.util.attribute.AttributeSetting")
 
@@ -4209,7 +4271,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def los_ability(line):
+    def los_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the LineOfSight ability to a line.
 
@@ -4268,7 +4330,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def move_ability(line):
+    def move_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Move ability to a line.
 
@@ -4454,7 +4516,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def move_projectile_ability(line, position=-1):
+    def move_projectile_ability(line: GenieGameEntityGroup, position: int = -1) -> ForwardRef:
         """
         Adds the Move ability to a projectile of the specified line.
 
@@ -4548,7 +4610,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def named_ability(line):
+    def named_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Named ability to a line.
 
@@ -4599,7 +4661,8 @@ class AoCAbilitySubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{game_entity_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(line, ability_ref)
         description_raw_api_object.set_location(description_location)
 
@@ -4618,7 +4681,8 @@ class AoCAbilitySubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{game_entity_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(line, ability_ref)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -4639,7 +4703,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def overlay_terrain_ability(line):
+    def overlay_terrain_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the OverlayTerrain to a line.
 
@@ -4680,7 +4744,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def passable_ability(line):
+    def passable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Passable ability to a line.
 
@@ -4743,7 +4807,8 @@ class AoCAbilitySubprocessor:
             if line.is_gate():
                 # Let friendly and own units pass through gate
                 stances = [
-                    dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object(),
+                    dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object(
+                    ),
                     dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"]
                 ]
                 mode_raw_api_object.add_raw_member("stances",
@@ -4764,7 +4829,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def production_queue_ability(line):
+    def production_queue_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProductionQueue ability to a line.
 
@@ -4824,7 +4889,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def projectile_ability(line, position=0):
+    def projectile_ability(line: GenieGameEntityGroup, position: int = 0) -> ForwardRef:
         """
         Adds a Projectile ability to projectiles in a line. Which projectile should
         be added is determined by the 'position' argument.
@@ -4936,7 +5001,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def provide_contingent_ability(line):
+    def provide_contingent_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProvideContingent ability to a line.
 
@@ -4965,7 +5030,8 @@ class AoCAbilitySubprocessor:
             type_id = storage["type"].get_value()
 
             if type_id == 4:
-                resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object(
+                )
                 resource_name = "PopSpace"
 
             else:
@@ -5014,7 +5080,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def rally_point_ability(line):
+    def rally_point_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RallyPoint ability to a line.
 
@@ -5043,7 +5109,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def regenerate_attribute_ability(line):
+    def regenerate_attribute_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RegenerateAttribute ability to a line.
 
@@ -5124,7 +5190,7 @@ class AoCAbilitySubprocessor:
         return [ability_forward_ref]
 
     @staticmethod
-    def regenerate_resource_spot_ability(line):
+    def regenerate_resource_spot_ability(line: GenieGameEntityGroup) -> None:
         """
         Adds the RegenerateResourceSpot ability to a line.
 
@@ -5136,7 +5202,7 @@ class AoCAbilitySubprocessor:
         # Unused in AoC
 
     @staticmethod
-    def remove_storage_ability(line):
+    def remove_storage_ability(line) -> ForwardRef:
         """
         Adds the RemoveStorage ability to a line.
 
@@ -5186,7 +5252,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def restock_ability(line, restock_target_id):
+    def restock_ability(line: GenieGameEntityGroup, restock_target_id: int) -> ForwardRef:
         """
         Adds the Restock ability to a line.
 
@@ -5325,7 +5391,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def research_ability(line):
+    def research_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Research ability to a line.
 
@@ -5401,7 +5467,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def resistance_ability(line):
+    def resistance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Resistance ability to a line.
 
@@ -5434,7 +5500,8 @@ class AoCAbilitySubprocessor:
                 resistances.extend(AoCEffectSubprocessor.get_heal_resistances(line, ability_ref))
 
             if isinstance(line, GenieBuildingLineGroup):
-                resistances.extend(AoCEffectSubprocessor.get_construct_resistances(line, ability_ref))
+                resistances.extend(
+                    AoCEffectSubprocessor.get_construct_resistances(line, ability_ref))
 
             if line.is_repairable():
                 resistances.extend(AoCEffectSubprocessor.get_repair_resistances(line, ability_ref))
@@ -5450,7 +5517,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def resource_storage_ability(line):
+    def resource_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ResourceStorage ability to a line.
 
@@ -5504,16 +5571,20 @@ class AoCAbilitySubprocessor:
                     resource_id = command["resource_in"].get_value()
 
                 if resource_id == 0:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
+                    )
 
                 elif resource_id == 1:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Wood"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Wood"].get_nyan_object(
+                    )
 
                 elif resource_id == 2:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object(
+                    )
 
                 elif resource_id == 3:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object(
+                    )
 
                 elif type_id == 111:
                     target_id = command["unit_id"].get_value()
@@ -5522,7 +5593,8 @@ class AoCAbilitySubprocessor:
                         continue
 
                     # Trade goods --> gold
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Gold"].get_nyan_object(
+                    )
 
                 else:
                     continue
@@ -5607,7 +5679,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -5621,7 +5694,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "MoveOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -5692,7 +5766,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def selectable_ability(line):
+    def selectable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds Selectable abilities to a line. Units will get two of these,
         one Rectangle box for the Self stance and one MatchToSprite box
@@ -5752,8 +5826,10 @@ class AoCAbilitySubprocessor:
 
             stances = [
                 dataset.pregen_nyan_objects["util.diplomatic_stance.types.Enemy"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Neutral"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Neutral"].get_nyan_object(
+                ),
+                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object(
+                )
             ]
             property_raw_api_object.add_raw_member("stances",
                                                    stances,
@@ -5877,7 +5953,7 @@ class AoCAbilitySubprocessor:
         return abilities
 
     @staticmethod
-    def send_back_to_task_ability(line):
+    def send_back_to_task_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the SendBackToTask ability to a line.
 
@@ -5918,7 +5994,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def shoot_projectile_ability(line, command_id):
+    def shoot_projectile_ability(line: GenieGameEntityGroup, command_id: int) -> ForwardRef:
         """
         Adds the ShootProjectile ability to a line.
 
@@ -6147,7 +6223,8 @@ class AoCAbilitySubprocessor:
 
         spawning_area_width = current_unit["attack_projectile_spawning_area_width"].get_value()
         spawning_area_height = current_unit["attack_projectile_spawning_area_length"].get_value()
-        spawning_area_randomness = current_unit["attack_projectile_spawning_area_randomness"].get_value()
+        spawning_area_randomness = current_unit["attack_projectile_spawning_area_randomness"].get_value(
+        )
 
         ability_raw_api_object.add_raw_member("spawning_area_width",
                                               spawning_area_width,
@@ -6176,7 +6253,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def stop_ability(line):
+    def stop_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Stop ability to a line.
 
@@ -6230,7 +6307,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def storage_ability(line):
+    def storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Storage ability to a line.
 
@@ -6292,7 +6369,8 @@ class AoCAbilitySubprocessor:
                 storage_def_raw_api_object = RawAPIObject(storage_def_ref,
                                                           f"{storage_element_name}StorageDef",
                                                           dataset.nyan_api_objects)
-                storage_def_raw_api_object.add_raw_parent("engine.util.storage.StorageElementDefinition")
+                storage_def_raw_api_object.add_raw_parent(
+                    "engine.util.storage.StorageElementDefinition")
                 storage_def_location = ForwardRef(line, container_name)
                 storage_def_raw_api_object.set_location(storage_def_location)
 
@@ -6383,7 +6461,8 @@ class AoCAbilitySubprocessor:
             override_raw_api_object = RawAPIObject(override_ref,
                                                    "IdleOverride",
                                                    dataset.nyan_api_objects)
-            override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+            override_raw_api_object.add_raw_parent(
+                "engine.util.animation_override.AnimationOverride")
             override_location = ForwardRef(line, property_ref)
             override_raw_api_object.set_location(override_location)
 
@@ -6419,7 +6498,8 @@ class AoCAbilitySubprocessor:
             override_raw_api_object = RawAPIObject(override_ref,
                                                    "MoveOverride",
                                                    dataset.nyan_api_objects)
-            override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+            override_raw_api_object.add_raw_parent(
+                "engine.util.animation_override.AnimationOverride")
             override_location = ForwardRef(line, property_ref)
             override_raw_api_object.set_location(override_location)
 
@@ -6570,7 +6650,8 @@ class AoCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -6580,7 +6661,8 @@ class AoCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "IdleOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -6641,11 +6723,13 @@ class AoCAbilitySubprocessor:
         # Empty condition
         if garrison_mode in (GenieGarrisonMode.UNIT_GARRISON, GenieGarrisonMode.MONK):
             # Empty before death
-            condition = [dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object()]
+            condition = [
+                dataset.pregen_nyan_objects["util.logic.literal.death.StandardHealthDeathLiteral"].get_nyan_object()]
 
         elif garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
             # Empty when HP < 20%
-            condition = [dataset.pregen_nyan_objects["util.logic.literal.garrison.BuildingDamageEmpty"].get_nyan_object()]
+            condition = [
+                dataset.pregen_nyan_objects["util.logic.literal.garrison.BuildingDamageEmpty"].get_nyan_object()]
 
         else:
             # Never empty automatically (transport ships)
@@ -6660,7 +6744,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def terrain_requirement_ability(line):
+    def terrain_requirement_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TerrainRequirement to a line.
 
@@ -6674,7 +6758,8 @@ class AoCAbilitySubprocessor:
         dataset = line.data
 
         name_lookup_dict = internal_name_lookups.get_entity_lookups(dataset.game_version)
-        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(dataset.game_version)
+        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(
+            dataset.game_version)
 
         game_entity_name = name_lookup_dict[current_unit_id][0]
 
@@ -6712,7 +6797,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def trade_ability(line):
+    def trade_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Trade ability to a line.
 
@@ -6763,7 +6848,8 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.Trade")
 
         # container
-        container_forward_ref = ForwardRef(line, f"{game_entity_name}.ResourceStorage.TradeContainer")
+        container_forward_ref = ForwardRef(
+            line, f"{game_entity_name}.ResourceStorage.TradeContainer")
         ability_raw_api_object.add_raw_member("container",
                                               container_forward_ref,
                                               "engine.ability.type.Trade")
@@ -6775,7 +6861,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def trade_post_ability(line):
+    def trade_post_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TradePost ability to a line.
 
@@ -6842,7 +6928,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def transfer_storage_ability(line):
+    def transfer_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TransferStorage ability to a line.
 
@@ -6915,7 +7001,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def turn_ability(line):
+    def turn_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Turn ability to a line.
 
@@ -6987,7 +7073,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def use_contingent_ability(line):
+    def use_contingent_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the UseContingent ability to a line.
 
@@ -7013,7 +7099,8 @@ class AoCAbilitySubprocessor:
             type_id = storage["type"].get_value()
 
             if type_id == 11:
-                resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object(
+                )
                 resource_name = "PopSpace"
 
             else:
@@ -7062,7 +7149,7 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def visibility_ability(line):
+    def visibility_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Visibility ability to a line.
 
@@ -7160,7 +7247,8 @@ class AoCAbilitySubprocessor:
             # Only the player and friendly players can see the construction site
             diplomatic_stances = [
                 dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"],
-                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.diplomatic_stance.types.Friendly"].get_nyan_object(
+                )
             ]
             property_raw_api_object.add_raw_member("stances", diplomatic_stances,
                                                    "engine.ability.property.type.Diplomatic")
@@ -7180,7 +7268,13 @@ class AoCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def create_animation(line, animation_id, location_ref, obj_name_prefix, filename_prefix):
+    def create_animation(
+        line: GenieGameEntityGroup,
+        animation_id: int,
+        location_ref: str,
+        obj_name_prefix: str,
+        filename_prefix: str
+    ) -> ForwardRef:
         """
         Generates an animation for an ability.
 
@@ -7230,8 +7324,15 @@ class AoCAbilitySubprocessor:
         return animation_forward_ref
 
     @staticmethod
-    def create_civ_animation(line, civ_group, animation_id, location_ref,
-                             obj_name_prefix, filename_prefix, exists=False):
+    def create_civ_animation(
+        line: GenieGameEntityGroup,
+        civ_group: GenieCivilizationGroup,
+        animation_id: int,
+        location_ref: str,
+        obj_name_prefix: str,
+        filename_prefix: str,
+        exists: bool = False
+    ) -> None:
         """
         Generates an animation as a patch for a civ.
 
@@ -7333,7 +7434,13 @@ class AoCAbilitySubprocessor:
         civ_group.add_raw_member_push(push_object)
 
     @staticmethod
-    def create_sound(line, sound_id, location_ref, obj_name_prefix, filename_prefix):
+    def create_sound(
+        line: GenieGameEntityGroup,
+        sound_id: int,
+        location_ref: str,
+        obj_name_prefix: str,
+        filename_prefix: str
+    ) -> ForwardRef:
         """
         Generates a sound for an ability.
 
@@ -7392,14 +7499,19 @@ class AoCAbilitySubprocessor:
         return sound_forward_ref
 
     @staticmethod
-    def create_language_strings(line, string_id, location_ref, obj_name_prefix):
+    def create_language_strings(
+        line: GenieGameEntityGroup,
+        string_id: int,
+        location_ref: str,
+        obj_name_prefix: str
+    ) -> list[ForwardRef]:
         """
         Generates a language string for an ability.
 
         :param line: ConverterObjectGroup that the animation object is added to.
         :type line: ConverterObjectGroup
-        :param sound_id: ID of the sound in the dataset.
-        :type sound_id: int
+        :param string_id: ID of the string in the dataset.
+        :type string_id: int
         :param location_ref: Reference of the object the string is nested in.
         :type location_ref: str
         :param obj_name_prefix: Name prefix for the string object.

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-public-methods,too-many-lines,too-many-locals
 # pylint: disable=too-many-branches,too-many-statements,too-many-arguments

--- a/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long,too-many-locals,too-many-branches,too-many-statements,no-else-return
 

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -5,6 +5,9 @@
 """
 Creates patches and modifiers for civs.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup
 from ....entity_object.conversion.combined_sprite import CombinedSprite
@@ -13,6 +16,10 @@ from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from .tech_subprocessor import AoCTechSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+
 
 class AoCCivSubprocessor:
     """
@@ -20,7 +27,7 @@ class AoCCivSubprocessor:
     """
 
     @classmethod
-    def get_civ_setup(cls, civ_group):
+    def get_civ_setup(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the patches for the civ setup which configures architecture sets
         unique units, unique techs, team boni and unique stat upgrades.
@@ -37,8 +44,8 @@ class AoCCivSubprocessor:
 
         return patches
 
-    @classmethod
-    def get_modifiers(cls, civ_group):
+    @ classmethod
+    def get_modifiers(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns global modifiers of a civ.
         """
@@ -51,8 +58,8 @@ class AoCCivSubprocessor:
 
         return modifiers
 
-    @staticmethod
-    def get_starting_resources(civ_group):
+    @ staticmethod
+    def get_starting_resources(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the starting resources of a civ.
         """
@@ -176,8 +183,8 @@ class AoCCivSubprocessor:
 
         return resource_amounts
 
-    @classmethod
-    def setup_civ_bonus(cls, civ_group):
+    @ classmethod
+    def setup_civ_bonus(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns global modifiers of a civ.
         """
@@ -267,8 +274,8 @@ class AoCCivSubprocessor:
 
         return patches
 
-    @staticmethod
-    def setup_unique_units(civ_group):
+    @ staticmethod
+    def setup_unique_units(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Patches the unique units into their train location.
         """
@@ -341,8 +348,8 @@ class AoCCivSubprocessor:
 
         return patches
 
-    @staticmethod
-    def setup_unique_techs(civ_group):
+    @ staticmethod
+    def setup_unique_techs(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Patches the unique techs into their research location.
         """
@@ -411,8 +418,8 @@ class AoCCivSubprocessor:
 
         return patches
 
-    @staticmethod
-    def setup_tech_tree(civ_group):
+    @ staticmethod
+    def setup_tech_tree(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Patches standard techs and units out of Research and Create.
         """
@@ -593,8 +600,14 @@ class AoCCivSubprocessor:
 
         return patches
 
-    @staticmethod
-    def create_animation(line, animation_id, nyan_patch_ref, animation_name, filename_prefix):
+    @ staticmethod
+    def create_animation(
+        line: GenieGameEntityGroup,
+        animation_id: int,
+        nyan_patch_ref: str,
+        animation_name: str,
+        filename_prefix: str
+    ) -> ForwardRef:
         """
         Generates an animation for an ability.
         """

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 

--- a/openage/convert/processor/conversion/aoc/effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/effect_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,invalid-name
 #

--- a/openage/convert/processor/conversion/aoc/effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/effect_subprocessor.py
@@ -9,11 +9,17 @@
 Creates effects and resistances for the Apply*Effect and Resistance
 abilities.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
     GenieBuildingLineGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
 
 
 class AoCEffectSubprocessor:
@@ -22,7 +28,11 @@ class AoCEffectSubprocessor:
     """
 
     @staticmethod
-    def get_attack_effects(line, location_ref, projectile=-1):
+    def get_attack_effects(
+        line: GenieGameEntityGroup,
+        location_ref: str,
+        projectile: int = -1
+    ) -> list[ForwardRef]:
         """
         Creates effects that are used for attacking (unit command: 7)
 
@@ -84,7 +94,8 @@ class AoCEffectSubprocessor:
             # Change value
             # =================================================================================
             amount_name = f"{location_ref}.{class_name}.ChangeAmount"
-            amount_raw_api_object = RawAPIObject(amount_name, "ChangeAmount", dataset.nyan_api_objects)
+            amount_raw_api_object = RawAPIObject(
+                amount_name, "ChangeAmount", dataset.nyan_api_objects)
             amount_raw_api_object.add_raw_parent("engine.util.attribute.AttributeAmount")
             amount_location = ForwardRef(line, attack_ref)
             amount_raw_api_object.set_location(amount_location)
@@ -121,7 +132,10 @@ class AoCEffectSubprocessor:
         return effects
 
     @staticmethod
-    def get_convert_effects(line, location_ref):
+    def get_convert_effects(
+        line: GenieGameEntityGroup,
+        location_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates effects that are used for conversion (unit command: 104)
 
@@ -174,7 +188,8 @@ class AoCEffectSubprocessor:
         # Max success (optional; not added because there is none in AoE2)
 
         # Chance
-        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100  # hardcoded resource
+        # hardcoded resource
+        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100
         convert_raw_api_object.add_raw_member("chance_success",
                                               chance_success,
                                               effect_parent)
@@ -215,7 +230,8 @@ class AoCEffectSubprocessor:
         # Max success (optional; not added because there is none in AoE2)
 
         # Chance
-        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100  # hardcoded resource
+        # hardcoded resource
+        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100
         convert_raw_api_object.add_raw_member("chance_success",
                                               chance_success,
                                               effect_parent)
@@ -239,7 +255,10 @@ class AoCEffectSubprocessor:
         return effects
 
     @staticmethod
-    def get_heal_effects(line, location_ref):
+    def get_heal_effects(
+        line: GenieGameEntityGroup,
+        location_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates effects that are used for healing (unit command: 105)
 
@@ -334,7 +353,10 @@ class AoCEffectSubprocessor:
         return effects
 
     @staticmethod
-    def get_repair_effects(line, location_ref):
+    def get_repair_effects(
+        line: GenieGameEntityGroup,
+        location_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates effects that are used for repairing (unit command: 106)
 
@@ -456,7 +478,10 @@ class AoCEffectSubprocessor:
         return effects
 
     @staticmethod
-    def get_construct_effects(line, location_ref):
+    def get_construct_effects(
+        line: GenieGameEntityGroup,
+        location_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates effects that are used for construction (unit command: 101)
 
@@ -546,7 +571,10 @@ class AoCEffectSubprocessor:
         return effects
 
     @staticmethod
-    def get_attack_resistances(line, ability_ref):
+    def get_attack_resistances(
+        line: GenieGameEntityGroup,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates resistances that are used for attacking (unit command: 7)
 
@@ -596,7 +624,8 @@ class AoCEffectSubprocessor:
             # Block value
             # =================================================================================
             amount_name = f"{ability_ref}.{class_name}.BlockAmount"
-            amount_raw_api_object = RawAPIObject(amount_name, "BlockAmount", dataset.nyan_api_objects)
+            amount_raw_api_object = RawAPIObject(
+                amount_name, "BlockAmount", dataset.nyan_api_objects)
             amount_raw_api_object.add_raw_parent("engine.util.attribute.AttributeAmount")
             amount_location = ForwardRef(line, armor_ref)
             amount_raw_api_object.set_location(amount_location)
@@ -628,7 +657,10 @@ class AoCEffectSubprocessor:
         return resistances
 
     @staticmethod
-    def get_convert_resistances(line, ability_ref):
+    def get_convert_resistances(
+        line: GenieGameEntityGroup,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates resistances that are used for conversion (unit command: 104)
 
@@ -648,7 +680,8 @@ class AoCEffectSubprocessor:
         convert_parent = "engine.resistance.discrete.convert.type.AoE2Convert"
 
         resistance_ref = f"{ability_ref}.Convert"
-        resistance_raw_api_object = RawAPIObject(resistance_ref, "Convert", dataset.nyan_api_objects)
+        resistance_raw_api_object = RawAPIObject(
+            resistance_ref, "Convert", dataset.nyan_api_objects)
         resistance_raw_api_object.add_raw_parent(convert_parent)
         resistance_location = ForwardRef(line, ability_ref)
         resistance_raw_api_object.set_location(resistance_location)
@@ -666,7 +699,8 @@ class AoCEffectSubprocessor:
                                                  resistance_parent)
 
         # Chance resist
-        chance_resist = dataset.genie_civs[0]["resources"][77].get_value() / 100  # hardcoded resource
+        # hardcoded resource
+        chance_resist = dataset.genie_civs[0]["resources"][77].get_value() / 100
         resistance_raw_api_object.add_raw_member("chance_resist",
                                                  chance_resist,
                                                  resistance_parent)
@@ -701,7 +735,10 @@ class AoCEffectSubprocessor:
         return resistances
 
     @staticmethod
-    def get_heal_resistances(line, ability_ref):
+    def get_heal_resistances(
+        line: GenieGameEntityGroup,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates resistances that are used for healing (unit command: 105)
 
@@ -764,7 +801,10 @@ class AoCEffectSubprocessor:
         return resistances
 
     @staticmethod
-    def get_repair_resistances(line, ability_ref):
+    def get_repair_resistances(
+        line: GenieGameEntityGroup,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates resistances that are used for repairing (unit command: 106)
 
@@ -827,7 +867,8 @@ class AoCEffectSubprocessor:
                                                  resistance_parent)
 
         # Stacking of villager repair HP increase
-        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingRepair"].get_nyan_object()
+        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingRepair"].get_nyan_object(
+        )
         properties = {
             api_objects["engine.resistance.property.type.Stacked"]: construct_property
         }
@@ -844,7 +885,10 @@ class AoCEffectSubprocessor:
         return resistances
 
     @staticmethod
-    def get_construct_resistances(line, ability_ref):
+    def get_construct_resistances(
+        line: GenieGameEntityGroup,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Creates resistances that are used for constructing (unit command: 101)
 
@@ -891,7 +935,8 @@ class AoCEffectSubprocessor:
         resistances.append(resistance_forward_ref)
 
         # Stacking of villager construction times
-        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingConstruct"].get_nyan_object()
+        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingConstruct"].get_nyan_object(
+        )
         properties = {
             api_objects["engine.resistance.property.type.Stacked"]: construct_property
         }
@@ -918,7 +963,8 @@ class AoCEffectSubprocessor:
                                                  attr_resistance_parent)
 
         # Stacking of villager construction HP increase
-        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingConstruct"].get_nyan_object()
+        construct_property = dataset.pregen_nyan_objects["resistance.property.types.BuildingConstruct"].get_nyan_object(
+        )
         properties = {
             api_objects["engine.resistance.property.type.Stacked"]: construct_property
         }

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -126,7 +126,7 @@ class AoCMediaSubprocessor:
         export_request = MediaExportRequest(
             MediaType.BLEND,
             "data/blend/",
-            full_data_set.game_version[0].media_paths[MediaType.BLEND][0],
+            full_data_set.game_version.edition.media_paths[MediaType.BLEND][0],
             "blendmode"
         )
         full_data_set.blend_exports.update({0: export_request})

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-few-public-methods
 """
@@ -15,7 +15,8 @@ from ....entity_object.export.media_export_request import MediaExportRequest
 from ....entity_object.export.metadata_export import SpriteMetadataExport
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class AoCMediaSubprocessor:

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -5,11 +5,17 @@
 Convert media information to metadata definitions and export
 requests. Subroutine of the main AoC processor.
 """
+from __future__ import annotations
+import typing
+
 from openage.convert.value_object.read.media_types import MediaType
 
 from ....entity_object.export.formats.sprite_metadata import LayerMode
 from ....entity_object.export.media_export_request import MediaExportRequest
 from ....entity_object.export.metadata_export import SpriteMetadataExport
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class AoCMediaSubprocessor:
@@ -18,7 +24,7 @@ class AoCMediaSubprocessor:
     """
 
     @classmethod
-    def convert(cls, full_data_set):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create all export requests for the dataset.
         """
@@ -27,7 +33,7 @@ class AoCMediaSubprocessor:
         cls.create_sound_requests(full_data_set)
 
     @staticmethod
-    def create_graphics_requests(full_data_set):
+    def create_graphics_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for graphics referenced by CombinedSprite objects.
         """
@@ -111,7 +117,7 @@ class AoCMediaSubprocessor:
             full_data_set.graphics_exports.update({slp_id: export_request})
 
     @staticmethod
-    def create_blend_requests(full_data_set):
+    def create_blend_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for Blendomatic objects.
 
@@ -126,7 +132,7 @@ class AoCMediaSubprocessor:
         full_data_set.blend_exports.update({0: export_request})
 
     @staticmethod
-    def create_sound_requests(full_data_set):
+    def create_sound_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for sounds referenced by CombinedSound objects.
         """

--- a/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
@@ -6,12 +6,18 @@
 Derives and adds abilities to lines or civ groups. Subroutine of the
 nyan subprocessor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup,\
     GenieBuildingLineGroup, GenieVillagerGroup, GenieAmbientGroup,\
     GenieVariantGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.nyan.nyan_structs import NyanObject
 
 
 class AoCModifierSubprocessor:
@@ -20,7 +26,7 @@ class AoCModifierSubprocessor:
     """
 
     @staticmethod
-    def elevation_attack_modifiers(converter_obj_group):
+    def elevation_attack_modifiers(converter_obj_group: GenieGameEntityGroup) -> list[NyanObject]:
         """
         Adds the pregenerated elevation damage multipliers to a line or civ group.
 
@@ -42,7 +48,7 @@ class AoCModifierSubprocessor:
         return modifiers
 
     @staticmethod
-    def flyover_effect_modifier(converter_obj_group):
+    def flyover_effect_modifier(converter_obj_group: GenieGameEntityGroup) -> NyanObject:
         """
         Adds the pregenerated fly-over-cliff damage multiplier to a line or civ group.
 
@@ -59,7 +65,7 @@ class AoCModifierSubprocessor:
         return modifier
 
     @staticmethod
-    def gather_rate_modifier(converter_obj_group):
+    def gather_rate_modifier(converter_obj_group: GenieGameEntityGroup) -> list[ForwardRef]:
         """
         Adds Gather modifiers to a line or civ group.
 
@@ -173,7 +179,7 @@ class AoCModifierSubprocessor:
         return modifiers
 
     @staticmethod
-    def move_speed_modifier(converter_obj_group, value=None):
+    def move_speed_modifier(converter_obj_group: GenieGameEntityGroup, value: float) -> ForwardRef:
         """
         Adds a MoveSpeed modifier to a line or civ group.
 

--- a/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks,too-many-statements
 

--- a/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
@@ -6,10 +6,17 @@
 Organize export data (nyan objects, media, scripts, etc.)
 into modpacks.
 """
+from __future__ import annotations
+import typing
+
+
 from .....nyan.import_tree import ImportTree
 from ....entity_object.conversion.modpack import Modpack
 from ....entity_object.export.formats.nyan_file import NyanFile
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class AoCModpackSubprocessor:
@@ -18,16 +25,16 @@ class AoCModpackSubprocessor:
     """
 
     @classmethod
-    def get_modpacks(cls, gamedata):
+    def get_modpacks(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Return all modpacks that can be created from the gamedata.
         """
-        aoe2_base = cls._get_aoe2_base(gamedata)
+        aoe2_base = cls._get_aoe2_base(full_data_set)
 
         return [aoe2_base]
 
     @classmethod
-    def _get_aoe2_base(cls, gamedata):
+    def _get_aoe2_base(cls, full_data_set: GenieObjectContainer) -> Modpack:
         """
         Create the aoe2-base modpack.
         """
@@ -39,13 +46,13 @@ class AoCModpackSubprocessor:
 
         mod_def.add_include("data/*")
 
-        cls.organize_nyan_objects(modpack, gamedata)
-        cls.organize_media_objects(modpack, gamedata)
+        cls.organize_nyan_objects(modpack, full_data_set)
+        cls.organize_media_objects(modpack, full_data_set)
 
         return modpack
 
     @staticmethod
-    def organize_nyan_objects(modpack, full_data_set):
+    def organize_nyan_objects(modpack: Modpack, full_data_set: GenieObjectContainer) -> None:
         """
         Put available nyan objects into a given modpack.
         """
@@ -115,7 +122,7 @@ class AoCModpackSubprocessor:
         AoCModpackSubprocessor._set_static_aliases(modpack, import_tree)
 
     @staticmethod
-    def organize_media_objects(modpack, full_data_set):
+    def organize_media_objects(modpack: Modpack, full_data_set: GenieObjectContainer) -> None:
         """
         Put export requests and sprite files into as given modpack.
         """
@@ -132,7 +139,7 @@ class AoCModpackSubprocessor:
             modpack.add_metadata_export(metadata_file)
 
     @staticmethod
-    def _set_static_aliases(modpack, import_tree):
+    def _set_static_aliases(modpack: Modpack, import_tree: ImportTree) -> None:
         """
         Set the aliases for the nyan import tree. The alias names
         and affected nodes are hardcoded in this function.

--- a/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches,too-few-public-methods,too-many-statements
 
@@ -16,7 +16,8 @@ from ....entity_object.export.formats.nyan_file import NyanFile
 from ....value_object.conversion.forward_ref import ForwardRef
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class AoCModpackSubprocessor:

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements,too-many-branches
 #

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -9,6 +9,9 @@
 Convert API-like objects to nyan objects. Subroutine of the
 main AoC processor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_tech import UnitLineUpgrade
 from ....entity_object.conversion.aoc.genie_unit import GenieGarrisonMode,\
     GenieMonkGroup, GenieStackBuildingGroup
@@ -24,6 +27,14 @@ from .modifier_subprocessor import AoCModifierSubprocessor
 from .tech_subprocessor import AoCTechSubprocessor
 from .upgrade_ability_subprocessor import AoCUpgradeAbilitySubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+    from openage.convert.entity_object.conversion.aoc.genie_terrain import GenieTerrainGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup,\
+        GenieUnitLineGroup, GenieBuildingLineGroup, GenieAmbientGroup, GenieVariantGroup
+
 
 class AoCNyanSubprocessor:
     """
@@ -31,18 +42,18 @@ class AoCNyanSubprocessor:
     """
 
     @classmethod
-    def convert(cls, gamedata):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects from the given dataset.
         """
-        cls._process_game_entities(gamedata)
-        cls._create_nyan_objects(gamedata)
-        cls._create_nyan_members(gamedata)
+        cls._process_game_entities(full_data_set)
+        cls._create_nyan_objects(full_data_set)
+        cls._create_nyan_members(full_data_set)
 
-        cls._check_objects(gamedata)
+        cls._check_objects(full_data_set)
 
     @classmethod
-    def _check_objects(cls, full_data_set):
+    def _check_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Check if objects are valid.
         """
@@ -68,7 +79,7 @@ class AoCNyanSubprocessor:
             civ_group.check_readiness()
 
     @classmethod
-    def _create_nyan_objects(cls, full_data_set):
+    def _create_nyan_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Creates nyan objects from the API objects.
         """
@@ -101,7 +112,7 @@ class AoCNyanSubprocessor:
             civ_group.execute_raw_member_pushs()
 
     @classmethod
-    def _create_nyan_members(cls, full_data_set):
+    def _create_nyan_members(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Fill nyan member values of the API objects.
         """
@@ -127,7 +138,7 @@ class AoCNyanSubprocessor:
             civ_group.create_nyan_members()
 
     @classmethod
-    def _process_game_entities(cls, full_data_set):
+    def _process_game_entities(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create the RawAPIObject representation of the objects.
         """
@@ -154,7 +165,7 @@ class AoCNyanSubprocessor:
             cls.civ_group_to_civ(civ_group)
 
     @staticmethod
-    def unit_line_to_game_entity(unit_line):
+    def unit_line_to_game_entity(unit_line: GenieUnitLineGroup) -> None:
         """
         Creates raw API objects for a unit line.
 
@@ -191,7 +202,8 @@ class AoCNyanSubprocessor:
         unit_type = current_unit["unit_type"].get_value()
 
         if unit_type >= 70:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_unit["unit_class"].get_value()
@@ -358,7 +370,7 @@ class AoCNyanSubprocessor:
             AoCAuxiliarySubprocessor.get_creatable_game_entity(unit_line)
 
     @staticmethod
-    def building_line_to_game_entity(building_line):
+    def building_line_to_game_entity(building_line: GenieBuildingLineGroup) -> None:
         """
         Creates raw API objects for a building line.
 
@@ -396,7 +408,8 @@ class AoCNyanSubprocessor:
         unit_type = current_building["unit_type"].get_value()
 
         if unit_type >= 80:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_building["unit_class"].get_value()
@@ -406,7 +419,8 @@ class AoCNyanSubprocessor:
         types_set.append(type_obj)
 
         if building_line.is_dropsite():
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
@@ -471,7 +485,8 @@ class AoCNyanSubprocessor:
             garrison_mode = building_line.get_garrison_mode()
 
             if garrison_mode == GenieGarrisonMode.NATURAL:
-                abilities_set.append(AoCAbilitySubprocessor.send_back_to_task_ability(building_line))
+                abilities_set.append(
+                    AoCAbilitySubprocessor.send_back_to_task_ability(building_line))
 
             if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                 abilities_set.append(AoCAbilitySubprocessor.rally_point_ability(building_line))
@@ -515,7 +530,7 @@ class AoCNyanSubprocessor:
             AoCAuxiliarySubprocessor.get_creatable_game_entity(building_line)
 
     @staticmethod
-    def ambient_group_to_game_entity(ambient_group):
+    def ambient_group_to_game_entity(ambient_group: GenieAmbientGroup) -> None:
         """
         Creates raw API objects for an ambient group.
 
@@ -549,7 +564,8 @@ class AoCNyanSubprocessor:
         # Create or use existing auxiliary types
         types_set = []
 
-        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object()
+        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object(
+        )
         types_set.append(type_obj)
 
         unit_class = ambient_unit["unit_class"].get_value()
@@ -606,7 +622,7 @@ class AoCNyanSubprocessor:
         raw_api_object.add_raw_member("variants", [], "engine.util.game_entity.GameEntity")
 
     @staticmethod
-    def variant_group_to_game_entity(variant_group):
+    def variant_group_to_game_entity(variant_group: GenieVariantGroup) -> None:
         """
         Creates raw API objects for a variant group.
 
@@ -640,7 +656,8 @@ class AoCNyanSubprocessor:
         # Create or use existing auxiliary types
         types_set = []
 
-        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object()
+        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object(
+        )
         types_set.append(type_obj)
 
         unit_class = variant_main_unit["unit_class"].get_value()
@@ -771,7 +788,7 @@ class AoCNyanSubprocessor:
                                       "engine.util.game_entity.GameEntity")
 
     @staticmethod
-    def tech_group_to_tech(tech_group):
+    def tech_group_to_tech(tech_group: GenieTechEffectBundleGroup) -> None:
         """
         Creates raw API objects for a tech group.
 
@@ -838,7 +855,8 @@ class AoCNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(tech_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -859,7 +877,8 @@ class AoCNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(tech_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -887,7 +906,7 @@ class AoCNyanSubprocessor:
             AoCAuxiliarySubprocessor.get_researchable_tech(tech_group)
 
     @staticmethod
-    def terrain_group_to_terrain(terrain_group):
+    def terrain_group_to_terrain(terrain_group: GenieTerrainGroup) -> None:
         """
         Creates raw API objects for a terrain group.
 
@@ -900,7 +919,8 @@ class AoCNyanSubprocessor:
 
         name_lookup_dict = internal_name_lookups.get_entity_lookups(dataset.game_version)
         terrain_lookup_dict = internal_name_lookups.get_terrain_lookups(dataset.game_version)
-        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(dataset.game_version)
+        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(
+            dataset.game_version)
 
         # Start with the Terrain object
         terrain_name = terrain_lookup_dict[terrain_index][1]
@@ -1051,7 +1071,7 @@ class AoCNyanSubprocessor:
                                       "engine.util.terrain.Terrain")
 
     @staticmethod
-    def civ_group_to_civ(civ_group):
+    def civ_group_to_civ(civ_group: GenieCivilizationGroup) -> None:
         """
         Creates raw API objects for a civ group.
 
@@ -1102,7 +1122,8 @@ class AoCNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(civ_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -1123,7 +1144,8 @@ class AoCNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(civ_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -1169,7 +1191,7 @@ class AoCNyanSubprocessor:
                                       "engine.util.setup.PlayerSetup")
 
     @staticmethod
-    def projectiles_from_line(line):
+    def projectiles_from_line(line: GenieGameEntityGroup) -> None:
         """
         Creates Projectile(GameEntity) raw API objects for a unit/building line.
 
@@ -1208,18 +1230,24 @@ class AoCNyanSubprocessor:
             # =======================================================================
             # Types
             # =======================================================================
-            types_set = [dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
-            proj_raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
+            types_set = [
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
+            proj_raw_api_object.add_raw_member(
+                "types", types_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Abilities
             # =======================================================================
             abilities_set = []
-            abilities_set.append(AoCAbilitySubprocessor.projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(line, 7, False, projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(
+                line, 7, False, projectile_num))
             # TODO: Death, Despawn
-            proj_raw_api_object.add_raw_member("abilities", abilities_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "abilities", abilities_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Modifiers
@@ -1229,12 +1257,14 @@ class AoCNyanSubprocessor:
             modifiers_set.append(AoCModifierSubprocessor.flyover_effect_modifier(line))
             modifiers_set.extend(AoCModifierSubprocessor.elevation_attack_modifiers(line))
 
-            proj_raw_api_object.add_raw_member("modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Variants
             # =======================================================================
             variants_set = []
-            proj_raw_api_object.add_raw_member("variants", variants_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "variants", variants_set, "engine.util.game_entity.GameEntity")
 
             line.add_raw_api_object(proj_raw_api_object)

--- a/openage/convert/processor/conversion/aoc/pregen_processor.py
+++ b/openage/convert/processor/conversion/aoc/pregen_processor.py
@@ -9,11 +9,17 @@
 Creates nyan objects for things that are hardcoded into the Genie Engine,
 but configurable in openage. E.g. HP.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberSpecialValue
 from ....entity_object.conversion.converter_object import RawAPIObject,\
     ConverterObjectGroup
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class AoCPregenSubprocessor:
@@ -22,28 +28,28 @@ class AoCPregenSubprocessor:
     """
 
     @classmethod
-    def generate(cls, gamedata):
+    def generate(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects for hardcoded properties.
         """
         # Stores pregenerated raw API objects as a container
         pregen_converter_group = ConverterObjectGroup("pregen")
 
-        cls.generate_attributes(gamedata, pregen_converter_group)
-        cls.generate_diplomatic_stances(gamedata, pregen_converter_group)
-        cls.generate_team_property(gamedata, pregen_converter_group)
-        cls.generate_entity_types(gamedata, pregen_converter_group)
-        cls.generate_effect_types(gamedata, pregen_converter_group)
-        cls.generate_exchange_objects(gamedata, pregen_converter_group)
-        cls.generate_formation_types(gamedata, pregen_converter_group)
-        cls.generate_language_objects(gamedata, pregen_converter_group)
-        cls.generate_misc_effect_objects(gamedata, pregen_converter_group)
-        cls.generate_modifiers(gamedata, pregen_converter_group)
-        cls.generate_terrain_types(gamedata, pregen_converter_group)
-        cls.generate_resources(gamedata, pregen_converter_group)
-        cls.generate_death_condition(gamedata, pregen_converter_group)
+        cls.generate_attributes(full_data_set, pregen_converter_group)
+        cls.generate_diplomatic_stances(full_data_set, pregen_converter_group)
+        cls.generate_team_property(full_data_set, pregen_converter_group)
+        cls.generate_entity_types(full_data_set, pregen_converter_group)
+        cls.generate_effect_types(full_data_set, pregen_converter_group)
+        cls.generate_exchange_objects(full_data_set, pregen_converter_group)
+        cls.generate_formation_types(full_data_set, pregen_converter_group)
+        cls.generate_language_objects(full_data_set, pregen_converter_group)
+        cls.generate_misc_effect_objects(full_data_set, pregen_converter_group)
+        cls.generate_modifiers(full_data_set, pregen_converter_group)
+        cls.generate_terrain_types(full_data_set, pregen_converter_group)
+        cls.generate_resources(full_data_set, pregen_converter_group)
+        cls.generate_death_condition(full_data_set, pregen_converter_group)
 
-        pregen_nyan_objects = gamedata.pregen_nyan_objects
+        pregen_nyan_objects = full_data_set.pregen_nyan_objects
         # Create nyan objects from the raw API objects
         for pregen_object in pregen_nyan_objects.values():
             pregen_object.create_nyan_object()
@@ -57,7 +63,10 @@ class AoCPregenSubprocessor:
                                 "Member or object not initialized." % (pregen_object))
 
     @staticmethod
-    def generate_attributes(full_data_set, pregen_converter_group):
+    def generate_attributes(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate Attribute objects.
 
@@ -167,7 +176,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({faith_abbrv_ref_in_modpack: faith_abbrv_value})
 
     @staticmethod
-    def generate_diplomatic_stances(full_data_set, pregen_converter_group):
+    def generate_diplomatic_stances(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate DiplomaticStance objects.
 
@@ -239,7 +251,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({gaia_ref_in_modpack: gaia_raw_api_object})
 
     @staticmethod
-    def generate_team_property(full_data_set, pregen_converter_group):
+    def generate_team_property(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate the property used in team patches objects.
 
@@ -275,7 +290,10 @@ class AoCPregenSubprocessor:
                                            "engine.util.patch.property.type.Diplomatic")
 
     @staticmethod
-    def generate_entity_types(full_data_set, pregen_converter_group):
+    def generate_entity_types(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate GameEntityType objects.
 
@@ -399,7 +417,10 @@ class AoCPregenSubprocessor:
             pregen_nyan_objects.update({class_obj_name: new_game_entity_type})
 
     @staticmethod
-    def generate_effect_types(full_data_set, pregen_converter_group):
+    def generate_effect_types(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate types for effects and resistances.
 
@@ -416,7 +437,8 @@ class AoCPregenSubprocessor:
         api_objects = full_data_set.nyan_api_objects
 
         name_lookup_dict = internal_name_lookups.get_entity_lookups(full_data_set.game_version)
-        armor_lookup_dict = internal_name_lookups.get_armor_class_lookups(full_data_set.game_version)
+        armor_lookup_dict = internal_name_lookups.get_armor_class_lookups(
+            full_data_set.game_version)
 
         # =======================================================================
         # Armor types
@@ -541,7 +563,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({type_ref_in_modpack: type_raw_api_object})
 
     @staticmethod
-    def generate_exchange_objects(full_data_set, pregen_converter_group):
+    def generate_exchange_objects(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate objects for market trading (ExchangeResources).
 
@@ -831,7 +856,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({price_mode_ref_in_modpack: price_mode_raw_api_object})
 
     @staticmethod
-    def generate_formation_types(full_data_set, pregen_converter_group):
+    def generate_formation_types(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate Formation and Subformation objects.
 
@@ -1041,7 +1069,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({subformation_ref_in_modpack: subformation_raw_api_object})
 
     @staticmethod
-    def generate_language_objects(full_data_set, pregen_converter_group):
+    def generate_language_objects(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate language objects from the string resources
 
@@ -1079,7 +1110,10 @@ class AoCPregenSubprocessor:
             pregen_nyan_objects.update({language_ref_in_modpack: language_raw_api_object})
 
     @staticmethod
-    def generate_misc_effect_objects(full_data_set, pregen_converter_group):
+    def generate_misc_effect_objects(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate fallback types and other standard objects for effects and resistances.
 
@@ -1398,7 +1432,10 @@ class AoCPregenSubprocessor:
                                            "engine.resistance.property.type.Stacked")
 
     @staticmethod
-    def generate_modifiers(full_data_set, pregen_converter_group):
+    def generate_modifiers(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate standard modifiers.
 
@@ -1551,7 +1588,10 @@ class AoCPregenSubprocessor:
                                                modifier_parent)
 
     @staticmethod
-    def generate_terrain_types(full_data_set, pregen_converter_group):
+    def generate_terrain_types(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate TerrainType objects.
 
@@ -1567,7 +1607,8 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects = full_data_set.pregen_nyan_objects
         api_objects = full_data_set.nyan_api_objects
 
-        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(full_data_set.game_version)
+        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(
+            full_data_set.game_version)
 
         type_parent = "engine.util.terrain_type.TerrainType"
         types_location = "data/util/terrain_type/"
@@ -1587,7 +1628,10 @@ class AoCPregenSubprocessor:
             pregen_nyan_objects.update({type_ref_in_modpack: type_raw_api_object})
 
     @staticmethod
-    def generate_resources(full_data_set, pregen_converter_group):
+    def generate_resources(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate Attribute objects.
 
@@ -1784,7 +1828,10 @@ class AoCPregenSubprocessor:
         pregen_nyan_objects.update({pop_name_ref_in_modpack: pop_name_value})
 
     @staticmethod
-    def generate_death_condition(full_data_set, pregen_converter_group):
+    def generate_death_condition(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate DeathCondition objects.
 

--- a/openage/convert/processor/conversion/aoc/pregen_processor.py
+++ b/openage/convert/processor/conversion/aoc/pregen_processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements
 #

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -5,6 +5,10 @@
 """
 Convert data from AoC to openage formats.
 """
+from __future__ import annotations
+import typing
+
+
 from .....log import info
 from ....entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
 from ....entity_object.conversion.aoc.genie_civ import GenieCivilizationObject
@@ -43,6 +47,13 @@ from .modpack_subprocessor import AoCModpackSubprocessor
 from .nyan_subprocessor import AoCNyanSubprocessor
 from .pregen_processor import AoCPregenSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.read.value_members import ArrayMember
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class AoCProcessor:
     """
@@ -50,7 +61,13 @@ class AoCProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game speification and media here and get a set of
         modpacks back.
@@ -83,7 +100,13 @@ class AoCProcessor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -115,7 +138,7 @@ class AoCProcessor:
         return dataset
 
     @classmethod
-    def _processor(cls, full_data_set):
+    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -156,7 +179,7 @@ class AoCProcessor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 
@@ -177,7 +200,7 @@ class AoCProcessor:
         return AoCModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def extract_genie_units(gamespec, full_data_set):
+    def extract_genie_units(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract units from the game data.
 
@@ -216,7 +239,7 @@ class AoCProcessor:
             unit.add_member(unit_commands)
 
     @staticmethod
-    def extract_genie_techs(gamespec, full_data_set):
+    def extract_genie_techs(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract techs from the game data.
 
@@ -239,7 +262,7 @@ class AoCProcessor:
             index += 1
 
     @staticmethod
-    def extract_genie_effect_bundles(gamespec, full_data_set):
+    def extract_genie_effect_bundles(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract effects and effect bundles from the game data.
 
@@ -282,7 +305,7 @@ class AoCProcessor:
             index_bundle += 1
 
     @staticmethod
-    def extract_genie_civs(gamespec, full_data_set):
+    def extract_genie_civs(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract civs from the game data.
 
@@ -308,7 +331,7 @@ class AoCProcessor:
             index += 1
 
     @staticmethod
-    def extract_age_connections(gamespec, full_data_set):
+    def extract_age_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract age connections from the game data.
 
@@ -326,7 +349,7 @@ class AoCProcessor:
             full_data_set.age_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_building_connections(gamespec, full_data_set):
+    def extract_building_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract building connections from the game data.
 
@@ -345,7 +368,7 @@ class AoCProcessor:
             full_data_set.building_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_unit_connections(gamespec, full_data_set):
+    def extract_unit_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract unit connections from the game data.
 
@@ -363,7 +386,7 @@ class AoCProcessor:
             full_data_set.unit_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_tech_connections(gamespec, full_data_set):
+    def extract_tech_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract tech connections from the game data.
 
@@ -381,7 +404,7 @@ class AoCProcessor:
             full_data_set.tech_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_genie_graphics(gamespec, full_data_set):
+    def extract_genie_graphics(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract graphic definitions from the game data.
 
@@ -412,7 +435,7 @@ class AoCProcessor:
             genie_graphic.detect_subgraphics()
 
     @staticmethod
-    def extract_genie_sounds(gamespec, full_data_set):
+    def extract_genie_sounds(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract sound definitions from the game data.
 
@@ -430,7 +453,7 @@ class AoCProcessor:
             full_data_set.genie_sounds.update({sound.get_id(): sound})
 
     @staticmethod
-    def extract_genie_terrains(gamespec, full_data_set):
+    def extract_genie_terrains(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract terrains from the game data.
 
@@ -451,7 +474,7 @@ class AoCProcessor:
             index += 1
 
     @staticmethod
-    def create_unit_lines(full_data_set):
+    def create_unit_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Sort units into lines, based on information in the unit connections.
 
@@ -551,13 +574,13 @@ class AoCProcessor:
             full_data_set.unit_ref.update({unit_id: unit_line})
 
     @staticmethod
-    def create_extra_unit_lines(full_data_set):
+    def create_extra_unit_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Create additional units that are not in the unit connections.
 
         :param full_data_set: GenieObjectContainer instance that
-                              contains all relevant data for the conversion
-                              process.
+                                contains all relevant data for the conversion
+                                process.
         :type full_data_set: class: ...dataformat.aoc.genie_object_container.GenieObjectContainer
         """
         extra_units = (48, 65, 594, 833)  # Wildlife
@@ -569,7 +592,7 @@ class AoCProcessor:
             full_data_set.unit_ref.update({unit_id: unit_line})
 
     @staticmethod
-    def create_building_lines(full_data_set):
+    def create_building_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Establish building lines, based on information in the building connections.
         Because of how Genie building lines work, this will only find the first
@@ -679,7 +702,7 @@ class AoCProcessor:
                 full_data_set.unit_ref.update({building_id: building_line})
 
     @staticmethod
-    def sanitize_effect_bundles(full_data_set):
+    def sanitize_effect_bundles(full_data_set: GenieObjectContainer) -> None:
         """
         Remove garbage data from effect bundles.
 
@@ -719,7 +742,7 @@ class AoCProcessor:
             bundle.sanitized = True
 
     @staticmethod
-    def create_tech_groups(full_data_set):
+    def create_tech_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create techs from tech connections and unit upgrades/unlocks
         from unit connections.
@@ -882,7 +905,7 @@ class AoCProcessor:
             full_data_set.civ_boni.update({civ_bonus.get_id(): civ_bonus})
 
     @staticmethod
-    def create_civ_groups(full_data_set):
+    def create_civ_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create civilization groups from civ objects.
 
@@ -902,7 +925,7 @@ class AoCProcessor:
             index += 1
 
     @staticmethod
-    def create_villager_groups(full_data_set):
+    def create_villager_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create task groups and assign the relevant male and female group to a
         villager group.
@@ -954,7 +977,7 @@ class AoCProcessor:
             full_data_set.unit_ref.update({unit_id: villager})
 
     @staticmethod
-    def create_ambient_groups(full_data_set):
+    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create ambient groups, mostly for resources and scenery.
 
@@ -973,7 +996,7 @@ class AoCProcessor:
             full_data_set.unit_ref.update({ambient_id: ambient_group})
 
     @staticmethod
-    def create_variant_groups(full_data_set):
+    def create_variant_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create variant groups.
 
@@ -993,7 +1016,7 @@ class AoCProcessor:
                 full_data_set.unit_ref.update({variant_id: variant_group})
 
     @staticmethod
-    def create_terrain_groups(full_data_set):
+    def create_terrain_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create terrain groups.
 
@@ -1019,7 +1042,7 @@ class AoCProcessor:
                 full_data_set.terrain_groups.update({terrain.get_id(): terrain_group})
 
     @staticmethod
-    def link_building_upgrades(full_data_set):
+    def link_building_upgrades(full_data_set: GenieObjectContainer) -> None:
         """
         Find building upgrades in the AgeUp techs and append them to the building lines.
 
@@ -1051,7 +1074,7 @@ class AoCProcessor:
                 full_data_set.unit_ref.update({upgrade_target_id: upgraded_line})
 
     @staticmethod
-    def link_creatables(full_data_set):
+    def link_creatables(full_data_set: GenieObjectContainer) -> None:
         """
         Link creatable units and buildings to their creating entity. This is done
         to provide quick access during conversion.
@@ -1084,7 +1107,7 @@ class AoCProcessor:
                     full_data_set.unit_lines[train_location_id].add_creatable(building_line)
 
     @staticmethod
-    def link_researchables(full_data_set):
+    def link_researchables(full_data_set: GenieObjectContainer) -> None:
         """
         Link techs to their buildings. This is done
         to provide quick access during conversion.
@@ -1102,7 +1125,7 @@ class AoCProcessor:
                 full_data_set.building_lines[research_location_id].add_researchable(tech)
 
     @staticmethod
-    def link_civ_uniques(full_data_set):
+    def link_civ_uniques(full_data_set: GenieObjectContainer) -> None:
         """
         Link civ bonus techs, unique units and unique techs to their civs.
 
@@ -1141,7 +1164,7 @@ class AoCProcessor:
                 full_data_set.civ_groups[civ_id].add_unique_tech(tech_group)
 
     @staticmethod
-    def link_gatherers_to_dropsites(full_data_set):
+    def link_gatherers_to_dropsites(full_data_set: GenieObjectContainer) -> None:
         """
         Link gatherers to the buildings they drop resources off. This is done
         to provide quick access during conversion.
@@ -1166,7 +1189,7 @@ class AoCProcessor:
                         drop_site.add_gatherer_id(unit_id)
 
     @staticmethod
-    def link_garrison(full_data_set):
+    def link_garrison(full_data_set: GenieObjectContainer) -> None:
         """
         Link a garrison unit to the lines that are stored and vice versa. This is done
         to provide quick access during conversion.
@@ -1279,7 +1302,7 @@ class AoCProcessor:
                             garrison_line.garrison_entities.append(unit_line)
 
     @staticmethod
-    def link_trade_posts(full_data_set):
+    def link_trade_posts(full_data_set: GenieObjectContainer) -> None:
         """
         Link a trade post building to the lines that it trades with.
 
@@ -1309,7 +1332,7 @@ class AoCProcessor:
                 full_data_set.building_lines[trade_post_id].add_trading_line(unit_line)
 
     @staticmethod
-    def link_repairables(full_data_set):
+    def link_repairables(full_data_set: GenieObjectContainer) -> None:
         """
         Set units/buildings as repairable
 

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-branches,too-many-statements
 # pylint: disable=too-many-locals,too-many-public-methods
@@ -262,7 +262,10 @@ class AoCProcessor:
             index += 1
 
     @staticmethod
-    def extract_genie_effect_bundles(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_genie_effect_bundles(
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> None:
         """
         Extract effects and effect bundles from the game data.
 
@@ -305,7 +308,10 @@ class AoCProcessor:
             index_bundle += 1
 
     @staticmethod
-    def extract_genie_civs(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_genie_civs(
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> None:
         """
         Extract civs from the game data.
 
@@ -349,7 +355,10 @@ class AoCProcessor:
             full_data_set.age_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_building_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_building_connections(
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> None:
         """
         Extract building connections from the game data.
 
@@ -368,7 +377,10 @@ class AoCProcessor:
             full_data_set.building_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_unit_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_unit_connections(
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> None:
         """
         Extract unit connections from the game data.
 
@@ -386,7 +398,10 @@ class AoCProcessor:
             full_data_set.unit_connections.update({connection.get_id(): connection})
 
     @staticmethod
-    def extract_tech_connections(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_tech_connections(
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> None:
         """
         Extract tech connections from the game data.
 

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -52,7 +52,7 @@ if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
     from openage.convert.value_object.read.value_members import ArrayMember
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class AoCProcessor:
@@ -103,7 +103,7 @@ class AoCProcessor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 #

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -116,14 +116,14 @@ class AoCTechSubprocessor:
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
             team_bonus = True
 
         elif isinstance(converter_group, CivBonus):
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
 
         else:
             effects = converter_group.get_effects()
@@ -320,15 +320,24 @@ class AoCTechSubprocessor:
 
         diff = upgrade_source.diff(upgrade_target)
 
-        patches.extend(AoCUpgradeAbilitySubprocessor.death_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.despawn_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.idle_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.live_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.los_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.named_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.resistance_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.selectable_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.turn_ability(converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.death_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.despawn_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.idle_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.live_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.los_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.named_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.resistance_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.selectable_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.turn_ability(
+            converter_group, line, tech_name, diff))
 
         if line.is_projectile_shooter():
             patches.extend(AoCUpgradeAbilitySubprocessor.shoot_projectile_ability(converter_group, line,
@@ -449,7 +458,8 @@ class AoCTechSubprocessor:
                                                        operator)
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -535,7 +545,8 @@ class AoCTechSubprocessor:
                                                        operator)
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -8,6 +8,10 @@
 """
 Creates patches for technologies.
 """
+from __future__ import annotations
+import typing
+
+
 from openage.log import warn
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup,\
@@ -20,6 +24,10 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from .upgrade_ability_subprocessor import AoCUpgradeAbilitySubprocessor
 from .upgrade_attribute_subprocessor import AoCUpgradeAttributeSubprocessor
 from .upgrade_resource_subprocessor import AoCUpgradeResourceSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject
 
 
 class AoCTechSubprocessor:
@@ -103,7 +111,7 @@ class AoCTechSubprocessor:
     }
 
     @classmethod
-    def get_patches(cls, converter_group):
+    def get_patches(cls, converter_group: ConverterObjectGroup) -> list[ForwardRef]:
         """
         Returns the patches for a converter group, depending on the type
         of its effects.
@@ -172,7 +180,11 @@ class AoCTechSubprocessor:
         return patches
 
     @staticmethod
-    def attribute_modify_effect(converter_group, effect, team=False):
+    def attribute_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying attributes of entities.
         """
@@ -237,7 +249,11 @@ class AoCTechSubprocessor:
         return patches
 
     @staticmethod
-    def resource_modify_effect(converter_group, effect, team=False):
+    def resource_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying resources.
         """
@@ -276,7 +292,10 @@ class AoCTechSubprocessor:
         return patches
 
     @staticmethod
-    def upgrade_unit_effect(converter_group, effect):
+    def upgrade_unit_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject
+    ) -> list[ForwardRef]:
         """
         Creates the patches for upgrading entities in a line.
         """
@@ -365,7 +384,11 @@ class AoCTechSubprocessor:
         return patches
 
     @staticmethod
-    def tech_cost_modify_effect(converter_group, effect, team=False):
+    def tech_cost_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying tech costs.
         """
@@ -481,7 +504,11 @@ class AoCTechSubprocessor:
         return patches
 
     @staticmethod
-    def tech_time_modify_effect(converter_group, effect, team=False):
+    def tech_time_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying tech research times.
         """

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -9,6 +9,10 @@
 """
 Creates upgrade patches for abilities.
 """
+from __future__ import annotations
+import typing
+
+
 from math import degrees
 
 from .....nyan.nyan_structs import MemberOperator, MemberSpecialValue
@@ -23,6 +27,12 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ....value_object.read.value_members import NoDiffMember
 from .upgrade_effect_subprocessor import AoCUpgradeEffectSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject,\
+        ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup,\
+        GenieUnitObject
+
 
 class AoCUpgradeAbilitySubprocessor:
     """
@@ -30,8 +40,14 @@ class AoCUpgradeAbilitySubprocessor:
     """
 
     @staticmethod
-    def apply_continuous_effect_ability(converter_group, line, container_obj_ref,
-                                        command_id, ranged=False, diff=None):
+    def apply_continuous_effect_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        command_id: int,
+        ranged: bool = False,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ApplyContinuousEffect ability of a line.
 
@@ -197,8 +213,14 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def apply_discrete_effect_ability(converter_group, line, container_obj_ref,
-                                      command_id, ranged=False, diff=None):
+    def apply_discrete_effect_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        command_id: int,
+        ranged: bool = False,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ApplyDiscreteEffect ability of a line.
 
@@ -387,7 +409,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def attribute_change_tracker_ability(converter_group, line, container_obj_ref, diff=None):
+    def attribute_change_tracker_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the AttributeChangeTracker ability of a line.
 
@@ -498,7 +525,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def death_ability(converter_group, line, container_obj_ref, diff=None):
+    def death_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Death ability of a line.
 
@@ -596,7 +628,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def despawn_ability(converter_group, line, container_obj_ref, diff=None):
+    def despawn_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Despawn ability of a line.
 
@@ -627,7 +664,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_dead_unit, NoDiffMember):
                 return patches
 
-            diff_animation_id = dataset.genie_units[diff_dead_unit.get_value()]["idle_graphic0"].get_value()
+            diff_animation_id = dataset.genie_units[diff_dead_unit.get_value(
+            )]["idle_graphic0"].get_value()
 
         else:
             return patches
@@ -694,7 +732,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def idle_ability(converter_group, line, container_obj_ref, diff=None):
+    def idle_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Idle ability of a line.
 
@@ -792,7 +835,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def live_ability(converter_group, line, container_obj_ref, diff=None):
+    def live_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Live ability of a line.
 
@@ -886,7 +934,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def los_ability(converter_group, line, container_obj_ref, diff=None):
+    def los_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the LineOfSight ability of a line.
 
@@ -974,7 +1027,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def move_ability(converter_group, line, container_obj_ref, diff=None):
+    def move_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Move ability of a line.
 
@@ -1099,7 +1157,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def named_ability(converter_group, line, container_obj_ref, diff=None):
+    def named_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Named ability of a line.
 
@@ -1189,7 +1252,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def resistance_ability(converter_group, line, container_obj_ref, diff=None):
+    def resistance_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Resistance ability of a line.
 
@@ -1225,7 +1293,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def selectable_ability(converter_group, line, container_obj_ref, diff=None):
+    def selectable_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Selectable ability of a line.
 
@@ -1397,9 +1470,15 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def shoot_projectile_ability(converter_group, line, container_obj_ref,
-                                 upgrade_source, upgrade_target,
-                                 command_id, diff=None):
+    def shoot_projectile_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        upgrade_source: GenieUnitObject,
+        upgrade_target: GenieUnitObject,
+        command_id: int,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Selectable ability of a line.
 
@@ -1679,7 +1758,12 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def turn_ability(converter_group, line, container_obj_ref, diff=None):
+    def turn_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Turn ability of a line.
 
@@ -1774,7 +1858,14 @@ class AoCUpgradeAbilitySubprocessor:
         return patches
 
     @staticmethod
-    def create_animation(converter_group, line, animation_id, nyan_patch_ref, animation_name, filename_prefix):
+    def create_animation(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        animation_id: int,
+        nyan_patch_ref: str,
+        animation_name: str,
+        filename_prefix: str
+    ) -> ForwardRef:
         """
         Generates an animation for an ability.
         """
@@ -1827,7 +1918,13 @@ class AoCUpgradeAbilitySubprocessor:
         return animation_forward_ref
 
     @staticmethod
-    def create_sound(converter_group, sound_id, nyan_patch_ref, sound_name, filename_prefix):
+    def create_sound(
+        converter_group: ConverterObjectGroup,
+        sound_id: int,
+        nyan_patch_ref: str,
+        sound_name: str,
+        filename_prefix: str
+    ) -> ForwardRef:
         """
         Generates a sound for an ability.
         """
@@ -1877,7 +1974,12 @@ class AoCUpgradeAbilitySubprocessor:
         return sound_forward_ref
 
     @staticmethod
-    def create_language_strings(converter_group, string_id, obj_ref, obj_name_prefix):
+    def create_language_strings(
+        converter_group: ConverterObjectGroup,
+        string_id: int,
+        obj_ref: str,
+        obj_name_prefix: str
+    ) -> list[ForwardRef]:
         """
         Generates a language string for an ability.
         """
@@ -1896,7 +1998,8 @@ class AoCUpgradeAbilitySubprocessor:
                 string_raw_api_object.set_location(string_location)
 
                 # Language identifier
-                lang_forward_ref = dataset.pregen_nyan_objects[f"util.language.{language}"].get_nyan_object()
+                lang_forward_ref = dataset.pregen_nyan_objects[f"util.language.{language}"].get_nyan_object(
+                )
                 string_raw_api_object.add_raw_member("language",
                                                      lang_forward_ref,
                                                      "engine.util.language.LanguageTextPair")

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,invalid-name
 # pylint: disable=too-many-public-methods,too-many-branches,too-many-arguments

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods
 #

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -8,11 +8,20 @@
 """
 Creates upgrade patches for attribute modification effects in AoC.
 """
+from __future__ import annotations
+import typing
+
+
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class AoCUpgradeAttributeSubprocessor:
@@ -21,7 +30,13 @@ class AoCUpgradeAttributeSubprocessor:
     """
 
     @staticmethod
-    def accuracy_upgrade(converter_group, line, value, operator, team=False):
+    def accuracy_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the accuracy modify effect (ID: 11).
 
@@ -30,7 +45,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -89,7 +104,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -106,7 +122,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def armor_upgrade(converter_group, line, value, operator, team=False):
+    def armor_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the armor modify effect (ID: 8).
 
@@ -115,7 +137,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -192,7 +214,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -209,7 +232,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def attack_upgrade(converter_group, line, value, operator, team=False):
+    def attack_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the attack modify effect (ID: 9).
 
@@ -218,7 +247,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -255,7 +284,8 @@ class AoCUpgradeAttributeSubprocessor:
         class_name = armor_lookup_dict[armor_class]
 
         if line.is_projectile_shooter():
-            primary_projectile_id = line.get_head_unit()["attack_projectile_primary_unit_id"].get_value()
+            primary_projectile_id = line.get_head_unit(
+            )["attack_projectile_primary_unit_id"].get_value()
             if primary_projectile_id == -1:
                 # Upgrade is skipped if the primary projectile is not defined
                 return patches
@@ -304,7 +334,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -321,7 +352,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def ballistics_upgrade(converter_group, line, value, operator, team=False):
+    def ballistics_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: int,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ballistics modify effect (ID: 19).
 
@@ -330,7 +367,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -408,7 +445,8 @@ class AoCUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -458,7 +496,8 @@ class AoCUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -475,7 +514,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def blast_radius_upgrade(converter_group, line, value, operator, team=False):
+    def blast_radius_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the blast radius modify effect (ID: 22).
 
@@ -484,7 +529,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -497,7 +542,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def carry_capacity_upgrade(converter_group, line, value, operator, team=False):
+    def carry_capacity_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the carry capacity modify effect (ID: 14).
 
@@ -506,7 +557,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -519,7 +570,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_food_upgrade(converter_group, line, value, operator, team=False):
+    def cost_food_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the food cost modify effect (ID: 103).
 
@@ -528,7 +585,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -600,7 +657,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -617,7 +675,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_wood_upgrade(converter_group, line, value, operator, team=False):
+    def cost_wood_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the wood cost modify effect (ID: 104).
 
@@ -626,7 +690,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -698,7 +762,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -715,7 +780,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_gold_upgrade(converter_group, line, value, operator, team=False):
+    def cost_gold_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the gold cost modify effect (ID: 105).
 
@@ -724,7 +795,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -796,7 +867,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -813,7 +885,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_stone_upgrade(converter_group, line, value, operator, team=False):
+    def cost_stone_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the stone cost modify effect (ID: 106).
 
@@ -822,7 +900,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -894,7 +972,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -911,7 +990,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def creation_time_upgrade(converter_group, line, value, operator, team=False):
+    def creation_time_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the creation time modify effect (ID: 101).
 
@@ -920,7 +1005,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -979,7 +1064,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -996,7 +1082,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def garrison_capacity_upgrade(converter_group, line, value, operator, team=False):
+    def garrison_capacity_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the garrison capacity modify effect (ID: 2).
 
@@ -1005,7 +1097,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1068,7 +1160,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1085,7 +1178,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def garrison_heal_upgrade(converter_group, line, value, operator, team=False):
+    def garrison_heal_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the garrison heal rate modify effect (ID: 108).
 
@@ -1094,7 +1193,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1107,7 +1206,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def graphics_angle_upgrade(converter_group, line, value, operator, team=False):
+    def graphics_angle_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: int,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the graphics angle modify effect (ID: 17).
 
@@ -1116,7 +1221,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1129,16 +1234,22 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def gold_counter_upgrade(converter_group, line, value, operator, team=False):
+    def gold_counter_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
-        Creates a patch for the gold cunter effect (ID: 49).
+        Creates a patch for the gold counter effect (ID: 49).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1151,7 +1262,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def hp_upgrade(converter_group, line, value, operator, team=False):
+    def hp_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the HP modify effect (ID: 0).
 
@@ -1160,7 +1277,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1224,7 +1341,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1241,7 +1359,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def imperial_tech_id_upgrade(converter_group, line, value, operator, team=False):
+    def imperial_tech_id_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the imperial tech ID effect (ID: 24).
 
@@ -1250,7 +1374,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1263,7 +1387,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def kidnap_storage_upgrade(converter_group, line, value, operator, team=False):
+    def kidnap_storage_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the kidnap storage effect (ID: 57).
 
@@ -1272,7 +1402,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1285,7 +1415,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def los_upgrade(converter_group, line, value, operator, team=False):
+    def los_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the line of sight modify effect (ID: 1).
 
@@ -1353,7 +1489,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1370,7 +1507,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def max_projectiles_upgrade(converter_group, line, value, operator, team=False):
+    def max_projectiles_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the max projectiles modify effect (ID: 107).
 
@@ -1379,7 +1522,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1438,7 +1581,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1455,7 +1599,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def min_projectiles_upgrade(converter_group, line, value, operator, team=False):
+    def min_projectiles_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the min projectiles modify effect (ID: 102).
 
@@ -1464,7 +1614,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1523,7 +1673,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1540,7 +1691,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def max_range_upgrade(converter_group, line, value, operator, team=False):
+    def max_range_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the max range modify effect (ID: 12).
 
@@ -1549,7 +1706,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1629,7 +1786,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1646,7 +1804,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def min_range_upgrade(converter_group, line, value, operator, team=False):
+    def min_range_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the min range modify effect (ID: 20).
 
@@ -1655,7 +1819,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1726,7 +1890,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1743,7 +1908,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def move_speed_upgrade(converter_group, line, value, operator, team=False):
+    def move_speed_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the move speed modify effect (ID: 5).
 
@@ -1752,7 +1923,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1811,7 +1982,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1828,7 +2000,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def projectile_unit_upgrade(converter_group, line, value, operator, team=False):
+    def projectile_unit_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the projectile modify effect (ID: 16).
 
@@ -1837,7 +2015,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1850,7 +2028,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def reload_time_upgrade(converter_group, line, value, operator, team=False):
+    def reload_time_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the reload time modify effect (ID: 10).
 
@@ -1859,7 +2043,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1934,7 +2118,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1951,7 +2136,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def resource_cost_upgrade(converter_group, line, value, operator, team=False):
+    def resource_cost_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the resource modify effect (ID: 100).
 
@@ -1960,7 +2151,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2050,7 +2241,8 @@ class AoCUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -2067,7 +2259,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def resource_storage_1_upgrade(converter_group, line, value, operator, team=False):
+    def resource_storage_1_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the resource storage 1 modify effect (ID: 21).
 
@@ -2076,7 +2274,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2149,7 +2347,8 @@ class AoCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -2166,7 +2365,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def rotation_speed_upgrade(converter_group, line, value, operator, team=False):
+    def rotation_speed_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the move speed modify effect (ID: 6).
 
@@ -2175,7 +2380,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2188,7 +2393,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def search_radius_upgrade(converter_group, line, value, operator, team=False):
+    def search_radius_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the search radius modify effect (ID: 23).
 
@@ -2197,7 +2408,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2263,7 +2474,8 @@ class AoCUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -2280,7 +2492,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def standing_wonders_upgrade(converter_group, line, value, operator, team=False):
+    def standing_wonders_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the standing wonders effect (ID: 42).
 
@@ -2289,7 +2507,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2302,7 +2520,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def tc_available_upgrade(converter_group, line, value, operator, team=False):
+    def tc_available_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the TC available effect (ID: 48).
 
@@ -2311,7 +2535,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2324,7 +2548,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def terrain_defense_upgrade(converter_group, line, value, operator, team=False):
+    def terrain_defense_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the terrain defense modify effect (ID: 18).
 
@@ -2333,7 +2563,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2346,7 +2576,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def tribute_inefficiency_upgrade(converter_group, line, value, operator, team=False):
+    def tribute_inefficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the tribute inefficiency effect (ID: 46).
 
@@ -2355,7 +2591,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2368,7 +2604,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def unit_size_x_upgrade(converter_group, line, value, operator, team=False):
+    def unit_size_x_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the unit size x modify effect (ID: 3).
 
@@ -2390,7 +2632,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def unit_size_y_upgrade(converter_group, line, value, operator, team=False):
+    def unit_size_y_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the unit size y modify effect (ID: 4).
 
@@ -2399,7 +2647,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -2412,7 +2660,13 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def work_rate_upgrade(converter_group, line, value, operator, team=False):
+    def work_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the work rate modify effect (ID: 13).
 
@@ -2421,7 +2675,7 @@ class AoCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 #

--- a/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
@@ -9,6 +9,10 @@
 Upgrades effects and resistances for the Apply*Effect and Resistance
 abilities.
 """
+from __future__ import annotations
+import typing
+
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
@@ -17,6 +21,11 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ....value_object.read.value_members import NoDiffMember,\
     LeftMissingMember, RightMissingMember
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+
 
 class AoCUpgradeEffectSubprocessor:
     """
@@ -24,7 +33,12 @@ class AoCUpgradeEffectSubprocessor:
     """
 
     @staticmethod
-    def get_attack_effects(tech_group, line, diff, ability_ref):
+    def get_attack_effects(
+        tech_group: GenieTechEffectBundleGroup,
+        line: GenieGameEntityGroup,
+        diff: ConverterObject,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Upgrades effects that are used for attacking (unit command: 7)
 
@@ -133,12 +147,14 @@ class AoCUpgradeEffectSubprocessor:
                 # Change value
                 # =================================================================================
                 amount_name = f"{nyan_patch_ref}.{class_name}.ChangeAmount"
-                amount_raw_api_object = RawAPIObject(amount_name, "ChangeAmount", dataset.nyan_api_objects)
+                amount_raw_api_object = RawAPIObject(
+                    amount_name, "ChangeAmount", dataset.nyan_api_objects)
                 amount_raw_api_object.add_raw_parent("engine.util.attribute.AttributeAmount")
                 amount_location = ForwardRef(line, attack_ref)
                 amount_raw_api_object.set_location(amount_location)
 
-                attribute = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object()
+                attribute = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object(
+                )
                 amount_raw_api_object.add_raw_member("type",
                                                      attribute,
                                                      "engine.util.attribute.AttributeAmount")
@@ -299,7 +315,12 @@ class AoCUpgradeEffectSubprocessor:
         return patches
 
     @staticmethod
-    def get_attack_resistances(tech_group, line, diff, ability_ref):
+    def get_attack_resistances(
+        tech_group: GenieTechEffectBundleGroup,
+        line: GenieGameEntityGroup,
+        diff: ConverterObject,
+        ability_ref: str
+    ) -> list[ForwardRef]:
         """
         Upgrades resistances that are used for attacking (unit command: 7)
 
@@ -399,12 +420,14 @@ class AoCUpgradeEffectSubprocessor:
                 # Block value
                 # =================================================================================
                 amount_name = f"{nyan_patch_ref}.{class_name}.BlockAmount"
-                amount_raw_api_object = RawAPIObject(amount_name, "BlockAmount", dataset.nyan_api_objects)
+                amount_raw_api_object = RawAPIObject(
+                    amount_name, "BlockAmount", dataset.nyan_api_objects)
                 amount_raw_api_object.add_raw_parent("engine.util.attribute.AttributeAmount")
                 amount_location = ForwardRef(line, attack_ref)
                 amount_raw_api_object.set_location(amount_location)
 
-                attribute = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object()
+                attribute = dataset.pregen_nyan_objects["util.attribute.types.Health"].get_nyan_object(
+                )
                 amount_raw_api_object.add_raw_member("type",
                                                      attribute,
                                                      "engine.util.attribute.AttributeAmount")

--- a/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods,invalid-name
 #

--- a/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_resource_subprocessor.py
@@ -8,11 +8,18 @@
 """
 Creates upgrade patches for resource modification effects in AoC.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class AoCUpgradeResourceSubprocessor:
@@ -21,14 +28,19 @@ class AoCUpgradeResourceSubprocessor:
     """
 
     @staticmethod
-    def berserk_heal_rate_upgrade(converter_group, value, operator, team=False):
+    def berserk_heal_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the berserk heal rate modify effect (ID: 96).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -90,7 +102,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -107,14 +120,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def bonus_population_upgrade(converter_group, value, operator, team=False):
+    def bonus_population_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the bonus population effect (ID: 32).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -168,7 +186,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -185,14 +204,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def building_conversion_upgrade(converter_group, value, operator, team=False):
+    def building_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the building conversion effect (ID: 28).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -244,7 +268,8 @@ class AoCUpgradeResourceSubprocessor:
         nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
         # New allowed types
-        allowed_types = [dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()]
+        allowed_types = [
+            dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()]
         nyan_patch_raw_api_object.add_raw_patch_member("allowed_types",
                                                        allowed_types,
                                                        "engine.ability.type.ApplyDiscreteEffect",
@@ -329,7 +354,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -346,14 +372,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def chinese_tech_discount_upgrade(converter_group, value, operator, team=False):
+    def chinese_tech_discount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the chinese tech discount effect (ID: 85).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -366,14 +397,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def construction_speed_upgrade(converter_group, value, operator, team=False):
+    def construction_speed_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the construction speed modify effect (ID: 195).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -386,14 +422,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_resistance_upgrade(converter_group, value, operator, team=False):
+    def conversion_resistance_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion resistance modify effect (ID: 77).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -406,14 +447,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_resistance_min_rounds_upgrade(converter_group, value, operator, team=False):
+    def conversion_resistance_min_rounds_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion resistance modify effect (ID: 178).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -426,14 +472,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_resistance_max_rounds_upgrade(converter_group, value, operator, team=False):
+    def conversion_resistance_max_rounds_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion resistance modify effect (ID: 179).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -446,14 +497,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def crenellations_upgrade(converter_group, value, operator, team=False):
+    def crenellations_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the crenellations effect (ID: 194).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -466,14 +522,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def faith_recharge_rate_upgrade(converter_group, value, operator, team=False):
+    def faith_recharge_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the faith_recharge_rate modify effect (ID: 35).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -533,7 +594,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -550,14 +612,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def farm_food_upgrade(converter_group, value, operator, team=False):
+    def farm_food_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the farm food modify effect (ID: 36).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -617,7 +684,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -634,14 +702,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def gather_food_efficiency_upgrade(converter_group, value, operator, team=False):
+    def gather_food_efficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the food gathering efficiency modify effect (ID: 190).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -654,14 +727,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def gather_wood_efficiency_upgrade(converter_group, value, operator, team=False):
+    def gather_wood_efficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the wood gathering efficiency modify effect (ID: 189).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -674,14 +752,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def gather_gold_efficiency_upgrade(converter_group, value, operator, team=False):
+    def gather_gold_efficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the gold gathering efficiency modify effect (ID: 47).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -694,14 +777,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def gather_stone_efficiency_upgrade(converter_group, value, operator, team=False):
+    def gather_stone_efficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the stone gathering efficiency modify effect (ID: 79).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -714,14 +802,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def heal_range_upgrade(converter_group, value, operator, team=False):
+    def heal_range_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the heal range modify effect (ID: 90).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -781,7 +874,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -798,14 +892,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def heal_rate_upgrade(converter_group, value, operator, team=False):
+    def heal_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the heal rate modify effect (ID: 89).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -818,14 +917,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def herding_dominance_upgrade(converter_group, value, operator, team=False):
+    def herding_dominance_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the herding dominance effect (ID: 97).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -838,14 +942,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def heresy_upgrade(converter_group, value, operator, team=False):
+    def heresy_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the heresy effect (ID: 192).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -858,14 +967,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def monk_conversion_upgrade(converter_group, value, operator, team=False):
+    def monk_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the monk conversion effect (ID: 27).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -926,7 +1040,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -943,14 +1058,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def relic_gold_bonus_upgrade(converter_group, value, operator, team=False):
+    def relic_gold_bonus_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the relic gold bonus modify effect (ID: 191).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -961,14 +1081,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def research_time_upgrade(converter_group, value, operator, team=False):
+    def research_time_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the research time modify effect (ID: 86).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -981,14 +1106,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def reveal_ally_upgrade(converter_group, value, operator, team=False):
+    def reveal_ally_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the reveal ally modify effect (ID: 50).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1001,14 +1131,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def reveal_enemy_upgrade(converter_group, value, operator, team=False):
+    def reveal_enemy_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the reveal enemy modify effect (ID: 183).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1021,14 +1156,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def ship_conversion_upgrade(converter_group, value, operator, team=False):
+    def ship_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ship conversion effect (ID: 87).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1041,14 +1181,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def spies_discount_upgrade(converter_group, value, operator, team=False):
+    def spies_discount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the spies discount effect (ID: 197).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1061,7 +1206,12 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_food_upgrade(converter_group, value, operator, team=False):
+    def starting_food_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting food modify effect (ID: 91).
 
@@ -1081,14 +1231,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_wood_upgrade(converter_group, value, operator, team=False):
+    def starting_wood_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting wood modify effect (ID: 92).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1101,14 +1256,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_stone_upgrade(converter_group, value, operator, team=False):
+    def starting_stone_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting stone modify effect (ID: 93).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1121,14 +1281,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_gold_upgrade(converter_group, value, operator, team=False):
+    def starting_gold_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting gold modify effect (ID: 94).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1141,14 +1306,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_villagers_upgrade(converter_group, value, operator, team=False):
+    def starting_villagers_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting villagers modify effect (ID: 84).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1161,14 +1331,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def starting_population_space_upgrade(converter_group, value, operator, team=False):
+    def starting_population_space_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the starting popspace modify effect (ID: 4).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1222,7 +1397,8 @@ class AoCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -1239,14 +1415,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def theocracy_upgrade(converter_group, value, operator, team=False):
+    def theocracy_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the theocracy effect (ID: 193).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1259,14 +1440,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def trade_penalty_upgrade(converter_group, value, operator, team=False):
+    def trade_penalty_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the trade penalty modify effect (ID: 78).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1279,14 +1465,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def tribute_inefficiency_upgrade(converter_group, value, operator, team=False):
+    def tribute_inefficiency_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the tribute inefficiency modify effect (ID: 46).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -1299,14 +1490,19 @@ class AoCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def wonder_time_increase_upgrade(converter_group, value, operator, team=False):
+    def wonder_time_increase_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the wonder time modify effect (ID: 196).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/conversion/de1/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de1/media_subprocessor.py
@@ -5,11 +5,17 @@
 Convert media information to metadata definitions and export
 requests. Subroutine of the main DE1 processor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.export.formats.sprite_metadata import LayerMode
 from ....entity_object.export.media_export_request import MediaExportRequest
 from ....entity_object.export.metadata_export import SpriteMetadataExport
 from ....value_object.read.media_types import MediaType
 from ..aoc.media_subprocessor import AoCMediaSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class DE1MediaSubprocessor:
@@ -18,7 +24,7 @@ class DE1MediaSubprocessor:
     """
 
     @classmethod
-    def convert(cls, full_data_set):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create all export requests for the dataset.
         """
@@ -26,7 +32,7 @@ class DE1MediaSubprocessor:
         AoCMediaSubprocessor.create_sound_requests(full_data_set)
 
     @staticmethod
-    def create_graphics_requests(full_data_set):
+    def create_graphics_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for graphics referenced by CombinedSprite objects.
         """

--- a/openage/convert/processor/conversion/de1/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de1/media_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals
 """
@@ -15,7 +15,8 @@ from ....value_object.read.media_types import MediaType
 from ..aoc.media_subprocessor import AoCMediaSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class DE1MediaSubprocessor:

--- a/openage/convert/processor/conversion/de1/processor.py
+++ b/openage/convert/processor/conversion/de1/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Convert data from DE1 to openage formats.
@@ -111,7 +111,11 @@ class DE1Processor:
         return dataset
 
     @classmethod
-    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
+    def _processor(
+        cls,
+        gamespec: ArrayMember,
+        full_data_set: GenieObjectContainer
+    ) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -169,7 +173,7 @@ class DE1Processor:
         return RoRModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def extract_genie_units(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
+    def extract_genie_graphics(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract graphic definitions from the game data.
 

--- a/openage/convert/processor/conversion/de1/processor.py
+++ b/openage/convert/processor/conversion/de1/processor.py
@@ -3,6 +3,8 @@
 """
 Convert data from DE1 to openage formats.
 """
+from __future__ import annotations
+import typing
 
 
 from .....log import info
@@ -18,6 +20,13 @@ from ..ror.pregen_subprocessor import RoRPregenSubprocessor
 from ..ror.processor import RoRProcessor
 from .media_subprocessor import DE1MediaSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.read.value_members import ArrayMember
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class DE1Processor:
     """
@@ -25,7 +34,13 @@ class DE1Processor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game specification and media here and get a set of
         modpacks back.
@@ -58,7 +73,13 @@ class DE1Processor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -90,7 +111,7 @@ class DE1Processor:
         return dataset
 
     @classmethod
-    def _processor(cls, gamespec, full_data_set):
+    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -128,7 +149,7 @@ class DE1Processor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 
@@ -148,7 +169,7 @@ class DE1Processor:
         return RoRModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def extract_genie_graphics(gamespec, full_data_set):
+    def extract_genie_units(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract graphic definitions from the game data.
 

--- a/openage/convert/processor/conversion/de1/processor.py
+++ b/openage/convert/processor/conversion/de1/processor.py
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
     from openage.convert.value_object.read.value_members import ArrayMember
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class DE1Processor:
@@ -76,7 +76,7 @@ class DE1Processor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/de2/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods,too-many-locals
 

--- a/openage/convert/processor/conversion/de2/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/ability_subprocessor.py
@@ -6,10 +6,16 @@
 Derives and adds abilities to lines. Subroutine of the
 nyan subprocessor.
 """
+from __future__ import annotations
+import typing
+
 
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
 
 
 class DE2AbilitySubprocessor:
@@ -18,7 +24,7 @@ class DE2AbilitySubprocessor:
     """
 
     @staticmethod
-    def regenerate_attribute_ability(line):
+    def regenerate_attribute_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RegenerateAttribute ability to a line.
 

--- a/openage/convert/processor/conversion/de2/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/civ_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 

--- a/openage/convert/processor/conversion/de2/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/civ_subprocessor.py
@@ -5,12 +5,18 @@
 """
 Creates patches and modifiers for civs.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.civ_subprocessor import AoCCivSubprocessor
 from .tech_subprocessor import DE2TechSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
 
 
 class DE2CivSubprocessor:
@@ -19,7 +25,7 @@ class DE2CivSubprocessor:
     """
 
     @classmethod
-    def get_civ_setup(cls, civ_group):
+    def get_civ_setup(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the patches for the civ setup which configures architecture sets
         unique units, unique techs, team boni and unique stat upgrades.
@@ -37,7 +43,7 @@ class DE2CivSubprocessor:
         return patches
 
     @classmethod
-    def setup_civ_bonus(cls, civ_group):
+    def setup_civ_bonus(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns global modifiers of a civ.
         """

--- a/openage/convert/processor/conversion/de2/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/media_subprocessor.py
@@ -5,10 +5,16 @@
 Convert media information to metadata definitions and export
 requests. Subroutine of the main DE2 processor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.export.formats.sprite_metadata import LayerMode
 from ....entity_object.export.media_export_request import MediaExportRequest
 from ....entity_object.export.metadata_export import SpriteMetadataExport
 from ....value_object.read.media_types import MediaType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class DE2MediaSubprocessor:
@@ -17,7 +23,7 @@ class DE2MediaSubprocessor:
     """
 
     @classmethod
-    def convert(cls, full_data_set):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create all export requests for the dataset.
         """
@@ -25,7 +31,7 @@ class DE2MediaSubprocessor:
         cls.create_sound_requests(full_data_set)
 
     @staticmethod
-    def create_graphics_requests(full_data_set):
+    def create_graphics_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for graphics referenced by CombinedSprite objects.
         """
@@ -97,7 +103,7 @@ class DE2MediaSubprocessor:
         # TODO: Terrain exports (DDS files)
 
     @staticmethod
-    def create_sound_requests(full_data_set):
+    def create_sound_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for sounds referenced by CombinedSound objects.
         """

--- a/openage/convert/processor/conversion/de2/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/media_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals
 """
@@ -14,7 +14,8 @@ from ....entity_object.export.metadata_export import SpriteMetadataExport
 from ....value_object.read.media_types import MediaType
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class DE2MediaSubprocessor:

--- a/openage/convert/processor/conversion/de2/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/modpack_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 
@@ -13,7 +13,8 @@ from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class DE2ModpackSubprocessor:

--- a/openage/convert/processor/conversion/de2/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/modpack_subprocessor.py
@@ -6,8 +6,14 @@
 Organize export data (nyan objects, media, scripts, etc.)
 into modpacks.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class DE2ModpackSubprocessor:
@@ -16,16 +22,16 @@ class DE2ModpackSubprocessor:
     """
 
     @classmethod
-    def get_modpacks(cls, gamedata):
+    def get_modpacks(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Return all modpacks that can be created from the gamedata.
         """
-        de2_base = cls._get_aoe2_base(gamedata)
+        de2_base = cls._get_aoe2_base(full_data_set)
 
         return [de2_base]
 
     @classmethod
-    def _get_aoe2_base(cls, gamedata):
+    def _get_aoe2_base(cls, full_data_set: GenieObjectContainer) -> Modpack:
         """
         Create the aoe2-base modpack.
         """
@@ -37,7 +43,7 @@ class DE2ModpackSubprocessor:
 
         mod_def.add_include("data/*")
 
-        AoCModpackSubprocessor.organize_nyan_objects(modpack, gamedata)
-        AoCModpackSubprocessor.organize_media_objects(modpack, gamedata)
+        AoCModpackSubprocessor.organize_nyan_objects(modpack, full_data_set)
+        AoCModpackSubprocessor.organize_media_objects(modpack, full_data_set)
 
         return modpack

--- a/openage/convert/processor/conversion/de2/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/nyan_subprocessor.py
@@ -8,6 +8,9 @@
 Convert API-like objects to nyan objects. Subroutine of the
 main DE2 processor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_tech import UnitLineUpgrade
 from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup,\
     GenieGarrisonMode, GenieMonkGroup, GenieStackBuildingGroup
@@ -24,6 +27,14 @@ from .ability_subprocessor import DE2AbilitySubprocessor
 from .civ_subprocessor import DE2CivSubprocessor
 from .tech_subprocessor import DE2TechSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+    from openage.convert.entity_object.conversion.aoc.genie_terrain import GenieTerrainGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
+        GenieBuildingLineGroup
+
 
 class DE2NyanSubprocessor:
     """
@@ -31,18 +42,18 @@ class DE2NyanSubprocessor:
     """
 
     @classmethod
-    def convert(cls, gamedata):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects from the given dataset.
         """
-        cls._process_game_entities(gamedata)
-        cls._create_nyan_objects(gamedata)
-        cls._create_nyan_members(gamedata)
+        cls._process_game_entities(full_data_set)
+        cls._create_nyan_objects(full_data_set)
+        cls._create_nyan_members(full_data_set)
 
-        cls._check_objects(gamedata)
+        cls._check_objects(full_data_set)
 
     @classmethod
-    def _check_objects(cls, full_data_set):
+    def _check_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Check if objects are valid.
         """
@@ -68,7 +79,7 @@ class DE2NyanSubprocessor:
             civ_group.check_readiness()
 
     @classmethod
-    def _create_nyan_objects(cls, full_data_set):
+    def _create_nyan_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Creates nyan objects from the API objects.
         """
@@ -101,7 +112,7 @@ class DE2NyanSubprocessor:
             civ_group.execute_raw_member_pushs()
 
     @classmethod
-    def _create_nyan_members(cls, full_data_set):
+    def _create_nyan_members(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Fill nyan member values of the API objects.
         """
@@ -127,7 +138,7 @@ class DE2NyanSubprocessor:
             civ_group.create_nyan_members()
 
     @classmethod
-    def _process_game_entities(cls, full_data_set):
+    def _process_game_entities(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create the RawAPIObject representation of the objects.
         """
@@ -154,7 +165,7 @@ class DE2NyanSubprocessor:
             cls.civ_group_to_civ(civ_group)
 
     @staticmethod
-    def unit_line_to_game_entity(unit_line):
+    def unit_line_to_game_entity(unit_line: GenieUnitLineGroup) -> None:
         """
         Creates raw API objects for a unit line.
 
@@ -191,7 +202,8 @@ class DE2NyanSubprocessor:
         unit_type = current_unit["unit_type"].get_value()
 
         if unit_type >= 70:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_unit["unit_class"].get_value()
@@ -358,7 +370,7 @@ class DE2NyanSubprocessor:
             AoCAuxiliarySubprocessor.get_creatable_game_entity(unit_line)
 
     @staticmethod
-    def building_line_to_game_entity(building_line):
+    def building_line_to_game_entity(building_line: GenieBuildingLineGroup) -> None:
         """
         Creates raw API objects for a building line.
 
@@ -396,7 +408,8 @@ class DE2NyanSubprocessor:
         unit_type = current_building["unit_type"].get_value()
 
         if unit_type >= 80:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_building["unit_class"].get_value()
@@ -406,7 +419,8 @@ class DE2NyanSubprocessor:
         types_set.append(type_obj)
 
         if building_line.is_dropsite():
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
@@ -471,7 +485,8 @@ class DE2NyanSubprocessor:
             garrison_mode = building_line.get_garrison_mode()
 
             if garrison_mode == GenieGarrisonMode.NATURAL:
-                abilities_set.append(AoCAbilitySubprocessor.send_back_to_task_ability(building_line))
+                abilities_set.append(
+                    AoCAbilitySubprocessor.send_back_to_task_ability(building_line))
 
             if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                 abilities_set.append(AoCAbilitySubprocessor.rally_point_ability(building_line))
@@ -515,7 +530,7 @@ class DE2NyanSubprocessor:
             AoCAuxiliarySubprocessor.get_creatable_game_entity(building_line)
 
     @staticmethod
-    def tech_group_to_tech(tech_group):
+    def tech_group_to_tech(tech_group: GenieTechEffectBundleGroup) -> None:
         """
         Creates raw API objects for a tech group.
 
@@ -582,7 +597,8 @@ class DE2NyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(tech_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -603,7 +619,8 @@ class DE2NyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(tech_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -631,7 +648,7 @@ class DE2NyanSubprocessor:
             AoCAuxiliarySubprocessor.get_researchable_tech(tech_group)
 
     @staticmethod
-    def terrain_group_to_terrain(terrain_group):
+    def terrain_group_to_terrain(terrain_group: GenieTerrainGroup) -> None:
         """
         Creates raw API objects for a terrain group.
 
@@ -644,7 +661,8 @@ class DE2NyanSubprocessor:
 
         # name_lookup_dict = internal_name_lookups.get_entity_lookups(dataset.game_version)
         terrain_lookup_dict = internal_name_lookups.get_terrain_lookups(dataset.game_version)
-        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(dataset.game_version)
+        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(
+            dataset.game_version)
 
         if terrain_index not in terrain_lookup_dict:
             # TODO: Not all terrains are used in DE2; filter out the unused terrains
@@ -798,7 +816,7 @@ class DE2NyanSubprocessor:
                                       "engine.util.terrain.Terrain")
 
     @staticmethod
-    def civ_group_to_civ(civ_group):
+    def civ_group_to_civ(civ_group: GenieCivilizationGroup) -> None:
         """
         Creates raw API objects for a civ group.
 
@@ -849,7 +867,8 @@ class DE2NyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(civ_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -870,7 +889,8 @@ class DE2NyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(civ_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 

--- a/openage/convert/processor/conversion/de2/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/nyan_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements,too-many-branches
 #

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -31,7 +31,7 @@ if typing.TYPE_CHECKING:
     from argparse import Namespace
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class DE2Processor:
@@ -82,7 +82,7 @@ class DE2Processor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long,too-many-lines,too-many-branches,too-many-statements
 """
@@ -280,7 +280,7 @@ class DE2Processor:
             full_data_set.unit_ref.update({ambient_id: ambient_group})
 
     @staticmethod
-    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
+    def create_variant_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create variant groups.
 

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -4,6 +4,9 @@
 """
 Convert data from DE2 to openage formats.
 """
+from __future__ import annotations
+import typing
+
 
 from openage.convert.value_object.read.value_members import ArrayMember, MemberTypes
 import openage.convert.value_object.conversion.aoc.internal_nyan_names as aoc_internal
@@ -24,6 +27,12 @@ from .media_subprocessor import DE2MediaSubprocessor
 from .modpack_subprocessor import DE2ModpackSubprocessor
 from .nyan_subprocessor import DE2NyanSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class DE2Processor:
     """
@@ -31,7 +40,13 @@ class DE2Processor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game speification and media here and get a set of
         modpacks back.
@@ -64,7 +79,13 @@ class DE2Processor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -96,7 +117,7 @@ class DE2Processor:
         return dataset
 
     @classmethod
-    def _processor(cls, full_data_set):
+    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -138,7 +159,7 @@ class DE2Processor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 
@@ -158,7 +179,7 @@ class DE2Processor:
         return DE2ModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def extract_genie_units(gamespec, full_data_set):
+    def extract_genie_units(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract units from the game data.
 
@@ -208,7 +229,7 @@ class DE2Processor:
                     unit.add_member(unit_commands)
 
     @staticmethod
-    def extract_genie_graphics(gamespec, full_data_set):
+    def extract_genie_graphics(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract graphic definitions from the game data.
 
@@ -238,7 +259,7 @@ class DE2Processor:
             genie_graphic.detect_subgraphics()
 
     @staticmethod
-    def create_ambient_groups(full_data_set):
+    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create ambient groups, mostly for resources and scenery.
 
@@ -259,7 +280,7 @@ class DE2Processor:
             full_data_set.unit_ref.update({ambient_id: ambient_group})
 
     @staticmethod
-    def create_variant_groups(full_data_set):
+    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create variant groups.
 
@@ -281,7 +302,7 @@ class DE2Processor:
                 full_data_set.unit_ref.update({variant_id: variant_group})
 
     @staticmethod
-    def create_extra_building_lines(full_data_set):
+    def create_extra_building_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Create additional units that are not in the building connections.
 

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import typing
 
 
-from openage.convert.value_object.read.value_members import ArrayMember, MemberTypes
+from openage.convert.value_object.read.value_members import ArrayMember, StorageType
 import openage.convert.value_object.conversion.aoc.internal_nyan_names as aoc_internal
 import openage.convert.value_object.conversion.de2.internal_nyan_names as de2_internal
 
@@ -224,7 +224,7 @@ class DE2Processor:
                 else:
                     # Create empty member if no headers are present
                     unit_commands = ArrayMember("unit_commands",
-                                                MemberTypes.CONTAINER_MEMBER,
+                                                StorageType.CONTAINER_MEMBER,
                                                 members=[])
                     unit.add_member(unit_commands)
 

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -5,6 +5,10 @@
 """
 Creates patches for technologies.
 """
+from __future__ import annotations
+import typing
+
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import CivTeamBonus, CivBonus
 from ..aoc.tech_subprocessor import AoCTechSubprocessor
@@ -12,6 +16,11 @@ from ..aoc.upgrade_attribute_subprocessor import AoCUpgradeAttributeSubprocessor
 from ..aoc.upgrade_resource_subprocessor import AoCUpgradeResourceSubprocessor
 from .upgrade_attribute_subprocessor import DE2UpgradeAttributeSubprocessor
 from .upgrade_resource_subprocessor import DE2UpgradeResourceSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject
+    from openage.convert.value_object.conversion.forward_ref import ForwardRef
 
 
 class DE2TechSubprocessor:
@@ -125,7 +134,7 @@ class DE2TechSubprocessor:
     }
 
     @classmethod
-    def get_patches(cls, converter_group):
+    def get_patches(cls, converter_group: ConverterObjectGroup) -> list[ForwardRef]:
         """
         Returns the patches for a converter group, depending on the type
         of its effects.
@@ -195,7 +204,11 @@ class DE2TechSubprocessor:
         return patches
 
     @staticmethod
-    def attribute_modify_effect(converter_group, effect, team=False):
+    def attribute_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying attributes of entities.
         """
@@ -260,7 +273,11 @@ class DE2TechSubprocessor:
         return patches
 
     @staticmethod
-    def resource_modify_effect(converter_group, effect, team=False):
+    def resource_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying resources.
         """

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -138,14 +138,14 @@ class DE2TechSubprocessor:
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
             team_bonus = True
 
         elif isinstance(converter_group, CivBonus):
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
 
         else:
             effects = converter_group.get_effects()

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 

--- a/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 #

--- a/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
@@ -8,6 +8,15 @@
 """
 Creates upgrade patches for attribute modification effects in DE2.
 """
+from __future__ import annotations
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.nyan.nyan_structs import MemberOperator
+    from openage.convert.value_object.conversion.forward_ref import ForwardRef
 
 
 class DE2UpgradeAttributeSubprocessor:
@@ -16,7 +25,13 @@ class DE2UpgradeAttributeSubprocessor:
     """
 
     @staticmethod
-    def regeneration_rate_upgrade(converter_group, line, value, operator, team=False):
+    def regeneration_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the regeneration rate modify effect (ID: 109).
 
@@ -27,7 +42,7 @@ class DE2UpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods,invalid-name
 #

--- a/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
@@ -8,6 +8,14 @@
 """
 Creates upgrade patches for resource modification effects in DE2.
 """
+from __future__ import annotations
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.nyan.nyan_structs import MemberOperator
+    from openage.convert.value_object.conversion.forward_ref import ForwardRef
 
 
 class DE2UpgradeResourceSubprocessor:
@@ -16,7 +24,12 @@ class DE2UpgradeResourceSubprocessor:
     """
 
     @staticmethod
-    def burgundian_vineyards_upgrade(converter_group, value, operator, team=False):
+    def burgundian_vineyards_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the burgundian vineyards effect (ID: 236).
 
@@ -36,7 +49,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def cliff_attack_upgrade(converter_group, value, operator, team=False):
+    def cliff_attack_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the cliff attack multiplier effect (ID: 212).
 
@@ -56,7 +74,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_min_adjustment_upgrade(converter_group, value, operator, team=False):
+    def conversion_min_adjustment_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion min adjustment modify effect (ID: 176).
 
@@ -78,7 +101,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_max_adjustment_upgrade(converter_group, value, operator, team=False):
+    def conversion_max_adjustment_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion max adjustment modify effect (ID: 177).
 
@@ -100,7 +128,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_min_building_upgrade(converter_group, value, operator, team=False):
+    def conversion_min_building_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion min building modify effect (ID: 180).
 
@@ -122,7 +155,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_max_building_upgrade(converter_group, value, operator, team=False):
+    def conversion_max_building_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion max building modify effect (ID: 181).
 
@@ -144,7 +182,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_building_chance_upgrade(converter_group, value, operator, team=False):
+    def conversion_building_chance_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion building chance modify effect (ID: 182).
 
@@ -166,7 +209,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def cuman_tc_upgrade(converter_group, value, operator, team=False):
+    def cuman_tc_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the cuman TC modify effect (ID: 218).
 
@@ -186,7 +234,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def current_food_amount_upgrade(converter_group, value, operator, team=False):
+    def current_food_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the current food amount modify effect (ID: 0).
 
@@ -208,7 +261,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def current_wood_amount_upgrade(converter_group, value, operator, team=False):
+    def current_wood_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the current wood amount modify effect (ID: 1).
 
@@ -230,7 +288,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def current_stone_amount_upgrade(converter_group, value, operator, team=False):
+    def current_stone_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the current stone amount modify effect (ID: 2).
 
@@ -252,7 +315,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def current_gold_amount_upgrade(converter_group, value, operator, team=False):
+    def current_gold_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the current gold amount modify effect (ID: 3).
 
@@ -274,7 +342,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def elevation_attack_upgrade(converter_group, value, operator, team=False):
+    def elevation_attack_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the elevation attack multiplier effect (ID: 211).
 
@@ -294,7 +367,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def feitoria_gold_upgrade(converter_group, value, operator, team=False):
+    def feitoria_gold_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the feitoria gold productivity effect (ID: 208).
 
@@ -314,7 +392,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def first_crusade_upgrade(converter_group, value, operator, team=False):
+    def first_crusade_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the first crusade effect (ID: 234).
 
@@ -334,7 +417,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def fish_trap_food_amount_upgrade(converter_group, value, operator, team=False):
+    def fish_trap_food_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the fish trap food amount modify effect (ID: 88).
 
@@ -356,7 +444,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def folwark_collect_upgrade(converter_group, value, operator, team=False):
+    def folwark_collect_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the folwark collect amount modify effect (ID: 237).
 
@@ -378,7 +471,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def folwark_flag_upgrade(converter_group, value, operator, team=False):
+    def folwark_flag_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the folwark flag effect (ID: 238).
 
@@ -400,7 +498,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def folwark_mill_id_upgrade(converter_group, value, operator, team=False):
+    def folwark_mill_id_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the folwark mill ID set effect (ID: 239).
 
@@ -422,7 +525,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def free_kipchaks_upgrade(converter_group, value, operator, team=False):
+    def free_kipchaks_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the current gold amount modify effect (ID: 214).
 
@@ -442,7 +550,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def relic_food_production_upgrade(converter_group, value, operator, team=False):
+    def relic_food_production_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the relic food production effect (ID: 220).
 
@@ -462,7 +575,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def reveal_enemy_tcs_upgrade(converter_group, value, operator, team=False):
+    def reveal_enemy_tcs_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the reveal enemy TCs effect (ID: 209).
 
@@ -484,7 +602,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def sheep_food_amount_upgrade(converter_group, value, operator, team=False):
+    def sheep_food_amount_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the sheep food amount modify effect (ID: 216).
 
@@ -504,7 +627,12 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def stone_gold_gen_upgrade(converter_group, value, operator, team=False):
+    def stone_gold_gen_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the polish stone gold generation effect (ID: 241).
 

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -6,10 +6,16 @@
 Convert media information to metadata definitions and export
 requests. Subroutine of the main HD processor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.export.formats.sprite_metadata import LayerMode
 from ....entity_object.export.media_export_request import MediaExportRequest
 from ....entity_object.export.metadata_export import SpriteMetadataExport
 from ....value_object.read.media_types import MediaType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class HDMediaSubprocessor:
@@ -18,7 +24,7 @@ class HDMediaSubprocessor:
     """
 
     @classmethod
-    def convert(cls, full_data_set):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create all export requests for the dataset.
         """
@@ -26,7 +32,7 @@ class HDMediaSubprocessor:
         cls.create_sound_requests(full_data_set)
 
     @staticmethod
-    def create_graphics_requests(full_data_set):
+    def create_graphics_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for graphics referenced by CombinedSprite objects.
         """
@@ -111,7 +117,7 @@ class HDMediaSubprocessor:
             full_data_set.graphics_exports.update({slp_id: export_request})
 
     @staticmethod
-    def create_sound_requests(full_data_set):
+    def create_sound_requests(full_data_set: GenieObjectContainer) -> None:
         """
         Create export requests for sounds referenced by CombinedSound objects.
         """

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals
 
@@ -15,7 +15,8 @@ from ....entity_object.export.metadata_export import SpriteMetadataExport
 from ....value_object.read.media_types import MediaType
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class HDMediaSubprocessor:

--- a/openage/convert/processor/conversion/hd/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/modpack_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 
@@ -13,7 +13,8 @@ from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class HDModpackSubprocessor:

--- a/openage/convert/processor/conversion/hd/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/modpack_subprocessor.py
@@ -6,8 +6,14 @@
 Organize export data (nyan objects, media, scripts, etc.)
 into modpacks.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class HDModpackSubprocessor:
@@ -16,16 +22,16 @@ class HDModpackSubprocessor:
     """
 
     @classmethod
-    def get_modpacks(cls, gamedata):
+    def get_modpacks(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Return all modpacks that can be created from the gamedata.
         """
-        hd_base = cls._get_aoe2_base(gamedata)
+        hd_base = cls._get_aoe2_base(full_data_set)
 
         return [hd_base]
 
     @classmethod
-    def _get_aoe2_base(cls, gamedata):
+    def _get_aoe2_base(cls, full_data_set: GenieObjectContainer) -> Modpack:
         """
         Create the aoe2_base modpack.
         """
@@ -37,7 +43,7 @@ class HDModpackSubprocessor:
 
         mod_def.add_include("data/*")
 
-        AoCModpackSubprocessor.organize_nyan_objects(modpack, gamedata)
-        AoCModpackSubprocessor.organize_media_objects(modpack, gamedata)
+        AoCModpackSubprocessor.organize_nyan_objects(modpack, full_data_set)
+        AoCModpackSubprocessor.organize_media_objects(modpack, full_data_set)
 
         return modpack

--- a/openage/convert/processor/conversion/hd/processor.py
+++ b/openage/convert/processor/conversion/hd/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 

--- a/openage/convert/processor/conversion/hd/processor.py
+++ b/openage/convert/processor/conversion/hd/processor.py
@@ -25,7 +25,7 @@ if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
     from openage.convert.value_object.read.value_members import ArrayMember
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class HDProcessor:
@@ -76,7 +76,7 @@ class HDProcessor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/hd/processor.py
+++ b/openage/convert/processor/conversion/hd/processor.py
@@ -5,6 +5,9 @@
 """
 Convert data from AoE2:HD to openage formats.
 """
+from __future__ import annotations
+import typing
+
 
 from .....log import info
 from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
@@ -17,6 +20,13 @@ from ..aoc.processor import AoCProcessor
 from .media_subprocessor import HDMediaSubprocessor
 from .modpack_subprocessor import HDModpackSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.read.value_members import ArrayMember
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class HDProcessor:
     """
@@ -24,7 +34,13 @@ class HDProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game speification and media here and get a set of
         modpacks back.
@@ -57,7 +73,13 @@ class HDProcessor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -89,7 +111,7 @@ class HDProcessor:
         return dataset
 
     @classmethod
-    def _processor(cls, full_data_set):
+    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -130,7 +152,7 @@ class HDProcessor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 

--- a/openage/convert/processor/conversion/ror/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/ability_subprocessor.py
@@ -9,6 +9,9 @@
 Derives and adds abilities to lines. Reimplements only
 abilities that are different from AoC.
 """
+from __future__ import annotations
+import typing
+
 from math import degrees
 
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup,\
@@ -19,6 +22,9 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.ability_subprocessor import AoCAbilitySubprocessor
 from ..aoc.effect_subprocessor import AoCEffectSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+
 
 class RoRAbilitySubprocessor:
     """
@@ -26,7 +32,12 @@ class RoRAbilitySubprocessor:
     """
 
     @staticmethod
-    def apply_discrete_effect_ability(line, command_id, ranged=False, projectile=-1):
+    def apply_discrete_effect_ability(
+        line: GenieGameEntityGroup,
+        command_id: int,
+        ranged: bool = False,
+        projectile: int = -1
+    ) -> ForwardRef:
         """
         Adds the ApplyDiscreteEffect ability to a line.
 
@@ -314,7 +325,8 @@ class RoRAbilitySubprocessor:
         else:
             allowed_types = [
                 dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+                )
             ]
 
         ability_raw_api_object.add_raw_member("allowed_types",
@@ -345,7 +357,7 @@ class RoRAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def game_entity_stance_ability(line):
+    def game_entity_stance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the GameEntityStance ability to a line.
 
@@ -432,7 +444,7 @@ class RoRAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def production_queue_ability(line):
+    def production_queue_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProductionQueue ability to a line.
 
@@ -490,7 +502,7 @@ class RoRAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def projectile_ability(line, position=0):
+    def projectile_ability(line: GenieGameEntityGroup, position: int = 0) -> ForwardRef:
         """
         Adds a Projectile ability to projectiles in a line. Which projectile should
         be added is determined by the 'position' argument.
@@ -597,7 +609,7 @@ class RoRAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def resistance_ability(line):
+    def resistance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Resistance ability to a line.
 
@@ -650,7 +662,7 @@ class RoRAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def shoot_projectile_ability(line, command_id):
+    def shoot_projectile_ability(line: GenieGameEntityGroup, command_id: int) -> ForwardRef:
         """
         Adds the ShootProjectile ability to a line.
 

--- a/openage/convert/processor/conversion/ror/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-branches,too-many-statements,too-many-locals
 #

--- a/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long,too-many-locals,too-many-branches,too-many-statements
 # pylint: disable=too-few-public-methods

--- a/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
@@ -7,6 +7,9 @@
 Derives complex auxiliary objects from unit lines, techs
 or other objects.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberSpecialValue
 from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup,\
     GenieBuildingLineGroup, GenieUnitLineGroup
@@ -16,6 +19,9 @@ from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.auxiliary_subprocessor import AoCAuxiliarySubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+
 
 class RoRAuxiliarySubprocessor:
     """
@@ -23,7 +29,7 @@ class RoRAuxiliarySubprocessor:
     """
 
     @staticmethod
-    def get_creatable_game_entity(line):
+    def get_creatable_game_entity(line: GenieGameEntityGroup) -> None:
         """
         Creates the CreatableGameEntity object for a unit/building line. In comparison
         to the AoC version, ths replaces some unit class IDs and removes garrison
@@ -129,7 +135,8 @@ class RoRAuxiliarySubprocessor:
                 resource_name = "Wood"
 
             elif resource_id == 2:
-                resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.Stone"].get_nyan_object(
+                )
                 resource_name = "Stone"
 
             elif resource_id == 3:
@@ -324,7 +331,8 @@ class RoRAuxiliarySubprocessor:
             placement_modes.append(place_forward_ref)
 
         else:
-            placement_modes.append(dataset.nyan_api_objects["engine.util.placement_mode.type.Eject"])
+            placement_modes.append(
+                dataset.nyan_api_objects["engine.util.placement_mode.type.Eject"])
 
         creatable_raw_api_object.add_raw_member("placement_modes",
                                                 placement_modes,

--- a/openage/convert/processor/conversion/ror/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/civ_subprocessor.py
@@ -5,9 +5,15 @@
 """
 Creates patches and modifiers for civs.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
 
 
 class RoRCivSubprocessor:
@@ -16,7 +22,7 @@ class RoRCivSubprocessor:
     """
 
     @staticmethod
-    def get_starting_resources(civ_group):
+    def get_starting_resources(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the starting resources of a civ.
         """

--- a/openage/convert/processor/conversion/ror/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/civ_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods,too-many-statements,too-many-locals
 

--- a/openage/convert/processor/conversion/ror/media_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/media_subprocessor.py
@@ -5,7 +5,13 @@
 Convert media information to metadata definitions and export
 requests. Subroutine of the main RoR processor.
 """
+from __future__ import annotations
+import typing
+
 from openage.convert.processor.conversion.aoc.media_subprocessor import AoCMediaSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class RoRMediaSubprocessor:
@@ -14,7 +20,7 @@ class RoRMediaSubprocessor:
     """
 
     @classmethod
-    def convert(cls, full_data_set):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create all export requests for the dataset.
         """

--- a/openage/convert/processor/conversion/ror/media_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/media_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-few-public-methods
 """
@@ -11,7 +11,8 @@ import typing
 from openage.convert.processor.conversion.aoc.media_subprocessor import AoCMediaSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class RoRMediaSubprocessor:

--- a/openage/convert/processor/conversion/ror/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/modpack_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 
@@ -14,7 +14,8 @@ from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class RoRModpackSubprocessor:

--- a/openage/convert/processor/conversion/ror/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/modpack_subprocessor.py
@@ -6,8 +6,15 @@
 Organize export data (nyan objects, media, scripts, etc.)
 into modpacks.
 """
+from __future__ import annotations
+import typing
+
+
 from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class RoRModpackSubprocessor:
@@ -16,16 +23,16 @@ class RoRModpackSubprocessor:
     """
 
     @classmethod
-    def get_modpacks(cls, gamedata):
+    def get_modpacks(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Return all modpacks that can be created from the gamedata.
         """
-        aoe1_base = cls._get_aoe1_base(gamedata)
+        aoe1_base = cls._get_aoe1_base(full_data_set)
 
         return [aoe1_base]
 
     @classmethod
-    def _get_aoe1_base(cls, gamedata):
+    def _get_aoe1_base(cls, full_data_set: GenieObjectContainer) -> Modpack:
         """
         Create the aoe1-base modpack.
         """
@@ -37,7 +44,7 @@ class RoRModpackSubprocessor:
 
         mod_def.add_include("data/*")
 
-        AoCModpackSubprocessor.organize_nyan_objects(modpack, gamedata)
-        AoCModpackSubprocessor.organize_media_objects(modpack, gamedata)
+        AoCModpackSubprocessor.organize_nyan_objects(modpack, full_data_set)
+        AoCModpackSubprocessor.organize_media_objects(modpack, full_data_set)
 
         return modpack

--- a/openage/convert/processor/conversion/ror/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/pregen_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals
 
@@ -15,7 +15,8 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.pregen_processor import AoCPregenSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class RoRPregenSubprocessor:

--- a/openage/convert/processor/conversion/ror/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/pregen_subprocessor.py
@@ -6,10 +6,16 @@
 Creates nyan objects for things that are hardcoded into the Genie Engine,
 but configurable in openage. E.g. HP.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.converter_object import ConverterObjectGroup,\
     RawAPIObject
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.pregen_processor import AoCPregenSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class RoRPregenSubprocessor:
@@ -18,26 +24,26 @@ class RoRPregenSubprocessor:
     """
 
     @classmethod
-    def generate(cls, gamedata):
+    def generate(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects for hardcoded properties.
         """
         # Stores pregenerated raw API objects as a container
         pregen_converter_group = ConverterObjectGroup("pregen")
 
-        AoCPregenSubprocessor.generate_attributes(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_diplomatic_stances(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_entity_types(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_effect_types(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_language_objects(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_misc_effect_objects(gamedata, pregen_converter_group)
+        AoCPregenSubprocessor.generate_attributes(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_diplomatic_stances(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_entity_types(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_effect_types(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_language_objects(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_misc_effect_objects(full_data_set, pregen_converter_group)
         # TODO:
         # cls._generate_modifiers(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_terrain_types(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_resources(gamedata, pregen_converter_group)
-        cls.generate_death_condition(gamedata, pregen_converter_group)
+        AoCPregenSubprocessor.generate_terrain_types(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_resources(full_data_set, pregen_converter_group)
+        cls.generate_death_condition(full_data_set, pregen_converter_group)
 
-        pregen_nyan_objects = gamedata.pregen_nyan_objects
+        pregen_nyan_objects = full_data_set.pregen_nyan_objects
         # Create nyan objects from the raw API objects
         for pregen_object in pregen_nyan_objects.values():
             pregen_object.create_nyan_object()
@@ -51,7 +57,10 @@ class RoRPregenSubprocessor:
                                 "Member or object not initialized." % (pregen_object))
 
     @staticmethod
-    def generate_death_condition(full_data_set, pregen_converter_group):
+    def generate_death_condition(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate DeathCondition objects.
 

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -34,7 +34,7 @@ if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
     from openage.convert.value_object.read.value_members import ArrayMember
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class RoRProcessor:
@@ -85,7 +85,7 @@ class RoRProcessor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long,too-many-lines,too-many-branches,too-many-statements,too-many-locals
 """

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -4,6 +4,9 @@
 """
 Convert data from RoR to openage formats.
 """
+from __future__ import annotations
+import typing
+
 from .....log import info
 from ....entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 from ....entity_object.conversion.aoc.genie_tech import InitiatedTech
@@ -26,6 +29,13 @@ from .modpack_subprocessor import RoRModpackSubprocessor
 from .nyan_subprocessor import RoRNyanSubprocessor
 from .pregen_subprocessor import RoRPregenSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.read.value_members import ArrayMember
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class RoRProcessor:
     """
@@ -33,7 +43,13 @@ class RoRProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game specification and media here and get a set of
         modpacks back.
@@ -66,7 +82,13 @@ class RoRProcessor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -98,7 +120,7 @@ class RoRProcessor:
         return dataset
 
     @classmethod
-    def _processor(cls, gamespec, full_data_set):
+    def _processor(cls, gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -136,7 +158,7 @@ class RoRProcessor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 
@@ -156,7 +178,7 @@ class RoRProcessor:
         return RoRModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def extract_genie_units(gamespec, full_data_set):
+    def extract_genie_units(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract units from the game data.
 
@@ -201,7 +223,7 @@ class RoRProcessor:
         full_data_set.genie_units = dict(sorted(full_data_set.genie_units.items()))
 
     @staticmethod
-    def extract_genie_sounds(gamespec, full_data_set):
+    def extract_genie_sounds(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Extract sound definitions from the game data.
 
@@ -219,7 +241,7 @@ class RoRProcessor:
             full_data_set.genie_sounds.update({sound.get_id(): sound})
 
     @staticmethod
-    def create_entity_lines(gamespec, full_data_set):
+    def create_entity_lines(gamespec: ArrayMember, full_data_set: GenieObjectContainer) -> None:
         """
         Sort units/buildings into lines, based on information from techs and civs.
 
@@ -322,7 +344,8 @@ class RoRProcessor:
                     break
 
                 if required_tech_id in full_data_set.unit_upgrades.keys():
-                    source_id = full_data_set.unit_upgrades[required_tech_id].get_upgrade_target_id()
+                    source_id = full_data_set.unit_upgrades[required_tech_id].get_upgrade_target_id(
+                    )
                     break
 
             unit_line = full_data_set.unit_lines[line_id]
@@ -356,7 +379,8 @@ class RoRProcessor:
                     break
 
                 if required_tech_id in full_data_set.building_upgrades.keys():
-                    source_id = full_data_set.building_upgrades[required_tech_id].get_upgrade_target_id()
+                    source_id = full_data_set.building_upgrades[required_tech_id].get_upgrade_target_id(
+                    )
                     break
 
             building_line = full_data_set.building_lines[line_id]
@@ -383,7 +407,7 @@ class RoRProcessor:
                     full_data_set.unit_ref.update({target_id: unit_line})
 
     @staticmethod
-    def create_ambient_groups(full_data_set):
+    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create ambient groups, mostly for resources and scenery.
 
@@ -402,7 +426,7 @@ class RoRProcessor:
             full_data_set.unit_ref.update({ambient_id: ambient_group})
 
     @staticmethod
-    def create_variant_groups(full_data_set):
+    def create_variant_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create variant groups.
 
@@ -422,7 +446,7 @@ class RoRProcessor:
                 full_data_set.unit_ref.update({variant_id: variant_group})
 
     @staticmethod
-    def create_tech_groups(full_data_set):
+    def create_tech_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create techs from tech connections and unit upgrades/unlocks
         from unit connections.
@@ -559,7 +583,7 @@ class RoRProcessor:
             full_data_set.initiated_techs.update({initiated_tech.get_id(): initiated_tech})
 
     @staticmethod
-    def link_garrison(full_data_set):
+    def link_garrison(full_data_set: GenieObjectContainer) -> None:
         """
         Link a garrison unit to the lines that are stored and vice versa. This is done
         to provide quick access during conversion.
@@ -602,7 +626,7 @@ class RoRProcessor:
                     line.garrison_locations.append(garrison)
 
     @staticmethod
-    def link_repairables(full_data_set):
+    def link_repairables(full_data_set: GenieObjectContainer) -> None:
         """
         Set units/buildings as repairable
 

--- a/openage/convert/processor/conversion/ror/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/tech_subprocessor.py
@@ -8,6 +8,9 @@
 """
 Creates patches for technologies.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup,\
     GenieUnitLineGroup
@@ -18,6 +21,11 @@ from ..aoc.upgrade_resource_subprocessor import AoCUpgradeResourceSubprocessor
 from .upgrade_ability_subprocessor import RoRUpgradeAbilitySubprocessor
 from .upgrade_attribute_subprocessor import RoRUpgradeAttributeSubprocessor
 from .upgrade_resource_subprocessor import RoRUpgradeResourceSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject
+    from openage.convert.value_object.conversion.forward_ref import ForwardRef
 
 
 class RoRTechSubprocessor:
@@ -63,7 +71,7 @@ class RoRTechSubprocessor:
     }
 
     @classmethod
-    def get_patches(cls, converter_group):
+    def get_patches(cls, converter_group: ConverterObjectGroup) -> list[ForwardRef]:
         """
         Returns the patches for a converter group, depending on the type
         of its effects.
@@ -89,7 +97,11 @@ class RoRTechSubprocessor:
         return patches
 
     @staticmethod
-    def attribute_modify_effect(converter_group, effect, team=False):
+    def attribute_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying attributes of entities.
         """
@@ -154,7 +166,11 @@ class RoRTechSubprocessor:
         return patches
 
     @staticmethod
-    def resource_modify_effect(converter_group, effect, team=False):
+    def resource_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying resources.
         """
@@ -194,7 +210,10 @@ class RoRTechSubprocessor:
         return patches
 
     @staticmethod
-    def upgrade_unit_effect(converter_group, effect):
+    def upgrade_unit_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject
+    ) -> list[ForwardRef]:
         """
         Creates the patches for upgrading entities in a line.
         """
@@ -222,15 +241,23 @@ class RoRTechSubprocessor:
 
         diff = upgrade_source.diff(upgrade_target)
 
-        patches.extend(AoCUpgradeAbilitySubprocessor.death_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.despawn_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.idle_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.live_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.los_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.named_ability(converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.death_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.despawn_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.idle_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.live_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.los_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.named_ability(
+            converter_group, line, tech_name, diff))
         # patches.extend(AoCUpgradeAbilitySubprocessor.resistance_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.selectable_ability(converter_group, line, tech_name, diff))
-        patches.extend(AoCUpgradeAbilitySubprocessor.turn_ability(converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.selectable_ability(
+            converter_group, line, tech_name, diff))
+        patches.extend(AoCUpgradeAbilitySubprocessor.turn_ability(
+            converter_group, line, tech_name, diff))
 
         if line.is_projectile_shooter():
             patches.extend(RoRUpgradeAbilitySubprocessor.shoot_projectile_ability(converter_group, line,

--- a/openage/convert/processor/conversion/ror/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 #

--- a/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements
 # pylint: disable=too-few-public-methods,too-many-branches

--- a/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
@@ -9,6 +9,9 @@
 """
 Creates upgrade patches for abilities.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_unit import GenieBuildingLineGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
@@ -17,6 +20,11 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ....value_object.read.value_members import NoDiffMember
 from ..aoc.upgrade_ability_subprocessor import AoCUpgradeAbilitySubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObject,\
+        ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+
 
 class RoRUpgradeAbilitySubprocessor:
     """
@@ -24,8 +32,13 @@ class RoRUpgradeAbilitySubprocessor:
     """
 
     @staticmethod
-    def shoot_projectile_ability(converter_group, line, container_obj_ref,
-                                 command_id, diff=None):
+    def shoot_projectile_ability(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        container_obj_ref: str,
+        command_id: int,
+        diff: ConverterObject = None
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the Selectable ability of a line.
 

--- a/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods
 #

--- a/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
@@ -8,10 +8,18 @@
 """
 Creates upgrade patches for attribute modification effects in RoR.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class RoRUpgradeAttributeSubprocessor:
@@ -20,7 +28,13 @@ class RoRUpgradeAttributeSubprocessor:
     """
 
     @staticmethod
-    def ballistics_upgrade(converter_group, line, value, operator, team=False):
+    def ballistics_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ballistics modify effect (ID: 19).
 
@@ -29,7 +43,7 @@ class RoRUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -97,7 +111,8 @@ class RoRUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -114,14 +129,20 @@ class RoRUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def population_upgrade(converter_group, line, value, operator, team=False):
+    def population_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the population effect (ID: 101).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/conversion/ror/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_resource_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods
 #

--- a/openage/convert/processor/conversion/ror/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_resource_subprocessor.py
@@ -8,11 +8,18 @@
 """
 Creates upgrade patches for resource modification effects in RoR.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class RoRUpgradeResourceSubprocessor:
@@ -21,14 +28,19 @@ class RoRUpgradeResourceSubprocessor:
     """
 
     @staticmethod
-    def building_conversion_upgrade(converter_group, value, operator, team=False):
+    def building_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the building conversion effect (ID: 28).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -118,14 +130,19 @@ class RoRUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def heal_bonus_upgrade(converter_group, value, operator, team=False):
+    def heal_bonus_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the AoE1 heal bonus effect (ID: 56).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -138,14 +155,19 @@ class RoRUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def martyrdom_upgrade(converter_group, value, operator, team=False):
+    def martyrdom_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the martyrdom effect (ID: 57).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
@@ -14,6 +14,9 @@ nyan subprocessor.
 For SWGB we use the functions of the AoCAbilitySubprocessor, but additionally
 create a diff for every civ line.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberSpecialValue
 from .....util.ordered_set import OrderedSet
 from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup,\
@@ -24,6 +27,10 @@ from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.ability_subprocessor import AoCAbilitySubprocessor
 from ..aoc.effect_subprocessor import AoCEffectSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+
 
 class SWGBCCAbilitySubprocessor:
     """
@@ -31,7 +38,7 @@ class SWGBCCAbilitySubprocessor:
     """
 
     @staticmethod
-    def active_transform_to_ability(line):
+    def active_transform_to_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ActiveTransformTo ability to a line.
 
@@ -47,7 +54,11 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def apply_continuous_effect_ability(line, command_id, ranged=False):
+    def apply_continuous_effect_ability(
+        line: GenieGameEntityGroup,
+        command_id: int,
+        ranged: bool = False
+    ) -> ForwardRef:
         """
         Adds the ApplyContinuousEffect ability to a line that is used to make entities die.
 
@@ -56,14 +67,20 @@ class SWGBCCAbilitySubprocessor:
         :returns: The forward reference for the ability.
         :rtype: ...dataformat.forward_ref.ForwardRef
         """
-        ability_forward_ref = AoCAbilitySubprocessor.apply_continuous_effect_ability(line, command_id, ranged)
+        ability_forward_ref = AoCAbilitySubprocessor.apply_continuous_effect_ability(
+            line, command_id, ranged)
 
         # TODO: Implement diffing of civ lines
 
         return ability_forward_ref
 
     @staticmethod
-    def apply_discrete_effect_ability(line, command_id, ranged=False, projectile=-1):
+    def apply_discrete_effect_ability(
+        line: GenieGameEntityGroup,
+        command_id: int,
+        ranged: bool = False,
+        projectile: int = -1
+    ) -> ForwardRef:
         """
         Adds the ApplyDiscreteEffect ability to a line that is used to make entities die.
 
@@ -100,7 +117,8 @@ class SWGBCCAbilitySubprocessor:
 
         if projectile == -1:
             ability_ref = f"{game_entity_name}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
@@ -109,7 +127,8 @@ class SWGBCCAbilitySubprocessor:
 
         else:
             ability_ref = f"{game_entity_name}.ShootProjectile.Projectile{str(projectile)}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
             ability_location = ForwardRef(line,
                                           "%s.ShootProjectile.Projectile%s"
@@ -321,7 +340,8 @@ class SWGBCCAbilitySubprocessor:
         # Allowed types (all buildings/units)
         if command_id == 104:
             # Convert
-            allowed_types = [dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()]
+            allowed_types = [
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()]
 
         else:
             allowed_types = [dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(),
@@ -361,7 +381,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def attribute_change_tracker_ability(line):
+    def attribute_change_tracker_ability(line) -> ForwardRef:
         """
         Adds the AttributeChangeTracker ability to a line.
 
@@ -386,7 +406,8 @@ class SWGBCCAbilitySubprocessor:
         game_entity_name = name_lookup_dict[current_unit_id][0]
 
         ability_ref = f"{game_entity_name}.AttributeChangeTracker"
-        ability_raw_api_object = RawAPIObject(ability_ref, "AttributeChangeTracker", dataset.nyan_api_objects)
+        ability_raw_api_object = RawAPIObject(
+            ability_ref, "AttributeChangeTracker", dataset.nyan_api_objects)
         ability_raw_api_object.add_raw_parent("engine.ability.type.AttributeChangeTracker")
         ability_location = ForwardRef(line, game_entity_name)
         ability_raw_api_object.set_location(ability_location)
@@ -441,7 +462,8 @@ class SWGBCCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "AnimationOverlay",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.AnimationOverlay")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.AnimationOverlay")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -481,7 +503,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def constructable_ability(line):
+    def constructable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Constructable ability to a line.
 
@@ -497,7 +519,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def death_ability(line):
+    def death_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Death ability to a line that is used to make entities die.
 
@@ -513,7 +535,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def exchange_resources_ability(line):
+    def exchange_resources_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ExchangeResources ability to a line.
 
@@ -535,13 +557,15 @@ class SWGBCCAbilitySubprocessor:
         for resource_name in resource_names:
             ability_name = f"MarketExchange{resource_name}"
             ability_ref = f"{game_entity_name}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent("engine.ability.type.ExchangeResources")
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
 
             # Resource that is exchanged (resource A)
-            resource_a = dataset.pregen_nyan_objects[f"util.resource.types.{resource_name}"].get_nyan_object()
+            resource_a = dataset.pregen_nyan_objects[f"util.resource.types.{resource_name}"].get_nyan_object(
+            )
             ability_raw_api_object.add_raw_member("resource_a",
                                                   resource_a,
                                                   "engine.ability.type.ExchangeResources")
@@ -561,8 +585,10 @@ class SWGBCCAbilitySubprocessor:
 
             # Exchange modes
             exchange_modes = [
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(),
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(),
+                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(
+                ),
+                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(
+                ),
             ]
             ability_raw_api_object.add_raw_member("exchange_modes",
                                                   exchange_modes,
@@ -575,7 +601,7 @@ class SWGBCCAbilitySubprocessor:
         return abilities
 
     @staticmethod
-    def gather_ability(line):
+    def gather_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Gather abilities to a line. Unlike the other methods, this
         creates multiple abilities.
@@ -631,16 +657,20 @@ class SWGBCCAbilitySubprocessor:
                     resource_id = command["resource_in"].get_value()
 
                 if resource_id == 0:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
+                    )
 
                 elif resource_id == 1:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object(
+                    )
 
                 elif resource_id == 2:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Ore"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Ore"].get_nyan_object(
+                    )
 
                 elif resource_id == 3:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object(
+                    )
 
                 else:
                     continue
@@ -683,7 +713,8 @@ class SWGBCCAbilitySubprocessor:
             ability_name = gather_lookup_dict[gatherer_unit_id][0]
 
             ability_ref = f"{game_entity_name}.{ability_name}"
-            ability_raw_api_object = RawAPIObject(ability_ref, ability_name, dataset.nyan_api_objects)
+            ability_raw_api_object = RawAPIObject(
+                ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent("engine.ability.type.Gather")
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
@@ -732,7 +763,8 @@ class SWGBCCAbilitySubprocessor:
 
             line.add_raw_api_object(property_raw_api_object)
 
-            diplomatic_stances = [dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"]]
+            diplomatic_stances = [
+                dataset.nyan_api_objects["engine.util.diplomatic_stance.type.Self"]]
             property_raw_api_object.add_raw_member("stances", diplomatic_stances,
                                                    "engine.ability.property.type.Diplomatic")
 
@@ -762,10 +794,12 @@ class SWGBCCAbilitySubprocessor:
             rate_location = ForwardRef(line, ability_ref)
             rate_raw_api_object.set_location(rate_location)
 
-            rate_raw_api_object.add_raw_member("type", resource, "engine.util.resource.ResourceRate")
+            rate_raw_api_object.add_raw_member(
+                "type", resource, "engine.util.resource.ResourceRate")
 
             gather_rate = gatherer["work_rate"].get_value()
-            rate_raw_api_object.add_raw_member("rate", gather_rate, "engine.util.resource.ResourceRate")
+            rate_raw_api_object.add_raw_member(
+                "rate", gather_rate, "engine.util.resource.ResourceRate")
 
             line.add_raw_api_object(rate_raw_api_object)
 
@@ -804,7 +838,7 @@ class SWGBCCAbilitySubprocessor:
         return abilities
 
     @staticmethod
-    def harvestable_ability(line):
+    def harvestable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Harvestable ability to a line.
 
@@ -839,7 +873,8 @@ class SWGBCCAbilitySubprocessor:
                 resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object()
 
             elif resource_id == 1:
-                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object(
+                )
 
             elif resource_id == 2:
                 resource = dataset.pregen_nyan_objects["util.resource.types.Ore"].get_nyan_object()
@@ -942,7 +977,8 @@ class SWGBCCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1023,7 +1059,8 @@ class SWGBCCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1103,7 +1140,8 @@ class SWGBCCAbilitySubprocessor:
             property_raw_api_object = RawAPIObject(property_ref,
                                                    "TerrainOverlay",
                                                    dataset.nyan_api_objects)
-            property_raw_api_object.add_raw_parent("engine.util.progress.property.type.TerrainOverlay")
+            property_raw_api_object.add_raw_parent(
+                "engine.util.progress.property.type.TerrainOverlay")
             property_location = ForwardRef(line, progress_ref)
             property_raw_api_object.set_location(property_location)
 
@@ -1183,7 +1221,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def hitbox_ability(line):
+    def hitbox_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Hitbox ability to a line.
 
@@ -1199,7 +1237,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def idle_ability(line):
+    def idle_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Idle ability to a line.
 
@@ -1215,7 +1253,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def live_ability(line):
+    def live_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Live ability to a line.
 
@@ -1231,7 +1269,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def los_ability(line):
+    def los_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the LineOfSight ability to a line.
 
@@ -1247,7 +1285,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def move_ability(line):
+    def move_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Move ability to a line.
 
@@ -1263,7 +1301,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def named_ability(line):
+    def named_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Named ability to a line.
 
@@ -1279,7 +1317,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def provide_contingent_ability(line):
+    def provide_contingent_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProvideContingent ability to a line.
 
@@ -1295,7 +1333,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def regenerate_attribute_ability(line):
+    def regenerate_attribute_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RegenerateAttribute ability to a line.
 
@@ -1376,7 +1414,7 @@ class SWGBCCAbilitySubprocessor:
         return [ability_forward_ref]
 
     @staticmethod
-    def resource_storage_ability(line):
+    def resource_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ResourceStorage ability to a line.
 
@@ -1429,16 +1467,20 @@ class SWGBCCAbilitySubprocessor:
                     resource_id = command["resource_in"].get_value()
 
                 if resource_id == 0:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
+                    )
 
                 elif resource_id == 1:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object(
+                    )
 
                 elif resource_id == 2:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Ore"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Ore"].get_nyan_object(
+                    )
 
                 elif resource_id == 3:
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object(
+                    )
 
                 elif type_id == 111:
                     target_id = command["unit_id"].get_value()
@@ -1447,7 +1489,8 @@ class SWGBCCAbilitySubprocessor:
                         continue
 
                     # Trade goods --> nova
-                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object()
+                    resource = dataset.pregen_nyan_objects["util.resource.types.Nova"].get_nyan_object(
+                    )
 
                 else:
                     continue
@@ -1471,7 +1514,8 @@ class SWGBCCAbilitySubprocessor:
                 container_name = "TradeContainer"
 
             container_ref = f"{ability_ref}.{container_name}"
-            container_raw_api_object = RawAPIObject(container_ref, container_name, dataset.nyan_api_objects)
+            container_raw_api_object = RawAPIObject(
+                container_ref, container_name, dataset.nyan_api_objects)
             container_raw_api_object.add_raw_parent("engine.util.storage.ResourceContainer")
             container_location = ForwardRef(line, ability_ref)
             container_raw_api_object.set_location(container_location)
@@ -1526,7 +1570,8 @@ class SWGBCCAbilitySubprocessor:
                 property_raw_api_object = RawAPIObject(property_ref,
                                                        "Animated",
                                                        dataset.nyan_api_objects)
-                property_raw_api_object.add_raw_parent("engine.util.progress.property.type.Animated")
+                property_raw_api_object.add_raw_parent(
+                    "engine.util.progress.property.type.Animated")
                 property_location = ForwardRef(line, progress_ref)
                 property_raw_api_object.set_location(property_location)
 
@@ -1540,7 +1585,8 @@ class SWGBCCAbilitySubprocessor:
                 override_raw_api_object = RawAPIObject(override_ref,
                                                        "MoveOverride",
                                                        dataset.nyan_api_objects)
-                override_raw_api_object.add_raw_parent("engine.util.animation_override.AnimationOverride")
+                override_raw_api_object.add_raw_parent(
+                    "engine.util.animation_override.AnimationOverride")
                 override_location = ForwardRef(line, property_ref)
                 override_raw_api_object.set_location(override_location)
 
@@ -1606,7 +1652,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def restock_ability(line, restock_target_id):
+    def restock_ability(line: GenieGameEntityGroup, restock_target_id: int) -> ForwardRef:
         """
         Adds the Restock ability to a line.
 
@@ -1622,7 +1668,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def selectable_ability(line):
+    def selectable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds Selectable abilities to a line. Units will get two of these,
         one Rectangle box for the Self stance and one MatchToSprite box
@@ -1640,7 +1686,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def send_back_to_task_ability(line):
+    def send_back_to_task_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the SendBackToTask ability to a line.
 
@@ -1656,13 +1702,15 @@ class SWGBCCAbilitySubprocessor:
 
         game_entity_name = name_lookup_dict[current_unit_id][0]
         ability_ref = f"{game_entity_name}.SendBackToTask"
-        ability_raw_api_object = RawAPIObject(ability_ref, "SendBackToTask", dataset.nyan_api_objects)
+        ability_raw_api_object = RawAPIObject(
+            ability_ref, "SendBackToTask", dataset.nyan_api_objects)
         ability_raw_api_object.add_raw_parent("engine.ability.type.SendBackToTask")
         ability_location = ForwardRef(line, game_entity_name)
         ability_raw_api_object.set_location(ability_location)
 
         # Only works on villagers
-        allowed_types = [dataset.pregen_nyan_objects["util.game_entity_type.types.Worker"].get_nyan_object()]
+        allowed_types = [
+            dataset.pregen_nyan_objects["util.game_entity_type.types.Worker"].get_nyan_object()]
         ability_raw_api_object.add_raw_member("allowed_types",
                                               allowed_types,
                                               "engine.ability.type.SendBackToTask")
@@ -1677,7 +1725,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def shoot_projectile_ability(line, command_id):
+    def shoot_projectile_ability(line: GenieGameEntityGroup, command_id: int) -> ForwardRef:
         """
         Adds the ShootProjectile ability to a line.
 
@@ -1693,7 +1741,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def trade_ability(line):
+    def trade_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Trade ability to a line.
 
@@ -1744,7 +1792,8 @@ class SWGBCCAbilitySubprocessor:
                                               "engine.ability.type.Trade")
 
         # container
-        container_forward_ref = ForwardRef(line, f"{game_entity_name}.ResourceStorage.TradeContainer")
+        container_forward_ref = ForwardRef(
+            line, f"{game_entity_name}.ResourceStorage.TradeContainer")
         ability_raw_api_object.add_raw_member("container",
                                               container_forward_ref,
                                               "engine.ability.type.Trade")
@@ -1756,7 +1805,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def trade_post_ability(line):
+    def trade_post_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TradePost ability to a line.
 
@@ -1821,7 +1870,7 @@ class SWGBCCAbilitySubprocessor:
         return ability_forward_ref
 
     @staticmethod
-    def turn_ability(line):
+    def turn_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Turn ability to a line.
 

--- a/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-public-methods,too-many-lines,too-many-locals
 # pylint: disable=too-many-branches,too-many-statements,too-many-arguments

--- a/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 #

--- a/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
@@ -9,6 +9,9 @@
 Derives complex auxiliary objects from unit lines, techs
 or other objects.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberSpecialValue
 from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup,\
     GenieBuildingLineGroup, GenieUnitLineGroup
@@ -18,6 +21,10 @@ from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.auxiliary_subprocessor import AoCAuxiliarySubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+
 
 class SWGBCCAuxiliarySubprocessor:
     """
@@ -25,7 +32,7 @@ class SWGBCCAuxiliarySubprocessor:
     """
 
     @staticmethod
-    def get_creatable_game_entity(line):
+    def get_creatable_game_entity(line: GenieGameEntityGroup) -> None:
         """
         Creates the CreatableGameEntity object for a unit/building line.
 
@@ -139,7 +146,8 @@ class SWGBCCAuxiliarySubprocessor:
                 resource_name = "Food"
 
             elif resource_id == 1:
-                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object(
+                )
                 resource_name = "Carbon"
 
             elif resource_id == 2:
@@ -364,7 +372,8 @@ class SWGBCCAuxiliarySubprocessor:
                 placement_modes.append(replace_forward_ref)
 
         else:
-            placement_modes.append(dataset.nyan_api_objects["engine.util.placement_mode.type.Eject"])
+            placement_modes.append(
+                dataset.nyan_api_objects["engine.util.placement_mode.type.Eject"])
 
             # OwnStorage mode
             obj_name = f"{game_entity_name}.CreatableGameEntity.OwnStorage"
@@ -396,7 +405,7 @@ class SWGBCCAuxiliarySubprocessor:
         line.add_raw_api_object(cost_raw_api_object)
 
     @staticmethod
-    def get_researchable_tech(tech_group):
+    def get_researchable_tech(tech_group: GenieTechEffectBundleGroup) -> None:
         """
         Creates the ResearchableTech object for a Tech.
 
@@ -470,7 +479,8 @@ class SWGBCCAuxiliarySubprocessor:
                 resource_name = "Food"
 
             elif resource_id == 1:
-                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object()
+                resource = dataset.pregen_nyan_objects["util.resource.types.Carbon"].get_nyan_object(
+                )
                 resource_name = "Carbon"
 
             elif resource_id == 2:

--- a/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
@@ -5,11 +5,18 @@
 """
 Creates patches and modifiers for civs.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.civ_subprocessor import AoCCivSubprocessor
 from .tech_subprocessor import SWGBCCTechSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
 
 
 class SWGBCCCivSubprocessor:
@@ -18,7 +25,7 @@ class SWGBCCCivSubprocessor:
     """
 
     @classmethod
-    def get_civ_setup(cls, civ_group):
+    def get_civ_setup(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the patches for the civ setup which configures architecture sets
         unique units, unique techs, team boni and unique stat upgrades.
@@ -36,7 +43,7 @@ class SWGBCCCivSubprocessor:
         return patches
 
     @classmethod
-    def get_modifiers(cls, civ_group):
+    def get_modifiers(cls, civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns global modifiers of a civ.
         """
@@ -50,7 +57,7 @@ class SWGBCCCivSubprocessor:
         return modifiers
 
     @staticmethod
-    def get_starting_resources(civ_group):
+    def get_starting_resources(civ_group: GenieCivilizationGroup) -> list[ForwardRef]:
         """
         Returns the starting resources of a civ.
         """

--- a/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 

--- a/openage/convert/processor/conversion/swgbcc/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/modpack_subprocessor.py
@@ -6,8 +6,14 @@
 Organize export data (nyan objects, media, scripts, etc.)
 into modpacks.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
 
 
 class SWGBCCModpackSubprocessor:
@@ -16,16 +22,16 @@ class SWGBCCModpackSubprocessor:
     """
 
     @classmethod
-    def get_modpacks(cls, gamedata):
+    def get_modpacks(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Return all modpacks that can be created from the gamedata.
         """
-        swgb_base = cls._get_swgb_base(gamedata)
+        swgb_base = cls._get_swgb_base(full_data_set)
 
         return [swgb_base]
 
     @classmethod
-    def _get_swgb_base(cls, gamedata):
+    def _get_swgb_base(cls, full_data_set: GenieObjectContainer) -> Modpack:
         """
         Create the swgb-base modpack.
         """
@@ -37,7 +43,7 @@ class SWGBCCModpackSubprocessor:
 
         mod_def.add_include("data/*")
 
-        AoCModpackSubprocessor.organize_nyan_objects(modpack, gamedata)
-        AoCModpackSubprocessor.organize_media_objects(modpack, gamedata)
+        AoCModpackSubprocessor.organize_nyan_objects(modpack, full_data_set)
+        AoCModpackSubprocessor.organize_media_objects(modpack, full_data_set)
 
         return modpack

--- a/openage/convert/processor/conversion/swgbcc/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/modpack_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 
@@ -13,7 +13,8 @@ from ....entity_object.conversion.modpack import Modpack
 from ..aoc.modpack_subprocessor import AoCModpackSubprocessor
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_object_container\
+        import GenieObjectContainer
 
 
 class SWGBCCModpackSubprocessor:

--- a/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
@@ -9,6 +9,9 @@
 Convert API-like objects to nyan objects. Subroutine of the
 main SWGB processor. Reuses functionality from the AoC subprocessor.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_tech import UnitLineUpgrade
 from ....entity_object.conversion.aoc.genie_unit import GenieVillagerGroup,\
     GenieStackBuildingGroup, GenieGarrisonMode, GenieMonkGroup
@@ -22,6 +25,13 @@ from .auxiliary_subprocessor import SWGBCCAuxiliarySubprocessor
 from .civ_subprocessor import SWGBCCCivSubprocessor
 from .tech_subprocessor import SWGBCCTechSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_civ import GenieCivilizationGroup
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
+        GenieBuildingLineGroup, GenieAmbientGroup
+
 
 class SWGBCCNyanSubprocessor:
     """
@@ -29,18 +39,18 @@ class SWGBCCNyanSubprocessor:
     """
 
     @classmethod
-    def convert(cls, gamedata):
+    def convert(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects from the given dataset.
         """
-        cls._process_game_entities(gamedata)
-        cls._create_nyan_objects(gamedata)
-        cls._create_nyan_members(gamedata)
+        cls._process_game_entities(full_data_set)
+        cls._create_nyan_objects(full_data_set)
+        cls._create_nyan_members(full_data_set)
 
-        cls._check_objects(gamedata)
+        cls._check_objects(full_data_set)
 
     @classmethod
-    def _check_objects(cls, full_data_set):
+    def _check_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Check if objects are valid.
         """
@@ -66,7 +76,7 @@ class SWGBCCNyanSubprocessor:
             civ_group.check_readiness()
 
     @classmethod
-    def _create_nyan_objects(cls, full_data_set):
+    def _create_nyan_objects(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Creates nyan objects from the API objects.
         """
@@ -99,7 +109,7 @@ class SWGBCCNyanSubprocessor:
             civ_group.execute_raw_member_pushs()
 
     @classmethod
-    def _create_nyan_members(cls, full_data_set):
+    def _create_nyan_members(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Fill nyan member values of the API objects.
         """
@@ -125,7 +135,7 @@ class SWGBCCNyanSubprocessor:
             civ_group.create_nyan_members()
 
     @classmethod
-    def _process_game_entities(cls, full_data_set):
+    def _process_game_entities(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create the RawAPIObject representation of the objects.
         """
@@ -152,7 +162,7 @@ class SWGBCCNyanSubprocessor:
             cls.civ_group_to_civ(civ_group)
 
     @staticmethod
-    def unit_line_to_game_entity(unit_line):
+    def unit_line_to_game_entity(unit_line: GenieUnitLineGroup) -> None:
         """
         Creates raw API objects for a unit line.
 
@@ -190,7 +200,8 @@ class SWGBCCNyanSubprocessor:
         unit_type = current_unit["unit_type"].get_value()
 
         if unit_type >= 70:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_unit["unit_class"].get_value()
@@ -354,7 +365,7 @@ class SWGBCCNyanSubprocessor:
             SWGBCCAuxiliarySubprocessor.get_creatable_game_entity(unit_line)
 
     @staticmethod
-    def building_line_to_game_entity(building_line):
+    def building_line_to_game_entity(building_line: GenieBuildingLineGroup) -> None:
         """
         Creates raw API objects for a building line.
 
@@ -392,7 +403,8 @@ class SWGBCCNyanSubprocessor:
         unit_type = current_building["unit_type"].get_value()
 
         if unit_type >= 80:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         unit_class = current_building["unit_class"].get_value()
@@ -402,7 +414,8 @@ class SWGBCCNyanSubprocessor:
         types_set.append(type_obj)
 
         if building_line.is_dropsite():
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
@@ -412,7 +425,8 @@ class SWGBCCNyanSubprocessor:
         # =======================================================================
         abilities_set = []
 
-        abilities_set.append(SWGBCCAbilitySubprocessor.attribute_change_tracker_ability(building_line))
+        abilities_set.append(
+            SWGBCCAbilitySubprocessor.attribute_change_tracker_ability(building_line))
         abilities_set.append(SWGBCCAbilitySubprocessor.death_ability(building_line))
         abilities_set.append(AoCAbilitySubprocessor.delete_ability(building_line))
         abilities_set.append(AoCAbilitySubprocessor.despawn_ability(building_line))
@@ -467,7 +481,8 @@ class SWGBCCNyanSubprocessor:
             garrison_mode = building_line.get_garrison_mode()
 
             if garrison_mode == GenieGarrisonMode.NATURAL:
-                abilities_set.append(SWGBCCAbilitySubprocessor.send_back_to_task_ability(building_line))
+                abilities_set.append(
+                    SWGBCCAbilitySubprocessor.send_back_to_task_ability(building_line))
 
             if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                 abilities_set.append(AoCAbilitySubprocessor.rally_point_ability(building_line))
@@ -489,7 +504,8 @@ class SWGBCCNyanSubprocessor:
 
         if building_line.get_id() == 84:
             # Spaceport trading
-            abilities_set.extend(SWGBCCAbilitySubprocessor.exchange_resources_ability(building_line))
+            abilities_set.extend(
+                SWGBCCAbilitySubprocessor.exchange_resources_ability(building_line))
 
         raw_api_object.add_raw_member("abilities", abilities_set,
                                       "engine.util.game_entity.GameEntity")
@@ -511,7 +527,7 @@ class SWGBCCNyanSubprocessor:
             SWGBCCAuxiliarySubprocessor.get_creatable_game_entity(building_line)
 
     @staticmethod
-    def ambient_group_to_game_entity(ambient_group):
+    def ambient_group_to_game_entity(ambient_group: GenieAmbientGroup) -> None:
         """
         Creates raw API objects for an ambient group.
 
@@ -545,7 +561,8 @@ class SWGBCCNyanSubprocessor:
         # Create or use existing auxiliary types
         types_set = []
 
-        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object()
+        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object(
+        )
         types_set.append(type_obj)
 
         unit_class = ambient_unit["unit_class"].get_value()
@@ -605,7 +622,7 @@ class SWGBCCNyanSubprocessor:
                                       "engine.util.game_entity.GameEntity")
 
     @staticmethod
-    def tech_group_to_tech(tech_group):
+    def tech_group_to_tech(tech_group: GenieTechEffectBundleGroup) -> None:
         """
         Creates raw API objects for a tech group.
 
@@ -672,7 +689,8 @@ class SWGBCCNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(tech_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -693,7 +711,8 @@ class SWGBCCNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(tech_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -723,7 +742,7 @@ class SWGBCCNyanSubprocessor:
         # TODO: Implement civ line techs
 
     @staticmethod
-    def civ_group_to_civ(civ_group):
+    def civ_group_to_civ(civ_group: GenieCivilizationGroup) -> None:
         """
         Creates raw API objects for a civ group.
 
@@ -774,7 +793,8 @@ class SWGBCCNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(civ_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -795,7 +815,8 @@ class SWGBCCNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(civ_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -880,18 +901,24 @@ class SWGBCCNyanSubprocessor:
             # =======================================================================
             # Types
             # =======================================================================
-            types_set = [dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
-            proj_raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
+            types_set = [
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
+            proj_raw_api_object.add_raw_member(
+                "types", types_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Abilities
             # =======================================================================
             abilities_set = []
-            abilities_set.append(AoCAbilitySubprocessor.projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(line, 7, False, projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(
+                line, 7, False, projectile_num))
             # TODO: Death, Despawn
-            proj_raw_api_object.add_raw_member("abilities", abilities_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "abilities", abilities_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # TODO: Modifiers
@@ -901,13 +928,15 @@ class SWGBCCNyanSubprocessor:
             # modifiers_set.append(AoCModifierSubprocessor.flyover_effect_modifier(line))
             # modifiers_set.extend(AoCModifierSubprocessor.elevation_attack_modifiers(line))
 
-            proj_raw_api_object.add_raw_member("modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Variants
             # =======================================================================
             variants_set = []
-            proj_raw_api_object.add_raw_member("variants", variants_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "variants", variants_set, "engine.util.game_entity.GameEntity")
 
             line.add_raw_api_object(proj_raw_api_object)
 

--- a/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements,too-many-branches
 #

--- a/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements
 #

--- a/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
@@ -9,6 +9,9 @@
 Creates nyan objects for things that are hardcoded into the Genie Engine,
 but configurable in openage. E.g. HP.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberSpecialValue
 from ....entity_object.conversion.converter_object import ConverterObjectGroup,\
     RawAPIObject
@@ -17,6 +20,9 @@ from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
 from ..aoc.pregen_processor import AoCPregenSubprocessor
 
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+
 
 class SWGBCCPregenSubprocessor:
     """
@@ -24,28 +30,28 @@ class SWGBCCPregenSubprocessor:
     """
 
     @classmethod
-    def generate(cls, gamedata):
+    def generate(cls, full_data_set: GenieObjectContainer) -> None:
         """
         Create nyan objects for hardcoded properties.
         """
         # Stores pregenerated raw API objects as a container
         pregen_converter_group = ConverterObjectGroup("pregen")
 
-        AoCPregenSubprocessor.generate_attributes(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_diplomatic_stances(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_team_property(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_entity_types(gamedata, pregen_converter_group)
-        cls.generate_effect_types(gamedata, pregen_converter_group)
-        cls.generate_exchange_objects(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_formation_types(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_language_objects(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_misc_effect_objects(gamedata, pregen_converter_group)
+        AoCPregenSubprocessor.generate_attributes(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_diplomatic_stances(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_team_property(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_entity_types(full_data_set, pregen_converter_group)
+        cls.generate_effect_types(full_data_set, pregen_converter_group)
+        cls.generate_exchange_objects(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_formation_types(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_language_objects(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_misc_effect_objects(full_data_set, pregen_converter_group)
         # cls._generate_modifiers(gamedata, pregen_converter_group) ??
         # cls._generate_terrain_types(gamedata, pregen_converter_group) TODO: Create terrain types
-        cls.generate_resources(gamedata, pregen_converter_group)
-        AoCPregenSubprocessor.generate_death_condition(gamedata, pregen_converter_group)
+        cls.generate_resources(full_data_set, pregen_converter_group)
+        AoCPregenSubprocessor.generate_death_condition(full_data_set, pregen_converter_group)
 
-        pregen_nyan_objects = gamedata.pregen_nyan_objects
+        pregen_nyan_objects = full_data_set.pregen_nyan_objects
         # Create nyan objects from the raw API objects
         for pregen_object in pregen_nyan_objects.values():
             pregen_object.create_nyan_object()
@@ -59,7 +65,10 @@ class SWGBCCPregenSubprocessor:
                                 "Member or object not initialized." % (pregen_object))
 
     @staticmethod
-    def generate_effect_types(full_data_set, pregen_converter_group):
+    def generate_effect_types(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate types for effects and resistances.
 
@@ -76,7 +85,8 @@ class SWGBCCPregenSubprocessor:
         api_objects = full_data_set.nyan_api_objects
 
         name_lookup_dict = internal_name_lookups.get_entity_lookups(full_data_set.game_version)
-        armor_lookup_dict = internal_name_lookups.get_armor_class_lookups(full_data_set.game_version)
+        armor_lookup_dict = internal_name_lookups.get_armor_class_lookups(
+            full_data_set.game_version)
 
         # =======================================================================
         # Armor types
@@ -205,7 +215,10 @@ class SWGBCCPregenSubprocessor:
         pregen_nyan_objects.update({type_ref_in_modpack: type_raw_api_object})
 
     @staticmethod
-    def generate_exchange_objects(full_data_set, pregen_converter_group):
+    def generate_exchange_objects(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate objects for market trading (ExchangeResources).
 
@@ -495,7 +508,10 @@ class SWGBCCPregenSubprocessor:
         pregen_nyan_objects.update({price_mode_ref_in_modpack: price_mode_raw_api_object})
 
     @staticmethod
-    def generate_resources(full_data_set, pregen_converter_group):
+    def generate_resources(
+        full_data_set: GenieObjectContainer,
+        pregen_converter_group: ConverterObjectGroup
+    ) -> None:
         """
         Generate Attribute objects.
 

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -40,7 +40,7 @@ if typing.TYPE_CHECKING:
     from openage.convert.entity_object.conversion.stringresource import StringResource
     from openage.convert.entity_object.conversion.modpack import Modpack
     from openage.convert.value_object.read.value_members import ArrayMember
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
 
 
 class SWGBCCProcessor:
@@ -91,7 +91,7 @@ class SWGBCCProcessor:
     def _pre_processor(
         cls,
         gamespec: ArrayMember,
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         string_resources: StringResource,
         existing_graphics: list[str]
     ) -> GenieObjectContainer:

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-branches,too-many-statements,too-many-locals
 #

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -7,6 +7,9 @@
 """
 Convert data from SWGB:CC to openage formats.
 """
+from __future__ import annotations
+import typing
+
 
 from openage.convert.entity_object.conversion.aoc.genie_tech import BuildingUnlock
 from .....log import info
@@ -32,6 +35,13 @@ from .modpack_subprocessor import SWGBCCModpackSubprocessor
 from .nyan_subprocessor import SWGBCCNyanSubprocessor
 from .pregen_subprocessor import SWGBCCPregenSubprocessor
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.value_object.read.value_members import ArrayMember
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+
 
 class SWGBCCProcessor:
     """
@@ -39,7 +49,13 @@ class SWGBCCProcessor:
     """
 
     @classmethod
-    def convert(cls, gamespec, args, string_resources, existing_graphics):
+    def convert(
+        cls,
+        gamespec: ArrayMember,
+        args: Namespace,
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> list[Modpack]:
         """
         Input game specification and media here and get a set of
         modpacks back.
@@ -72,7 +88,13 @@ class SWGBCCProcessor:
         return modpacks
 
     @classmethod
-    def _pre_processor(cls, gamespec, game_version, string_resources, existing_graphics):
+    def _pre_processor(
+        cls,
+        gamespec: ArrayMember,
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        string_resources: StringResource,
+        existing_graphics: list[str]
+    ) -> GenieObjectContainer:
         """
         Store data from the reader in a conversion container.
 
@@ -108,7 +130,7 @@ class SWGBCCProcessor:
         return dataset
 
     @classmethod
-    def _processor(cls, full_data_set):
+    def _processor(cls, full_data_set: GenieObjectContainer) -> GenieObjectContainer:
         """
         Transfer structures used in Genie games to more openage-friendly
         Python objects.
@@ -149,7 +171,7 @@ class SWGBCCProcessor:
         return full_data_set
 
     @classmethod
-    def _post_processor(cls, full_data_set):
+    def _post_processor(cls, full_data_set: GenieObjectContainer) -> list[Modpack]:
         """
         Convert API-like Python objects to nyan.
 
@@ -170,7 +192,7 @@ class SWGBCCProcessor:
         return SWGBCCModpackSubprocessor.get_modpacks(full_data_set)
 
     @staticmethod
-    def create_unit_lines(full_data_set):
+    def create_unit_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Sort units into lines, based on information in the unit connections.
 
@@ -309,7 +331,7 @@ class SWGBCCProcessor:
         full_data_set.unit_lines.update(final_unit_lines)
 
     @staticmethod
-    def create_extra_unit_lines(full_data_set):
+    def create_extra_unit_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Create additional units that are not in the unit connections.
 
@@ -329,7 +351,7 @@ class SWGBCCProcessor:
             full_data_set.unit_ref.update({unit_id: unit_line})
 
     @staticmethod
-    def create_building_lines(full_data_set):
+    def create_building_lines(full_data_set: GenieObjectContainer) -> None:
         """
         Establish building lines, based on information in the building connections.
         Because of how Genie building lines work, this will only find the first
@@ -378,7 +400,8 @@ class SWGBCCProcessor:
                     if not age_up:
                         # Add an unlock tech group to the data set
                         building_unlock = BuildingUnlock(tech_id, unit_id_a, full_data_set)
-                        full_data_set.building_unlocks.update({building_unlock.get_id(): building_unlock})
+                        full_data_set.building_unlocks.update(
+                            {building_unlock.get_id(): building_unlock})
 
                 elif effect_type == 2 and unit_id_a in full_data_set.genie_units.keys():
                     # Check if this is a stacked unit (gate or command center)
@@ -392,7 +415,8 @@ class SWGBCCProcessor:
 
                         if not age_up:
                             building_unlock = BuildingUnlock(tech_id, unit_id_a, full_data_set)
-                            full_data_set.building_unlocks.update({building_unlock.get_id(): building_unlock})
+                            full_data_set.building_unlocks.update(
+                                {building_unlock.get_id(): building_unlock})
 
                 if effect_type == 3 and unit_id_b in building_connections.keys():
                     # Upgrades
@@ -487,7 +511,7 @@ class SWGBCCProcessor:
             full_data_set.building_upgrades.update({building_upgrade.get_id(): building_upgrade})
 
     @staticmethod
-    def create_villager_groups(full_data_set):
+    def create_villager_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create task groups and assign the relevant worker group to a
         villager group.
@@ -543,7 +567,7 @@ class SWGBCCProcessor:
             full_data_set.unit_ref.update({unit_id: villager})
 
     @staticmethod
-    def create_ambient_groups(full_data_set):
+    def create_ambient_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create ambient groups, mostly for resources and scenery.
 
@@ -562,7 +586,7 @@ class SWGBCCProcessor:
             full_data_set.unit_ref.update({ambient_id: ambient_group})
 
     @staticmethod
-    def create_variant_groups(full_data_set):
+    def create_variant_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create variant groups.
 
@@ -582,7 +606,7 @@ class SWGBCCProcessor:
                 full_data_set.unit_ref.update({variant_id: variant_group})
 
     @staticmethod
-    def create_tech_groups(full_data_set):
+    def create_tech_groups(full_data_set: GenieObjectContainer) -> None:
         """
         Create techs from tech connections and unit upgrades/unlocks
         from unit connections.
@@ -752,7 +776,7 @@ class SWGBCCProcessor:
             full_data_set.civ_boni.update({civ_bonus.get_id(): civ_bonus})
 
     @staticmethod
-    def link_garrison(full_data_set):
+    def link_garrison(full_data_set: GenieObjectContainer) -> None:
         """
         Link a garrison unit to the lines that are stored and vice versa. This is done
         to provide quick access during conversion.
@@ -870,7 +894,7 @@ class SWGBCCProcessor:
                             garrison_line.garrison_entities.append(unit_line)
 
     @staticmethod
-    def link_repairables(full_data_set):
+    def link_repairables(full_data_set: GenieObjectContainer) -> None:
         """
         Set units/buildings as repairable
 

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 #

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -8,6 +8,9 @@
 """
 Creates patches for technologies.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import CivTeamBonus, CivBonus
 from ..aoc.tech_subprocessor import AoCTechSubprocessor
@@ -15,6 +18,11 @@ from ..aoc.upgrade_attribute_subprocessor import AoCUpgradeAttributeSubprocessor
 from ..aoc.upgrade_resource_subprocessor import AoCUpgradeResourceSubprocessor
 from .upgrade_attribute_subprocessor import SWGBCCUpgradeAttributeSubprocessor
 from .upgrade_resource_subprocessor import SWGBCCUpgradeResourceSubprocessor
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_effect import GenieEffectObject
+    from openage.convert.value_object.conversion.forward_ref import ForwardRef
 
 
 class SWGBCCTechSubprocessor:
@@ -101,7 +109,7 @@ class SWGBCCTechSubprocessor:
     }
 
     @classmethod
-    def get_patches(cls, converter_group):
+    def get_patches(cls, converter_group: ConverterObjectGroup) -> list[ForwardRef]:
         """
         Returns the patches for a converter group, depending on the type
         of its effects.
@@ -176,7 +184,11 @@ class SWGBCCTechSubprocessor:
         return patches
 
     @staticmethod
-    def attribute_modify_effect(converter_group, effect, team=False):
+    def attribute_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying attributes of entities.
         """
@@ -241,7 +253,11 @@ class SWGBCCTechSubprocessor:
         return patches
 
     @staticmethod
-    def resource_modify_effect(converter_group, effect, team=False):
+    def resource_modify_effect(
+        converter_group: ConverterObjectGroup,
+        effect: GenieEffectObject,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates the patches for modifying resources.
         """

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -114,14 +114,14 @@ class SWGBCCTechSubprocessor:
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
             team_bonus = True
 
         elif isinstance(converter_group, CivBonus):
             effects = converter_group.get_effects()
 
             # Change converter group here, so that the Civ object gets the patches
-            converter_group = dataset.civ_groups[converter_group.get_civilization()]
+            converter_group = dataset.civ_groups[converter_group.get_civilization_id()]
 
         else:
             effects = converter_group.get_effects()

--- a/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods
 #

--- a/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
@@ -8,10 +8,18 @@
 """
 Creates upgrade patches for attribute modification effects in SWGB.
 """
+from __future__ import annotations
+import typing
+
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.convert.entity_object.conversion.aoc.genie_unit import GenieGameEntityGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class SWGBCCUpgradeAttributeSubprocessor:
@@ -20,7 +28,13 @@ class SWGBCCUpgradeAttributeSubprocessor:
     """
 
     @staticmethod
-    def cost_carbon_upgrade(converter_group, line, value, operator, team=False):
+    def cost_carbon_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the carbon cost modify effect (ID: 104).
 
@@ -29,7 +43,7 @@ class SWGBCCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -89,7 +103,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -106,7 +121,13 @@ class SWGBCCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_nova_upgrade(converter_group, line, value, operator, team=False):
+    def cost_nova_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the nova cost modify effect (ID: 105).
 
@@ -115,7 +136,7 @@ class SWGBCCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -175,7 +196,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -192,7 +214,13 @@ class SWGBCCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def cost_ore_upgrade(converter_group, line, value, operator, team=False):
+    def cost_ore_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the ore cost modify effect (ID: 106).
 
@@ -201,7 +229,7 @@ class SWGBCCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -261,7 +289,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -278,7 +307,13 @@ class SWGBCCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
-    def resource_cost_upgrade(converter_group, line, value, operator, team=False):
+    def resource_cost_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the resource modify effect (ID: 100).
 
@@ -287,7 +322,7 @@ class SWGBCCUpgradeAttributeSubprocessor:
         :param line: Unit/Building line that has the ability.
         :type line: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -377,7 +412,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }

--- a/openage/convert/processor/conversion/swgbcc/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_resource_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-lines,too-many-statements,too-many-public-methods
 #

--- a/openage/convert/processor/conversion/swgbcc/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_resource_subprocessor.py
@@ -8,11 +8,18 @@
 """
 Creates upgrade patches for resource modification effects in SWGB.
 """
+from __future__ import annotations
+import typing
+
 from .....nyan.nyan_structs import MemberOperator
 from ....entity_object.conversion.aoc.genie_tech import GenieTechEffectBundleGroup
 from ....entity_object.conversion.converter_object import RawAPIObject
 from ....service.conversion import internal_name_lookups
 from ....value_object.conversion.forward_ref import ForwardRef
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup
+    from openage.nyan.nyan_structs import MemberOperator
 
 
 class SWGBCCUpgradeResourceSubprocessor:
@@ -21,14 +28,19 @@ class SWGBCCUpgradeResourceSubprocessor:
     """
 
     @staticmethod
-    def assault_mech_anti_air_upgrade(converter_group, value, operator, team=False):
+    def assault_mech_anti_air_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the assault mech anti air effect (ID: 31).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -41,14 +53,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def berserk_heal_rate_upgrade(converter_group, value, operator, team=False):
+    def berserk_heal_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the berserk heal rate modify effect (ID: 96).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -110,7 +127,8 @@ class SWGBCCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -127,14 +145,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def building_conversion_upgrade(converter_group, value, operator, team=False):
+    def building_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the building conversion effect (ID: 28).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -189,7 +212,8 @@ class SWGBCCUpgradeResourceSubprocessor:
 
             # New allowed types
             allowed_types = [
-                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+                )
             ]
             nyan_patch_raw_api_object.add_raw_patch_member("allowed_types",
                                                            allowed_types,
@@ -226,14 +250,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def cloak_upgrade(converter_group, value, operator, team=False):
+    def cloak_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the force cloak effect (ID: 56).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -246,14 +275,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def concentration_upgrade(converter_group, value, operator, team=False):
+    def concentration_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the concentration effect (ID: 87).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -266,14 +300,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def conversion_range_upgrade(converter_group, value, operator, team=False):
+    def conversion_range_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the conversion range modify effect (ID: 5).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -286,14 +325,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def detect_cloak_upgrade(converter_group, value, operator, team=False):
+    def detect_cloak_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the force detect cloak effect (ID: 58).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -306,14 +350,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def faith_recharge_rate_upgrade(converter_group, value, operator, team=False):
+    def faith_recharge_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the faith_recharge_rate modify effect (ID: 35).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -375,7 +424,8 @@ class SWGBCCUpgradeResourceSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -392,14 +442,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def heal_range_upgrade(converter_group, value, operator, team=False):
+    def heal_range_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the heal range modify effect (ID: 90).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -460,7 +515,8 @@ class SWGBCCUpgradeResourceSubprocessor:
                                               "engine.util.patch.Patch")
 
         if team:
-            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+            team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+            )
             properties = {
                 dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
             }
@@ -477,14 +533,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def monk_conversion_upgrade(converter_group, value, operator, team=False):
+    def monk_conversion_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the monk conversion effect (ID: 27).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -547,7 +608,8 @@ class SWGBCCUpgradeResourceSubprocessor:
                                                   "engine.util.patch.Patch")
 
             if team:
-                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object()
+                team_property = dataset.pregen_nyan_objects["util.patch.property.types.Team"].get_nyan_object(
+                )
                 properties = {
                     dataset.nyan_api_objects["engine.util.patch.property.type.Diplomatic"]: team_property
                 }
@@ -564,14 +626,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def shield_air_units_upgrade(converter_group, value, operator, team=False):
+    def shield_air_units_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the shield bomber/fighter effect (ID: 38).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -584,14 +651,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def shield_dropoff_time_upgrade(converter_group, value, operator, team=False):
+    def shield_dropoff_time_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the shield dropoff time modify effect (ID: 26).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -604,14 +676,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def shield_power_core_upgrade(converter_group, value, operator, team=False):
+    def shield_power_core_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the shield power core effect (ID: 33).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -624,14 +701,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def shield_recharge_rate_upgrade(converter_group, value, operator, team=False):
+    def shield_recharge_rate_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the shield recharge rate modify effect (ID: 10).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: int, float
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.
@@ -644,14 +726,19 @@ class SWGBCCUpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
-    def submarine_detect_upgrade(converter_group, value, operator, team=False):
+    def submarine_detect_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Any,
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
         """
         Creates a patch for the submarine detect effect (ID: 23).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
         :param value: Value used for patching the member.
-        :type value: MemberOperator
+        :type value: Any
         :param operator: Operator used for patching the member.
         :type operator: MemberOperator
         :returns: The forward references for the generated patches.

--- a/openage/convert/processor/export/data_exporter.py
+++ b/openage/convert/processor/export/data_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 """

--- a/openage/convert/processor/export/data_exporter.py
+++ b/openage/convert/processor/export/data_exporter.py
@@ -5,6 +5,14 @@
 Exports data formats from a modpack to files.
 """
 
+from __future__ import annotations
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.directory import Directory
+    from openage.convert.entity_object.export.data_definition import DataDefinition
+
 
 class DataExporter:
     """
@@ -12,7 +20,7 @@ class DataExporter:
     """
 
     @staticmethod
-    def export(data_files, exportdir):
+    def export(data_files: list[DataDefinition], exportdir: Directory) -> None:
         """
         Exports data files.
 

--- a/openage/convert/processor/export/generate_manifest_hashes.py
+++ b/openage/convert/processor/export/generate_manifest_hashes.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 """
 Provides functions for traversing a directory and
 generating hash values for all the items inside.

--- a/openage/convert/processor/export/generate_manifest_hashes.py
+++ b/openage/convert/processor/export/generate_manifest_hashes.py
@@ -4,11 +4,21 @@ Provides functions for traversing a directory and
 generating hash values for all the items inside.
 """
 
+from __future__ import annotations
+import typing
+
+
 import os
+
 from openage.util.hash import hash_file
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.directory import Directory
+    from openage.util.fslike.path import Path
+    from openage.convert.entity_object.conversion.modpack import Modpack
 
-def bfs_directory(root):
+
+def bfs_directory(root: Path) -> typing.Generator[Path, None, None]:
     """
     Traverse the given directory with breadth-first way.
 
@@ -34,7 +44,12 @@ def bfs_directory(root):
         dirs = next_level
 
 
-def generate_hashes(modpack, exportdir, hash_algo='sha3_256', bufsize=32768):
+def generate_hashes(
+    modpack: Modpack,
+    exportdir: Directory,
+    hash_algo: str = 'sha3_256',
+    bufsize: int = 32768
+) -> None:
     """
     Generate hashes for all the items in a
     given modpack and adds them to the manifest

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -4,8 +4,12 @@
 """
 Converts media requested by export requests to files.
 """
+from __future__ import annotations
+import typing
+
 import logging
 import os
+
 
 from openage.convert.entity_object.export.texture import Texture
 from openage.convert.service import debug_info
@@ -14,6 +18,14 @@ from openage.convert.value_object.read.media.blendomatic import Blendomatic
 from openage.convert.value_object.read.media_types import MediaType
 from openage.log import dbg, get_loglevel
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+
+    from openage.convert.entity_object.export.media_export_request import MediaExportRequest
+    from openage.convert.value_object.read.media.colortable import ColorTable
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.util.fslike.path import Path
+
 
 class MediaExporter:
     """
@@ -21,7 +33,12 @@ class MediaExporter:
     """
 
     @staticmethod
-    def export(export_requests, sourcedir, exportdir, args):
+    def export(
+        export_requests: dict[MediaType, list[MediaExportRequest]],
+        sourcedir: Path,
+        exportdir: Path,
+        args: Namespace
+    ) -> None:
         """
         Converts files requested by MediaExportRequests.
 
@@ -33,8 +50,8 @@ class MediaExporter:
                           and target filename should be stored in the export request.
         :param args: Converter arguments.
         :type export_requests: dict
-        :type sourcedir: Directory
-        :type exportdir: Directory
+        :type sourcedir: Path
+        :type exportdir: Path
         :type args: Namespace
         """
         cache_info = {}
@@ -94,7 +111,12 @@ class MediaExporter:
             )
 
     @staticmethod
-    def _export_blend(export_request, sourcedir, exportdir, blend_mode_count=None):
+    def _export_blend(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        exportdir: Path,
+        blend_mode_count: int = None
+    ) -> None:
         """
         Convert and export a blending mode.
 
@@ -105,8 +127,8 @@ class MediaExporter:
                           and target filename should be stored in the export request.
         :param blend_mode_count: Number of blending modes extracted from the source file.
         :type export_request: MediaExportRequest
-        :type sourcedir: Directory
-        :type exportdir: Directory
+        :type sourcedir: Path
+        :type exportdir: Path
         :type blend_mode_count: int
         """
         source_file = sourcedir.joinpath(export_request.source_filename)
@@ -133,8 +155,14 @@ class MediaExporter:
                 )
 
     @staticmethod
-    def _export_graphics(export_request, sourcedir, exportdir, palettes,
-                         compression_level, cache_info=None):
+    def _export_graphics(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        exportdir: Path,
+        palettes: dict[int, ColorTable],
+        compression_level: int,
+        cache_info: dict = None
+    ) -> None:
         """
         Convert and export a graphics file.
 
@@ -147,8 +175,8 @@ class MediaExporter:
         :param compression_level: PNG compression level for the resulting image file.
         :param cache_info: Media cache information with compression parameters from a previous run.
         :type export_request: MediaExportRequest
-        :type sourcedir: Directory
-        :type exportdir: Directory
+        :type sourcedir: Path
+        :type exportdir: Path
         :type palettes: dict
         :type compression_level: int
         :type cache_info: tuple
@@ -218,21 +246,33 @@ class MediaExporter:
             )
 
     @staticmethod
-    def _export_interface(export_request, sourcedir, **kwargs):
+    def _export_interface(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        **kwargs
+    ) -> None:
         """
         Convert and export a sprite file.
         """
         # TODO: Implement
 
     @staticmethod
-    def _export_palette(export_request, sourcedir, **kwargs):
+    def _export_palette(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        **kwargs
+    ) -> None:
         """
         Convert and export a palette file.
         """
         # TODO: Implement
 
     @staticmethod
-    def _export_sound(export_request, sourcedir, exportdir):
+    def _export_sound(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        exportdir: Path,
+    ) -> None:
         """
         Convert and export a sound file.
 
@@ -242,8 +282,8 @@ class MediaExporter:
         :param exportdir: Directory the resulting file(s) will be exported to. Target subfolder
                           and target filename should be stored in the export request.
         :type export_request: MediaExportRequest
-        :type sourcedir: Directory
-        :type exportdir: DirectoryVersion of the game
+        :type sourcedir: Path
+        :type exportdir: Path
         """
         source_file = sourcedir[
             export_request.get_type().value,
@@ -280,8 +320,14 @@ class MediaExporter:
             )
 
     @staticmethod
-    def _export_terrain(export_request, sourcedir, exportdir, palettes,
-                        game_version, compression_level):
+    def _export_terrain(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        exportdir: Path,
+        palettes: dict[int, ColorTable],
+        game_version: tuple[GameEdition, list[GameExpansion]],
+        compression_level: int
+    ) -> None:
         """
         Convert and export a terrain graphics file.
 
@@ -350,7 +396,12 @@ class MediaExporter:
             )
 
     @staticmethod
-    def _get_media_cache(export_request, sourcedir, palettes, compression_level):
+    def _get_media_cache(
+        export_request: MediaExportRequest,
+        sourcedir: Path,
+        palettes: dict[int, ColorTable],
+        compression_level: int
+    ) -> None:
         """
         Convert a media file and return the used settings. This performs
         a dry run, i.e. the graphics media is not saved on the filesystem.
@@ -363,8 +414,8 @@ class MediaExporter:
         :param palettes: Palettes used by the game.
         :param compression_level: PNG compression level for the resulting image file.
         :type export_request: MediaExportRequest
-        :type sourcedir: Directory
-        :type exportdir: Directory
+        :type sourcedir: Path
+        :type exportdir: Path
         :type palettes: dict
         :type compression_level: int
         """
@@ -414,7 +465,14 @@ class MediaExporter:
         return texture.get_cache_params()
 
     @staticmethod
-    def save_png(texture, targetdir, filename, compression_level=1, cache=None, dry_run=False):
+    def save_png(
+        texture: Texture,
+        targetdir: Path,
+        filename: str,
+        compression_level: int = 1,
+        cache: dict = None,
+        dry_run: bool = False
+    ) -> None:
         """
         Store the image data into the target directory path,
         with given filename="dir/out.png".
@@ -466,7 +524,10 @@ class MediaExporter:
             texture.best_compr = (compression_level, *compr_params)
 
     @staticmethod
-    def log_fileinfo(source_file, target_file):
+    def log_fileinfo(
+        source_file: Path,
+        target_file: Path
+    ) -> None:
         """
         Log source and target file information to the shell.
         """

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments,too-many-locals
 """

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
 
     from openage.convert.entity_object.export.media_export_request import MediaExportRequest
     from openage.convert.value_object.read.media.colortable import ColorTable
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
     from openage.util.fslike.path import Path
 
 
@@ -55,8 +55,8 @@ class MediaExporter:
         :type args: Namespace
         """
         cache_info = {}
-        if args.game_version[0].media_cache:
-            cache_info = load_media_cache(args.game_version[0].media_cache)
+        if args.game_version.edition.media_cache:
+            cache_info = load_media_cache(args.game_version.edition.media_cache)
 
         for media_type in export_requests.keys():
             cur_export_requests = export_requests[media_type]
@@ -325,7 +325,7 @@ class MediaExporter:
         sourcedir: Path,
         exportdir: Path,
         palettes: dict[int, ColorTable],
-        game_version: tuple[GameEdition, list[GameExpansion]],
+        game_version: GameVersion,
         compression_level: int
     ) -> None:
         """
@@ -343,7 +343,7 @@ class MediaExporter:
         :type sourcedir: Directory
         :type exportdir: Directory
         :type palettes: dict
-        :type game_version: tuple
+        :type game_version: GameVersion
         :type compression_level: int
         """
         source_file = sourcedir[
@@ -372,7 +372,7 @@ class MediaExporter:
             raise Exception(f"Source file {source_file.name} has an unrecognized extension: "
                             f"{source_file.suffix.lower()}")
 
-        if game_version[0].game_id in ("AOC", "SWGB"):
+        if game_version.edition.game_id in ("AOC", "SWGB"):
             from .terrain_merge import merge_terrain
             texture = Texture(image, palettes)
             merge_terrain(texture)

--- a/openage/convert/processor/export/modpack_exporter.py
+++ b/openage/convert/processor/export/modpack_exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 """

--- a/openage/convert/processor/export/modpack_exporter.py
+++ b/openage/convert/processor/export/modpack_exporter.py
@@ -4,11 +4,19 @@
 """
 Export data from a modpack to files.
 """
+from __future__ import annotations
+import typing
+
 
 from ....log import info
 from .data_exporter import DataExporter
 from .generate_manifest_hashes import generate_hashes
 from .media_exporter import MediaExporter
+
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
+
+    from openage.convert.entity_object.conversion.modpack import Modpack
 
 
 class ModpackExporter:
@@ -17,7 +25,7 @@ class ModpackExporter:
     """
 
     @staticmethod
-    def export(modpack, args):
+    def export(modpack: Modpack, args: Namespace) -> None:
         """
         Export a modpack to a directory.
 

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides functions that retrieve name lookup dicts for internal nyan object
@@ -267,7 +267,9 @@ def get_gather_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
                     % game_edition.edition_name)
 
 
-def get_graphic_set_lookups(game_version: GameVersion) -> dict[int, tuple[tuple[int, ...], str, str]]:
+def get_graphic_set_lookups(
+    game_version: GameVersion
+) -> dict[int, tuple[tuple[int, ...], str, str]]:
     """
     Return the name lookup dicts for civ graphic sets.
 
@@ -382,7 +384,9 @@ def get_tech_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
                     % game_edition.edition_name)
 
 
-def get_terrain_lookups(game_version: GameVersion) -> dict[int, tuple[tuple[int, ...], str, str]]:
+def get_terrain_lookups(
+    game_version: GameVersion
+) -> dict[int, tuple[tuple[int, ...], str, str]]:
     """
     Return the name lookup dicts for terrain groups.
 

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -4,6 +4,9 @@
 Provides functions that retrieve name lookup dicts for internal nyan object
 names or filenames.
 """
+from __future__ import annotations
+import typing
+
 import openage.convert.value_object.conversion.aoc.internal_nyan_names as aoc_internal
 import openage.convert.value_object.conversion.de1.internal_nyan_names as de1_internal
 import openage.convert.value_object.conversion.de2.internal_nyan_names as de2_internal
@@ -13,8 +16,11 @@ import openage.convert.value_object.conversion.hd.raj.internal_nyan_names as raj
 import openage.convert.value_object.conversion.ror.internal_nyan_names as ror_internal
 import openage.convert.value_object.conversion.swgb.internal_nyan_names as swgb_internal
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
 
-def get_armor_class_lookups(game_version):
+
+def get_armor_class_lookups(game_version: GameVersion) -> dict[int, str]:
     """
     Return the name lookup dicts for armor classes.
 
@@ -62,7 +68,7 @@ def get_armor_class_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_civ_lookups(game_version):
+def get_civ_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for civs.
 
@@ -106,7 +112,7 @@ def get_civ_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_class_lookups(game_version):
+def get_class_lookups(game_version: GameVersion) -> dict[int, str]:
     """
     Return the name lookup dicts for unit classes.
 
@@ -129,7 +135,7 @@ def get_class_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_command_lookups(game_version):
+def get_command_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for unit commands.
 
@@ -152,7 +158,7 @@ def get_command_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_entity_lookups(game_version):
+def get_entity_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for game entities.
 
@@ -238,7 +244,7 @@ def get_entity_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_gather_lookups(game_version):
+def get_gather_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for gather tasks.
 
@@ -261,7 +267,7 @@ def get_gather_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_graphic_set_lookups(game_version):
+def get_graphic_set_lookups(game_version: GameVersion) -> dict[int, tuple[tuple[int, ...], str, str]]:
     """
     Return the name lookup dicts for civ graphic sets.
 
@@ -305,7 +311,7 @@ def get_graphic_set_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_restock_lookups(game_version):
+def get_restock_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for restock targets.
 
@@ -332,7 +338,7 @@ def get_restock_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_tech_lookups(game_version):
+def get_tech_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     """
     Return the name lookup dicts for tech groups.
 
@@ -376,7 +382,7 @@ def get_tech_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_terrain_lookups(game_version):
+def get_terrain_lookups(game_version: GameVersion) -> dict[int, tuple[tuple[int, ...], str, str]]:
     """
     Return the name lookup dicts for terrain groups.
 
@@ -420,7 +426,7 @@ def get_terrain_lookups(game_version):
                     % game_edition.edition_name)
 
 
-def get_terrain_type_lookups(game_version):
+def get_terrain_type_lookups(game_version: GameVersion) -> dict[int, tuple]:
     """
     Return the name lookup dicts for terrain types.
 

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -19,10 +19,10 @@ def get_armor_class_lookups(game_version):
     Return the name lookup dicts for armor classes.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.ARMOR_CLASS_LOOKUPS
@@ -67,10 +67,10 @@ def get_civ_lookups(game_version):
     Return the name lookup dicts for civs.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.CIV_GROUP_LOOKUPS
@@ -111,10 +111,10 @@ def get_class_lookups(game_version):
     Return the name lookup dicts for unit classes.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id in ("ROR", "AOE1DE"):
         return ror_internal.CLASS_ID_LOOKUPS
@@ -134,10 +134,10 @@ def get_command_lookups(game_version):
     Return the name lookup dicts for unit commands.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id in ("ROR", "AOE1DE"):
         return ror_internal.COMMAND_TYPE_LOOKUPS
@@ -157,10 +157,10 @@ def get_entity_lookups(game_version):
     Return the name lookup dicts for game entities.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     entity_lookup_dict = {}
 
@@ -243,10 +243,10 @@ def get_gather_lookups(game_version):
     Return the name lookup dicts for gather tasks.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id in ("ROR", "AOE1DE"):
         return ror_internal.GATHER_TASK_LOOKUPS
@@ -266,10 +266,10 @@ def get_graphic_set_lookups(game_version):
     Return the name lookup dicts for civ graphic sets.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.GRAPHICS_SET_LOOKUPS
@@ -310,10 +310,10 @@ def get_restock_lookups(game_version):
     Return the name lookup dicts for restock targets.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return None
@@ -337,10 +337,10 @@ def get_tech_lookups(game_version):
     Return the name lookup dicts for tech groups.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.TECH_GROUP_LOOKUPS
@@ -381,10 +381,10 @@ def get_terrain_lookups(game_version):
     Return the name lookup dicts for terrain groups.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.TERRAIN_GROUP_LOOKUPS
@@ -425,10 +425,10 @@ def get_terrain_type_lookups(game_version):
     Return the name lookup dicts for terrain types.
 
     :param game_version: Game edition and expansions for which the lookups should be.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
-    game_edition = game_version[0]
-    # game_expansions = game_version[1]
+    game_edition = game_version.edition
+    # game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         return ror_internal.TERRAIN_TYPE_LOOKUPS

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -71,12 +71,12 @@ def debug_game_version(debugdir, loglevel, args):
 
     logtext += (
         f"game edition:\n"
-        f"    - {args.game_version[0]}\n"
+        f"    - {args.game_version.edition}\n"
     )
 
-    if len(args.game_version[1]) > 0:
+    if len(args.game_version.expansions) > 0:
         logtext += "game expansions:\n"
-        for expansion in args.game_version[1]:
+        for expansion in args.game_version.expansions:
             logtext += f"    - {expansion}\n"
 
     else:
@@ -160,7 +160,7 @@ def debug_gamedata_format(debugdir, loglevel, game_version):
     :param loglevel: Determines how detailed the output is.
     :type loglevel: int
     :param game_version: Game version the .dat file comes with.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
     if loglevel < 2:
         return
@@ -628,7 +628,7 @@ def debug_media_cache(debugdir, loglevel, sourcedir, cachedata, game_version):
     :param cachedata: Dict with cache data.
     :type cachedata: dict
     :param game_version: Game version.
-    :type game_version: tuple
+    :type game_version: GameVersion
     """
     if loglevel < 6:
         return

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -4,6 +4,11 @@
 """
 Creates debug output from data in a conversion run.
 """
+
+from __future__ import annotations
+import typing
+
+
 from openage.convert.entity_object.conversion.aoc.genie_tech import AgeUpgrade,\
     UnitLineUpgrade, BuildingLineUpgrade, UnitUnlock, BuildingUnlock
 from openage.convert.entity_object.conversion.aoc.genie_unit import GenieUnitLineGroup,\
@@ -18,8 +23,17 @@ from openage.util.fslike.filecollection import FileCollectionPath
 from openage.util.fslike.path import Path
 from openage.util.hash import hash_file
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def debug_cli_args(debugdir, loglevel, args):
+    from openage.convert.entity_object.conversion.modpack import Modpack
+    from openage.convert.entity_object.conversion.stringresource import StringResource
+    from openage.convert.entity_object.conversion.aoc.genie_object_container import GenieObjectContainer
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.util.fslike.directory import Directory
+
+
+def debug_cli_args(debugdir: Directory, loglevel: int, args: Namespace) -> None:
     """
     Create debug output for the converter CLI args.
 
@@ -51,7 +65,7 @@ def debug_cli_args(debugdir, loglevel, args):
         log.write(logtext)
 
 
-def debug_game_version(debugdir, loglevel, args):
+def debug_game_version(debugdir: Directory, loglevel: int, args: Namespace) -> None:
     """
     Create debug output for the detected game version.
 
@@ -86,7 +100,7 @@ def debug_game_version(debugdir, loglevel, args):
         log.write(logtext)
 
 
-def debug_mounts(debugdir, loglevel, args):
+def debug_mounts(debugdir: Directory, loglevel: int, args: Namespace) -> None:
     """
     Create debug output for the mounted files and folders.
 
@@ -151,7 +165,7 @@ def debug_mounts(debugdir, loglevel, args):
         log.write(logtext)
 
 
-def debug_gamedata_format(debugdir, loglevel, game_version):
+def debug_gamedata_format(debugdir: Directory, loglevel: int, game_version: GameVersion) -> None:
     """
     Create debug output for the converted .dat format.
 
@@ -212,7 +226,7 @@ def debug_gamedata_format(debugdir, loglevel, game_version):
         log.write(logtext)
 
 
-def debug_string_resources(debugdir, loglevel, string_resources):
+def debug_string_resources(debugdir: Directory, loglevel: int, string_resources: StringResource) -> None:
     """
     Create debug output for found string resources.
 
@@ -240,7 +254,7 @@ def debug_string_resources(debugdir, loglevel, string_resources):
         log.write(logtext)
 
 
-def debug_registered_graphics(debugdir, loglevel, existing_graphics):
+def debug_registered_graphics(debugdir: Directory, loglevel: int, existing_graphics: list[str]) -> None:
     """
     Create debug output for found graphics files.
 
@@ -266,7 +280,7 @@ def debug_registered_graphics(debugdir, loglevel, existing_graphics):
         log.write(logtext)
 
 
-def debug_converter_objects(debugdir, loglevel, dataset):
+def debug_converter_objects(debugdir: Directory, loglevel: int, dataset: GenieObjectContainer) -> None:
     """
     Create debug output for ConverterObject instances from the
     conversion preprocessor.
@@ -302,7 +316,7 @@ def debug_converter_objects(debugdir, loglevel, dataset):
         log.write(logtext)
 
 
-def debug_converter_object_groups(debugdir, loglevel, dataset):
+def debug_converter_object_groups(debugdir: Directory, loglevel: int, dataset: GenieObjectContainer) -> None:
     """
     Create debug output for ConverterObjectGroup instances from the
     conversion preprocessor.
@@ -557,7 +571,7 @@ def debug_converter_object_groups(debugdir, loglevel, dataset):
             log.write(logtext)
 
 
-def debug_modpack(debugdir, loglevel, modpack):
+def debug_modpack(debugdir: Directory, loglevel: int, modpack: Modpack) -> None:
     """
     Create debug output for a modpack.
 
@@ -614,7 +628,13 @@ def debug_modpack(debugdir, loglevel, modpack):
         log.write(logtext)
 
 
-def debug_media_cache(debugdir, loglevel, sourcedir, cachedata, game_version):
+def debug_media_cache(
+    debugdir: Directory,
+    loglevel: int,
+    sourcedir: Directory,
+    cachedata: dict,
+    game_version: GameVersion
+) -> None:
     """
     Create media cache data for graphics files. This allows using deterministic
     packer and compression settings for graphics file conversion.
@@ -624,7 +644,7 @@ def debug_media_cache(debugdir, loglevel, sourcedir, cachedata, game_version):
     :param loglevel: Determines how detailed the output is.
     :type loglevel: int
     :param sourcedir: Sourcedir where the graphics files are mounted.
-    :type sourcedir: int
+    :type sourcedir: Directory
     :param cachedata: Dict with cache data.
     :type cachedata: dict
     :param game_version: Game version.

--- a/openage/convert/service/debug_info.py
+++ b/openage/convert/service/debug_info.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 """

--- a/openage/convert/service/export/interface/cutter.py
+++ b/openage/convert/service/export/interface/cutter.py
@@ -1,6 +1,11 @@
 # Copyright 2016-2020 the openage authors. See copying.md for legal info.
 
-""" Cutting some user interface assets into subtextures """
+"""
+Cutting some user interface assets into subtextures.
+"""
+
+from __future__ import annotations
+import typing
 
 from ....entity_object.export.texture import TextureImage
 from ....value_object.read.media.hardcoded.interface import (TOP_STRIP_PATTERN_CORNERS,
@@ -12,16 +17,19 @@ from ....value_object.read.media.hardcoded.interface import (TOP_STRIP_PATTERN_C
                                                              INGAME_HUD_BACKGROUNDS_SET)
 from .visgrep import visgrep, crop_array
 
+if typing.TYPE_CHECKING:
+    from numpy import ndarray
+
 
 class InterfaceCutter:
     """
     Cuts interface textures into repeatable parts.
     """
 
-    def __init__(self, idx):
+    def __init__(self, idx: int):
         self.idx = idx
 
-    def cut(self, image):
+    def cut(self, image: TextureImage) -> TextureImage:
         """
         Create subtextures by searching for patterns at hardcoded positions.
         """
@@ -45,7 +53,12 @@ class InterfaceCutter:
         else:
             yield image
 
-    def cut_strip(self, img_array, pattern_corners, search_area_corners):
+    def cut_strip(
+        self,
+        img_array: ndarray,
+        pattern_corners: tuple[int, int, int, int],
+        search_area_corners: tuple[int, int, int, int]
+    ) -> TextureImage:
         """
         Finds a horizontally tilable piece of the strip (ex. the top of the HUD).
 
@@ -77,14 +90,14 @@ class InterfaceCutter:
         )
 
 
-def ingame_hud_background_index(idx):
+def ingame_hud_background_index(idx: int):
     """
     Index in the hardcoded list of the known ingame hud backgrounds to match the civ.
     """
     return INGAME_HUD_BACKGROUNDS.index(int(idx))
 
 
-def is_ingame_hud_background(idx):
+def is_ingame_hud_background(idx: int):
     """
     True if in the hardcoded list of the known ingame hud backgrounds.
     """

--- a/openage/convert/service/export/interface/cutter.py
+++ b/openage/convert/service/export/interface/cutter.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 the openage authors. See copying.md for legal info.
+# Copyright 2016-2022 the openage authors. See copying.md for legal info.
 
 """
 Cutting some user interface assets into subtextures.

--- a/openage/convert/service/export/interface/rename.py
+++ b/openage/convert/service/export/interface/rename.py
@@ -1,12 +1,20 @@
 # Copyright 2016-2020 the openage authors. See copying.md for legal info.
 
-""" Renaming interface assets and splitting into directories """
+"""
+Renaming interface assets and splitting into directories.
+"""
+from __future__ import annotations
+import typing
+
 
 from ....value_object.read.media.hardcoded.interface import ASSETS
 from .cutter import ingame_hud_background_index
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.path import Path
 
-def hud_rename(filepath):
+
+def hud_rename(filepath: Path) -> Path:
     """
     Returns a human-usable name according to the original
     and hardcoded metadata.
@@ -21,7 +29,7 @@ def hud_rename(filepath):
         return asset_rename(filepath)
 
 
-def asset_rename(filepath):
+def asset_rename(filepath: Path) -> Path:
     """
     Rename a slp asset path by the lookup map above.
     """

--- a/openage/convert/service/export/interface/rename.py
+++ b/openage/convert/service/export/interface/rename.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 the openage authors. See copying.md for legal info.
+# Copyright 2016-2022 the openage authors. See copying.md for legal info.
 
 """
 Renaming interface assets and splitting into directories.

--- a/openage/convert/service/export/load_media_cache.py
+++ b/openage/convert/service/export/load_media_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Load data of media cache files.

--- a/openage/convert/service/export/load_media_cache.py
+++ b/openage/convert/service/export/load_media_cache.py
@@ -3,10 +3,16 @@
 """
 Load data of media cache files.
 """
+from __future__ import annotations
+import typing
+
 import toml
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.path import Path
 
-def load_media_cache(filepath):
+
+def load_media_cache(filepath: Path) -> dict[str, dict[str, tuple]]:
     """
     Parses a media cache file and returns it as a dict.
     """

--- a/openage/convert/service/export/opus/demo.py
+++ b/openage/convert/service/export/opus/demo.py
@@ -10,7 +10,7 @@ from . import opusenc
 from .....log import info, crit
 
 
-def convert(args):
+def convert(args) -> int:
     """ Demonstrates the usage of the opusenc module. """
 
     cli = argparse.ArgumentParser()

--- a/openage/convert/service/export/opus/demo.py
+++ b/openage/convert/service/export/opus/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 the openage authors. See copying.md for legal info.
+# Copyright 2018-2022 the openage authors. See copying.md for legal info.
 """
 Demo for the opusenc module.
 """

--- a/openage/convert/service/init/changelog.py
+++ b/openage/convert/service/init/changelog.py
@@ -6,7 +6,8 @@ Asset version change log
 used to determine whether assets that were converted by an earlier version of
 openage are still up to date.
 """
-
+from __future__ import annotations
+import typing
 from ....log import warn
 from ....testing.testing import TestError
 
@@ -41,11 +42,10 @@ CHANGES = (
 ASSET_VERSION = len(CHANGES) - 1
 
 
-def changes(asset_version):
+def changes(asset_version: int) -> set:
     """
     return all changed components since the passed version number.
     """
-
     if asset_version >= len(CHANGES):
         warn("asset version from the future: %d", asset_version)
         warn("current version is: %d", ASSET_VERSION)
@@ -59,11 +59,10 @@ def changes(asset_version):
     return changed_components
 
 
-def test():
+def test() -> typing.NoReturn:
     """
     verify only allowed versions are stored in the changes
     """
-
     for entry in CHANGES:
         if entry > COMPONENTS:
             invalid = entry - COMPONENTS

--- a/openage/convert/service/init/changelog.py
+++ b/openage/convert/service/init/changelog.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Asset version change log

--- a/openage/convert/service/init/conversion_required.py
+++ b/openage/convert/service/init/conversion_required.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Test whether there already are converted modpacks present.

--- a/openage/convert/service/init/conversion_required.py
+++ b/openage/convert/service/init/conversion_required.py
@@ -3,11 +3,19 @@
 """
 Test whether there already are converted modpacks present.
 """
+from __future__ import annotations
+import typing
+
 from . import changelog
 from ....log import info, dbg
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def conversion_required(asset_dir, args):
+    from openage.util.fslike.directory import Directory
+
+
+def conversion_required(asset_dir: Directory, args: Namespace) -> bool:
     """
     Returns true if an asset conversion is required to run the game.
 

--- a/openage/convert/service/init/mount_asset_dirs.py
+++ b/openage/convert/service/init/mount_asset_dirs.py
@@ -14,14 +14,13 @@ from ....util.fslike.union import Union
 from ...value_object.read.media.drs import DRS
 
 if typing.TYPE_CHECKING:
-    from openage.convert.value_object.init.game_version import GameEdition
-    from openage.convert.value_object.init.game_version import GameExpansion
+    from openage.convert.value_object.init.game_version import GameVersion
     from openage.util.fslike.directory import Directory
 
 
 def mount_asset_dirs(
     srcdir: Directory,
-    game_version: tuple[GameEdition, list[GameExpansion]]
+    game_version: GameVersion
 ) -> Directory:
     """
     Returns a Union path where srcdir is mounted at /,
@@ -37,10 +36,10 @@ def mount_asset_dirs(
         """
 
         drspath = srcdir[filename]
-        result[target].mount(DRS(drspath.open('rb'), game_version[0].game_id).root)
+        result[target].mount(DRS(drspath.open('rb'), game_version.edition.game_id).root)
 
     # Mount the media sources of the game edition
-    for media_type, media_paths in game_version[0].media_paths.items():
+    for media_type, media_paths in game_version.edition.media_paths.items():
         for media_path in media_paths:
             path_to_media = srcdir[media_path]
             if path_to_media.is_dir():
@@ -56,7 +55,7 @@ def mount_asset_dirs(
                 raise Exception(f"Media at path {path_to_media} could not be found")
 
     # Mount the media sources of the game edition
-    for expansion in game_version[1]:
+    for expansion in game_version.expansions:
         for media_type, media_paths in expansion.media_paths.items():
             for media_path in media_paths:
                 path_to_media = srcdir[media_path]

--- a/openage/convert/service/init/mount_asset_dirs.py
+++ b/openage/convert/service/init/mount_asset_dirs.py
@@ -4,9 +4,7 @@
 """
 Mount asset dirs of a game version into the conversion folder.
 """
-
 from __future__ import annotations
-
 import typing
 
 
@@ -21,7 +19,7 @@ if typing.TYPE_CHECKING:
 def mount_asset_dirs(
     srcdir: Directory,
     game_version: GameVersion
-) -> Directory:
+) -> Union:
     """
     Returns a Union path where srcdir is mounted at /,
     and all the asset files are mounted in subfolders.
@@ -34,7 +32,6 @@ def mount_asset_dirs(
         """
         Mounts the DRS file from srcdir's filename at result's target.
         """
-
         drspath = srcdir[filename]
         result[target].mount(DRS(drspath.open('rb'), game_version.edition.game_id).root)
 

--- a/openage/convert/service/init/mount_asset_dirs.py
+++ b/openage/convert/service/init/mount_asset_dirs.py
@@ -33,7 +33,7 @@ def mount_asset_dirs(
         Mounts the DRS file from srcdir's filename at result's target.
         """
         drspath = srcdir[filename]
-        result[target].mount(DRS(drspath.open('rb'), game_version.edition.game_id).root)
+        result[target].mount(DRS(drspath.open('rb'), game_version).root)
 
     # Mount the media sources of the game edition
     for media_type, media_paths in game_version.edition.media_paths.items():

--- a/openage/convert/service/init/mount_asset_dirs.py
+++ b/openage/convert/service/init/mount_asset_dirs.py
@@ -1,15 +1,28 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-branches
 """
 Mount asset dirs of a game version into the conversion folder.
 """
 
+from __future__ import annotations
+
+import typing
+
+
 from ....util.fslike.union import Union
 from ...value_object.read.media.drs import DRS
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameEdition
+    from openage.convert.value_object.init.game_version import GameExpansion
+    from openage.util.fslike.directory import Directory
 
-def mount_asset_dirs(srcdir, game_version):
+
+def mount_asset_dirs(
+    srcdir: Directory,
+    game_version: tuple[GameEdition, list[GameExpansion]]
+) -> Directory:
     """
     Returns a Union path where srcdir is mounted at /,
     and all the asset files are mounted in subfolders.
@@ -18,7 +31,7 @@ def mount_asset_dirs(srcdir, game_version):
     result = Union().root
     result.mount(srcdir)
 
-    def mount_drs(filename, target):
+    def mount_drs(filename: str, target: str) -> None:
         """
         Mounts the DRS file from srcdir's filename at result's target.
         """

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -25,7 +25,7 @@ def iterate_game_versions(
     srcdir: Directory,
     avail_game_eds: list[GameEdition],
     avail_game_exps: list[GameExpansion]
-) -> tuple[GameEdition, list[GameExpansion]]:
+) -> GameVersion:
     """
     Determine what editions and expansions of a game are installed in srcdir
     by iterating through all versions the converter knows about.

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -14,7 +14,7 @@ import toml
 
 from ....log import info, warn, dbg
 from ....util.hash import hash_file
-from ...value_object.init.game_version import GameEdition, GameExpansion, Support
+from ...value_object.init.game_version import GameEdition, GameExpansion, GameVersion, Support
 
 if typing.TYPE_CHECKING:
     from openage.util.fslike.directory import Directory
@@ -90,7 +90,7 @@ def iterate_game_versions(
     else:
         # Either no version or an unsupported or broken was found
         # Return the last detected edition
-        return best_edition, []
+        return GameVersion(edition=best_edition)
 
     for game_expansion in best_edition.expansions:
         for existing_game_expansion in avail_game_exps:
@@ -126,7 +126,7 @@ def iterate_game_versions(
 
             expansions.append(game_expansion)
 
-    return best_edition, expansions
+    return GameVersion(edition=best_edition, expansions=expansions)
 
 
 def create_version_objects(srcdir: Directory) -> tuple[list[GameEdition], list[GameExpansion]]:

--- a/openage/convert/service/init/version_detect.py
+++ b/openage/convert/service/init/version_detect.py
@@ -1,18 +1,31 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
 """
 Detects the base version of the game and installed expansions.
 """
 
+from __future__ import annotations
+
+import typing
+
 import toml
+
 
 from ....log import info, warn, dbg
 from ....util.hash import hash_file
 from ...value_object.init.game_version import GameEdition, GameExpansion, Support
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.directory import Directory
+    from openage.util.fslike.path import Path
 
-def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
+
+def iterate_game_versions(
+    srcdir: Directory,
+    avail_game_eds: list[GameEdition],
+    avail_game_exps: list[GameExpansion]
+) -> tuple[GameEdition, list[GameExpansion]]:
     """
     Determine what editions and expansions of a game are installed in srcdir
     by iterating through all versions the converter knows about.
@@ -116,7 +129,7 @@ def iterate_game_versions(srcdir, avail_game_eds, avail_game_exps):
     return best_edition, expansions
 
 
-def create_version_objects(srcdir):
+def create_version_objects(srcdir: Directory) -> tuple[list[GameEdition], list[GameExpansion]]:
     """
     Create GameEdition and GameExpansion objects from auxiliary
     config files.
@@ -152,7 +165,11 @@ def create_version_objects(srcdir):
     return game_edition_list, game_expansion_list
 
 
-def create_game_obj(game_info, aux_path, expansion=False):
+def create_game_obj(
+    game_info: dict[str, str],
+    aux_path: Path,
+    expansion: bool = False
+) -> typing.Union[GameEdition, GameExpansion]:
     """
     Create a GameEdition or GameExpansion object from the contents
     of the game_info dictionary and its version hash file.

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -3,17 +3,27 @@
 """
 Module for reading .dat files.
 """
+from __future__ import annotations
+import typing
+
 import os
 import pickle
 from tempfile import gettempdir
 from zlib import decompress
 
+
 from ....log import spam, dbg, info, warn
 from ...value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
 from ...value_object.read.media_types import MediaType
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.read_members import ArrayMember
+    from openage.util.fslike.directory import Directory
+    from openage.util.fslike.wrapper import GuardedFile
 
-def get_gamespec(srcdir, game_version, dont_pickle):
+
+def get_gamespec(srcdir: Directory, game_version: GameVersion, pickle_cache: bool) -> ArrayMember:
     """
     Reads empires.dat file.
     """
@@ -38,12 +48,17 @@ def get_gamespec(srcdir, game_version, dont_pickle):
         gamespec = load_gamespec(empiresdat_file,
                                  game_version,
                                  cache_file,
-                                 not dont_pickle)
+                                 pickle_cache)
 
     return gamespec
 
 
-def load_gamespec(fileobj, game_version, cachefile_name=None, load_cache=False):
+def load_gamespec(
+    fileobj: GuardedFile,
+    game_version: GameVersion,
+    cachefile_name: str = None,
+    pickle_cache: bool = False
+) -> ArrayMember:
     """
     Helper method that loads the contents of a 'empires.dat' gzipped wrapper
     file.
@@ -52,7 +67,7 @@ def load_gamespec(fileobj, game_version, cachefile_name=None, load_cache=False):
     load.
     """
     # try to use the cached result from a previous run
-    if cachefile_name and load_cache:
+    if cachefile_name:
         try:
             with open(cachefile_name, "rb") as cachefile:
                 # pickle.load() can fail in many ways, we need to catch all.
@@ -89,7 +104,7 @@ def load_gamespec(fileobj, game_version, cachefile_name=None, load_cache=False):
     # Remove the list sorrounding the converted data
     gamespec = gamespec[0]
 
-    if cachefile_name:
+    if cachefile_name and pickle_cache:
         dbg("dumping dat file contents to cache file: %s", cachefile_name)
         with open(cachefile_name, "wb") as cachefile:
             pickle.dump(gamespec, cachefile)

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -17,21 +17,22 @@ def get_gamespec(srcdir, game_version, dont_pickle):
     """
     Reads empires.dat file.
     """
-    if game_version[0].game_id in ("ROR", "AOE1DE", "AOC", "HDEDITION", "AOE2DE"):
-        filepath = srcdir.joinpath(game_version[0].media_paths[MediaType.DATFILE][0])
+    if game_version.edition.game_id in ("ROR", "AOE1DE", "AOC", "HDEDITION", "AOE2DE"):
+        filepath = srcdir.joinpath(game_version.edition.media_paths[MediaType.DATFILE][0])
 
-    elif game_version[0].game_id == "SWGB":
-        if "SWGB_CC" in [expansion.game_id for expansion in game_version[1]]:
-            filepath = srcdir.joinpath(game_version[1][0].media_paths[MediaType.DATFILE][0])
+    elif game_version.edition.game_id == "SWGB":
+        if "SWGB_CC" in [expansion.game_id for expansion in game_version.expansions]:
+            filepath = srcdir.joinpath(game_version.expansions[0].media_paths[MediaType.DATFILE][0])
 
         else:
-            filepath = srcdir.joinpath(game_version[0].media_paths[MediaType.DATFILE][0])
+            filepath = srcdir.joinpath(game_version.edition.media_paths[MediaType.DATFILE][0])
 
     else:
         raise Exception("No service found for reading data file of version %s"
-                        % game_version[0].game_id)
+                        % game_version.edition.game_id)
 
-    cache_file = os.path.join(gettempdir(), f"{game_version[0].game_id}_{filepath.name}.pickle")
+    cache_file = os.path.join(
+        gettempdir(), f"{game_version.edition.game_id}_{filepath.name}.pickle")
 
     with filepath.open('rb') as empiresdat_file:
         gamespec = load_gamespec(empiresdat_file,

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Module for reading .dat files.

--- a/openage/convert/service/read/nyan_api_loader.py
+++ b/openage/convert/service/read/nyan_api_loader.py
@@ -7,6 +7,7 @@ Loads the API into the converter.
 TODO: Implement a parser instead of hardcoded
 object creation.
 """
+from __future__ import annotations
 
 from ....nyan.nyan_structs import NyanMemberType
 from ....nyan.nyan_structs import NyanObject, NyanMember, MemberType, MemberSpecialValue,\
@@ -21,7 +22,7 @@ N_FILE = NyanMemberType("file")
 N_BOOL = NyanMemberType("bool")
 
 
-def load_api():
+def load_api() -> dict[str, NyanObject]:
     """
     Returns a dict with the API object's fqon as keys
     and the API objects as values.
@@ -34,7 +35,7 @@ def load_api():
     return api_objects
 
 
-def _create_objects(api_objects):
+def _create_objects(api_objects) -> None:
     """
     Creates the API objects.
     """
@@ -2413,7 +2414,7 @@ def _create_objects(api_objects):
     return api_objects
 
 
-def _insert_members(api_objects):
+def _insert_members(api_objects) -> None:
     """
     Creates members for API objects.
     """
@@ -2815,13 +2816,16 @@ def _insert_members(api_objects):
     # engine.ability.type.Named
     api_object = api_objects["engine.ability.type.Named"]
 
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("description", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("long_description", member_type, None, None, 0)
     api_object.add_member(member)
 
@@ -3176,10 +3180,12 @@ def _insert_members(api_objects):
     # engine.util.attribute.Attribute
     api_object = api_objects["engine.util.attribute.Attribute"]
 
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("abbreviation", member_type, None, None, 0)
     api_object.add_member(member)
 
@@ -3850,7 +3856,8 @@ def _insert_members(api_objects):
     # engine.util.resource.Resource
     api_object = api_objects["engine.util.resource.Resource"]
 
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
     member = NyanMember("max_storage", N_INT, None, None, 0)
@@ -3906,13 +3913,16 @@ def _insert_members(api_objects):
     # engine.util.setup.PlayerSetup
     api_object = api_objects["engine.util.setup.PlayerSetup"]
 
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("description", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("long_description", member_type, None, None, 0)
     api_object.add_member(member)
     elem_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
@@ -4053,7 +4063,8 @@ def _insert_members(api_objects):
 
     member = NyanMember("activation_message", N_TEXT, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("display_message", member_type, None, None, 0)
     api_object.add_member(member)
     member_type = NyanMemberType(api_objects["engine.util.sound.Sound"])
@@ -4068,13 +4079,16 @@ def _insert_members(api_objects):
     member_type = NyanMemberType(MemberType.SET, (elem_type,))
     member = NyanMember("types", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("description", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedMarkupFile"])
     member = NyanMember("long_description", member_type, None, None, 0)
     api_object.add_member(member)
     elem_type = NyanMemberType(api_objects["engine.util.patch.Patch"])
@@ -4090,7 +4104,8 @@ def _insert_members(api_objects):
     member_type = NyanMemberType(MemberType.SET, (elem_type,))
     member = NyanMember("types", member_type, None, None, 0)
     api_object.add_member(member)
-    member_type = NyanMemberType(api_objects["engine.util.language.translated.type.TranslatedString"])
+    member_type = NyanMemberType(
+        api_objects["engine.util.language.translated.type.TranslatedString"])
     member = NyanMember("name", member_type, None, None, 0)
     api_object.add_member(member)
     member_type = NyanMemberType(api_objects["engine.util.graphics.Terrain"])

--- a/openage/convert/service/read/nyan_api_loader.py
+++ b/openage/convert/service/read/nyan_api_loader.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long,too-many-lines,too-many-statements
 """

--- a/openage/convert/service/read/palette.py
+++ b/openage/convert/service/read/palette.py
@@ -3,11 +3,22 @@
 """
 Module for reading palette files.
 """
+from __future__ import annotations
+import typing
+
 from ...value_object.read.media.colortable import ColorTable
 from ...value_object.read.media_types import MediaType
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.util.fslike.directory import Directory
 
-def get_palettes(srcdir, game_version, index=None):
+
+def get_palettes(
+    srcdir: Directory,
+    game_version: GameVersion,
+    index: int = None
+) -> dict[int, ColorTable]:
     """
     Read and create the color palettes.
     """

--- a/openage/convert/service/read/palette.py
+++ b/openage/convert/service/read/palette.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Module for reading palette files.

--- a/openage/convert/service/read/palette.py
+++ b/openage/convert/service/read/palette.py
@@ -11,7 +11,7 @@ def get_palettes(srcdir, game_version, index=None):
     """
     Read and create the color palettes.
     """
-    game_edition = game_version[0]
+    game_edition = game_version.edition
 
     palettes = {}
 

--- a/openage/convert/service/read/register_media.py
+++ b/openage/convert/service/read/register_media.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Module for registering media files.

--- a/openage/convert/service/read/register_media.py
+++ b/openage/convert/service/read/register_media.py
@@ -3,11 +3,17 @@
 """
 Module for registering media files.
 """
+from __future__ import annotations
+import typing
+
 
 from ...value_object.read.media_types import MediaType
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def get_existing_graphics(args):
+
+def get_existing_graphics(args: Namespace) -> list[str]:
     """
     List the graphics files that exist in the graphics file paths.
     """

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -3,8 +3,12 @@
 """
 Module for reading plaintext-based language files.
 """
+from __future__ import annotations
+import typing
+
 
 import re
+
 
 from ....log import dbg
 from ...entity_object.conversion.stringresource import StringResource
@@ -12,8 +16,15 @@ from ...value_object.read.media.langcodes import LANGCODES_DE1, LANGCODES_DE2, L
 from ...value_object.read.media.pefile import PEFile
 from ...value_object.read.media_types import MediaType
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def get_string_resources(args):
+    from openage.util.fslike.directory import Directory
+    from openage.util.fslike.path import Path
+    from openage.util.fslike.wrapper import GuardedFile
+
+
+def get_string_resources(args: Namespace) -> StringResource:
     """ reads the (language) string resources """
 
     stringres = StringResource()
@@ -53,7 +64,7 @@ def get_string_resources(args):
     return stringres
 
 
-def read_age2_hd_fe_stringresources(stringres, path):
+def read_age2_hd_fe_stringresources(stringres: StringResource, path: Path) -> int:
     """
     Fill the string resources from text specifications found
     in the given path.
@@ -62,7 +73,6 @@ def read_age2_hd_fe_stringresources(stringres, path):
 
     The data is stored in the `stringres` storage.
     """
-
     count = 0
 
     # multiple string files in the program source dir
@@ -91,7 +101,7 @@ def read_age2_hd_fe_stringresources(stringres, path):
     return count
 
 
-def read_age2_hd_3x_stringresources(stringres, srcdir):
+def read_age2_hd_3x_stringresources(stringres: StringResource, srcdir: Directory) -> int:
     """
     HD Edition 3.x and below store language .txt files
     in the Bin/ folder.
@@ -99,7 +109,6 @@ def read_age2_hd_3x_stringresources(stringres, srcdir):
 
     The data is stored in the `stringres` storage.
     """
-
     count = 0
 
     for lang in srcdir["bin"].list():
@@ -137,11 +146,14 @@ def read_age2_hd_3x_stringresources(stringres, srcdir):
     return count
 
 
-def read_hd_language_file_old(fileobj, langcode, enc='utf-8'):
+def read_hd_language_file_old(
+    fileobj: GuardedFile,
+    langcode: str,
+    enc: str = 'utf-8'
+) -> dict[str, StringResource]:
     """
     Takes a file object, and the file's language code.
     """
-
     dbg("parse HD Language file %s", langcode)
     strings = {}
 
@@ -166,7 +178,11 @@ def read_hd_language_file_old(fileobj, langcode, enc='utf-8'):
     return {lang: strings}
 
 
-def read_hd_language_file(srcdir, language_file, enc='utf-8'):
+def read_hd_language_file(
+    srcdir: Directory,
+    language_file: GuardedFile,
+    enc: str = 'utf-8'
+) -> dict[str, StringResource]:
     """
     HD Edition stores language .txt files in the resources/ folder.
     Specific language strings are in resources/$LANG/strings/key-value/*.txt.
@@ -202,7 +218,10 @@ def read_hd_language_file(srcdir, language_file, enc='utf-8'):
     return {lang: strings}
 
 
-def read_de1_language_file(srcdir, language_file):
+def read_de1_language_file(
+    srcdir: Directory,
+    language_file: GuardedFile
+) -> dict[str, StringResource]:
     """
     Definitve Edition stores language .txt files in the Localization folder.
     Specific language strings are in Data/Localization/$LANG/strings.txt.
@@ -239,7 +258,10 @@ def read_de1_language_file(srcdir, language_file):
     return {lang: strings}
 
 
-def read_de2_language_file(srcdir, language_file):
+def read_de2_language_file(
+    srcdir: Directory,
+    language_file: GuardedFile
+) -> dict[str, StringResource]:
     """
     Definitve Edition stores language .txt files in the resources/ folder.
     Specific language strings are in resources/$LANG/strings/key-value/*.txt.

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -19,7 +19,7 @@ def get_string_resources(args):
     stringres = StringResource()
 
     srcdir = args.srcdir
-    game_edition = args.game_version[0]
+    game_edition = args.game_version.edition
 
     language_files = game_edition.media_paths[MediaType.LANGUAGE]
 

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Module for reading plaintext-based language files.

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Receives cleaned-up srcdir and targetdir objects from .main, and drives the

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -4,6 +4,9 @@
 Receives cleaned-up srcdir and targetdir objects from .main, and drives the
 actual conversion process.
 """
+from __future__ import annotations
+import typing
+
 
 from ...log import info, dbg
 from ..processor.export.modpack_exporter import ModpackExporter
@@ -16,8 +19,13 @@ from ..service.read.palette import get_palettes
 from ..service.read.register_media import get_existing_graphics
 from ..service.read.string_resource import get_string_resources
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def convert(args):
+    from openage.convert.value_object.init.game_version import GameVersion
+
+
+def convert(args: Namespace) -> typing.Generator[str, None, None]:
     """
     args must hold srcdir and targetdir (FS-like objects),
     plus any additional configuration options.
@@ -37,7 +45,7 @@ def convert(args):
     info(f"asset conversion complete; asset version: {ASSET_VERSION}", )
 
 
-def convert_metadata(args):
+def convert_metadata(args: Namespace) -> typing.Generator[str, None, None]:
     """
     Converts the metadata part.
     """
@@ -64,7 +72,7 @@ def convert_metadata(args):
     # Read .dat
     yield "empires.dat"
     debug_gamedata_format(args.debugdir, args.debug_info, args.game_version)
-    gamespec = get_gamespec(args.srcdir, args.game_version, args.flag("no_pickle_cache"))
+    gamespec = get_gamespec(args.srcdir, args.game_version, not args.flag("no_pickle_cache"))
 
     # Blending mode count
     if args.game_version.edition.game_id == "SWGB":
@@ -112,7 +120,7 @@ def convert_metadata(args):
         #     player_palette.save_visualization(outfile)
 
 
-def get_converter(game_version):
+def get_converter(game_version: GameVersion):
     """
     Returns the converter for the specified game version.
     """

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -67,7 +67,7 @@ def convert_metadata(args):
     gamespec = get_gamespec(args.srcdir, args.game_version, args.flag("no_pickle_cache"))
 
     # Blending mode count
-    if args.game_version[0].game_id == "SWGB":
+    if args.game_version.edition.game_id == "SWGB":
         args.blend_mode_count = gamespec[0]["blend_mode_count_swgb"].get_value()
 
     else:
@@ -116,8 +116,8 @@ def get_converter(game_version):
     """
     Returns the converter for the specified game version.
     """
-    game_edition = game_version[0]
-    game_expansions = game_version[1]
+    game_edition = game_version.edition
+    game_expansions = game_version.expansions
 
     if game_edition.game_id == "ROR":
         from ..processor.conversion.ror.processor import RoRProcessor

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Interactive browser for game asset files.

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -3,6 +3,9 @@
 """
 Interactive browser for game asset files.
 """
+from __future__ import annotations
+import typing
+
 
 import os
 import readline  # pylint: disable=unused-import
@@ -15,8 +18,13 @@ from ..service.init.mount_asset_dirs import mount_asset_dirs
 from ..service.init.version_detect import create_version_objects
 from .subtool.version_select import get_game_version
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.read.media.colortable import ColorTable
+    from openage.util.fslike.directory import Directory
+    from openage.util.fslike.path import Path
 
-def interactive_browser(cfg, srcdir=None):
+
+def interactive_browser(cfg: Path, srcdir: Directory = None) -> typing.NoReturn:
     """
     launch an interactive view for browsing the original
     archives.
@@ -46,7 +54,7 @@ def interactive_browser(cfg, srcdir=None):
         warn("cannot launch browser as no valid input assets were found.")
         return
 
-    def save(path, target):
+    def save(path: Path, target: Path) -> None:
         """
         save a path to a custom target
         """
@@ -54,7 +62,7 @@ def interactive_browser(cfg, srcdir=None):
             with open(target, "rb") as outfile:
                 outfile.write(infile.read())
 
-    def save_slp(path, target, palette=None):
+    def save_slp(path: Path, target: Path, palette: ColorTable = None) -> None:
         """
         save a slp as png.
         """
@@ -80,7 +88,7 @@ def interactive_browser(cfg, srcdir=None):
                 filename
             )
 
-    def save_smx(path, target, palette=None):
+    def save_smx(path: Path, target: Path, palette: ColorTable = None) -> None:
         """
         save a smx as png.
         """

--- a/openage/convert/tool/interactive.py
+++ b/openage/convert/tool/interactive.py
@@ -36,7 +36,7 @@ def interactive_browser(cfg, srcdir=None):
 
     # Acquire game version info
     game_version = get_game_version(srcdir, avail_game_eds, avail_game_exps)
-    if not game_version[0]:
+    if not game_version.edition:
         warn("cannot launch browser as no valid game version was found.")
         return
 

--- a/openage/convert/tool/singlefile.py
+++ b/openage/convert/tool/singlefile.py
@@ -10,6 +10,7 @@ import typing
 from pathlib import Path
 
 from openage.convert.processor.export.media_exporter import MediaExporter
+from openage.convert.value_object.init.game_version import GameEdition, GameVersion
 
 from ...log import info
 from ...util.fslike.directory import Directory
@@ -17,8 +18,12 @@ from ..entity_object.export.texture import Texture
 from ..value_object.read.media.colortable import ColorTable
 from ..value_object.read.media.drs import DRS
 
-if typing.TYPE_CHECKING:
-    pass
+AOC_GAME_VERSION = GameVersion(
+    edition=GameEdition("Dummy AOC", "AOC", "YES", [], [], [], [])
+)
+SWGB_GAME_VERSION = GameVersion(
+    edition=GameEdition("Dummy SWGB", "SWGB", "YES", [], [], [], [])
+)
 
 
 def init_subparser(cli):
@@ -119,7 +124,7 @@ def read_palettes(palettes_path: Path) -> dict[str, ColorTable]:
         # open from drs archive
         # TODO: Also allow SWGB's DRS files
         palette_file = Path(palettes_path).open("rb")
-        game_version = ("AOC", [])
+        game_version = AOC_GAME_VERSION
         palette_dir = DRS(palette_file, game_version)
 
         info("parsing palette data...")
@@ -187,7 +192,7 @@ def read_slp_in_drs_file(
 
     # open from drs archive
     # TODO: Also allow SWGB's DRS files
-    game_version = ("AOC", [])
+    game_version = AOC_GAME_VERSION
     drs_file = DRS(drs, game_version)
 
     info("opening slp in drs '%s:%s'...", drs.name, slp_path)
@@ -327,7 +332,7 @@ def read_wav_in_drs_file(drs: Path, wav_path: Path, output_path: Path) -> None:
 
     # open from drs archive
     # TODO: Also allow SWGB's DRS files
-    game_version = ("AOC", [])
+    game_version = AOC_GAME_VERSION
     drs_file = DRS(drs, game_version)
 
     info("opening wav in drs '%s:%s'...", drs.name, wav_path)

--- a/openage/convert/tool/singlefile.py
+++ b/openage/convert/tool/singlefile.py
@@ -1,10 +1,9 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Convert a single slp/wav file from some drs archive to a png/opus file.
 """
 from __future__ import annotations
-import typing
 
 
 from pathlib import Path

--- a/openage/convert/tool/singlefile.py
+++ b/openage/convert/tool/singlefile.py
@@ -3,6 +3,9 @@
 """
 Convert a single slp/wav file from some drs archive to a png/opus file.
 """
+from __future__ import annotations
+import typing
+
 
 from pathlib import Path
 
@@ -13,6 +16,9 @@ from ...util.fslike.directory import Directory
 from ..entity_object.export.texture import Texture
 from ..value_object.read.media.colortable import ColorTable
 from ..value_object.read.media.drs import DRS
+
+if typing.TYPE_CHECKING:
+    pass
 
 
 def init_subparser(cli):
@@ -75,7 +81,7 @@ def main(args, error):
         raise Exception("format could not be determined")
 
 
-def read_palettes(palettes_path):
+def read_palettes(palettes_path: Path) -> dict[str, ColorTable]:
     """
     Reads the palettes from the palettes folder/archive.
     """
@@ -128,7 +134,12 @@ def read_palettes(palettes_path):
     return palettes
 
 
-def read_slp_file(slp_path, output_path, palettes, compression_level):
+def read_slp_file(
+    slp_path: Path,
+    output_path: Path,
+    palettes: dict[str, ColorTable],
+    compression_level: int
+) -> None:
     """
     Reads a single SLP file.
     """
@@ -162,7 +173,13 @@ def read_slp_file(slp_path, output_path, palettes, compression_level):
     )
 
 
-def read_slp_in_drs_file(drs, slp_path, output_path, palettes, compression_level):
+def read_slp_in_drs_file(
+    drs: Path,
+    slp_path: Path,
+    output_path: Path,
+    palettes: dict[str, ColorTable],
+    compression_level: int
+) -> None:
     """
     Reads a SLP file from a DRS archive.
     """
@@ -200,7 +217,12 @@ def read_slp_in_drs_file(drs, slp_path, output_path, palettes, compression_level
     )
 
 
-def read_smp_file(smp_path, output_path, palettes, compression_level):
+def read_smp_file(
+    smp_path: Path,
+    output_path: Path,
+    palettes: dict[str, ColorTable],
+    compression_level: int
+) -> None:
     """
     Reads a single SMP file.
     """
@@ -234,7 +256,12 @@ def read_smp_file(smp_path, output_path, palettes, compression_level):
     )
 
 
-def read_smx_file(smx_path, output_path, palettes, compression_level):
+def read_smx_file(
+    smx_path: Path,
+    output_path: Path,
+    palettes: dict[str, ColorTable],
+    compression_level: int
+) -> None:
     """
     Reads a single SMX (compressed SMP) file.
     """
@@ -268,7 +295,7 @@ def read_smx_file(smx_path, output_path, palettes, compression_level):
     )
 
 
-def read_wav_file(wav_path, output_path):
+def read_wav_file(wav_path: Path, output_path: Path) -> None:
     """
     Reads a single WAV file.
     """
@@ -292,7 +319,7 @@ def read_wav_file(wav_path, output_path):
     output_file.write_bytes(opus_data)
 
 
-def read_wav_in_drs_file(drs, wav_path, output_path):
+def read_wav_in_drs_file(drs: Path, wav_path: Path, output_path: Path) -> None:
     """
     Reads a WAV file from a DRS archive.
     """

--- a/openage/convert/tool/subtool/acquire_sourcedir.py
+++ b/openage/convert/tool/subtool/acquire_sourcedir.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Acquire the sourcedir for the game that is supposed to be converted.
@@ -9,6 +9,7 @@ from pathlib import Path
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
+from typing import AnyStr, Generator
 
 from ....log import warn, info, dbg
 from ....util.files import which
@@ -26,13 +27,13 @@ REGISTRY_SUFFIX_AOK = "Age of Empires\\2.0"
 REGISTRY_SUFFIX_TC = "Age of Empires II: The Conquerors Expansion\\1.0"
 
 
-def expand_relative_path(path):
+def expand_relative_path(path: str) -> AnyStr:
     """Expand relative path to an absolute one, including abbreviations like
     ~ and environment variables"""
     return os.path.realpath(os.path.expandvars(os.path.expanduser(path)))
 
 
-def wanna_convert():
+def wanna_convert() -> bool:
     """
     Ask the user if assets should be converted.
     """
@@ -50,7 +51,7 @@ def wanna_convert():
     return answer
 
 
-def wanna_use_wine():
+def wanna_use_wine() -> bool:
     """
     Ask the user if wine should be used.
     Wine is not used if user has no wine installed.
@@ -83,7 +84,7 @@ def wanna_use_wine():
     return answer
 
 
-def set_custom_wineprefix():
+def set_custom_wineprefix() -> None:
     """
     Allow the customization of the WINEPREFIX environment variable.
     """
@@ -116,7 +117,7 @@ def set_custom_wineprefix():
         os.environ["WINEPREFIX"] = new_wineprefix
 
 
-def query_source_dir(proposals):
+def query_source_dir(proposals: set[str]) -> AnyStr:
     """
     Query interactively for a conversion source directory.
     Lists proposals and allows selection if some were found.
@@ -149,7 +150,7 @@ def query_source_dir(proposals):
     return sourcedir
 
 
-def acquire_conversion_source_dir(prev_source_dir_path=None):
+def acquire_conversion_source_dir(prev_source_dir_path: str = None) -> Path:
     """
     Acquires source dir for the asset conversion.
 
@@ -197,19 +198,19 @@ def acquire_conversion_source_dir(prev_source_dir_path=None):
     return CaseIgnoringDirectory(sourcedir).root
 
 
-def wine_to_real_path(path):
+def wine_to_real_path(path: str) -> str:
     """
     Turn a Wine file path (C:\\xyz) into a local filesystem path (~/.wine/xyz)
     """
     return subprocess.check_output(('winepath', path)).strip().decode()
 
 
-def unescape_winereg(value):
+def unescape_winereg(value: str):
     """Remove quotes and escapes from a Wine registry value"""
     return value.strip('"').replace(r'\\\\', '\\')
 
 
-def source_dir_proposals(call_wine):
+def source_dir_proposals(call_wine: bool) -> Generator[str, None, None]:
     """Yield a list of directory names where an installation might be found"""
     if "WINEPREFIX" in os.environ:
         yield "$WINEPREFIX/" + STANDARD_PATH_IN_32BIT_WINEPREFIX

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -13,7 +13,8 @@ from ...service.init.version_detect import iterate_game_versions
 from ...value_object.init.game_version import Support
 
 if typing.TYPE_CHECKING:
-    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion, GameVersion
+    from openage.convert.value_object.init.game_version import GameEdition,\
+        GameExpansion, GameVersion
     from openage.util.fslike.directory import Directory
 
 

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -5,7 +5,6 @@ Initial version detection based on user input.
 TODO: Version selection.
 """
 from __future__ import annotations
-
 import typing
 
 
@@ -14,8 +13,7 @@ from ...service.init.version_detect import iterate_game_versions
 from ...value_object.init.game_version import Support
 
 if typing.TYPE_CHECKING:
-    from openage.convert.value_object.init.game_version import GameEdition
-    from openage.convert.value_object.init.game_version import GameExpansion
+    from openage.convert.value_object.init.game_version import GameEdition, GameExpansion, GameVersion
     from openage.util.fslike.directory import Directory
 
 
@@ -23,7 +21,7 @@ def get_game_version(
     srcdir: Directory,
     avail_game_eds: list[GameEdition],
     avail_game_exps: list[GameExpansion]
-) -> typing.Union[tuple[GameEdition, list[GameExpansion]], tuple[bool, set]]:
+) -> GameVersion:
     """
     Mount the input folders for conversion.
     """
@@ -67,7 +65,7 @@ def get_game_version(
             if edition.support == Support.YES:
                 warn(" * \x1b[34m%s\x1b[m", edition)
 
-        return (False, set())
+        return GameVersion(edition=None)
 
     info("Compatible game edition detected:")
     info(" * %s", game_version.edition.edition_name)

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -1,15 +1,29 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 """
 Initial version detection based on user input.
 
 TODO: Version selection.
 """
+from __future__ import annotations
+
+import typing
+
+
 from ....log import warn, info
 from ...service.init.version_detect import iterate_game_versions
 from ...value_object.init.game_version import Support
 
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameEdition
+    from openage.convert.value_object.init.game_version import GameExpansion
+    from openage.util.fslike.directory import Directory
 
-def get_game_version(srcdir, avail_game_eds, avail_game_exps):
+
+def get_game_version(
+    srcdir: Directory,
+    avail_game_eds: list[GameEdition],
+    avail_game_exps: list[GameExpansion]
+) -> typing.Union[tuple[GameEdition, list[GameExpansion]], tuple[bool, set]]:
     """
     Mount the input folders for conversion.
     """

--- a/openage/convert/tool/subtool/version_select.py
+++ b/openage/convert/tool/subtool/version_select.py
@@ -32,7 +32,7 @@ def get_game_version(
         srcdir, avail_game_eds, avail_game_exps)
 
     no_support = False
-    if not game_version[0] or game_version[0].support == Support.NOPE:
+    if not game_version.edition or game_version.edition.support == Support.NOPE:
         warn("No valid game version(s) could not be detected "
              f"in {srcdir.resolve_native_path()}")
 
@@ -41,16 +41,16 @@ def get_game_version(
 
     else:
         # Check for broken edition
-        broken_edition = game_version[0].support == Support.BREAKS
+        broken_edition = game_version.edition.support == Support.BREAKS
 
         # a broken edition is installed
         if broken_edition:
             warn("You have installed an incompatible game edition:")
-            warn(" * \x1b[31;1m%s\x1b[m", game_version[0])
+            warn(" * \x1b[31;1m%s\x1b[m", game_version.edition)
             no_support = True
 
         broken_expansions = []
-        for expansion in game_version[1]:
+        for expansion in game_version.expansions:
             if expansion.support == Support.BREAKS:
                 broken_expansions.append(expansion)
 
@@ -70,10 +70,10 @@ def get_game_version(
         return (False, set())
 
     info("Compatible game edition detected:")
-    info(" * %s", game_version[0].edition_name)
-    if game_version[1]:
+    info(" * %s", game_version.edition.edition_name)
+    if game_version.expansions:
         info("Compatible expansions detected:")
-        for expansion in game_version[1]:
+        for expansion in game_version.expansions:
             info(" * %s", expansion.expansion_name)
 
     return game_version

--- a/openage/convert/value_object/conversion/forward_ref.py
+++ b/openage/convert/value_object/conversion/forward_ref.py
@@ -8,10 +8,11 @@ once the object has been created.
 """
 
 from __future__ import annotations
-
 import typing
 
+
 if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup, RawAPIObject
     from openage.nyan.nyan_structs import NyanObject
 
 
@@ -20,36 +21,36 @@ class ForwardRef:
     Declares a forward reference to a RawAPIObject.
     """
 
-    __slots__ = ('group_object', 'raw_api_object_name')
+    __slots__ = ('group_object', 'raw_api_object_ref')
 
-    def __init__(self, converter_object_group_ref, raw_api_object_ref):
+    def __init__(self, converter_object_group: ConverterObjectGroup, raw_api_object_ref: str):
         """
         Creates a forward reference to a RawAPIObject that will be created
         by a converter object group.
 
-        :param converter_object_group_ref: ConverterObjectGroup where the RawAPIObject
-                                           will be created.
-        :type converter_object_group_ref: ConverterObjectGroup
-        :param raw_api_object_ref: Name of the RawAPIObject.
+        :param converter_object_group: ConverterObjectGroup where the RawAPIObject
+                                       will be created.
+        :type converter_object_group: ConverterObjectGroup
+        :param raw_api_object_ref: Reference of the RawAPIObject in the group.
         :type raw_api_object_ref: str
         """
 
-        self.group_object = converter_object_group_ref
-        self.raw_api_object_name = raw_api_object_ref
+        self.group_object = converter_object_group
+        self.raw_api_object_ref = raw_api_object_ref
 
     def resolve(self) -> NyanObject:
         """
         Returns the nyan object reference for the pointer.
         """
-        raw_api_obj = self.group_object.get_raw_api_object(self.raw_api_object_name)
+        raw_api_obj = self.group_object.get_raw_api_object(self.raw_api_object_ref)
 
         return raw_api_obj.get_nyan_object()
 
-    def resolve_raw(self):
+    def resolve_raw(self) -> RawAPIObject:
         """
         Returns the raw API object reference for the pointer.
         """
-        return self.group_object.get_raw_api_object(self.raw_api_object_name)
+        return self.group_object.get_raw_api_object(self.raw_api_object_ref)
 
     def __repr__(self):
-        return f"ForwardRef<{self.raw_api_object_name}>"
+        return f"ForwardRef<{self.raw_api_object_ref}>"

--- a/openage/convert/value_object/conversion/forward_ref.py
+++ b/openage/convert/value_object/conversion/forward_ref.py
@@ -7,6 +7,13 @@ while B->A during conversion. The pointer can be resolved
 once the object has been created.
 """
 
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from openage.nyan.nyan_structs import NyanObject
+
 
 class ForwardRef:
     """
@@ -30,7 +37,7 @@ class ForwardRef:
         self.group_object = converter_object_group_ref
         self.raw_api_object_name = raw_api_object_ref
 
-    def resolve(self):
+    def resolve(self) -> NyanObject:
         """
         Returns the nyan object reference for the pointer.
         """

--- a/openage/convert/value_object/conversion/forward_ref.py
+++ b/openage/convert/value_object/conversion/forward_ref.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Forward references point to an object that is not created yet.
@@ -12,7 +12,8 @@ import typing
 
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup, RawAPIObject
+    from openage.convert.entity_object.conversion.converter_object import ConverterObjectGroup,\
+        RawAPIObject
     from openage.nyan.nyan_structs import NyanObject
 
 

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Associate files or filepaths with hash values to determine the exact version of a game.

--- a/openage/convert/value_object/init/game_file_version.py
+++ b/openage/convert/value_object/init/game_file_version.py
@@ -12,7 +12,7 @@ class GameFileVersion:
     """
     hash_algo = "SHA3-256"
 
-    def __init__(self, filepaths, hashes):
+    def __init__(self, filepaths: list[str], hashes: dict[str, str]):
         """
         Create a new file hash to version association.
 
@@ -30,13 +30,13 @@ class GameFileVersion:
 
         self.hashes = hashes
 
-    def get_paths(self):
+    def get_paths(self) -> list[str]:
         """
         Return all known paths to the file.
         """
         return self.paths
 
-    def get_hashes(self):
+    def get_hashes(self) -> dict[str, str]:
         """
         Return the hash-version association for the file paths.
         """

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-arguments
 

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -6,6 +6,7 @@
 Stores information about base game editions and expansions.
 """
 
+from dataclasses import dataclass
 import enum
 
 from ..read.media_types import MediaType
@@ -145,3 +146,13 @@ class GameEdition(GameBase):
 
     def __str__(self):
         return self.edition_name
+
+
+@dataclass(frozen=True)
+class GameVersion:
+    """
+    Combination of edition and expansions that defines the exact version
+    of a detected game in a folder.
+    """
+    edition: GameEdition
+    expansions: tuple[GameExpansion, ...] = tuple()

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -28,8 +28,15 @@ class GameBase:
     Common base class for GameEdition and GameExpansion
     """
 
-    def __init__(self, game_id, support, game_version_info, media_paths,
-                 modpacks, **flags):
+    def __init__(
+        self,
+        game_id: str,
+        support: bool,
+        game_version_info: list[tuple[list[str], dict[str, str]]],
+        media_paths: list[tuple[str, list[str]]],
+        modpacks: list[str],
+        **flags
+    ):
         """
         :param game_id: Unique id for the given game.
         :type_param: str
@@ -63,7 +70,7 @@ class GameBase:
         for media_type, paths in media_paths:
             self.add_media_paths(media_type, paths)
 
-    def add_game_file_versions(self, filepaths, hashes):
+    def add_game_file_versions(self, filepaths: list[str], hashes: dict[str, str]) -> None:
         """
         Add a GameFileVersion object for files which are unique
         to this version of the game.
@@ -78,7 +85,7 @@ class GameBase:
         """
         self.game_file_versions.append(GameFileVersion(filepaths, hashes))
 
-    def add_media_paths(self, media_type, paths):
+    def add_media_paths(self, media_type: str, paths: list[str]) -> None:
         """
         Add a media type with the associated files.
 
@@ -95,18 +102,30 @@ class GameExpansion(GameBase):
     An optional expansion to a GameEdition.
     """
 
-    def __init__(self, name, game_id, support, game_hashes, media_paths,
-                 modpacks, **flags):
+    def __init__(
+        self,
+        name: str,
+        game_id: str,
+        support: bool,
+        game_version_info: list[tuple[list[str], dict[str, str]]],
+        media_paths: list[tuple[str, list[str]]],
+        modpacks: list[str],
+        **flags
+    ):
         """
         Create a new GameExpansion instance.
 
         :param name: Name of the game.
         :type name: str
-        :param game_id: Unique id for the given game.
-        :type game_id: str
         """
-        super().__init__(game_id, support, game_hashes, media_paths,
-                         modpacks, **flags)
+        super().__init__(
+            game_id,
+            support,
+            game_version_info,
+            media_paths,
+            modpacks,
+            **flags
+        )
 
         self.expansion_name = name
 
@@ -124,22 +143,33 @@ class GameEdition(GameBase):
     The Conquerors are considered "downgrade" expansions.
     """
 
-    def __init__(self, name, game_id, support, game_hashes, media_paths,
-                 modpacks, expansions, **flags):
+    def __init__(
+        self,
+        name: str,
+        game_id: str,
+        support: bool,
+        game_version_info: list[tuple[list[str], dict[str, str]]],
+        media_paths: list[tuple[str, list[str]]],
+        modpacks: list[str],
+        expansions: list[str],
+        **flags
+    ):
         """
         Create a new GameEdition instance.
 
         :param name: Name of the game.
         :type name: str
-        :param game_id: Unique id for the given game.
-        :type game_id: str
         :param expansions: A list of expansions.
         :type expansion: list
-        :param flags: Anything else specific to this version which is useful
-                      for the converter.
         """
-        super().__init__(game_id, support, game_hashes, media_paths,
-                         modpacks, **flags)
+        super().__init__(
+            game_id,
+            support,
+            game_version_info,
+            media_paths,
+            modpacks,
+            **flags
+        )
 
         self.edition_name = name
         self.expansions = expansions

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=too-many-function-args
 

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -8,12 +8,26 @@ Those originate from blendomatic.dat.
 
 For more information, see doc/media/blendomatic.md
 """
+from __future__ import annotations
+import typing
+
 
 from math import sqrt
 from struct import Struct, unpack_from
+import numpy
+
 
 from .....log import dbg
 from ....entity_object.conversion.genie_structure import GenieStructure
+
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.export.texture import Texture
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
+    from openage.convert.value_object.read.value_members import StorageType
+    from openage.util.fslike.wrapper import GuardedFile
 
 
 class BlendingTile:
@@ -24,18 +38,15 @@ class BlendingTile:
 
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, row_data, width, height):
+    def __init__(self, row_data: list[list[int]], width: int, height: int):
         self.row_data = row_data
         self.width = width
         self.height = height
 
-    def get_picture_data(self):
+    def get_picture_data(self) -> numpy.array:
         """
         Return a numpy array of image data for a blending tile.
         """
-
-        import numpy
-
         tile_rows = []
 
         for picture_row in self.row_data:
@@ -72,7 +83,13 @@ class BlendingMode:
 
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, idx, data_file, tile_count, header):
+    def __init__(
+        self,
+        idx: int,
+        data_file: GuardedFile,
+        tile_count: int,
+        header: tuple
+    ):
         """
         initialize one blending mode,
         consisting of multiple frames for all blending directions
@@ -133,7 +150,7 @@ class BlendingMode:
 
             self.bitmasks.append(self.get_tile_from_data(pixels))
 
-    def get_tile_from_data(self, data):
+    def get_tile_from_data(self, data: list[int]) -> BlendingTile:
         """
         get the data pixels, interprete them in isometric tile format
 
@@ -215,7 +232,7 @@ class Blendomatic(GenieStructure):
     # };
     blendomatic_header = Struct("< I I")
 
-    def __init__(self, fileobj, custom_mode_count=None):
+    def __init__(self, fileobj: GuardedFile, custom_mode_count: int = None):
         super().__init__()
 
         buf = fileobj.read(Blendomatic.blendomatic_header.size)
@@ -246,7 +263,7 @@ class Blendomatic(GenieStructure):
 
         fileobj.close()
 
-    def get_textures(self):
+    def get_textures(self) -> list[Texture]:
         """
         generate a list of textures.
 
@@ -257,7 +274,10 @@ class Blendomatic(GenieStructure):
         return [Texture(b_mode) for b_mode in self.blending_modes]
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/colortable.py
+++ b/openage/convert/value_object/read/media/colortable.py
@@ -1,19 +1,31 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,too-many-function-args
+from __future__ import annotations
+import typing
 
 import math
 
 import numpy
 
+
 from .....log import dbg
 from ....entity_object.conversion.genie_structure import GenieStructure
+
+if typing.TYPE_CHECKING:
+    from PIL import Image
+
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
+    from openage.convert.value_object.read.value_members import StorageType
+    from openage.util.fslike.wrapper import GuardedFile
 
 
 class ColorTable(GenieStructure):
     __slots__ = ('header', 'version', 'palette')
 
-    def __init__(self, data):
+    def __init__(self, data: typing.Union[list, tuple, bytes]):
         super().__init__()
 
         if isinstance(data, list) or isinstance(data, tuple):
@@ -24,10 +36,10 @@ class ColorTable(GenieStructure):
         # Fast access for media conversion
         self.array = self.get_ndarray()
 
-    def fill_from_array(self, ar):
+    def fill_from_array(self, ar: typing.Union[list, tuple]) -> None:
         self.palette = [tuple(e) for e in ar]
 
-    def fill(self, data):
+    def fill(self, data: bytes) -> None:
         # split all lines of the input data
         # \r\n windows windows windows baby
         lines = data.decode('ascii').split('\r\n')
@@ -81,7 +93,7 @@ class ColorTable(GenieStructure):
     def __str__(self):
         return f"{repr(self)}\n{self.palette}"
 
-    def gen_image(self, draw_text=True, squaresize=100):
+    def gen_image(self, draw_text: bool = True, squaresize: int = 100) -> Image:
         """
         writes this color table (palette) to a png image.
         """
@@ -144,14 +156,17 @@ class ColorTable(GenieStructure):
 
         return palette_image
 
-    def get_ndarray(self):
+    def get_ndarray(self) -> numpy.array:
         return numpy.array(self.palette, dtype=numpy.uint8, order='C')
 
-    def save_visualization(self, fileobj):
+    def save_visualization(self, fileobj: GuardedFile) -> None:
         self.gen_image().save(fileobj, 'png')
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -175,7 +190,7 @@ class PlayerColorTable(GenieStructure):
 
     __slots__ = ('header', 'version', 'palette')
 
-    def __init__(self, base_table):
+    def __init__(self, base_table: ColorTable):
         super().__init__()
 
         if not isinstance(base_table, ColorTable):
@@ -196,7 +211,10 @@ class PlayerColorTable(GenieStructure):
                 self.palette.append((r, g, b))
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/colortable.py
+++ b/openage/convert/value_object/read/media/colortable.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,too-many-function-args
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -1,17 +1,28 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 from . import unit
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import MultisubtypeMember, EnumLookupMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class Civ(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -20,7 +20,7 @@ class Civ(GenieStructure):
             (SKIP, "player_type", StorageType.INT_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -37,11 +37,11 @@ class Civ(GenieStructure):
             (READ_GEN, "tech_tree_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             # links to tech id as well
             data_format.append((READ_GEN, "team_bonus_id", StorageType.ID_MEMBER, "int16_t"))
 
-            if game_version[0].game_id == "SWGB":
+            if game_version.edition.game_id == "SWGB":
                 data_format.extend([
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[20]"),
                     (READ_GEN, "unique_unit_techs", StorageType.ARRAY_ID, "int16_t[4]"),

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -1,6 +1,9 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from . import civ
 from . import graphic
@@ -14,7 +17,12 @@ from . import unit
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP
 from ....read.read_members import SubdataMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 # this file can parse and represent the empires2_x1_p1.dat file.
@@ -32,7 +40,10 @@ class EmpiresDat(GenieStructure):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -342,7 +353,10 @@ class EmpiresDatWrapper(GenieStructure):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -38,7 +38,7 @@ class EmpiresDat(GenieStructure):
         """
         data_format = [(READ_GEN, "versionstr", StorageType.STRING_MEMBER, "char[8]")]
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "civ_count_swgb", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_UNKNOWN, None, StorageType.INT_MEMBER, "int32_t"),
@@ -53,11 +53,13 @@ class EmpiresDat(GenieStructure):
         data_format.extend([
             (READ, "terrain_restriction_count", StorageType.INT_MEMBER, "uint16_t"),
             (READ, "terrain_count", StorageType.INT_MEMBER, "uint16_t"),   # number of "used" terrains
-            (READ, "float_ptr_terrain_tables", StorageType.ARRAY_ID, "int32_t[terrain_restriction_count]"),
+            (READ, "float_ptr_terrain_tables", StorageType.ARRAY_ID,
+             "int32_t[terrain_restriction_count]"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
-            data_format.append((READ, "terrain_pass_graphics_ptrs", StorageType.ARRAY_ID, "int32_t[terrain_restriction_count]"))
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
+            data_format.append((READ, "terrain_pass_graphics_ptrs",
+                               StorageType.ARRAY_ID, "int32_t[terrain_restriction_count]"))
 
         data_format.extend([
             (READ_GEN, "terrain_restrictions", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -105,23 +107,23 @@ class EmpiresDat(GenieStructure):
 
         # Stored terrain number is hardcoded.
         # Usually less terrains are used by the game
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=55,
             )))
-        elif game_version[0].game_id == "AOE2DE":
+        elif game_version.edition.game_id == "AOE2DE":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=200,
             )))
-        elif game_version[0].game_id == "AOE1DE":
+        elif game_version.edition.game_id == "AOE1DE":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=96,
             )))
-        elif game_version[0].game_id == "HDEDITION":
-            if len(game_version[1]) > 0:
+        elif game_version.edition.game_id == "HDEDITION":
+            if len(game_version.expansions) > 0:
                 data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=terrain.Terrain,
                     length=100,
@@ -133,18 +135,18 @@ class EmpiresDat(GenieStructure):
                     length=42,
                 )))
 
-        elif game_version[0].game_id == "AOC":
+        elif game_version.edition.game_id == "AOC":
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=42,
             )))
-        else:  # game_version[0].game_id == "ROR"
+        else:  # game_version.edition.game_id == "ROR"
             data_format.append((READ_GEN, "terrains", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=terrain.Terrain,
                 length=32,
             )))
 
-        if game_version[0].game_id != "AOE2DE":
+        if game_version.edition.game_id != "AOE2DE":
             data_format.extend([
                 (READ_GEN, "terrain_border", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=terrain.TerrainBorder,
@@ -153,7 +155,7 @@ class EmpiresDat(GenieStructure):
                 (SKIP, "map_row_offset", StorageType.INT_MEMBER, "int32_t"),
             ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "map_min_x", StorageType.FLOAT_MEMBER, "float"),
                 (SKIP, "map_min_y", StorageType.FLOAT_MEMBER, "float"),
@@ -180,7 +182,7 @@ class EmpiresDat(GenieStructure):
             (SKIP, "block_end_column", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "search_map_ptr", StorageType.INT_MEMBER, "int32_t"),
                 (SKIP, "search_map_rows_ptr", StorageType.INT_MEMBER, "int32_t"),
@@ -198,13 +200,13 @@ class EmpiresDat(GenieStructure):
             (SKIP, "fog_flag", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id != "AOE2DE":
-            if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id != "AOE2DE":
+            if game_version.edition.game_id == "SWGB":
                 data_format.extend([
                     (READ_UNKNOWN, "terrain_blob0", StorageType.ARRAY_INT, "uint8_t[25]"),
                     (READ_UNKNOWN, "terrain_blob1", StorageType.ARRAY_INT, "uint32_t[157]"),
                 ])
-            elif game_version[0].game_id in ("ROR", "AOE1DE"):
+            elif game_version.edition.game_id in ("ROR", "AOE1DE"):
                 data_format.extend([
                     (READ_UNKNOWN, "terrain_blob0", StorageType.ARRAY_INT, "uint8_t[2]"),
                     (READ_UNKNOWN, "terrain_blob1", StorageType.ARRAY_INT, "uint32_t[5]"),
@@ -236,7 +238,7 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ, "unit_line_count", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "unit_lines", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -246,7 +248,7 @@ class EmpiresDat(GenieStructure):
             ])
 
         # unit header data
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ, "unit_count", StorageType.INT_MEMBER, "uint32_t"),
                 (READ_GEN, "unit_headers", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -264,7 +266,7 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.append((READ_UNKNOWN, None, StorageType.INT_MEMBER, "int8_t"))
 
         # research data
@@ -276,10 +278,10 @@ class EmpiresDat(GenieStructure):
             )),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.append((READ_UNKNOWN, None, StorageType.INT_MEMBER, "int8_t"))
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "time_slice", StorageType.INT_MEMBER, "int32_t"),
                 (SKIP, "unit_kill_rate", StorageType.INT_MEMBER, "int32_t"),
@@ -296,11 +298,13 @@ class EmpiresDat(GenieStructure):
                 (READ, "building_connection_count", StorageType.INT_MEMBER, "uint8_t"),
             ])
 
-            if game_version[0].game_id == "SWGB":
-                data_format.append((READ, "unit_connection_count", StorageType.INT_MEMBER, "uint16_t"))
+            if game_version.edition.game_id == "SWGB":
+                data_format.append((READ, "unit_connection_count",
+                                   StorageType.INT_MEMBER, "uint16_t"))
 
             else:
-                data_format.append((READ, "unit_connection_count", StorageType.INT_MEMBER, "uint8_t"))
+                data_format.append((READ, "unit_connection_count",
+                                   StorageType.INT_MEMBER, "uint8_t"))
 
             data_format.extend([
                 (READ, "tech_connection_count", StorageType.INT_MEMBER, "uint8_t"),

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -73,7 +73,7 @@ class GraphicAttackSound(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format = [
                 (READ_GEN, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=DE2SoundProp,
@@ -102,7 +102,7 @@ class Graphic(GenieStructure):
         data_format = []
 
         # internal name: e.g. ARRG2NNE = archery range feudal Age north european
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -111,18 +111,19 @@ class Graphic(GenieStructure):
                 (READ, "filename_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[filename_len]"),
             ])
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (SKIP, "particle_effect_name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                     (READ, "particle_effect_name_len", StorageType.INT_MEMBER, "uint16_t"),
-                    (READ_GEN, "particle_effect_name", StorageType.STRING_MEMBER, "char[particle_effect_name_len]"),
+                    (READ_GEN, "particle_effect_name", StorageType.STRING_MEMBER,
+                     "char[particle_effect_name_len]"),
                 ])
-            if game_version[0].game_id == "AOE1DE":
+            if game_version.edition.game_id == "AOE1DE":
                 data_format.extend([
                     (READ_GEN, "first_frame", StorageType.ID_MEMBER, "uint16_t"),
                 ])
 
-        elif game_version[0].game_id == "SWGB":
+        elif game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[25]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[25]"),
@@ -134,7 +135,8 @@ class Graphic(GenieStructure):
             ])
 
         data_format.extend([
-            (READ_GEN, "slp_id", StorageType.ID_MEMBER, "int32_t"),             # id of the graphics file in the drs
+            # id of the graphics file in the drs
+            (READ_GEN, "slp_id", StorageType.ID_MEMBER, "int32_t"),
             (SKIP, "is_loaded", StorageType.BOOLEAN_MEMBER, "int8_t"),             # unused
             (SKIP, "old_color_flag", StorageType.BOOLEAN_MEMBER, "int8_t"),        # unused
             (READ_GEN, "layer", StorageType.ID_MEMBER, EnumLookupMember(       # originally 40 layers, higher -> drawn on top
@@ -142,32 +144,39 @@ class Graphic(GenieStructure):
                 type_name   = "graphics_layer",
                 lookup_dict = GRAPHICS_LAYER
             )),
-            (READ_GEN, "player_color_force_id", StorageType.ID_MEMBER, "int8_t"),    # force given player color
-            (READ_GEN, "adapt_color", StorageType.INT_MEMBER, "int8_t"),             # playercolor can be changed on sight (like sheep)
+            (READ_GEN, "player_color_force_id", StorageType.ID_MEMBER,
+             "int8_t"),    # force given player color
+            # playercolor can be changed on sight (like sheep)
+            (READ_GEN, "adapt_color", StorageType.INT_MEMBER, "int8_t"),
             (READ_GEN, "transparent_selection", StorageType.INT_MEMBER, "uint8_t"),  # loop animation
             (READ, "coordinates", StorageType.ARRAY_INT, "int16_t[4]"),
             (READ, "delta_count", StorageType.INT_MEMBER, "uint16_t"),
             (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_sound_id", StorageType.ID_MEMBER, "uint32_t"),
             ])
 
         data_format.extend([
             (READ, "attack_sound_used", StorageType.INT_MEMBER, "uint8_t"),
-            (READ_GEN, "frame_count", StorageType.INT_MEMBER, "uint16_t"),           # number of frames per angle
-            (READ_GEN, "angle_count", StorageType.INT_MEMBER, "uint16_t"),           # number of heading angles stored, some of the frames must be mirrored
-            (READ_GEN, "speed_adjust", StorageType.FLOAT_MEMBER, "float"),                  # multiplies the speed of the unit this graphic is applied to
-            (READ_GEN, "frame_rate", StorageType.FLOAT_MEMBER, "float"),             # how long a frame is displayed
-            (READ_GEN, "replay_delay", StorageType.FLOAT_MEMBER, "float"),           # seconds to wait before current_frame=0 again
+            (READ_GEN, "frame_count", StorageType.INT_MEMBER,
+             "uint16_t"),           # number of frames per angle
+            # number of heading angles stored, some of the frames must be mirrored
+            (READ_GEN, "angle_count", StorageType.INT_MEMBER, "uint16_t"),
+            # multiplies the speed of the unit this graphic is applied to
+            (READ_GEN, "speed_adjust", StorageType.FLOAT_MEMBER, "float"),
+            (READ_GEN, "frame_rate", StorageType.FLOAT_MEMBER,
+             "float"),             # how long a frame is displayed
+            # seconds to wait before current_frame=0 again
+            (READ_GEN, "replay_delay", StorageType.FLOAT_MEMBER, "float"),
             (READ_GEN, "sequence_type", StorageType.ID_MEMBER, "int8_t"),
             (READ_GEN, "graphic_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "mirroring_mode", StorageType.ID_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             # sprite editor thing for AoK
             data_format.append((SKIP, "editor_flag", StorageType.BOOLEAN_MEMBER, "int8_t"))
 

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -1,18 +1,29 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
 from .lookup_dicts import GRAPHICS_LAYER
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class GraphicDelta(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -32,7 +43,10 @@ class GraphicDelta(GenieStructure):
 class DE2SoundProp(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -54,7 +68,10 @@ class DE2SoundProp(GenieStructure):
 class SoundProp(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -69,7 +86,10 @@ class SoundProp(GenieStructure):
 class GraphicAttackSound(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -95,7 +115,10 @@ class GraphicAttackSound(GenieStructure):
 class Graphic(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/maps.py
+++ b/openage/convert/value_object/read/media/datfile/maps.py
@@ -1,17 +1,28 @@
 # Copyright 2015-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, SKIP
 from ....read.read_members import SubdataMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class MapInfo(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -42,7 +53,10 @@ class MapInfo(GenieStructure):
 class MapLand(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -70,7 +84,10 @@ class MapLand(GenieStructure):
 class MapTerrain(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -89,7 +106,10 @@ class MapTerrain(GenieStructure):
 class MapUnit(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -115,7 +135,10 @@ class MapUnit(GenieStructure):
 class MapElevation(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -134,7 +157,10 @@ class MapElevation(GenieStructure):
 class Map(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/maps.py
+++ b/openage/convert/value_object/read/media/datfile/maps.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -1,16 +1,27 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ_GEN
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class PlayerColor(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -15,7 +15,7 @@ class PlayerColor(GenieStructure):
         Return the members in this struct.
         """
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format = [
                 (READ_GEN, "id", StorageType.ID_MEMBER, "int32_t"),
                 # palette index offset, where the 8 player colors start

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -1,18 +1,29 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
 from .lookup_dicts import RESOURCE_TYPES
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class TechResourceCost(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -32,7 +43,10 @@ class TechResourceCost(GenieStructure):
 class Tech(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -36,7 +36,7 @@ class Tech(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format = [
                 # research ids of techs that are required for activating the possible research
                 (READ_GEN, "required_techs", StorageType.ARRAY_ID, "int16_t[6]"),
@@ -52,37 +52,48 @@ class Tech(GenieStructure):
                 ref_type=TechResourceCost,
                 length=3,
             )),
-            (READ_GEN, "required_tech_count", StorageType.INT_MEMBER, "int16_t"),       # a subset of the above required techs may be sufficient, this defines the minimum amount
+            # a subset of the above required techs may be sufficient, this defines the minimum amount
+            (READ_GEN, "required_tech_count", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
-                (READ_GEN, "civilization_id", StorageType.ID_MEMBER, "int16_t"),           # id of the civ that gets this technology
-                (READ_GEN, "full_tech_mode", StorageType.BOOLEAN_MEMBER, "int16_t"),       # 1: research is available when the full tech tree is activated on game start, 0: not
+                # id of the civ that gets this technology
+                (READ_GEN, "civilization_id", StorageType.ID_MEMBER, "int16_t"),
+                # 1: research is available when the full tech tree is activated on game start, 0: not
+                (READ_GEN, "full_tech_mode", StorageType.BOOLEAN_MEMBER, "int16_t"),
             ])
 
         data_format.extend([
-            (READ_GEN, "research_location_id", StorageType.ID_MEMBER, "int16_t"),      # unit id, where the tech will appear to be researched
+            # unit id, where the tech will appear to be researched
+            (READ_GEN, "research_location_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint16_t"),
             (READ_GEN, "language_dll_description", StorageType.ID_MEMBER, "uint16_t"),
-            (READ_GEN, "research_time", StorageType.INT_MEMBER, "int16_t"),            # time in seconds that are needed to finish this research
-            (READ_GEN, "tech_effect_id", StorageType.ID_MEMBER, "int16_t"),            # techage id that actually contains the research effect information
-            (READ_GEN, "tech_type", StorageType.ID_MEMBER, "int16_t"),                 # 0: normal tech, 2: show in Age progress bar
-            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),                   # frame id - 1 in icon slp (57029)
-            (READ_GEN, "button_id", StorageType.ID_MEMBER, "int8_t"),                  # button id as defined in the unit.py button matrix
-            (READ_GEN, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),         # 100000 + the language file id for the name/description
-            (READ_GEN, "language_dll_techtree", StorageType.ID_MEMBER, "int32_t"),     # 149000 + lang_dll_description
+            # time in seconds that are needed to finish this research
+            (READ_GEN, "research_time", StorageType.INT_MEMBER, "int16_t"),
+            # techage id that actually contains the research effect information
+            (READ_GEN, "tech_effect_id", StorageType.ID_MEMBER, "int16_t"),
+            # 0: normal tech, 2: show in Age progress bar
+            (READ_GEN, "tech_type", StorageType.ID_MEMBER, "int16_t"),
+            # frame id - 1 in icon slp (57029)
+            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),
+            # button id as defined in the unit.py button matrix
+            (READ_GEN, "button_id", StorageType.ID_MEMBER, "int8_t"),
+            # 100000 + the language file id for the name/description
+            (READ_GEN, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),
+            (READ_GEN, "language_dll_techtree", StorageType.ID_MEMBER,
+             "int32_t"),     # 149000 + lang_dll_description
             (READ_GEN, "hotkey", StorageType.ID_MEMBER, "int32_t"),                    # -1 for every tech
         ])
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_length_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "repeatable", StorageType.INT_MEMBER, "int8_t"),
                 ])
@@ -93,7 +104,7 @@ class Tech(GenieStructure):
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0].game_id == "SWGB":
+            if game_version.edition.game_id == "SWGB":
                 data_format.extend([
                     (READ, "name2_length", StorageType.INT_MEMBER, "uint16_t"),
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -1,17 +1,28 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ_GEN, READ, SKIP
 from ....read.read_members import SubdataMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class SoundItem(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -49,7 +60,10 @@ class SoundItem(GenieStructure):
 class Sound(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -17,13 +17,13 @@ class SoundItem(GenieStructure):
         """
         data_format = []
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ])
-        elif game_version[0].game_id == "SWGB":
+        elif game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[27]"),
             ])
@@ -37,7 +37,7 @@ class SoundItem(GenieStructure):
             (READ_GEN, "probablilty", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "civilization_id", StorageType.ID_MEMBER, "int16_t"),
                 (READ_GEN, "icon_set", StorageType.ID_MEMBER, "int16_t"),
@@ -60,7 +60,7 @@ class Sound(GenieStructure):
             (SKIP, "cache_time", StorageType.INT_MEMBER, "int32_t"),                   # always 300000
         ]
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "total_probability", StorageType.ID_MEMBER, "int16_t"),
             ])

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -1,18 +1,29 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
 from .lookup_dicts import EFFECT_APPLY_TYPE, CONNECTION_MODE
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class Effect(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -34,7 +45,10 @@ class Effect(GenieStructure):
 class EffectBundle(GenieStructure):  # also called techage in some other tools
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -64,7 +78,10 @@ class EffectBundle(GenieStructure):  # also called techage in some other tools
 class OtherConnection(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -82,7 +99,10 @@ class OtherConnection(GenieStructure):
 class AgeTechTree(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -177,7 +197,10 @@ class AgeTechTree(GenieStructure):
 class BuildingConnection(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -264,7 +287,10 @@ class BuildingConnection(GenieStructure):
 class UnitConnection(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -340,7 +366,10 @@ class UnitConnection(GenieStructure):
 class ResearchConnection(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -38,7 +38,7 @@ class EffectBundle(GenieStructure):  # also called techage in some other tools
         """
         Return the members in this struct.
         """
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format = [
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -97,7 +97,7 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "status", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id != "ROR":
+        if game_version.edition.game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "buildings", StorageType.ARRAY_ID, "int32_t[building_count]"),
@@ -120,7 +120,7 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -128,7 +128,7 @@ class AgeTechTree(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0].game_id == "ROR":
+        elif game_version.edition.game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -149,12 +149,12 @@ class AgeTechTree(GenieStructure):
             (READ_GEN, "building_level_count", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "buildings_per_zone", StorageType.ARRAY_INT, "int8_t[20]"),
                 (READ_GEN, "group_length_per_zone", StorageType.ARRAY_INT, "int8_t[20]"),
             ])
-        elif game_version[0].game_id == "ROR":
+        elif game_version.edition.game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "buildings_per_zone", StorageType.ARRAY_INT, "int8_t[3]"),
                 (READ_GEN, "group_length_per_zone", StorageType.ARRAY_INT, "int8_t[3]"),
@@ -195,7 +195,7 @@ class BuildingConnection(GenieStructure):
             (READ, "status", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id != "ROR":
+        if game_version.edition.game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 # new buildings available when this building was created
@@ -221,7 +221,7 @@ class BuildingConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -229,7 +229,7 @@ class BuildingConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0].game_id == "ROR":
+        elif game_version.edition.game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -282,7 +282,7 @@ class UnitConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ]
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -290,7 +290,7 @@ class UnitConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0].game_id == "ROR":
+        elif game_version.edition.game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -311,7 +311,7 @@ class UnitConnection(GenieStructure):
             (READ_GEN, "vertical_line", StorageType.ID_MEMBER, "int32_t"),
         ])
 
-        if game_version[0].game_id != "ROR":
+        if game_version.edition.game_id != "ROR":
             data_format.extend([
                 (READ, "unit_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "units", StorageType.ARRAY_ID, "int32_t[unit_count]"),
@@ -323,7 +323,8 @@ class UnitConnection(GenieStructure):
             ])
 
         data_format.extend([
-            (READ_GEN, "location_in_age", StorageType.ID_MEMBER, "int32_t"),    # 0=hidden, 1=first, 2=second
+            (READ_GEN, "location_in_age", StorageType.ID_MEMBER,
+             "int32_t"),    # 0=hidden, 1=first, 2=second
             # min amount of researches to be discovered for this unit to be
             # available
             (READ_GEN, "required_research", StorageType.ID_MEMBER, "int32_t"),
@@ -355,7 +356,7 @@ class ResearchConnection(GenieStructure):
             (READ_GEN, "upper_building", StorageType.ID_MEMBER, "int32_t"),
         ]
 
-        if game_version[0].game_id != "ROR":
+        if game_version.edition.game_id != "ROR":
             data_format.extend([
                 (READ, "building_count", StorageType.INT_MEMBER, "uint8_t"),
                 (READ_GEN, "buildings", StorageType.ARRAY_ID, "int32_t[building_count]"),
@@ -378,7 +379,7 @@ class ResearchConnection(GenieStructure):
             (READ_GEN, "connected_slots_used", StorageType.INT_MEMBER, "int32_t"),
         ])
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[20]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -386,7 +387,7 @@ class ResearchConnection(GenieStructure):
                     length=20,
                 )),
             ])
-        elif game_version[0].game_id == "ROR":
+        elif game_version.edition.game_id == "ROR":
             data_format.extend([
                 (READ_GEN, "other_connected_ids", StorageType.ARRAY_ID, "int32_t[5]"),
                 (READ_GEN, "other_connections", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -405,7 +406,8 @@ class ResearchConnection(GenieStructure):
 
         data_format.extend([
             (READ_GEN, "vertical_line", StorageType.ID_MEMBER, "int32_t"),
-            (READ_GEN, "location_in_age", StorageType.ID_MEMBER, "int32_t"),    # 0=hidden, 1=first, 2=second
+            (READ_GEN, "location_in_age", StorageType.ID_MEMBER,
+             "int32_t"),    # 0=hidden, 1=first, 2=second
             # 0=first age unlocks
             # 4=research
             (READ_GEN, "line_mode", StorageType.ID_MEMBER, "int32_t"),

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -38,7 +38,7 @@ class TerrainPassGraphic(GenieStructure):
             (READ_GEN, "slp_id_walk_tile", StorageType.ID_MEMBER, "int32_t"),
         ]
 
-        if game_version[0].game_id == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             data_format.append((READ_GEN, "walk_sprite_rate", StorageType.FLOAT_MEMBER, "float"))
         else:
             data_format.append((READ_GEN, "replication_amount", StorageType.INT_MEMBER, "int32_t"))
@@ -67,7 +67,7 @@ class TerrainRestriction(GenieStructure):
             (READ_GEN, "accessible_dmgmultiplier", StorageType.ARRAY_FLOAT, "float[terrain_count]")
         ]
 
-        if game_version[0].game_id != "ROR":
+        if game_version.edition.game_id != "ROR":
             data_format.append(
                 (READ_GEN, "pass_graphics", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=TerrainPassGraphic,
@@ -121,14 +121,14 @@ class Terrain(GenieStructure):
             (READ_GEN, "random", StorageType.INT_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "is_water", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "hide_in_editor", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "string_id", StorageType.ID_MEMBER, "int32_t"),
             ])
 
-            if game_version[0].game_id == "AOE1DE":
+            if game_version.edition.game_id == "AOE1DE":
                 data_format.extend([
                     (READ_GEN, "blend_priority", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "blend_type", StorageType.ID_MEMBER, "int16_t"),
@@ -142,7 +142,7 @@ class Terrain(GenieStructure):
                 (READ, "filename_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[filename_len]"),
             ])
-        elif game_version[0].game_id == "SWGB":
+        elif game_version.edition.game_id == "SWGB":
             data_format.extend([
                 (READ_GEN, "internal_name", StorageType.STRING_MEMBER, "char[17]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[17]"),
@@ -159,27 +159,29 @@ class Terrain(GenieStructure):
             (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int32_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_stop_sound_id", StorageType.ID_MEMBER, "uint32_t"),
             ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 # see doc/media/blendomatic.md for blending stuff
                 (READ_GEN, "blend_priority", StorageType.ID_MEMBER, "int32_t"),
                 (READ_GEN, "blend_mode", StorageType.ID_MEMBER, "int32_t"),
             ])
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (SKIP, "overlay_mask_name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                     (READ, "overlay_mask_name_len", StorageType.INT_MEMBER, "uint16_t"),
-                    (READ_GEN, "overlay_mask_name", StorageType.STRING_MEMBER, "char[overlay_mask_name_len]"),
+                    (READ_GEN, "overlay_mask_name", StorageType.STRING_MEMBER,
+                     "char[overlay_mask_name_len]"),
                 ])
 
         data_format.extend([
-            (READ_GEN, "map_color_hi", StorageType.ID_MEMBER, "uint8_t"),       # color of this terrain tile, mainly used in the minimap.
+            # color of this terrain tile, mainly used in the minimap.
+            (READ_GEN, "map_color_hi", StorageType.ID_MEMBER, "uint8_t"),
             (READ_GEN, "map_color_med", StorageType.ID_MEMBER, "uint8_t"),
             (READ_GEN, "map_color_low", StorageType.ID_MEMBER, "uint8_t"),
             (READ_GEN, "map_color_cliff_lt", StorageType.ID_MEMBER, "uint8_t"),
@@ -194,31 +196,32 @@ class Terrain(GenieStructure):
                 length=19,
             )),
 
-            (READ_GEN, "terrain_replacement_id", StorageType.ID_MEMBER, "int16_t"),     # draw this ground instead (e.g. forrest draws forrest ground)
+            # draw this ground instead (e.g. forrest draws forrest ground)
+            (READ_GEN, "terrain_replacement_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "terrain_to_draw0", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "terrain_to_draw1", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.append(
                 (READ_GEN, "terrain_unit_masked_density", StorageType.ARRAY_INT, "int16_t[30]")
             )
-        elif game_version[0].game_id == "SWGB":
+        elif game_version.edition.game_id == "SWGB":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     55
                 ))
             )
-        elif game_version[0].game_id == "AOE1DE":
+        elif game_version.edition.game_id == "AOE1DE":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     96
                 ))
             )
-        elif game_version[0].game_id == "HDEDITION":
-            if len(game_version[1]) > 0:
+        elif game_version.edition.game_id == "HDEDITION":
+            if len(game_version.expansions) > 0:
                 data_format.append(
                     (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                         "int16_t",
@@ -233,14 +236,14 @@ class Terrain(GenieStructure):
                     ))
                 )
 
-        elif game_version[0].game_id == "AOC":
+        elif game_version.edition.game_id == "AOC":
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
                     42
                 ))
             )
-        else:  # game_version[0].game_id == "ROR"
+        else:  # game_version.edition.game_id == "ROR"
             data_format.append(
                 (READ_GEN, "borders", StorageType.ARRAY_INT, ArrayMember(
                     "int16_t",
@@ -259,7 +262,7 @@ class Terrain(GenieStructure):
             (READ_GEN, "terrain_units_used_count", StorageType.INT_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id != "SWGB":
+        if game_version.edition.game_id != "SWGB":
             data_format.append((READ, "phantom", StorageType.INT_MEMBER, "int16_t"))
 
         return data_format

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -1,17 +1,28 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import ArrayMember, SubdataMember, IncludeMembers
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class FrameData(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -27,7 +38,10 @@ class FrameData(GenieStructure):
 class TerrainPassGraphic(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -52,7 +66,10 @@ class TerrainRestriction(GenieStructure):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -81,7 +98,10 @@ class TerrainRestriction(GenieStructure):
 class TerrainAnimation(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -112,7 +132,10 @@ class TerrainAnimation(GenieStructure):
 class Terrain(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -271,7 +294,10 @@ class Terrain(GenieStructure):
 class TerrainBorder(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -303,7 +329,10 @@ class TerrainBorder(GenieStructure):
 class TileSize(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -75,7 +75,7 @@ class UnitCommand(GenieStructure):
             (READ_GEN, "resource_deposit_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ]
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_resource_gather_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 # sound to play on resource drop
@@ -230,7 +230,7 @@ class UnitObject(GenieStructure):
         """
         Return the members in this struct.
         """
-        if game_version[0].game_id not in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id not in ("AOE1DE", "AOE2DE"):
             data_format = [
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
             ]
@@ -241,7 +241,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "id0", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "language_dll_creation", StorageType.ID_MEMBER, "uint32_t"),
@@ -261,7 +261,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "idle_graphic0", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "idle_graphic1", StorageType.ID_MEMBER, "int16_t"),
             ])
@@ -283,7 +283,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "train_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "damage_sound_id", StorageType.ID_MEMBER, "int16_t"))
 
         data_format.extend([
@@ -291,7 +291,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "dead_unit_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ_GEN, "blood_unit_id", StorageType.ID_MEMBER, "int16_t"),
             ])
@@ -300,14 +300,15 @@ class UnitObject(GenieStructure):
             # 0=placable on top of others in scenario editor, 5=can't
             (READ_GEN, "placement_mode", StorageType.ID_MEMBER, "int8_t"),
             (READ_GEN, "can_be_built_on", StorageType.BOOLEAN_MEMBER, "int8_t"),  # 1=no footprints
-            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),      # frame id of the icon slp (57029) to place on the creation button
+            # frame id of the icon slp (57029) to place on the creation button
+            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),
             (SKIP, "hidden_in_editor", StorageType.BOOLEAN_MEMBER, "int8_t"),
             (SKIP, "old_portrait_icon_id", StorageType.ID_MEMBER, "int16_t"),
             # 0=unlocked by research, 1=insta-available
             (READ_GEN, "enabled", StorageType.BOOLEAN_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ, "disabled", StorageType.BOOLEAN_MEMBER, "int8_t"))
 
         data_format.extend([
@@ -387,7 +388,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "resource_gather_drop", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             # bit 0 == 1 && val != 7: mask shown behind buildings,
             # bit 0 == 0 && val != {6, 10}: no mask displayed,
             # val == {-1, 7}: in open area mask is partially displayed
@@ -415,7 +416,7 @@ class UnitObject(GenieStructure):
                 # leftover from trait+civ variable
                 (SKIP, "attribute_piece", StorageType.INT_MEMBER, "int16_t"),
             ])
-        elif game_version[0].game_id == "AOE1DE":
+        elif game_version.edition.game_id == "AOE1DE":
             data_format.extend([
                 (READ_GEN, "obstruction_type", StorageType.ID_MEMBER, EnumLookupMember(
                     raw_type="int8_t",
@@ -440,7 +441,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "selection_shape_z", StorageType.FLOAT_MEMBER, "float"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ, "scenario_trigger_data0", StorageType.ID_MEMBER, "uint32_t"),
                 (READ, "scenario_trigger_data1", StorageType.ID_MEMBER, "uint32_t"),
@@ -460,7 +461,7 @@ class UnitObject(GenieStructure):
             (READ_GEN, "dying_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_creation_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_damage_sound_id", StorageType.ID_MEMBER, "uint32_t"),
@@ -474,10 +475,11 @@ class UnitObject(GenieStructure):
                 type_name="attack_modes",
                 lookup_dict=ATTACK_MODES
             )),
-            (SKIP, "convert_terrain", StorageType.INT_MEMBER, "int8_t"),        # leftover from alpha. would et units change terrain under them
+            # leftover from alpha. would et units change terrain under them
+            (SKIP, "convert_terrain", StorageType.INT_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id in ("AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("AOE1DE", "AOE2DE"):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
@@ -489,7 +491,7 @@ class UnitObject(GenieStructure):
                 (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
-            if game_version[0].game_id == "SWGB":
+            if game_version.edition.game_id == "SWGB":
                 data_format.extend([
                     (READ, "name2_length", StorageType.INT_MEMBER, "uint16_t"),
                     (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),
@@ -499,9 +501,9 @@ class UnitObject(GenieStructure):
 
         data_format.append((READ_GEN, "id1", StorageType.ID_MEMBER, "int16_t"))
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "id2", StorageType.ID_MEMBER, "int16_t"))
-        elif game_version[0].game_id == "AOE1DE":
+        elif game_version.edition.game_id == "AOE1DE":
             data_format.append((READ_GEN, "telemetry_id", StorageType.ID_MEMBER, "int16_t"))
 
         return data_format
@@ -587,7 +589,7 @@ class MovingUnit(DoppelgangerUnit):
             (SKIP, "old_move_algorithm", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (READ_GEN, "turn_radius", StorageType.FLOAT_MEMBER, "float"),
                 (READ_GEN, "turn_radius_speed", StorageType.FLOAT_MEMBER, "float"),
@@ -596,7 +598,7 @@ class MovingUnit(DoppelgangerUnit):
                 (READ_GEN, "max_yaw_per_sec_stationary", StorageType.FLOAT_MEMBER, "float"),
             ])
 
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "min_collision_size_multiplier", StorageType.FLOAT_MEMBER, "float"),
                 ])
@@ -626,7 +628,7 @@ class ActionUnit(MovingUnit):
             (READ_GEN, "work_rate", StorageType.FLOAT_MEMBER, "float"),
         ]
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "drop_sites", StorageType.ARRAY_ID, "int16_t[3]"),
             ])
@@ -636,7 +638,8 @@ class ActionUnit(MovingUnit):
             ])
 
         data_format.extend([
-            (READ_GEN, "task_group", StorageType.ID_MEMBER, "int8_t"),   # 1: male villager; 2: female villager; 3+: free slots
+            # 1: male villager; 2: female villager; 3+: free slots
+            (READ_GEN, "task_group", StorageType.ID_MEMBER, "int8_t"),
             # basically this
             # creates a "swap
             # group id" where you
@@ -649,7 +652,7 @@ class ActionUnit(MovingUnit):
             (READ_GEN, "stop_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "wwise_command_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                 (READ_GEN, "wwise_stop_sound_id", StorageType.ID_MEMBER, "uint32_t"),
@@ -660,7 +663,7 @@ class ActionUnit(MovingUnit):
             (SKIP, "run_pattern", StorageType.ID_MEMBER, "int8_t"),
         ])
 
-        if game_version[0].game_id in ("ROR", "AOE1DE", "AOE2DE"):
+        if game_version.edition.game_id in ("ROR", "AOE1DE", "AOE2DE"):
             data_format.extend([
                 (READ, "unit_command_count", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "unit_commands", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -687,7 +690,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, None, None, IncludeMembers(cls=ActionUnit)),
         ]
 
-        if game_version[0].game_id == "ROR":
+        if game_version.edition.game_id == "ROR":
             data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "uint8_t"))
         else:
             data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "int16_t"))
@@ -712,8 +715,9 @@ class ProjectileUnit(ActionUnit):
             )),
         ])
 
-        if game_version[0].game_id == "AOE2DE":
-            data_format.append((READ_GEN, "bonus_damage_resistance", StorageType.FLOAT_MEMBER, "float"))
+        if game_version.edition.game_id == "AOE2DE":
+            data_format.append((READ_GEN, "bonus_damage_resistance",
+                               StorageType.FLOAT_MEMBER, "float"))
 
         data_format.extend([
             (READ_GEN, "weapon_range_max", StorageType.FLOAT_MEMBER, "float"),
@@ -739,7 +743,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, "weapon_range_min", StorageType.FLOAT_MEMBER, "float"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "accuracy_dispersion", StorageType.FLOAT_MEMBER, "float"))
 
         data_format.extend([
@@ -799,7 +803,8 @@ class LivingUnit(ProjectileUnit):
                 length=3,
             )),
             (READ_GEN, "creation_time", StorageType.INT_MEMBER, "int16_t"),     # in seconds
-            (READ_GEN, "train_location_id", StorageType.ID_MEMBER, "int16_t"),  # e.g. 118 = villager builder
+            (READ_GEN, "train_location_id", StorageType.ID_MEMBER,
+             "int16_t"),  # e.g. 118 = villager builder
 
             # where to place the button with the given icon
             # creation page:
@@ -822,8 +827,8 @@ class LivingUnit(ProjectileUnit):
             (READ, "creation_button_id", StorageType.ID_MEMBER, "int8_t"),
         ]
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
-            if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "heal_timer", StorageType.FLOAT_MEMBER, "float"),
                 ])
@@ -848,7 +853,7 @@ class LivingUnit(ProjectileUnit):
                 # duplicated projectiles
             ])
 
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "spawn_graphic_id", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "upgrade_graphic_id", StorageType.ID_MEMBER, "int16_t"),
@@ -907,10 +912,10 @@ class BuildingUnit(LivingUnit):
             (READ_GEN, "construction_graphic_id", StorageType.ID_MEMBER, "int16_t"),
         ]
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.append((READ_GEN, "snow_graphic_id", StorageType.ID_MEMBER, "int16_t"))
 
-            if game_version[0].game_id == "AOE2DE":
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "destruction_graphic_id", StorageType.ID_MEMBER, "int16_t"),
                     (READ_GEN, "destruction_rubble_graphic_id", StorageType.ID_MEMBER, "int16_t"),
@@ -934,7 +939,7 @@ class BuildingUnit(LivingUnit):
             (READ_GEN, "research_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "can_burn", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 (READ_GEN, "building_annex", StorageType.ARRAY_CONTAINER, SubdataMember(
@@ -950,8 +955,8 @@ class BuildingUnit(LivingUnit):
 
         data_format.append((READ_GEN, "construction_sound_id", StorageType.ID_MEMBER, "int16_t"))
 
-        if game_version[0].game_id not in ("ROR", "AOE1DE"):
-            if game_version[0].game_id == "AOE2DE":
+        if game_version.edition.game_id not in ("ROR", "AOE1DE"):
+            if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
                     (READ_GEN, "wwise_construction_sound_id", StorageType.ID_MEMBER, "uint32_t"),
                     (READ_GEN, "wwise_transform_sound_id", StorageType.ID_MEMBER, "uint32_t"),

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -1,17 +1,25 @@
 # Copyright 2013-2021 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,too-many-lines
+from __future__ import annotations
+import typing
+
 
 from .....entity_object.conversion.genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import EnumLookupMember, ContinueReadMember, IncludeMembers, SubdataMember
-from ....read.value_members import MemberTypes as StorageType
+from ....read.value_members import StorageType
 from .lookup_dicts import COMMAND_ABILITY, OWNER_TYPE, RESOURCE_HANDLING, RESOURCE_TYPES,\
     DAMAGE_DRAW_TYPE, ARMOR_CLASS, UNIT_CLASSES, ELEVATION_MODES, FOG_VISIBILITY,\
     TERRAIN_RESTRICTIONS, BLAST_DEFENSE_TYPES, COMBAT_LEVELS, INTERACTION_MODES,\
     MINIMAP_MODES, UNIT_LEVELS, OBSTRUCTION_TYPES, SELECTION_EFFECTS,\
     ATTACK_MODES, BOUNDARY_IDS, BLAST_OFFENSE_TYPES, CREATABLE_TYPES,\
     GARRISON_TYPES
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.member_access import MemberAccess
+    from openage.convert.value_object.read.read_members import ReadMember
 
 
 class UnitCommand(GenieStructure):
@@ -21,7 +29,10 @@ class UnitCommand(GenieStructure):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -88,7 +99,10 @@ class UnitCommand(GenieStructure):
 class UnitHeader(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -108,7 +122,10 @@ class UnitHeader(GenieStructure):
 class UnitLine(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -126,7 +143,10 @@ class UnitLine(GenieStructure):
 class ResourceStorage(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -146,7 +166,10 @@ class ResourceStorage(GenieStructure):
 class DamageGraphic(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -168,7 +191,10 @@ class DamageGraphic(GenieStructure):
 class HitType(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -187,7 +213,10 @@ class HitType(GenieStructure):
 class ResourceCost(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -207,7 +236,10 @@ class ResourceCost(GenieStructure):
 class BuildingAnnex(GenieStructure):
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -226,7 +258,10 @@ class UnitObject(GenieStructure):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -515,7 +550,10 @@ class TreeUnit(UnitObject):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -533,7 +571,10 @@ class AnimatedUnit(UnitObject):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -551,7 +592,10 @@ class DoppelgangerUnit(AnimatedUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -569,7 +613,10 @@ class MovingUnit(DoppelgangerUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -613,7 +660,10 @@ class ActionUnit(MovingUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -682,7 +732,10 @@ class ProjectileUnit(ActionUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -764,7 +817,10 @@ class MissileUnit(ProjectileUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -792,7 +848,10 @@ class LivingUnit(ProjectileUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """
@@ -903,7 +962,10 @@ class BuildingUnit(LivingUnit):
     """
 
     @classmethod
-    def get_data_format_members(cls, game_version):
+    def get_data_format_members(
+        cls,
+        game_version: GameVersion
+    ) -> list[tuple[MemberAccess, str, StorageType, typing.Union[str, ReadMember]]]:
         """
         Return the members in this struct.
         """

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R,too-many-lines
 from __future__ import annotations

--- a/openage/convert/value_object/read/media/drs.py
+++ b/openage/convert/value_object/read/media/drs.py
@@ -6,12 +6,19 @@ Code for reading Genie .DRS archives.
 Note that .DRS archives can't store file names; they just store the file
 extension, and a file number.
 """
+from __future__ import annotations
+import typing
+
 
 from .....log import spam, dbg
 from .....util.filelike.stream import StreamFragment
 from .....util.fslike.filecollection import FileCollection
 from .....util.strings import decode_until_null
 from .....util.struct import NamedStruct
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.util.fslike.wrapper import GuardedFile
 
 
 # version of the drs files, hardcoded for now
@@ -84,14 +91,14 @@ class DRS(FileCollection):
     represents a file archive in DRS format.
     """
 
-    def __init__(self, fileobj, game_version):
+    def __init__(self, fileobj: GuardedFile, game_version: GameVersion):
         super().__init__()
 
         # queried from the outside
         self.fileobj = fileobj
 
         # read header
-        if game_version == "SWGB":
+        if game_version.edition.edition_name == "SWGB":
             header = DRSHeaderLucasArts.read(fileobj)
 
         else:
@@ -105,7 +112,7 @@ class DRS(FileCollection):
         dbg(header)
 
         # read table info
-        self.tables = []
+        self.tables: list[tuple[str, int, int]] = []
         for _ in range(header.table_count):
             table_header = DRSTableInfo.read(fileobj)
 
@@ -128,7 +135,7 @@ class DRS(FileCollection):
                 (open_r, None, lambda size=size: size, None)
             )
 
-    def read_tables(self):
+    def read_tables(self) -> typing.Generator[tuple[str, str, str], None, None]:
         """
         Reads the tables from self.tables, and yields tuples of
         filename, offset, size.

--- a/openage/convert/value_object/read/media/drs.py
+++ b/openage/convert/value_object/read/media/drs.py
@@ -98,7 +98,7 @@ class DRS(FileCollection):
         self.fileobj = fileobj
 
         # read header
-        if game_version.edition.edition_name == "SWGB":
+        if game_version.edition.game_id == "SWGB":
             header = DRSHeaderLucasArts.read(fileobj)
 
         else:

--- a/openage/convert/value_object/read/media/drs.py
+++ b/openage/convert/value_object/read/media/drs.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 """
 Code for reading Genie .DRS archives.

--- a/openage/convert/value_object/read/media/pefile.py
+++ b/openage/convert/value_object/read/media/pefile.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides PEFile, a class for reading MS portable executable files.

--- a/openage/convert/value_object/read/media/pefile.py
+++ b/openage/convert/value_object/read/media/pefile.py
@@ -7,9 +7,16 @@ Primary doc sources:
 http://www.csn.ul.ie/~caolan/pub/winresdump/winresdump/doc/pefile2.html
 http://en.wikibooks.org/wiki/X86_Disassembly/Windows_Executable_Files
 """
+from __future__ import annotations
+import typing
+
 
 from .....util.filelike.stream import StreamFragment
 from .....util.struct import NamedStruct
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.read.media.peresource import PEResources
+    from openage.util.fslike.wrapper import GuardedFile
 
 
 class PEDOSHeader(NamedStruct):
@@ -153,7 +160,7 @@ class PEFile:
     The constructor takes a file-like object.
     """
 
-    def __init__(self, fileobj):
+    def __init__(self, fileobj: GuardedFile):
         # read DOS header
         doshdr = PEDOSHeader.read(fileobj)
         if doshdr.signature != b'MZ':
@@ -181,7 +188,7 @@ class PEFile:
             opthdr.data_directories.append(PEDataDirectory.read(fileobj))
 
         # read section headers
-        sections = {}
+        sections: dict[str, tuple] = {}
 
         for _ in range(coffhdr.number_of_sections):
             section = PESection.read(fileobj)
@@ -201,7 +208,7 @@ class PEFile:
 
         self.sections = sections
 
-    def open_section(self, section_name):
+    def open_section(self, section_name: str) -> StreamFragment:
         """
         Returns a tuple of data, va for the given section.
 
@@ -218,7 +225,7 @@ class PEFile:
             section.file_offset,
             section.virtual_size), section.virtual_address
 
-    def resources(self):
+    def resources(self) -> PEResources:
         """
         Returns a PEResources object for self.
         """

--- a/openage/convert/value_object/read/media/peresource.py
+++ b/openage/convert/value_object/read/media/peresource.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides PEResources, which reads the resource section from a PEFile.

--- a/openage/convert/value_object/read/media/peresource.py
+++ b/openage/convert/value_object/read/media/peresource.py
@@ -3,12 +3,20 @@
 """
 Provides PEResources, which reads the resource section from a PEFile.
 """
+from __future__ import annotations
+import typing
+
 
 from collections import defaultdict
+
 
 from .....util.filelike.stream import StreamFragment
 from .....util.struct import NamedStruct
 from .langcodes import LANGCODES_AOC
+
+if typing.TYPE_CHECKING:
+    from openage.convert.value_object.read.media.pefile import PEFile
+    from openage.util.fslike.wrapper import GuardedFile
 
 
 # types for id in resource directory root node
@@ -107,7 +115,7 @@ class ResourceLeaf(NamedStruct):
     # filled in later
     fileobj               = None    # used for open
 
-    def open(self):
+    def open(self) -> StreamFragment:
         """
         Returns a file-like object for this resource.
         """
@@ -127,10 +135,10 @@ class StringLiteral(NamedStruct):
     length             = "H"
 
     # filled later by read_content()
-    value              = None
+    value: str         = None
 
     @classmethod
-    def readall(cls, fileobj):
+    def readall(cls, fileobj: GuardedFile) -> StringLiteral:
         """
         In addition to the static data, reads the string.
         """
@@ -146,7 +154,7 @@ class PEResources:
     The constructor takes a PEFile object.
     """
 
-    def __init__(self, pefile):
+    def __init__(self, pefile: PEFile):
         self.data, self.datava = pefile.open_section('.rsrc')
 
         # self.data is at position 0 (i.e. it points at the root directory).
@@ -156,7 +164,7 @@ class PEResources:
     def __getitem__(self, key):
         return self.rootdir[key]
 
-    def read_directory(self):
+    def read_directory(self) -> dict[str, typing.Any]:
         """
         reads the directory that's currently pointed at by self.data.
 
@@ -208,7 +216,7 @@ class PEResources:
 
         return result
 
-    def read_strings(self):
+    def read_strings(self) -> dict[str, dict[int, str]]:
         """
         reads all ressource strings from self.root;
         returns a dict of dicts: {languageid: {stringid: str}}

--- a/openage/convert/value_object/read/read_members.py
+++ b/openage/convert/value_object/read/read_members.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 #
 # TODO pylint: disable=C,R,abstract-method
 

--- a/openage/convert/value_object/read/value_members.py
+++ b/openage/convert/value_object/read/value_members.py
@@ -21,6 +21,9 @@ Quick usage guide on when to use which ValueMember:
                    when repeating substructures appear in a data file.
                    (e.g. multiple unit objects, list of coordinates)
 """
+from __future__ import annotations
+import typing
+
 
 from enum import Enum
 from math import isclose
@@ -33,31 +36,31 @@ class ValueMember:
 
     __slots__ = ('name', 'value')
 
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.name = name
         self.value = None
 
-    def get_name(self):
+    def get_name(self) -> str:
         """
         Returns the name of the member.
         """
         return self.name
 
-    def get_value(self):
+    def get_value(self) -> typing.Any:
         """
         Returns the value of a member.
         """
         raise NotImplementedError(
             f"{type(self)} cannot have values")
 
-    def get_type(self):
+    def get_type(self) -> StorageType:
         """
         Returns the type of a member.
         """
         raise NotImplementedError(
             f"{type(self)} cannot have a type")
 
-    def diff(self, other):
+    def diff(self, other: ValueMember) -> ValueMember:
         """
         Returns a new member object that contains the diff between
         self's and other's values.
@@ -77,18 +80,21 @@ class IntMember(ValueMember):
     Stores numeric integer values.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: typing.Union[int, float]):
         super().__init__(name)
 
         self.value = int(value)
 
-    def get_value(self):
+    def get_value(self) -> int:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.INT_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.INT_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: IntMember
+    ) -> typing.Union[NoDiffMember, IntMember]:
         if self.get_type() is other.get_type():
 
             if self.get_value() == other.get_value():
@@ -112,18 +118,21 @@ class FloatMember(ValueMember):
     Stores numeric floating point values.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: typing.Union[int, float]):
         super().__init__(name)
 
         self.value = float(value)
 
-    def get_value(self):
+    def get_value(self) -> float:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.FLOAT_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.FLOAT_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: FloatMember
+    ) -> typing.Union[NoDiffMember, FloatMember]:
         if self.get_type() is other.get_type():
             # Float must have the last 6 digits in common
             if isclose(self.get_value(), other.get_value(), rel_tol=1e-7):
@@ -147,18 +156,21 @@ class BooleanMember(ValueMember):
     Stores boolean values.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: bool):
         super().__init__(name)
 
         self.value = bool(value)
 
-    def get_value(self):
+    def get_value(self) -> bool:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.BOOLEAN_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.BOOLEAN_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: BooleanMember
+    ) -> typing.Union[NoDiffMember, BooleanMember]:
         if self.get_type() is other.get_type():
             if self.get_value() == other.get_value():
                 return NoDiffMember(self.name, self)
@@ -179,18 +191,21 @@ class IDMember(ValueMember):
     Stores references to media/resource IDs.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: int):
         super().__init__(name)
 
         self.value = int(value)
 
-    def get_value(self):
+    def get_value(self) -> int:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.ID_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.ID_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: IDMember
+    ) -> typing.Union[NoDiffMember, IDMember]:
         if self.get_type() is other.get_type():
             if self.get_value() == other.get_value():
                 return NoDiffMember(self.name, self)
@@ -211,15 +226,15 @@ class BitfieldMember(ValueMember):
     Stores bit field members.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: int):
         super().__init__(name)
 
         self.value = value
 
-    def get_value(self):
+    def get_value(self) -> int:
         return self.value
 
-    def get_value_at_pos(self, pos):
+    def get_value_at_pos(self, pos: int) -> bool:
         """
         Return the boolean value stored at a specific position
         in the bitfield.
@@ -229,10 +244,13 @@ class BitfieldMember(ValueMember):
         """
         return bool(self.value & (2 ** pos))
 
-    def get_type(self):
-        return MemberTypes.BITFIELD_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.BITFIELD_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: BitfieldMember
+    ) -> typing.Union[NoDiffMember, BitfieldMember]:
         """
         Uses XOR to determine which bits are different in 'other'.
         """
@@ -260,18 +278,21 @@ class StringMember(ValueMember):
     Stores string values.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: StringMember):
         super().__init__(name)
 
         self.value = str(value)
 
-    def get_value(self):
+    def get_value(self) -> str:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.STRING_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.STRING_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: StringMember
+    ) -> typing.Union[NoDiffMember, StringMember]:
         if self.get_type() is other.get_type():
             if self.get_value() == other.get_value():
                 return NoDiffMember(self.name, self)
@@ -298,7 +319,18 @@ class ContainerMember(ValueMember):
     are the value of the dict.
     """
 
-    def __init__(self, name, submembers):
+    def __init__(
+        self,
+        name: str,
+        submembers: list[typing.Union[IntMember,
+                                      FloatMember,
+                                      BooleanMember,
+                                      IDMember,
+                                      BitfieldMember,
+                                      StringMember,
+                                      ArrayMember,
+                                      ContainerMember]]
+    ):
         """
         :param submembers: Stored members as a list or dict
         :type submembers: list, dict
@@ -314,13 +346,23 @@ class ContainerMember(ValueMember):
         else:
             self.value = submembers
 
-    def get_value(self):
+    def get_value(self) -> dict[str, typing.Union[IntMember,
+                                                  FloatMember,
+                                                  BooleanMember,
+                                                  IDMember,
+                                                  BitfieldMember,
+                                                  StringMember,
+                                                  ArrayMember,
+                                                  ContainerMember]]:
         return self.value
 
-    def get_type(self):
-        return MemberTypes.CONTAINER_MEMBER
+    def get_type(self) -> StorageType:
+        return StorageType.CONTAINER_MEMBER
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: ContainerMember
+    ) -> typing.Union[NoDiffMember, ContainerMember]:
         if self.get_type() is other.get_type():
             diff_dict = {}
 
@@ -351,7 +393,14 @@ class ContainerMember(ValueMember):
             raise Exception(
                 f"type {type(self)} member cannot be diffed with type {type(other)}")
 
-    def _create_dict(self, member_list):
+    def _create_dict(self, member_list: list[typing.Union[IntMember,
+                                                          FloatMember,
+                                                          BooleanMember,
+                                                          IDMember,
+                                                          BitfieldMember,
+                                                          StringMember,
+                                                          ArrayMember,
+                                                          ContainerMember]]) -> None:
         """
         Creates the dict from the member list passed to __init__.
         """
@@ -380,7 +429,19 @@ class ArrayMember(ValueMember):
 
     __slots__ = ('_allowed_member_type')
 
-    def __init__(self, name, allowed_member_type, members):
+    def __init__(
+        self,
+        name: str,
+        allowed_member_type: StorageType,
+        members: list[typing.Union[IntMember,
+                                   FloatMember,
+                                   BooleanMember,
+                                   IDMember,
+                                   BitfieldMember,
+                                   StringMember,
+                                   ArrayMember,
+                                   ContainerMember]]
+    ):
         super().__init__(name)
 
         self.value = members
@@ -394,34 +455,46 @@ class ArrayMember(ValueMember):
                     raise Exception("%s has type %s, but this ArrayMember only allows %s"
                                     % (member, member.get_type(), allowed_member_type))
 
-    def get_value(self):
+    def get_value(self) -> list[typing.Union[IntMember,
+                                             FloatMember,
+                                             BooleanMember,
+                                             IDMember,
+                                             BitfieldMember,
+                                             StringMember,
+                                             ArrayMember,
+                                             ContainerMember]]:
         return self.value
 
-    def get_type(self):
-        if self._allowed_member_type is MemberTypes.INT_MEMBER:
-            return MemberTypes.ARRAY_INT
+    def get_type(self) -> StorageType:
+        if self._allowed_member_type is StorageType.INT_MEMBER:
+            return StorageType.ARRAY_INT
 
-        elif self._allowed_member_type is MemberTypes.FLOAT_MEMBER:
-            return MemberTypes.ARRAY_FLOAT
+        elif self._allowed_member_type is StorageType.FLOAT_MEMBER:
+            return StorageType.ARRAY_FLOAT
 
-        elif self._allowed_member_type is MemberTypes.BOOLEAN_MEMBER:
-            return MemberTypes.ARRAY_BOOL
+        elif self._allowed_member_type is StorageType.BOOLEAN_MEMBER:
+            return StorageType.ARRAY_BOOL
 
-        elif self._allowed_member_type is MemberTypes.ID_MEMBER:
-            return MemberTypes.ARRAY_ID
+        elif self._allowed_member_type is StorageType.ID_MEMBER:
+            return StorageType.ARRAY_ID
 
-        elif self._allowed_member_type is MemberTypes.BITFIELD_MEMBER:
-            return MemberTypes.ARRAY_BITFIELD
+        elif self._allowed_member_type is StorageType.BITFIELD_MEMBER:
+            return StorageType.ARRAY_BITFIELD
 
-        elif self._allowed_member_type is MemberTypes.STRING_MEMBER:
-            return MemberTypes.ARRAY_STRING
+        elif self._allowed_member_type is StorageType.STRING_MEMBER:
+            return StorageType.ARRAY_STRING
 
-        elif self._allowed_member_type is MemberTypes.CONTAINER_MEMBER:
-            return MemberTypes.ARRAY_CONTAINER
+        elif self._allowed_member_type is StorageType.CONTAINER_MEMBER:
+            return StorageType.ARRAY_CONTAINER
 
         raise Exception(f"{self} has no valid member type")
 
-    def get_container(self, key_member_name, force_not_found= False, force_duplicate=False):
+    def get_container(
+        self,
+        key_member_name: str,
+        force_not_found: bool = False,
+        force_duplicate: bool = False
+    ) -> ContainerMember:
         """
         Returns a ContainerMember generated from an array with type ARRAY_CONTAINER.
         It uses the values of the members with the specified name as keys.
@@ -435,7 +508,7 @@ class ArrayMember(ValueMember):
         :param force_duplicate: Do not raise an exception if the same key value is used twice.
         :type force_duplicate: bool
         """
-        if self.get_type() is not MemberTypes.ARRAY_CONTAINER:
+        if self.get_type() is not StorageType.ARRAY_CONTAINER:
             raise Exception("%s: Container can only be generated from arrays with"
                             " type 'contarray', not %s"
                             % (self, self.get_type()))
@@ -462,7 +535,10 @@ class ArrayMember(ValueMember):
 
         return ContainerMember(self.name, member_dict)
 
-    def diff(self, other):
+    def diff(
+        self,
+        other: ArrayMember
+    ) -> typing.Union[NoDiffMember, ArrayMember]:
         if self.get_type() == other.get_type():
             diff_list = []
             other_list = other.get_value()
@@ -517,7 +593,7 @@ class NoDiffMember(ValueMember):
     Is returned when no difference between two members is found.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: ValueMember):
         """
         :param value: Reference to the one of the diffed members.
         :type value: ValueMember
@@ -526,7 +602,7 @@ class NoDiffMember(ValueMember):
 
         self.value = value
 
-    def get_reference(self):
+    def get_reference(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
@@ -543,7 +619,7 @@ class LeftMissingMember(ValueMember):
     side member as value.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: ValueMember):
         """
         :param value: Reference to the right member's object.
         :type value: ValueMember
@@ -552,7 +628,7 @@ class LeftMissingMember(ValueMember):
 
         self.value = value
 
-    def get_reference(self):
+    def get_reference(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
@@ -569,7 +645,7 @@ class RightMissingMember(ValueMember):
     side member as value.
     """
 
-    def __init__(self, name, value):
+    def __init__(self, name: str, value: ValueMember):
         """
         :param value: Reference to the left member's object.
         :type value: ValueMember
@@ -578,7 +654,7 @@ class RightMissingMember(ValueMember):
 
         self.value = value
 
-    def get_reference(self):
+    def get_reference(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
@@ -588,7 +664,7 @@ class RightMissingMember(ValueMember):
         return f"RightMissingMember<{self.name}>"
 
 
-class MemberTypes(Enum):
+class StorageType(Enum):
     """
     Types for values members.
     """

--- a/openage/convert/value_object/read/value_members.py
+++ b/openage/convert/value_object/read/value_members.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 # TODO pylint: disable=C,R,abstract-method
 
 """

--- a/openage/cvar/config_file.py
+++ b/openage/cvar/config_file.py
@@ -1,13 +1,20 @@
-# Copyright 2016-2020 the openage authors. See copying.md for legal info.
+# Copyright 2016-2022 the openage authors. See copying.md for legal info.
 
 """
 Load and save the configuration : file <-> console var system
 """
 
+from __future__ import annotations
+import typing
+
 from ..log import info, spam
 
 
-def load_config_file(path, set_cvar_func, loaded_files=None):
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.path import Path
+
+
+def load_config_file(path: Path, set_cvar_func: typing.Callable, loaded_files: set = None) -> None:
     """
     Load a config file, with possible subfile, into the cvar system.
 

--- a/openage/cvar/location.py
+++ b/openage/cvar/location.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 Determine the config file location and set up mounts.
@@ -13,7 +13,7 @@ from ..util.fslike.union import Union
 from ..util.fslike.wrapper import WriteBlocker
 
 
-def get_config_path(custom_cfg_dir=None):
+def get_config_path(custom_cfg_dir: str = None) -> Directory:
     """
     Locates the main configuration file by name in some searchpaths.
     Optionally, mount a custom directory with highest priority.

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -1,17 +1,23 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals
 
 """
 Holds the game entry point for openage.
 """
+from __future__ import annotations
+import typing
+
 
 import sys
 from ..convert.tool.subtool.acquire_sourcedir import wanna_convert
 from ..log import err, info
 
+if typing.TYPE_CHECKING:
+    from argparse import ArgumentParser
 
-def init_subparser(cli):
+
+def init_subparser(cli: ArgumentParser) -> None:
     """ Initializes the parser for game-specific args. """
     cli.set_defaults(entrypoint=main)
 

--- a/openage/main/main.py
+++ b/openage/main/main.py
@@ -1,13 +1,18 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Main engine entry point for openage.
 """
+from __future__ import annotations
+import typing
 
 from ..log import err, info
 
+if typing.TYPE_CHECKING:
+    from argparse import ArgumentParser
 
-def init_subparser(cli):
+
+def init_subparser(cli: ArgumentParser):
     """ Initializes the parser for game-specific args. """
     cli.set_defaults(entrypoint=main)
 

--- a/openage/nyan/import_tree.py
+++ b/openage/nyan/import_tree.py
@@ -1,9 +1,130 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 
 """
 Tree structure for resolving imports.
 """
+from __future__ import annotations
 from enum import Enum
+import typing
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.export.formats.nyan_file import NyanFile
+    from openage.nyan.nyan_structs import NyanObject
+
+
+class NodeType(Enum):
+    """
+    Types for nodes.
+    """
+    ROOT      = "r"     # tree root
+    FILESYS   = "f"     # directory or file
+    OBJECT    = "o"     # object in file (top level)
+    NESTED    = "no"    # nested object
+
+
+class Node:
+    """
+    Node in the import tree. This can be a directory, a file
+    or an object.
+    """
+
+    __slots__ = ('name', 'node_type', 'parent', 'depth', 'children', 'alias')
+
+    def __init__(self, name: str, node_type: NodeType, parent):
+        """
+        Create a node for an import tree.
+
+        :param name: Name of the node.
+        :type name: str
+        :param node_type: Type of the node.
+        :type node_type: NodeType
+        :param parent: Parent node of this node.
+        :type parent: Node
+        """
+
+        self.name = name
+        self.node_type = node_type
+        self.parent: Node = parent
+
+        if not self.parent and self.node_type is not NodeType.ROOT:
+            raise Exception("Only node with type ROOT are allowed to have no parent")
+
+        self.depth = 0
+        if self.node_type is NodeType.ROOT:
+            self.depth = 0
+
+        else:
+            self.depth = self.parent.depth + 1
+
+        self.children = {}
+
+        self.alias = ""
+
+    def add_child(self, child_node) -> None:
+        """
+        Adds a child node to this node.
+        """
+        self.children.update({child_node.name: child_node})
+
+    def has_ancestor(self, ancestor_node, max_distance: int = 128) -> bool:
+        """
+        Checks is the node has a given node as ancestor.
+
+        :param ancestor_node: Ancestor candidate node.
+        :type ancestor_node: Node
+        """
+        current_node = self
+        distance = 0
+        while distance < max_distance:
+            if current_node.parent is ancestor_node:
+                return True
+
+            elif not current_node.parent:
+                return False
+
+            current_node = current_node.parent
+            distance += 1
+
+        return False
+
+    def has_child(self, name: str) -> bool:
+        """
+        Checks if a child with the given name exists.
+
+        :param name: Name of the child node.
+        :type name: str
+        """
+        return name in self.children.keys()
+
+    def get_child(self, name: str):
+        """
+        Returns the child noe with the given name.
+
+        :param name: Name of the child node.
+        :type name: str
+        """
+        return self.children[name]
+
+    def get_fqon(self) -> tuple[str]:
+        """
+        Get the fqon that is associated with this node by traversing the tree upwards.
+        """
+        current_node = self
+        fqon = []
+        while current_node.node_type is not NodeType.ROOT:
+            fqon.insert(0, current_node.name)
+            current_node = current_node.parent
+
+        return tuple(fqon)
+
+    def set_alias(self, alias: str) -> None:
+        """
+        Give this node an alias name.
+
+        :param alias: Alias for the node.
+        :type alias: str
+        """
+        self.alias = alias
 
 
 class ImportTree:
@@ -18,9 +139,14 @@ class ImportTree:
 
         self.alias_nodes = set()
 
-    def add_alias(self, fqon, alias):
+    def add_alias(self, fqon: tuple[str], alias: str) -> None:
         """
         Adds an alias to the node with the specified fqon.
+
+        :param fqon: Identifier of the node.
+        :type fqon: tuple[str]
+        :param alias: Alias for the node.
+        :type alias: str
         """
         current_node = self.root
         for node_str in fqon:
@@ -35,18 +161,18 @@ class ImportTree:
 
         current_node.set_alias(alias)
 
-    def clear_marks(self):
+    def clear_marks(self) -> None:
         """
         Remove all alias marks from the tree.
         """
         self.alias_nodes.clear()
 
-    def expand_from_file(self, nyan_file):
+    def expand_from_file(self, nyan_file: NyanFile) -> None:
         """
         Expands the tree from a nyan file.
 
         :param nyan_file: File with nyan objects.
-        :type nyan_file: .convert.export.formats.nyan_file.NyanFile
+        :type nyan_file: NyanFile
         """
         current_node = self.root
         fqon = nyan_file.get_fqon()
@@ -67,12 +193,12 @@ class ImportTree:
         for nyan_object in nyan_file.nyan_objects:
             self.expand_from_object(nyan_object)
 
-    def expand_from_object(self, nyan_object):
+    def expand_from_object(self, nyan_object: NyanObject) -> None:
         """
         Expands the tree from a nyan object.
 
         :param nyan_object: A nyan object.
-        :type nyan_object: .nyan_structs.NyanObject
+        :type nyan_object: NyanObject
         """
         # Process the object
         fqon = nyan_object.get_fqon()
@@ -149,7 +275,7 @@ class ImportTree:
                     current_node.add_child(new_node)
                     current_node = new_node
 
-    def get_import_dict(self):
+    def get_import_dict(self) -> dict[str, tuple[str]]:
         """
         Get the fqons of the nodes that are used for alias, i.e. fqons of all
         nodes in self.alias_nodes. The dict can be used for creating imports
@@ -170,17 +296,17 @@ class ImportTree:
 
         return aliases
 
-    def get_alias_fqon(self, fqon, namespace=None):
+    def get_alias_fqon(self, fqon: tuple[str], namespace: tuple[str] = None) -> tuple[str]:
         """
         Find the (shortened) fqon by traversing the tree to the fqon node and
         then going upwards until an alias is found.
 
         :param fqon: Object reference for which an alias should be found.
-        :type fqon: tuple
+        :type fqon: tuple[str]
         :param namespace: Identifier of a namespace. If this is a (nested) object,
                           we check if the fqon is in the namespace before
                           searching for an alias.
-        :type namespace: tuple
+        :type namespace: tuple[str]
         """
         if namespace:
             current_node = self.root
@@ -218,107 +344,3 @@ class ImportTree:
             current_node = current_node.parent
 
         return tuple(sfqon)
-
-
-class Node:
-    """
-    Node in the import tree. This can be a directory, a file
-    or an object.
-    """
-
-    __slots__ = ('name', 'node_type', 'parent', 'depth', 'children', 'alias')
-
-    def __init__(self, name, node_type, parent):
-        """
-        Create a node for an import tree.
-
-        :param name: Name of the node.
-        :type name: str
-        :param node_type: Type of the node.
-        :type node_type: NodeType
-        :param parent: Parent node of this node.
-        :type parent: Node
-        """
-
-        self.name = name
-        self.node_type = node_type
-        self.parent = parent
-
-        if not self.parent and self.node_type is not NodeType.ROOT:
-            raise Exception("Only node with type ROOT are allowed to have no parent")
-
-        self.depth = 0
-        if self.node_type is NodeType.ROOT:
-            self.depth = 0
-
-        else:
-            self.depth = self.parent.depth + 1
-
-        self.children = {}
-
-        self.alias = ""
-
-    def add_child(self, child_node):
-        """
-        Adds a child node to this node.
-        """
-        self.children.update({child_node.name: child_node})
-
-    def has_ancestor(self, ancestor_node, max_distance=128):
-        """
-        Checks is the node has a given node as ancestor.
-        """
-        current_node = self
-        distance = 0
-        while distance < max_distance:
-            if current_node.parent is ancestor_node:
-                return True
-
-            elif not current_node.parent:
-                return False
-
-            current_node = current_node.parent
-            distance += 1
-
-        return False
-
-    def has_child(self, name):
-        """
-        Checks if a child with the given name exists.
-        """
-        return name in self.children.keys()
-
-    def get_child(self, name):
-        """
-        Returns the child noe with the given name.
-        """
-        return self.children[name]
-
-    def get_fqon(self):
-        """
-        Get the fqon that is associated with this node by traversing the tree upwards.
-        """
-        current_node = self
-        fqon = []
-        while current_node.node_type is not NodeType.ROOT:
-            fqon.insert(0, current_node.name)
-            current_node = current_node.parent
-
-        return tuple(fqon)
-
-    def set_alias(self, alias):
-        """
-        Give this node an alias name.
-        """
-        self.alias = alias
-
-
-class NodeType(Enum):
-    """
-    Types for nodes.
-    """
-
-    ROOT      = "r"     # tree root
-    FILESYS   = "f"     # directory or file
-    OBJECT    = "o"     # object in file (top level)
-    NESTED    = "no"    # nested object

--- a/openage/nyan/nyan_structs.py
+++ b/openage/nyan/nyan_structs.py
@@ -41,9 +41,9 @@ class NyanObject:
     def __init__(
         self,
         name: str,
-        parents: OrderedSet = None,
-        members: OrderedSet = None,
-        nested_objects: OrderedSet = None
+        parents: OrderedSet[NyanObject] = None,
+        members: OrderedSet[NyanMember] = None,
+        nested_objects: OrderedSet[NyanObject] = None
     ):
         """
         Initializes the object and does some correctness
@@ -82,7 +82,7 @@ class NyanObject:
         if len(self._parents) > 0:
             self._process_inheritance()
 
-    def add_nested_object(self, new_nested_object) -> None:
+    def add_nested_object(self, new_nested_object: NyanObject) -> None:
         """
         Adds a nested object to the nyan object.
         """
@@ -98,7 +98,7 @@ class NyanObject:
         new_nested_object.set_fqon((*self._fqon,
                                     new_nested_object.get_name()))
 
-    def add_member(self, new_member) -> None:
+    def add_member(self, new_member: NyanMember) -> None:
         """
         Adds a member to the nyan object.
         """
@@ -124,7 +124,7 @@ class NyanObject:
             )
             child.update_inheritance(inherited_member)
 
-    def add_child(self, new_child) -> None:
+    def add_child(self, new_child: NyanObject) -> None:
         """
         Registers another object as a child.
         """
@@ -160,7 +160,7 @@ class NyanObject:
             )
             new_child.update_inheritance(inherited_member)
 
-    def has_member(self, member_name: str, origin=None) -> bool:
+    def has_member(self, member_name: str, origin: NyanObject = None) -> bool:
         """
         Returns True if the NyanMember with the specified name exists.
         """
@@ -183,13 +183,13 @@ class NyanObject:
         """
         return self._fqon
 
-    def get_members(self) -> OrderedSet:
+    def get_members(self) -> OrderedSet[NyanMember]:
         """
         Returns all NyanMembers of the object, including inherited members.
         """
         return self._members.union(self._inherited_members)
 
-    def get_member_by_name(self, member_name: str, origin=None):
+    def get_member_by_name(self, member_name: str, origin: NyanObject = None) -> NyanMember:
         """
         Returns the NyanMember with the specified name.
         """
@@ -227,19 +227,19 @@ class NyanObject:
         """
         return self.name
 
-    def get_nested_objects(self) -> OrderedSet:
+    def get_nested_objects(self) -> OrderedSet[NyanObject]:
         """
         Returns all nested NyanObjects of this object.
         """
         return self._nested_objects
 
-    def get_parents(self) -> OrderedSet:
+    def get_parents(self) -> OrderedSet[NyanObject]:
         """
         Returns all nested parents of this object.
         """
         return self._parents
 
-    def has_ancestor(self, nyan_object) -> bool:
+    def has_ancestor(self, nyan_object: NyanObject) -> bool:
         """
         Returns True if the given nyan object is an ancestor
         of this nyan object.
@@ -285,7 +285,7 @@ class NyanObject:
             nested_fqon = (*new_fqon, nested_object.get_name())
             nested_object.set_fqon(nested_fqon)
 
-    def update_inheritance(self, new_inherited_member) -> None:
+    def update_inheritance(self, new_inherited_member: InheritedNyanMember) -> None:
         """
         Add an inherited member to the object. Should only be used by
         parent objects.
@@ -620,8 +620,8 @@ class NyanMemberType:
 
     def __init__(
         self,
-        member_type,
-        element_types=None
+        member_type: typing.Union[MemberType, NyanObject],
+        element_types: typing.Collection[NyanMemberType] = None
     ):
         """
         Initializes the member type and does some correctness
@@ -640,13 +640,13 @@ class NyanMemberType:
         # check for errors in the initilization
         self._sanity_check()
 
-    def get_type(self):
+    def get_type(self) -> MemberType:
         """
         Returns the member type.
         """
         return self._member_type
 
-    def get_real_type(self):
+    def get_real_type(self) -> MemberType:
         """
         Returns the member type without wrapping modifiers.
         """
@@ -655,13 +655,13 @@ class NyanMemberType:
 
         return self._member_type
 
-    def get_element_types(self) -> tuple:
+    def get_element_types(self) -> tuple[NyanMemberType, ...]:
         """
         Returns the element types.
         """
         return self._element_types
 
-    def get_real_element_types(self) -> tuple:
+    def get_real_element_types(self) -> tuple[NyanMemberType, ...]:
         """
         Returns the element types without wrapping modifiers.
         """
@@ -680,7 +680,7 @@ class NyanMemberType:
                                      MemberType.FILE,
                                      MemberType.BOOLEAN)
 
-    def is_real_primitive(self) -> tuple:
+    def is_real_primitive(self) -> bool:
         """
         Returns True if the member type is a primitive wrapped in a modifier.
         """
@@ -689,7 +689,7 @@ class NyanMemberType:
 
         return self.is_primitive()
 
-    def is_complex(self) -> tuple:
+    def is_complex(self) -> bool:
         """
         Returns True if the member type is a collection.
         """
@@ -697,7 +697,7 @@ class NyanMemberType:
                                      MemberType.ORDEREDSET,
                                      MemberType.DICT)
 
-    def is_real_complex(self) -> tuple:
+    def is_real_complex(self) -> bool:
         """
         Returns True if the member type is a collection wrapped in a modifier.
         """
@@ -706,13 +706,13 @@ class NyanMemberType:
 
         return self.is_complex()
 
-    def is_object(self) -> tuple:
+    def is_object(self) -> bool:
         """
         Returns True if the member type is an object.
         """
         return isinstance(self._member_type, NyanObject)
 
-    def is_real_object(self) -> tuple:
+    def is_real_object(self) -> bool:
         """
         Returns True if the member type is an object wrapped in a modifier.
         """
@@ -721,7 +721,7 @@ class NyanMemberType:
 
         return self.is_object()
 
-    def is_modifier(self) -> tuple:
+    def is_modifier(self) -> bool:
         """
         Returns True if the member type is a modifier.
         """
@@ -729,13 +729,13 @@ class NyanMemberType:
                                      MemberType.CHILDREN,
                                      MemberType.OPTIONAL)
 
-    def is_composite(self) -> tuple:
+    def is_composite(self) -> bool:
         """
         Returns True if the member is a composite type with at least one element type.
         """
         return self.is_complex() or self.is_modifier()
 
-    def accepts_op(self, operator) -> tuple:
+    def accepts_op(self, operator: MemberOperator) -> bool:
         """
         Check if an operator is compatible with the member type.
         """
@@ -791,7 +791,7 @@ class NyanMemberType:
 
         return True
 
-    def accepts_value(self, value) -> tuple:
+    def accepts_value(self, value) -> bool:
         """
         Check if a value is compatible with the member type.
         """
@@ -880,9 +880,9 @@ class NyanMember:
     def __init__(
         self,
         name: str,
-        member_type,
+        member_type: NyanMemberType,
         value=None,
-        operator=None,
+        operator: MemberOperator = None,
         override_depth: int = 0
     ):
         """
@@ -918,13 +918,13 @@ class NyanMember:
         """
         return self.name
 
-    def get_member_type(self):
+    def get_member_type(self) -> NyanMemberType:
         """
         Returns the type of the member.
         """
         return self._member_type
 
-    def get_operator(self):
+    def get_operator(self) -> MemberOperator:
         """
         Returns the operator of the member.
         """
@@ -979,7 +979,7 @@ class NyanMember:
         """
         return self.value is not None
 
-    def set_value(self, value, operator=None) -> None:
+    def set_value(self, value, operator: MemberOperator = None) -> None:
         """
         Set the value of the nyan member to the specified value and
         optionally, the operator.
@@ -1105,7 +1105,7 @@ class NyanMember:
 
     @staticmethod
     def _get_primitive_value_str(
-        member_type,
+        member_type: NyanMemberType,
         value,
         import_tree: ImportTree = None,
         namespace: tuple[str] = None
@@ -1135,7 +1135,7 @@ class NyanMember:
     def _get_complex_value_str(
         self,
         indent_depth: int,
-        member_type,
+        member_type: NyanMemberType,
         value,
         import_tree: ImportTree = None,
         namespace: tuple[str] = None
@@ -1293,7 +1293,7 @@ class NyanPatchMember(NyanMember):
         patch_target: NyanObject,
         member_origin: NyanObject,
         value,
-        operator,
+        operator: MemberOperator,
         override_depth: int = 0
     ):
         """
@@ -1386,11 +1386,11 @@ class InheritedNyanMember(NyanMember):
     def __init__(
         self,
         name: str,
-        member_type,
+        member_type: NyanMemberType,
         parent: NyanObject,
         origin: NyanObject,
         value=None,
-        operator=None,
+        operator: MemberOperator = None,
         override_depth: int = 0
     ):
         """
@@ -1490,21 +1490,21 @@ class MemberType(Enum):
     """
 
     # Primitive types
-    INT = "int"
-    FLOAT = "float"
-    TEXT = "text"
-    FILE = "file"
-    BOOLEAN = "bool"
+    INT        = "int"
+    FLOAT      = "float"
+    TEXT       = "text"
+    FILE       = "file"
+    BOOLEAN    = "bool"
 
     # Complex types
-    SET = "set"
+    SET        = "set"
     ORDEREDSET = "orderedset"
-    DICT = "dict"
+    DICT       = "dict"
 
     # Modifier types
-    ABSTRACT = "abstract"
-    CHILDREN = "children"
-    OPTIONAL = "optional"
+    ABSTRACT   = "abstract"
+    CHILDREN   = "children"
+    OPTIONAL   = "optional"
 
 
 class MemberSpecialValue(Enum):
@@ -1515,7 +1515,7 @@ class MemberSpecialValue(Enum):
     NYAN_NONE = "None"
 
     # infinite value for float and int
-    NYAN_INF = "inf"
+    NYAN_INF  = "inf"
 
 
 class MemberOperator(Enum):
@@ -1523,10 +1523,10 @@ class MemberOperator(Enum):
     Symbols for nyan member operators.
     """
 
-    ASSIGN = "="        # assignment
-    ADD = "+="          # addition, append, insertion, union
-    SUBTRACT = "-="     # subtraction, remove
-    MULTIPLY = "*="     # multiplication
-    DIVIDE = "/="       # division
-    AND = "&="          # logical AND, intersect
-    OR = "|="           # logical OR, union
+    ASSIGN    = "="      # assignment
+    ADD       = "+="     # addition, append, insertion, union
+    SUBTRACT  = "-="     # subtraction, remove
+    MULTIPLY  = "*="     # multiplication
+    DIVIDE    = "/="     # division
+    AND       = "&="     # logical AND, intersect
+    OR        = "|="     # logical OR, union

--- a/openage/testing/benchmark.py
+++ b/openage/testing/benchmark.py
@@ -1,18 +1,19 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """ Benchmarking tools for the tests. """
 
 from timeit import timeit
 from sys import stdout
 from time import sleep
+from typing import Callable
 
 
-def benchmark_test_function():
+def benchmark_test_function() -> None:
     """ Simple function to call in for benchmarking. """
     sleep(0.1)
 
 
-def benchmark(func):
+def benchmark(func: Callable) -> None:
     """
     Benchmark the given function. Repeated execution helps to give a maximum to
     the consumed time, until one iteration takes more than 5s, summed up 10s.

--- a/openage/testing/list_processor.py
+++ b/openage/testing/list_processor.py
@@ -1,15 +1,16 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """ Processes the raw test lists from the testlist module. """
 
 
 from collections import OrderedDict
 from importlib import import_module
+from typing import Callable
 
 from ..util.strings import lstrip_once
 
 
-def list_targets(test_lister, demo_lister, benchmark_lister):
+def list_targets(test_lister: Callable, demo_lister: Callable, benchmark_lister: Callable):
     """
     Yields tuples of (testname, type, description, condition_function)
     for given test and demo listers.
@@ -65,7 +66,7 @@ def list_targets_cpp():
         yield val
 
 
-def get_all_targets():
+def get_all_targets() -> OrderedDict:
     """
     Reads the Python and C++ testspec.
 

--- a/openage/testing/main.py
+++ b/openage/testing/main.py
@@ -1,9 +1,10 @@
-# Copyright 2014-2017 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """ CLI module for running all tests. """
 
 import argparse
 import sys
+import typing
 
 from ..util.strings import format_progress
 
@@ -11,8 +12,11 @@ from .benchmark import benchmark
 from .testing import TestError
 from .list_processor import get_all_targets
 
+if typing.TYPE_CHECKING:
+    from argparse import Namespace
 
-def print_test_list(test_list):
+
+def print_test_list(test_list: typing.OrderedDict) -> None:
     """
     Prints a list of all tests and demos in test_list.
     """
@@ -49,7 +53,7 @@ def init_subparser(cli):
     cli.add_argument("test", nargs='*', help="run this test")
 
 
-def process_args(args, error):
+def process_args(args: argparse.Namespace, error):
     """ Processes the given args, detecting errors. """
     if not (args.run_all_tests or args.demo or args.test or args.benchmark):
         args.list = True

--- a/openage/testing/testing.py
+++ b/openage/testing/testing.py
@@ -1,8 +1,9 @@
-# Copyright 2014-2019 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """ Testing utilities, such as TestError, assert_value, assert_raises. """
 
 from contextlib import contextmanager
+from typing import NoReturn
 
 
 class TestError(Exception):
@@ -35,7 +36,7 @@ def assert_value(value, expected=None, validator=None):
     raise TestError("unexpected result: " + repr(value))
 
 
-def result(value):
+def result(value) -> NoReturn:
     """
     Shall be called when a result is unexpectedly returned in an assert_raises
     block.

--- a/openage/util/bytequeue.py
+++ b/openage/util/bytequeue.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides ByteQueue, a high-performance queue for bytes objects.
@@ -6,6 +6,7 @@ Provides ByteQueue, a high-performance queue for bytes objects.
 
 from collections import deque
 from bisect import bisect
+from typing import Generator
 
 
 class ByteQueue:
@@ -41,7 +42,7 @@ class ByteQueue:
         """
         return self.size
 
-    def append(self, data):
+    def append(self, data: bytes) -> None:
         """
         Adds bytes to the buffer.
         """
@@ -51,7 +52,7 @@ class ByteQueue:
         self.bufs.append(data)
         self.size += len(data)
 
-    def popleft(self, size):
+    def popleft(self, size: int) -> bytes:
         """
         Returns the requested amount of bytes from the buffer.
         """
@@ -86,6 +87,7 @@ class ByteBuffer:
     Similar to ByteQueue, but instead of popleft, allows reading random slices,
     and trimleft, which discards data from the left.
     """
+
     def __init__(self):
         # holds all appended bytes objects
         # discarded bytes objects are replaced by None.
@@ -103,7 +105,7 @@ class ByteBuffer:
     def __len__(self):
         return self.index[-1]
 
-    def append(self, data):
+    def append(self, data: bytes) -> None:
         """
         appends new data to the right of the buffer
         """
@@ -113,7 +115,7 @@ class ByteBuffer:
         self.bufs.append(data)
         self.index.append(len(self) + len(data))
 
-    def discardleft(self, keep):
+    def discardleft(self, keep: int) -> None:
         """
         discards data at the beginning of the buffer.
         keeps at least the 'keep' most recent bytes.
@@ -131,7 +133,7 @@ class ByteBuffer:
         self.discardedbufs = discardto
         self.discardedbytes = discardamount
 
-    def hasbeendiscarded(self, position):
+    def hasbeendiscarded(self, position: int) -> bool:
         """
         returns True if the given position has already been discarded
         and is no longer valid.
@@ -175,7 +177,7 @@ class ByteBuffer:
         data has already been discarded.
         """
 
-    def get_buffers(self, start, end):
+    def get_buffers(self, start: int, end: int) -> Generator[bytes, None, None]:
         """
         yields any amount of bytes objects that constitute the data
         between start and end.

--- a/openage/util/decorators.py
+++ b/openage/util/decorators.py
@@ -1,11 +1,14 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Some utility function decorators
 """
 
 
-def run_once(func):
+from typing import Callable
+
+
+def run_once(func: Callable) -> Callable:
     """
     Decorator to run func only at its first invocation.
 

--- a/openage/util/filelike/abstract.py
+++ b/openage/util/filelike/abstract.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2019 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides the FileLikeObject abstract base class, which specifies a file-like
@@ -19,11 +19,12 @@ class FileLikeObject(ABC):
 
     Does not implement/force implementation of line-reading functionality.
     """
+
     def __init__(self):
         self.closed = False
 
     @abstractmethod
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """
         Read at most size bytes (less if EOF has been reached).
 
@@ -31,13 +32,13 @@ class FileLikeObject(ABC):
         """
 
     @abstractmethod
-    def readable(self):
+    def readable(self) -> bool:
         """
         Returns True if read() is allowed.
         """
 
     @abstractmethod
-    def write(self, data):
+    def write(self, data) -> None:
         """
         Writes all of data to the file.
 
@@ -47,13 +48,13 @@ class FileLikeObject(ABC):
         """
 
     @abstractmethod
-    def writable(self):
+    def writable(self) -> bool:
         """
         Returns True if write() is allowed.
         """
 
     @abstractmethod
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset: int, whence=os.SEEK_SET) -> None:
         """
         Seeks to a given position.
 
@@ -67,7 +68,7 @@ class FileLikeObject(ABC):
         """
 
     @abstractmethod
-    def seekable(self):
+    def seekable(self) -> bool:
         """
         Returns True if seek() is allowed.
         """
@@ -95,7 +96,7 @@ class FileLikeObject(ABC):
         """
 
     @abstractmethod
-    def get_size(self):
+    def get_size(self) -> int:
         """
         Returns the size of the object, if known.
         Returns -1 otherwise.
@@ -113,7 +114,7 @@ class FileLikeObject(ABC):
 
         self.close()
 
-    def seek_helper(self, offset, whence):
+    def seek_helper(self, offset: int, whence) -> int:
         """
         Helper function for use by implementations of seek().
 

--- a/openage/util/filelike/fifo.py
+++ b/openage/util/filelike/fifo.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides a FileLikeObject that acts like a FIFO.
@@ -6,6 +6,7 @@ Provides a FileLikeObject that acts like a FIFO.
 
 import os
 from io import UnsupportedOperation
+from typing import NoReturn
 
 from .abstract import FileLikeObject
 from ..bytequeue import ByteQueue
@@ -34,7 +35,7 @@ class FIFO(FileLikeObject):
         self.queue = ByteQueue()
         self.pos = 0
 
-    def tell(self):
+    def tell(self) -> int:
         """
         Warning: Returns the position for reading.
 
@@ -42,13 +43,13 @@ class FIFO(FileLikeObject):
         """
         return self.pos
 
-    def tellw(self):
+    def tellw(self) -> int:
         """
         Returns the position for writing.
         """
         return self.pos + len(self.queue)
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset, whence=os.SEEK_SET) -> NoReturn:
         """
         Unsupported because this is a FIFO.
         """
@@ -56,7 +57,7 @@ class FIFO(FileLikeObject):
 
         raise UnsupportedOperation("unseekable stream")
 
-    def seekable(self):
+    def seekable(self) -> bool:
         return False
 
     def __len__(self):
@@ -65,7 +66,7 @@ class FIFO(FileLikeObject):
         """
         return len(self.queue)
 
-    def seteof(self):
+    def seteof(self) -> None:
         """
         Declares that no more data will be added using write().
 
@@ -74,7 +75,7 @@ class FIFO(FileLikeObject):
         """
         self.eof = True
 
-    def write(self, data):
+    def write(self, data: bytes) -> None:
         """
         Works until seteof() has been called; accepts bytes objects.
         """
@@ -83,10 +84,10 @@ class FIFO(FileLikeObject):
 
         self.queue.append(data)
 
-    def writable(self):
+    def writable(self) -> bool:
         return True
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """
         If seteof() has not been called yet, requesting more data than
         len(self) raises a ValueError.
@@ -104,16 +105,16 @@ class FIFO(FileLikeObject):
 
         return self.queue.popleft(size)
 
-    def readable(self):
+    def readable(self) -> bool:
         return True
 
-    def get_size(self):
+    def get_size(self) -> int:
         return len(self.queue)
 
-    def flush(self):
+    def flush(self) -> None:
         # no-op
         pass
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         self.queue = None

--- a/openage/util/filelike/readonly.py
+++ b/openage/util/filelike/readonly.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides an abstract read-only FileLikeObject.
@@ -6,6 +6,7 @@ Provides an abstract read-only FileLikeObject.
 
 import os
 from io import UnsupportedOperation
+from typing import NoReturn
 
 from .abstract import FileLikeObject
 
@@ -21,18 +22,18 @@ class ReadOnlyFileLikeObject(FileLikeObject):
     # pylint doesn't understand that this class is supposed to be abstract.
     # pylint: disable=abstract-method
 
-    def flush(self):
+    def flush(self) -> None:
         # no flushing is needed for read-only objects.
         pass
 
-    def readable(self):
+    def readable(self) -> bool:
         return True
 
-    def write(self, data):
+    def write(self, data) -> NoReturn:
         del data  # unused
         raise UnsupportedOperation("read-only file")
 
-    def writable(self):
+    def writable(self) -> bool:
         return False
 
 
@@ -50,11 +51,11 @@ class PosSavingReadOnlyFileLikeObject(ReadOnlyFileLikeObject):
         super().__init__()
         self.pos = 0
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset: int, whence=os.SEEK_SET) -> None:
         self.pos = self.seek_helper(offset, whence)
 
-    def seekable(self):
+    def seekable(self) -> bool:
         return True
 
-    def tell(self):
+    def tell(self) -> int:
         return self.pos

--- a/openage/util/filelike/stream.py
+++ b/openage/util/filelike/stream.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2017 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides FileLikeObject for binary stream interaction.
@@ -33,7 +33,8 @@ class StreamSeekBuffer(PosSavingReadOnlyFileLikeObject):
         of bytes (performance optimization).
         By default, entire megabytes are read at once.
     """
-    def __init__(self, wrappee, keepbuffered=INF, minread=1048576):
+
+    def __init__(self, wrappee, keepbuffered: int = INF, minread: int = 1048576):
         super().__init__()
 
         self.wrapped = wrappee
@@ -43,14 +44,14 @@ class StreamSeekBuffer(PosSavingReadOnlyFileLikeObject):
         # invariant: len(self.buf) == self.wrapped.tell()
         self.buf = ByteBuffer()
 
-    def resetwrappeed(self):
+    def resetwrappeed(self) -> None:
         """
         resets the wrappeed object, and clears self.buf.
         """
         self.wrapped.reset()
         self.buf = ByteBuffer()
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         if size < 0:
             size = INF
 
@@ -125,7 +126,7 @@ class StreamFragment(PosSavingReadOnlyFileLikeObject):
         if size < 0:
             raise ValueError("size must be positive")
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> None:
         if size < 0:
             size = INF
 
@@ -144,9 +145,9 @@ class StreamFragment(PosSavingReadOnlyFileLikeObject):
         self.pos += len(data)
         return data
 
-    def get_size(self):
+    def get_size(self) -> int:
         return self.size
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         del self.stream

--- a/openage/util/files.py
+++ b/openage/util/files.py
@@ -1,12 +1,19 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 """
 Some file handling utilities
 """
 
+from __future__ import annotations
+
+import typing
 import os
+from typing import Union
+
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.abstract import FSLikeObject
 
 
-def read_guaranteed(fileobj, size):
+def read_guaranteed(fileobj: FSLikeObject, size: int) -> bytes:
     """
     As regular fileobj.read(size), but raises EOFError if fewer bytes
     than requested are returned.
@@ -25,7 +32,7 @@ def read_guaranteed(fileobj, size):
     return b"".join(result)
 
 
-def read_nullterminated_string(fileobj, maxlen=255):
+def read_nullterminated_string(fileobj: FSLikeObject, maxlen: int = 255) -> bytes:
     """
     Reads bytes until a null terminator is reached.
     """
@@ -45,13 +52,13 @@ def read_nullterminated_string(fileobj, maxlen=255):
     return bytes(result)
 
 
-def which(filename):
+def which(filename: str) -> Union[str, None]:
     """
     Like the which (1) tool to get the full path of a command
     by looking at the PATH environment variable.
     """
 
-    def is_executable(fpath):
+    def is_executable(fpath: str) -> bool:
         """
         Test if the given file exists and has an executable bit.
         """

--- a/openage/util/fslike/abstract.py
+++ b/openage/util/fslike/abstract.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides filesystem-like interfaces:
@@ -11,11 +11,16 @@ Provides filesystem-like interfaces:
 
 For interface implementations, see the fslike module.
 """
+from __future__ import annotations
+import typing
 
 from abc import ABC, abstractmethod
 from io import UnsupportedOperation
 
 from .path import Path
+
+if typing.TYPE_CHECKING:
+    from io import BufferedReader
 
 
 class FSLikeObject(ABC):
@@ -45,34 +50,34 @@ class FSLikeObject(ABC):
         """
         return Path(self, [])
 
-    def pretty(self, parts):
+    def pretty(self, parts) -> str:
         """
         pretty-format a path in this filesystem like object.
         """
         return f"[{str(self)}]:{b'/'.join(parts).decode(errors='replace')}"
 
     @abstractmethod
-    def open_r(self, parts):
+    def open_r(self, parts) -> BufferedReader:
         """ Shall return a BufferedReader for the given file ("mode 'rb'"). """
 
     @abstractmethod
-    def open_w(self, parts):
+    def open_w(self, parts) -> BufferedReader:
         """ Shall return a BufferedWriter for the given file ("mode 'wb'"). """
 
-    def open_rw(self, parts):
+    def open_rw(self, parts) -> BufferedReader:
         """ Shall return a BufferedWriter for the given file ("mode 'r+'"). """
 
-    def open_a(self, parts):
+    def open_a(self, parts) -> BufferedReader:
         """ Shall return a BufferedWriter for the given file ("mode 'a'"). """
 
-    def open_ar(self, parts):
+    def open_ar(self, parts) -> BufferedReader:
         """ Shall return a BufferedWriter for the given file ("mode 'a+'"). """
 
     def exists(self, parts):
         """ Test if the parts are a file or a directory """
         return self.is_file(parts) or self.is_dir(parts)
 
-    def resolve_r(self, parts):
+    def resolve_r(self, parts) -> typing.Union[Path, None]:
         """
         Returns a new, flattened, Path if the target exists.
         The fslike parts in between may be skipped,
@@ -82,7 +87,7 @@ class FSLikeObject(ABC):
         """
         return Path(self, parts) if self.exists(parts) else None
 
-    def resolve_w(self, parts):
+    def resolve_w(self, parts) -> typing.Union[Path, None]:
         """
         Returns a new flattened path. This skips funny mounts in between.
 
@@ -90,7 +95,7 @@ class FSLikeObject(ABC):
         """
         return Path(self, parts) if self.writable(parts) else None
 
-    def get_native_path(self, parts):  # pylint: disable=no-self-use,unused-argument,useless-return
+    def get_native_path(self, parts) -> typing.ByteString:  # pylint: disable=no-self-use,unused-argument,useless-return
         """
         Return the path bytestring that represents a location usable
         by your kernel.
@@ -100,66 +105,66 @@ class FSLikeObject(ABC):
         return None
 
     @abstractmethod
-    def list(self, parts):
+    def list(self, parts) -> typing.Generator[str | bytes, None, None]:
         """ Shall yield the entry names of the given directory. """
 
     @abstractmethod
-    def filesize(self, parts):
+    def filesize(self, parts) -> int:
         """
         Shall determine the file size (bytes),
         and return None if unknown.
         """
 
     @abstractmethod
-    def mtime(self, parts):
+    def mtime(self, parts) -> typing.Union[float, None]:
         """
         Shall determine the last modification time (UNIX timestamp),
         and return None if unknown.
         """
 
     @abstractmethod
-    def mkdirs(self, parts):
+    def mkdirs(self, parts) -> None:
         """ Shall ensure that the directory exists. """
 
     @abstractmethod
-    def rmdir(self, parts):
+    def rmdir(self, parts) -> None:
         """ Shall remove an empty directory. """
 
     @abstractmethod
-    def unlink(self, parts):
+    def unlink(self, parts) -> None:
         """ Shall remove a single file. """
 
     @abstractmethod
-    def touch(self, parts):
+    def touch(self, parts) -> None:
         """ Shall create the file or update its timestamp. """
 
     @abstractmethod
-    def rename(self, srcparts, tgtparts):
+    def rename(self, srcparts, tgtparts) -> None:
         """ Shall rename a file or directory to the target name. """
 
     @abstractmethod
-    def is_file(self, parts):
+    def is_file(self, parts) -> bool:
         """
         Shall return true if the path is a file (or symlink to one).
         Shall not raise.
         """
 
     @abstractmethod
-    def is_dir(self, parts):
+    def is_dir(self, parts) -> bool:
         """
         Shall return true if the path is a directory (or symlink to one).
         Shall not raise.
         """
 
     @abstractmethod
-    def writable(self, parts):
+    def writable(self, parts) -> bool:
         """
         Shall return an educated guess whether the path can be written to.
         Shall not raise.
         """
 
     @abstractmethod
-    def watch(self, parts, callback):
+    def watch(self, parts, callback) -> bool:
         """
         Shall install callback as a watcher for the given path, if supported.
         Shall return True if a watcher was installed, False if no operation was
@@ -184,30 +189,30 @@ class ReadOnlyFSLikeObject(FSLikeObject):
     # pylint doesn't understand that this class is supposed to be abstract.
     # pylint: disable=abstract-method
 
-    def read_only_error(self, parts):
+    def read_only_error(self, parts) -> typing.NoReturn:
         """ Helper method to be called from all other methods. """
         del parts  # unused
         raise UnsupportedOperation("read-only: " + str(self))
 
-    def open_w(self, parts):
+    def open_w(self, parts) -> typing.NoReturn:
         self.read_only_error(parts)
 
-    def mkdirs(self, parts):
+    def mkdirs(self, parts) -> typing.NoReturn:
         self.read_only_error(parts)
 
-    def rmdir(self, parts):
+    def rmdir(self, parts) -> typing.NoReturn:
         self.read_only_error(parts)
 
-    def unlink(self, parts):
+    def unlink(self, parts) -> typing.NoReturn:
         self.read_only_error(parts)
 
-    def touch(self, parts):
+    def touch(self, parts) -> typing.NoReturn:
         self.read_only_error(parts)
 
-    def rename(self, srcparts, tgtparts):
+    def rename(self, srcparts, tgtparts) -> typing.NoReturn:
         del tgtparts  # unused
         self.read_only_error(srcparts)
 
-    def writable(self, parts):
+    def writable(self, parts) -> bool:
         del parts  # unused
         return False

--- a/openage/util/fslike/filecollection.py
+++ b/openage/util/fslike/filecollection.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides Filecollection, a utility class for combining multiple file-like
@@ -7,6 +7,7 @@ objects to a FSLikeObject.
 
 from collections import OrderedDict
 from io import UnsupportedOperation
+from typing import NoReturn
 
 from .abstract import FSLikeObject
 from .path import Path
@@ -30,7 +31,7 @@ class FileCollection(FSLikeObject):
     def root(self):
         return FileCollectionPath(self, [])
 
-    def get_direntries(self, parts=None, create=False):
+    def get_direntries(self, parts=None, create: bool = False) -> tuple[OrderedDict, OrderedDict]:
         """
         Fetches the fileentries, subdirentries tuple for the given dir.
 
@@ -100,7 +101,7 @@ class FileCollection(FSLikeObject):
 
         return entries[0][name]
 
-    def open_r(self, parts):
+    def open_r(self, parts) -> None:
         open_r, _, _, _ = self.get_fileentry(parts)
 
         if open_r is None:
@@ -110,7 +111,7 @@ class FileCollection(FSLikeObject):
 
         return open_r()
 
-    def open_w(self, parts):
+    def open_w(self, parts) -> None:
         _, open_w, _, _ = self.get_fileentry(parts)
 
         if open_w is None:
@@ -124,7 +125,7 @@ class FileCollection(FSLikeObject):
         yield from subdirs
         yield from fileentries
 
-    def filesize(self, parts):
+    def filesize(self, parts) -> int:
         _, _, filesize, _ = self.get_fileentry(parts)
 
         if filesize is None:
@@ -132,7 +133,7 @@ class FileCollection(FSLikeObject):
 
         return filesize()
 
-    def mtime(self, parts):
+    def mtime(self, parts) -> float:
         _, _, _, mtime = self.get_fileentry(parts)
 
         if mtime is None:
@@ -140,10 +141,10 @@ class FileCollection(FSLikeObject):
 
         return mtime()
 
-    def mkdirs(self, parts):
+    def mkdirs(self, parts) -> None:
         self.get_direntries(parts, create=True)
 
-    def rmdir(self, parts):
+    def rmdir(self, parts) -> None:
         if not parts:
             raise UnsupportedOperation("can't rmdir FileCollection.root")
 
@@ -164,7 +165,7 @@ class FileCollection(FSLikeObject):
 
         del parent_dirs[name]
 
-    def unlink(self, parts):
+    def unlink(self, parts) -> None:
         if not parts:
             raise IsADirectoryError("FileCollection.root")
 
@@ -179,27 +180,27 @@ class FileCollection(FSLikeObject):
         except KeyError:
             raise FileNotFoundError(b'/'.join(parts)) from None
 
-    def touch(self, parts):
+    def touch(self, parts) -> NoReturn:
         raise UnsupportedOperation("FileCollection.touch")
 
-    def rename(self, srcparts, tgtparts):
+    def rename(self, srcparts, tgtparts) -> NoReturn:
         raise UnsupportedOperation("FileCollection.rename")
 
-    def is_file(self, parts):
+    def is_file(self, parts) -> bool:
         try:
             self.get_fileentry(parts)
             return True
         except IOError:
             return False
 
-    def is_dir(self, parts):
+    def is_dir(self, parts) -> bool:
         try:
             self.get_direntries(parts)
             return True
         except IOError:
             return False
 
-    def writable(self, parts):
+    def writable(self, parts) -> bool:
         try:
             _, open_w, _, _ = self.get_fileentry(parts)
             return open_w is not None
@@ -208,11 +209,11 @@ class FileCollection(FSLikeObject):
             # though some of the existing files inside might be.
             return False
 
-    def watch(self, parts, callback):
+    def watch(self, parts, callback) -> bool:
         del self, parts, callback  # unused
         return False
 
-    def poll_watches(self):
+    def poll_watches(self) -> None:
         pass
 
 
@@ -221,7 +222,13 @@ class FileCollectionPath(Path):
     Provides an additional method for adding a file at this path.
     """
 
-    def add_file(self, open_r=None, open_w=None, filesize=None, mtime=None):
+    def add_file(
+        self,
+        open_r=None,
+        open_w=None,
+        filesize: int = None,
+        mtime: float = None
+    ) -> bool:
         """
         All parent directories are 'created', if needed.
 
@@ -231,7 +238,7 @@ class FileCollectionPath(Path):
         return self.fsobj.add_fileentry(
             self.parts, (open_r, open_w, filesize, mtime))
 
-    def add_file_from_path(self, path):
+    def add_file_from_path(self, path: Path) -> None:
         """
         Like add_file, but uses a Path object instead of callables.
         """

--- a/openage/util/fslike/path.py
+++ b/openage/util/fslike/path.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides Path, which is analogous to pathlib.Path,
@@ -6,6 +6,7 @@ and the type of FSLikeObject.root.
 """
 
 from io import UnsupportedOperation, TextIOWrapper
+from typing import NoReturn
 
 
 class Path:
@@ -74,19 +75,19 @@ class Path:
 
         return f"Path({repr(self.fsobj)}, {repr(self.parts)})"
 
-    def exists(self):
+    def exists(self) -> bool:
         """ True if path exists """
         return self.fsobj.exists(self.parts)
 
-    def is_dir(self):
+    def is_dir(self) -> bool:
         """ True if path points to dir (or symlink to one) """
         return self.fsobj.is_dir(self.parts)
 
-    def is_file(self):
+    def is_file(self) -> bool:
         """ True if path points to file (or symlink to one) """
         return self.fsobj.is_file(self.parts)
 
-    def writable(self):
+    def writable(self) -> bool:
         """ True if path is probably writable """
         return self.fsobj.writable(self.parts)
 
@@ -99,7 +100,7 @@ class Path:
         for name in self.fsobj.list(self.parts):
             yield type(self)(self.fsobj, self.parts + (name,))
 
-    def mkdirs(self):
+    def mkdirs(self) -> None:
         """ Creates this path (including parents). No-op if path exists. """
         return self.fsobj.mkdirs(self.parts)
 
@@ -321,7 +322,7 @@ class Path:
 
         return self.parent.joinpath(self.stem + suffix)
 
-    def mount(self, pathobj, priority=0):
+    def mount(self, pathobj, priority=0) -> NoReturn:
         """This is only valid for UnionPath, don't call here"""
         # pylint: disable=no-self-use,unused-argument
         # TODO: https://github.com/PyCQA/pylint/issues/2329

--- a/openage/util/fslike/union.py
+++ b/openage/util/fslike/union.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides Union, a utility class for combining multiple FSLikeObjects to a
@@ -45,7 +45,7 @@ class Union(FSLikeObject):
     def root(self):
         return UnionPath(self, [])
 
-    def add_mount(self, pathobj, mountpoint, priority):
+    def add_mount(self, pathobj: Path, mountpoint, priority: int) -> None:
         """
         This method should not be called directly; instead, use the mount
         method of Path objects that were obtained from this.
@@ -68,7 +68,7 @@ class Union(FSLikeObject):
         for subdir in mountpoint:
             dirstructure = dirstructure.setdefault(subdir, {})
 
-    def remove_mount(self, search_mountpoint, source_pathobj=None):
+    def remove_mount(self, search_mountpoint, source_pathobj: Path = None) -> None:
         """
         Remove a mount from the union by searching for the source
         that provides the given mountpoint.
@@ -168,27 +168,27 @@ class Union(FSLikeObject):
         if not dir_exists:
             raise FileNotFoundError(b'/'.join(parts))
 
-    def filesize(self, parts):
+    def filesize(self, parts) -> int:
         for path in self.candidate_paths(parts):
             if path.is_file():
                 return path.filesize
 
         raise FileNotFoundError(b'/'.join(parts))
 
-    def mtime(self, parts):
+    def mtime(self, parts) -> float:
         for path in self.candidate_paths(parts):
             if path.exists():
                 return path.mtime
 
         raise FileNotFoundError(b'/'.join(parts))
 
-    def mkdirs(self, parts):
+    def mkdirs(self, parts) -> None:
         for path in self.candidate_paths(parts):
             if path.writable():
                 return path.mkdirs()
         return None
 
-    def rmdir(self, parts):
+    def rmdir(self, parts) -> None:
         found = False
 
         # remove the directory in all mounts where it exists
@@ -200,7 +200,7 @@ class Union(FSLikeObject):
         if not found:
             raise FileNotFoundError(b'/'.join(parts))
 
-    def unlink(self, parts):
+    def unlink(self, parts) -> None:
         found = False
 
         # remove the file in all mounts where it exists
@@ -212,14 +212,14 @@ class Union(FSLikeObject):
         if not found:
             raise FileNotFoundError(b'/'.join(parts))
 
-    def touch(self, parts):
+    def touch(self, parts) -> None:
         for path in self.candidate_paths(parts):
             if path.writable():
                 return path.touch()
 
         raise FileNotFoundError(b'/'.join(parts))
 
-    def rename(self, srcparts, tgtparts):
+    def rename(self, srcparts, tgtparts) -> None:
         found = False
 
         for srcpath in self.candidate_paths(srcparts):
@@ -237,14 +237,14 @@ class Union(FSLikeObject):
                 b'/'.join(tgtparts).decode(errors='replace'))
         raise FileNotFoundError(b'/'.join(srcparts))
 
-    def is_file(self, parts):
+    def is_file(self, parts) -> bool:
         for path in self.candidate_paths(parts):
             if path.is_file():
                 return True
 
         return False
 
-    def is_dir(self, parts):
+    def is_dir(self, parts) -> bool:
         try:
             dirstructure = self.dirstructure
             for part in parts:
@@ -259,14 +259,14 @@ class Union(FSLikeObject):
 
         return False
 
-    def writable(self, parts):
+    def writable(self, parts) -> bool:
         for path in self.candidate_paths(parts):
             if path.writable():
                 return True
 
         return False
 
-    def watch(self, parts, callback):
+    def watch(self, parts, callback) -> bool:
         watching = False
         for path in self.candidate_paths(parts):
             if path.exists():
@@ -283,13 +283,14 @@ class UnionPath(Path):
     """
     Provides an additional method for mounting an other path at this path.
     """
-    def mount(self, pathobj, priority=0):
+
+    def mount(self, pathobj: Path, priority: int = 0) -> None:
         """
         Mounts pathobj here. All parent directories are 'created', if needed.
         """
         return self.fsobj.add_mount(pathobj, self.parts, priority)
 
-    def unmount(self, pathobj=None):
+    def unmount(self, pathobj: Path = None) -> None:
         """
         Unmount a path from the union described by this path.
         This is like "unmounting /home", no matter what the source was.

--- a/openage/util/fslike/wrapper.py
+++ b/openage/util/fslike/wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides
@@ -29,7 +29,7 @@ class Wrapper(FSLikeObject):
     Pass a context guard to protect calls.
     """
 
-    def __init__(self, obj, contextguard=None):
+    def __init__(self, obj: Path, contextguard = None):
         if not isinstance(obj, Path):
             raise TypeError(f"Path expected as obj, got '{type(obj)}'")
 
@@ -76,48 +76,48 @@ class Wrapper(FSLikeObject):
         with self.contextguard:
             return list(self.obj.joinpath(parts).list())
 
-    def filesize(self, parts):
+    def filesize(self, parts) -> int:
         with self.contextguard:
             return self.obj.joinpath(parts).filesize
 
-    def mtime(self, parts):
+    def mtime(self, parts) -> float:
         with self.contextguard:
             return self.obj.joinpath(parts).mtime
 
-    def mkdirs(self, parts):
+    def mkdirs(self, parts) -> None:
         with self.contextguard:
             return self.obj.joinpath(parts).mkdirs()
 
-    def rmdir(self, parts):
+    def rmdir(self, parts) -> None:
         with self.contextguard:
             return self.obj.joinpath(parts).rmdir()
 
-    def unlink(self, parts):
+    def unlink(self, parts) -> None:
         with self.contextguard:
             return self.obj.joinpath(parts).unlink()
 
-    def touch(self, parts):
+    def touch(self, parts) -> None:
         with self.contextguard:
             return self.obj.joinpath(parts).touch()
 
-    def rename(self, srcparts, tgtparts):
+    def rename(self, srcparts, tgtparts) -> None:
         with self.contextguard:
             return self.obj.joinpath(srcparts).rename(
                 self.obj.joinpath(tgtparts))
 
-    def is_file(self, parts):
+    def is_file(self, parts) -> bool:
         with self.contextguard:
             return self.obj.joinpath(parts).is_file()
 
-    def is_dir(self, parts):
+    def is_dir(self, parts) -> bool:
         with self.contextguard:
             return self.obj.joinpath(parts).is_dir()
 
-    def writable(self, parts):
+    def writable(self, parts) -> bool:
         with self.contextguard:
             return self.obj.joinpath(parts).writable()
 
-    def watch(self, parts, callback):
+    def watch(self, parts, callback) -> bool:
         with self.contextguard:
             return self.obj.joinpath(parts).watch(callback)
 
@@ -158,32 +158,32 @@ class GuardedFile(FileLikeObject):
     context guard.
     """
 
-    def __init__(self, obj, guard):
+    def __init__(self, obj: FileLikeObject, guard):
         super().__init__()
         self.obj = obj
         self.guard = guard
 
-    def read(self, size=-1):
+    def read(self, size: int = -1):
         with self.guard:
             return self.obj.read(size)
 
-    def readable(self):
+    def readable(self) -> bool:
         with self.guard:
             return self.obj.readable()
 
-    def write(self, data):
+    def write(self, data) -> None:
         with self.guard:
             return self.obj.write(data)
 
-    def writable(self):
+    def writable(self) -> bool:
         with self.guard:
             return self.obj.writable()
 
-    def seek(self, offset, whence=os.SEEK_SET):
+    def seek(self, offset: int, whence=os.SEEK_SET) -> None:
         with self.guard:
             return self.obj.seek(offset, whence)
 
-    def seekable(self):
+    def seekable(self) -> bool:
         with self.guard:
             return self.obj.seekable()
 
@@ -199,7 +199,7 @@ class GuardedFile(FileLikeObject):
         with self.guard:
             return self.obj.flush()
 
-    def get_size(self):
+    def get_size(self) -> int:
         with self.guard:
             return self.obj.get_size()
 

--- a/openage/util/fsprinting.py
+++ b/openage/util/fsprinting.py
@@ -1,9 +1,12 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Methods for printing paths and other file system-related info.
 """
 
+from __future__ import annotations
+
+import typing
 from collections import OrderedDict
 
 from .strings import colorize
@@ -11,8 +14,11 @@ from .math import INF
 
 RULE_CACHE = OrderedDict()
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.abstract import FSLikeObject
 
-def get_color_rules():
+
+def get_color_rules() -> OrderedDict[str, str]:
     """
     Returns a dict of pattern : colorcode, retrieved from LS_COLORS.
     """
@@ -43,7 +49,7 @@ def get_color_rules():
     return RULE_CACHE
 
 
-def colorize_filename(filename):
+def colorize_filename(filename: str) -> str:
     """
     Colorizes the filename, using the globbing rules from LS_COLORS.
     """
@@ -58,14 +64,19 @@ def colorize_filename(filename):
     return colorize(filename, rules.get('fi'))
 
 
-def colorize_dirname(dirname):
+def colorize_dirname(dirname: str) -> str:
     """
     Colorizes the dirname, using the 'di' rule from LS_COLORS.
     """
     return colorize(dirname, get_color_rules().get('di'))
 
 
-def print_tree(obj, path="", prefix="", max_entries=INF):
+def print_tree(
+    obj: FSLikeObject,
+    path: str = "",
+    prefix: str = "",
+    max_entries: str = INF
+) -> None:
     """
     Obj is a filesystem-like object; path must be a string.
 

--- a/openage/util/hash.py
+++ b/openage/util/hash.py
@@ -1,12 +1,22 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Functions for hashing files.
 """
+from __future__ import annotations
+
+import typing
 import hashlib
 
+if typing.TYPE_CHECKING:
+    from openage.util.fslike.path import Path
 
-def hash_file(path, hash_algo="sha3_256", bufsize=32768):
+
+def hash_file(
+    path: Path,
+    hash_algo: str = "sha3_256",
+    bufsize: int = 32768
+) -> str:
     """
     Get the hash value of a given file.
 

--- a/openage/util/iterators.py
+++ b/openage/util/iterators.py
@@ -1,11 +1,14 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides all sorts of iterator-related stuff.
 """
 
 
-def denote_last(iterable):
+from typing import Iterable
+
+
+def denote_last(iterable: Iterable):
     """
     Similar to enumerate, this iterates over an iterable, and yields
     tuples of item, is_last.

--- a/openage/util/math.py
+++ b/openage/util/math.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Holds some math constants and helpers
@@ -14,7 +14,7 @@ TAU = 2 * math.pi
 DEGSPERRAD = TAU / 360
 
 
-def clamp(val, minval, maxval):
+def clamp(val: int, minval: int, maxval: int) -> int:
     """
     clamps val to be at least minval, and at most maxval.
 

--- a/openage/util/observer.py
+++ b/openage/util/observer.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-few-public-methods
 
@@ -15,6 +15,7 @@ ignored the garbage collection. Weakrefs with dead references
 are removed during notification of the observers.
 """
 
+from typing import Any, Optional
 import weakref
 
 
@@ -23,7 +24,7 @@ class Observer:
     Implements a Java 8-like Observer interface.
     """
 
-    def update(self, observable, message=None):
+    def update(self, observable, message: Optional[Any] = None):
         """
         Called by an Observable object that has registered this observer
         whenever it changes.
@@ -45,7 +46,7 @@ class Observable:
         self.observers = set()
         self.changed = False
 
-    def add_observer(self, observer):
+    def add_observer(self, observer: Observer) -> None:
         """
         Adds an observer to this object's set of observers.
 
@@ -58,13 +59,13 @@ class Observable:
 
         self.observers.add(weakref.ref(observer))
 
-    def clear_changed(self):
+    def clear_changed(self) -> None:
         """
         Indicate that this object has no longer changed.
         """
         self.changed = True
 
-    def delete_observer(self, observer):
+    def delete_observer(self, observer: Observer) -> None:
         """
         Remove an observer from the set.
 
@@ -73,25 +74,25 @@ class Observable:
         """
         self.observers.remove(observer)
 
-    def delete_observers(self):
+    def delete_observers(self) -> None:
         """
         Remove all currently registered observers.
         """
         self.observers.clear()
 
-    def get_observer_count(self):
+    def get_observer_count(self) -> int:
         """
         Return the number of registered observers.
         """
         return len(self.observers)
 
-    def has_changed(self):
+    def has_changed(self) -> bool:
         """
         Return whether the object has changed.
         """
         return self.changed
 
-    def notify_observers(self, message=None):
+    def notify_observers(self, message: Optional[Any] = None) -> None:
         """
         Notify the observers if the object has changed. Include
         an optional message.
@@ -106,7 +107,7 @@ class Observable:
                 else:
                     self.delete_observer(observer)
 
-    def set_changed(self):
+    def set_changed(self) -> None:
         """
         Indicate that the object has changed.
         """

--- a/openage/util/ordered_set.py
+++ b/openage/util/ordered_set.py
@@ -1,10 +1,13 @@
-# Copyright 2019-2020 the openage authors. See copying.md for legal info.
+# Copyright 2019-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides a very simple implementation of an ordered set. We use the
 Python dictionaries as a basis because they are guaranteed to
 be ordered since Python 3.6.
 """
+
+
+from typing import Hashable
 
 
 class OrderedSet:
@@ -14,19 +17,19 @@ class OrderedSet:
 
     __slots__ = ('ordered_set',)
 
-    def __init__(self, elements=None):
+    def __init__(self, elements: Hashable = None):
         self.ordered_set = {}
 
         if elements:
             self.update(elements)
 
-    def add(self, elem):
+    def add(self, elem: Hashable) -> None:
         """
         Set-like add that calls append_right().
         """
         self.append_right(elem)
 
-    def append_left(self, elem):
+    def append_left(self, elem: Hashable) -> None:
         """
         Add an element to the front of the set.
         """
@@ -40,14 +43,14 @@ class OrderedSet:
             temp_set.update(self.ordered_set)
             self.ordered_set = temp_set
 
-    def append_right(self, elem):
+    def append_right(self, elem: Hashable) -> None:
         """
         Add an element to the back of the set.
         """
         if elem not in self.ordered_set:
             self.ordered_set[elem] = len(self)
 
-    def discard(self, elem):
+    def discard(self, elem: Hashable) -> None:
         """
         Remove an element from the set.
         """
@@ -59,13 +62,13 @@ class OrderedSet:
                 if value > index:
                     self.ordered_set[key] -= 1
 
-    def get_list(self):
+    def get_list(self) -> list:
         """
         Returns a normal list containing the values from the ordered set.
         """
         return list(self.ordered_set.keys())
 
-    def index(self, elem):
+    def index(self, elem: Hashable) -> int:
         """
         Returns the index of the element in the set or
         -1 if it is not in the set.
@@ -94,7 +97,7 @@ class OrderedSet:
         element_list = self.get_list() + other.get_list()
         return OrderedSet(element_list)
 
-    def update(self, other):
+    def update(self, other) -> None:
         """
         Append the elements of another iterable to the right of the
         ordered set.

--- a/openage/util/profiler.py
+++ b/openage/util/profiler.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 Profiling utilities
@@ -23,8 +23,8 @@ class Profiler:
     p.enable() and p.disable().
     """
 
-    profile = None
-    profile_stats = None
+    profile: cProfile.Profile = None
+    profile_stats: pstats.Stats = None
     profile_stream = None
 
     def __init__(self, oStream=None):
@@ -44,7 +44,7 @@ class Profiler:
         """
         self.disable()
 
-    def write_report(self, sortby='calls'):
+    def write_report(self, sortby: str = 'calls') -> None:
         """
         Write the profile stats to profile_stream's file.
         """
@@ -52,7 +52,7 @@ class Profiler:
         self.profile_stats.sort_stats(sortby)
         self.profile_stats.print_stats()
 
-    def report(self, sortby='calls'):
+    def report(self, sortby: str = 'calls'):
         """
         Return the profile_stats to the console.
         """
@@ -105,7 +105,12 @@ class Tracemalloc:
         """
         self.disable()
 
-    def report(self, sortby='lineno', cumulative=True, limit=100):
+    def report(
+        self,
+        sortby: str = 'lineno',
+        cumulative: bool = True,
+        limit: int = 100
+    ) -> None:
         """
         Return the snapshot statistics to the console.
         """
@@ -113,13 +118,13 @@ class Tracemalloc:
             print(stat)
 
     @staticmethod
-    def enable():
+    def enable() -> None:
         """
         Begins profiling calls.
         """
         tracemalloc.start()
 
-    def disable(self):
+    def disable(self) -> None:
         """
         Stop profiling calls.
         """

--- a/openage/util/strings.py
+++ b/openage/util/strings.py
@@ -1,11 +1,11 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 """
 Misc string helper functions; this includes encoding, decoding,
 manipulation, ...
 """
 
 
-def decode_until_null(data, encoding='utf-8'):
+def decode_until_null(data: bytes, encoding: str = 'utf-8') -> str:
     """
     decodes a bytes object, aborting at the first \\0 character.
 
@@ -19,7 +19,7 @@ def decode_until_null(data, encoding='utf-8'):
     return data.decode(encoding)
 
 
-def try_decode(data):
+def try_decode(data: bytes) -> str:
     """
     does its best to attempt decoding the given string of unknown encoding.
     """
@@ -31,7 +31,7 @@ def try_decode(data):
     return data.decode('iso-8859-1')
 
 
-def binstr(num, bits=None, group=8):
+def binstr(num: int, bits: int = None, group: int = 8) -> str:
     """
     Similar to the built-in bin(), but optionally takes
     the number of bits as an argument, and prints underscores instead of
@@ -54,7 +54,7 @@ def binstr(num, bits=None, group=8):
     return result
 
 
-def colorize(string, colorcode):
+def colorize(string: str, colorcode: str) -> str:
     """
     Colorizes string with the given EMCA-48 SGR code.
 
@@ -70,7 +70,7 @@ def colorize(string, colorcode):
     return colorized
 
 
-def lstrip_once(string, substr):
+def lstrip_once(string: str, substr: str) -> str:
     """
     Removes substr at the start of string, and raises ValueError on failure.
 
@@ -86,7 +86,7 @@ def lstrip_once(string, substr):
     return string[len(substr):]
 
 
-def rstrip_once(string, substr):
+def rstrip_once(string: str, substr: str) -> str:
     """
     Removes substr at the end of string, and raises ValueError on failure.
 
@@ -100,7 +100,7 @@ def rstrip_once(string, substr):
     return string[:-len(substr)]
 
 
-def format_progress(progress, total):
+def format_progress(progress: int, total: int) -> str:
     """
     Formats an "x out of y" string with fixed width.
 

--- a/openage/util/system.py
+++ b/openage/util/system.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Various OS utilities
@@ -10,7 +10,7 @@ from sys import platform
 from .math import INF
 
 
-def free_memory():
+def free_memory() -> int:
     """
     Returns the amount of free bytes of memory.
     On failure, returns +inf.

--- a/openage/util/threading.py
+++ b/openage/util/threading.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Threading utilities.
@@ -57,6 +57,7 @@ class ClosableQueue(Queue):
     Behaves like Queue until close() has been called.
     After that, any call to put() raises RuntimeError.
     """
+
     def __init__(self):
         super().__init__()
         self.closed = False
@@ -95,7 +96,7 @@ class GeneratorEvent(Enum):
     STOP_ITERATION = 2
 
 
-def generator_to_queue(generator, queue):
+def generator_to_queue(generator, queue: ClosableQueue) -> None:
     """
     For use by concurrent_chain.
     Appends all of the generator's events to the queue,
@@ -111,7 +112,7 @@ def generator_to_queue(generator, queue):
         queue.put((GeneratorEvent.EXCEPTION, exc))
 
 
-def test_concurrent_chain():
+def test_concurrent_chain() -> None:
     """ Tests concurrent_chain """
     from ..testing.testing import assert_value, assert_raises, result
 


### PR DESCRIPTION
Resolves https://github.com/SFTtech/openage/issues/1431

This adds type hints for all Python modules (excluding Cython). It also introduces some smaller changes to the game version detection (by using an immutable dataclass instance instead of a tuple for the game version object).

The version of type hints used here requires bumping the required Python version to Python 3.9.