### PR TITLE
Added 'shell.nix'. Was able to compile openage without error (in arch)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,39 @@
+{ pkgs? import <nixpkgs> {} }:
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.gcc
+    pkgs.clang
+    #pkgs.glibc
+    #pkgs.libcxx
+    #pkgs.lld
+    #pkgs.gdb
+    pkgs.cmake
+    pkgs.gnumake
+    pkgs.qt5.full
+    #pkgs.qtcreator
+
+    pkgs.eigen
+    pkgs.python39
+    pkgs.python39Packages.jinja2
+    pkgs.python39Packages.pillow
+    pkgs.python39Packages.numpy
+    pkgs.python39Packages.lz4
+    pkgs.python39Packages.pygments
+    pkgs.python39Packages.cython
+    pkgs.libepoxy
+    pkgs.libogg
+    pkgs.libpng
+    pkgs.dejavu_fonts
+    pkgs.ftgl
+    pkgs.fontconfig
+    pkgs.harfbuzz
+    pkgs.SDL2
+    pkgs.SDL2_image
+    pkgs.opusfile
+    pkgs.libopus
+    pkgs.python39Packages.pylint
+    pkgs.python39Packages.toml
+    pkgs.libsForQt5.qt5.qtdeclarative
+    pkgs.libsForQt5.qt5.qtquickcontrols
+  ];
+}


### PR DESCRIPTION
I've recently found Nix and it helps a lot in dependency installation and maintenance. I'm an absolute noob but I figured this might help someone else in installing openage. With nix and this file, it's as easy as running `nix-shell`!

I am a noob so please do tell me everything I do wrong. I'm not sure if this is the correct way of making a pull request, for example. Thanks opeange team, keep going, this project is awesome!