### PR TITLE
Update GitHub actions to v3

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # caching dependencies and ccache
       # https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows

--- a/.github/workflows/ubuntu-21.04.yml
+++ b/.github/workflows/ubuntu-21.04.yml
@@ -6,7 +6,7 @@ jobs:
   build-devenv:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: sudo DOCKER_BUILDKIT=1 docker build ./docker/devenv --file ./docker/devenv/Dockerfile.ubuntu.2104 --tag openage-devenv:latest
       shell: bash

--- a/.github/workflows/windows-server-2019.yml
+++ b/.github/workflows/windows-server-2019.yml
@@ -6,7 +6,7 @@ jobs:
   build-x64:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         path: source

--- a/.github/workflows/windows-server-2022.yml
+++ b/.github/workflows/windows-server-2022.yml
@@ -6,7 +6,7 @@ jobs:
   build-x64:
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         path: source


### PR DESCRIPTION
Uses the newer checkouts version `actions/checkout@v3`