### PR TITLE
Dynasties of India + Speedup

### DIFF
--- a/buildsystem/codecompliance/__main__.py
+++ b/buildsystem/codecompliance/__main__.py
@@ -166,7 +166,7 @@ def main(args):
     issues_count = 0
     for title, text, apply_fix in find_all_issues(args, check_files):
         issues_count += 1
-        print("\x1b[33;1mWARNING\x1b[m {}: {}".format(title, text))
+        print(f"\x1b[33;1mWARNING\x1b[m {title}: {text}")
 
         if apply_fix:
             fixes_possible = True
@@ -181,8 +181,7 @@ def main(args):
         print()
 
     if args.fix and auto_fixes:
-        print("\x1b[33;1mApplying %d "
-              "automatic fixes...\x1b[m" % len(auto_fixes))
+        print(f"\x1b[33;1mApplying {len(auto_fixes):d} automatic fixes...\x1b[m")
 
         for auto_fix in auto_fixes:
             print(auto_fix())
@@ -198,10 +197,7 @@ def main(args):
         else:
             remainfound = ("were" if issues_count > 1 else "was") + " found"
 
-        print("==> \x1b[33;1m{num} issue{plural}\x1b[m {remainfound}."
-              "".format(num=issues_count,
-                        plural=plural,
-                        remainfound=remainfound))
+        print(f"==> \x1b[33;1m{issues_count} issue{plural}\x1b[m {remainfound}.")
 
         if not args.fix and fixes_possible:
             print("When invoked with --fix, I can try "

--- a/buildsystem/codecompliance/legal.py
+++ b/buildsystem/codecompliance/legal.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 the openage authors. See copying.md for legal info.
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
 
 """
 Checks the legal headers of all files.
@@ -184,8 +184,8 @@ def test_headers(check_files, paths, git_change_years, third_party_files):
             yield (
                 "Bad copyright year",
                 (filename + "\n" +
-                 "\tExpected %d\n" % expected_end_year +
-                 "\tFound    %d" % found_end_year),
+                 f"\tExpected {expected_end_year}\n" +
+                 f"\tFound    {found_end_year}"),
                 fix
             )
 
@@ -215,8 +215,8 @@ def find_issues(check_files, paths, git_change_years=False):
         if has_ext(filename, EXTENSIONS_REQUIRING_LEGAL_HEADERS):
             yield (
                 "third-party file listing issue",
-                ("{}\n\tlisted in copying.md, but has no "
-                 "third-party license header.").format(filename),
+                (f"{filename}\n\tlisted in copying.md, but has no "
+                 "third-party license header."),
                 None
             )
 
@@ -224,7 +224,7 @@ def find_issues(check_files, paths, git_change_years=False):
     for filename in sorted(third_party_files - listed_files):
         yield (
             "third-party file listing issue",
-            ("{}\n\thas a third-party license header, but isn't "
-             "listed in copying.md").format(filename),
+            (f"{filename}\n\thas a third-party license header, but isn't "
+             "listed in copying.md"),
             None
         )

--- a/buildsystem/codecompliance/modes.py
+++ b/buildsystem/codecompliance/modes.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2020 the openage authors. See copying.md for legal info.
+# Copyright 2016-2022 the openage authors. See copying.md for legal info.
 
 """
 Checks the mode of all files and prevents executable source files.
@@ -39,7 +39,7 @@ def check_mode(filename):
         if path.suffix in EXTENSIONS_SHEBANG_XBIT:
             # if the file is allowed to have a shebang,
             # allow its executable bit if it actually has a shebang
-            with path.open() as file:
+            with path.open(encoding='utf-8') as file:
                 firstline = file.readline()
 
                 if SHEBANG_RE.match(firstline):

--- a/buildsystem/compilepy.py
+++ b/buildsystem/compilepy.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Compiles python modules with cpython to pyc/pyo files.
@@ -96,9 +96,8 @@ def main():
     maxwidth = len(str(len(to_compile)))
     for idx, (module, outputfile) in enumerate(to_compile):
         try:
-            print("[%*d/%d] Compiling %s to %s" % (maxwidth, idx + 1,
-                                                   len(to_compile), module,
-                                                   outputfile))
+            print(f"[{idx+1:{maxwidth}}/{len(to_compile)}] "
+                  f"Compiling {module} to {outputfile}")
             py_compile.compile(module, cfile=outputfile, doraise=True)
 
         except py_compile.PyCompileError as exc:

--- a/buildsystem/pxdgen.py
+++ b/buildsystem/pxdgen.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Auto-generates PXD files from annotated C++ headers.
@@ -237,7 +237,7 @@ class PXDGenerator:
 
             if (token, val) != (Token.Punctuation, '{'):
                 raise self.parser_error("expected '{' or '::' after "
-                                        "'namespace %s'" % self.stack[-1])
+                                        f"'namespace {self.stack[-1]}'")
             # { found, so fill the stack
             self.stack.append('::'.join(namespace_parts))
             namespace_parts.clear()
@@ -284,8 +284,8 @@ class PXDGenerator:
 
         from datetime import datetime
         year = datetime.now().year
-        yield ("# Copyright 2013-{} the openage authors. "
-               "See copying.md for legal info.".format(year))
+        yield (f"# Copyright 2013-{year} the openage authors. "
+               "See copying.md for legal info.")
 
         yield ""
 
@@ -382,11 +382,11 @@ class PXDGenerator:
                     return False
 
         with open(pxdfile, 'w', encoding='utf8') as outfile:
-            print("\x1b[36mpxdgen: generate %s\x1b[0m" % os.path.relpath(pxdfile, CWD))
+            print(f"\x1b[36mpxdgen: generate {os.path.relpath(pxdfile, CWD)}\x1b[0m")
             outfile.write(result)
 
         if print_warnings and self.warnings:
-            print("\x1b[33;1mWARNING\x1b[m pxdgen[%s]:" % self.filename)
+            print(f"\x1b[33;1mWARNING\x1b[m pxdgen[{self.filename}]:")
             for warning in self.warnings:
                 print(warning)
 
@@ -472,8 +472,8 @@ def main():
             for extension in ("py", "pxd"):
                 initfile = template.with_suffix("." + extension)
                 if not initfile.exists():
-                    print("\x1b[36mpxdgen: create package index %s\x1b[0m" % (
-                        initfile.relative_to(args.output_dir)))
+                    print("\x1b[36mpxdgen: create package index "
+                          f"{initfile.relative_to(args.output_dir)}\x1b[0m")
 
                     initfile.touch()
 

--- a/cfg/converter/games/game_editions.toml
+++ b/cfg/converter/games/game_editions.toml
@@ -128,7 +128,7 @@ expansions = [ ]
 
   [AOE2DE.mediapaths]
   datfile = [ "resources/_common/dat/empires2_x2_p1.dat" ]
-  gamedata = [ "resources/_common/drs/gamedata_x1/" ]
+  gamedata = [ "resources/_common/drs/gamedata_x2/" ]
   graphics = [ "resources/_common/drs/graphics/" ]
   language = [
   "resources/br/strings/key-value/key-value-strings-utf8.txt",

--- a/openage/__init__.py
+++ b/openage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 the openage authors. See copying.md for legal info.
+# Copyright 2013-2022 the openage authors. See copying.md for legal info.
 
 """
 The Python part of openage, a free engine re-write of
@@ -29,34 +29,21 @@ else:
     VERSION = config.VERSION
 
     LONGVERSION = (
-        "openage {version}{devmode}\n"
-        "{config_options}, ci-cfg {cicfg}\n"
-        "{compiler} [{compilerflags}]\n"
+        f"openage {config.VERSION}"
+        f"{' [devmode]' if config.DEVMODE else ''}\n"
+        f"{config.CONFIG_OPTIONS}, ci-cfg {config.CICFGVERSION}\n"
+        f"{config.COMPILER} [{config.COMPILERFLAGS}]\n"
         "\n"
         "== Python ==\n"
-        "Python        {python_interpreter}\n"
-        "Python C API  {python_c_api}\n"
-        "Cython        {cython}\n"
-        "Jinja2        {jinja2}\n"
-        "NumPy         {numpy}\n"
-        "Pillow        {pillow}\n"
-        "Pygments      {pygments}\n"
+        f"Python        {config.PYTHONINTERPRETER}\n"
+        f"Python C API  {config.PYTHONCAPI}\n"
+        f"Cython        {config.CYTHONVERSION}\n"
+        f"Jinja2        {config.JINJAVERSION}\n"
+        f"NumPy         {config.NUMPYVERSION}\n"
+        f"Pillow        {config.PILVERSION}\n"
+        f"Pygments      {config.PYGMENTSVERSION}\n"
         "\n"
         "== C++ =="
-    ).format(
-        version=config.VERSION,
-        devmode=(" [devmode]" if config.DEVMODE else ""),
-        config_options=config.CONFIG_OPTIONS,
-        compiler=config.COMPILER,
-        compilerflags=config.COMPILERFLAGS,
-        cicfg=config.CICFGVERSION,
-        python_interpreter=config.PYTHONINTERPRETER,
-        python_c_api=config.PYTHONCAPI,
-        cython=config.CYTHONVERSION,
-        jinja2=config.JINJAVERSION,
-        numpy=config.NUMPYVERSION,
-        pillow=config.PILVERSION,
-        pygments=config.PYGMENTSVERSION,
     )
 
 

--- a/openage/cabextract/cab.py
+++ b/openage/cabextract/cab.py
@@ -333,7 +333,7 @@ class CABFile(FileCollection):
 
             elif compression_type == 3:
                 window_bits = (folder.typeCompress >> 8) & 0x1f
-                folder.comp_name = "LZX (window_bits = %d)" % window_bits
+                folder.comp_name = f"LZX (window_bits = {window_bits:d})"
 
                 from .lzxdstream import LZXDStream
                 from ..util.filelike.stream import StreamSeekBuffer
@@ -346,8 +346,7 @@ class CABFile(FileCollection):
                 folder.plain_stream = StreamSeekBuffer(unseekable_plain_stream)
 
             else:
-                raise Exception("Unknown compression type %d"
-                                % compression_type)
+                raise Exception(f"Unknown compression type {compression_type:d}")
 
             dbg(folder)
             yield folder

--- a/openage/codegen/codegen.py
+++ b/openage/codegen/codegen.py
@@ -148,7 +148,7 @@ def codegen(mode: CodegenMode, input_dir: str, output_dir: str) -> tuple[list[st
             # write new content to file
             wpath.parent.mkdirs()
             with wpath.open('wb') as outfile:
-                print("\x1b[36mcodegen: %s\x1b[0m" % b'/'.join(parts).decode(errors='replace'))
+                print(f"\x1b[36mcodegen: {b'/'.join(parts).decode(errors='replace')}\x1b[0m")
                 outfile.write(data)
 
         elif mode == CodegenMode.DRYRUN:
@@ -245,9 +245,9 @@ def get_header_lines() -> Generator[str, None, None]:
     """
 
     yield (
-        "Copyright 2013-{year} the openage authors. "
+        f"Copyright 2013-{datetime.now().year} the openage authors. "
         "See copying.md for legal info."
-    ).format(year=datetime.now().year)
+    )
 
     yield ""
     yield "Warning: this file was auto-generated; manual changes are futile."

--- a/openage/codegen/cpp_testlist.py
+++ b/openage/codegen/cpp_testlist.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Generates code for C++ testing, mostly the table to look up symbols from test
@@ -14,6 +14,7 @@ class Namespace:
 
     gen_prototypes() generates the code for the namespace.
     """
+
     def __init__(self):
         self.namespaces = collections.defaultdict(self.__class__)
         self.functions = []
@@ -42,10 +43,10 @@ class Namespace:
             yield f"void {name}();\n"
 
         for namespacename, namespace in sorted(self.namespaces.items()):
-            yield "namespace %s {\n" % namespacename
+            yield f"namespace {namespacename} {{\n"
             for line in namespace.gen_prototypes():
                 yield line
-            yield "} // %s\n\n" % namespacename
+            yield f"}} // {namespacename}\n\n"
 
     def get_functionnames(self):
         """
@@ -76,8 +77,9 @@ def generate_testlist(projectdir):
     func_prototypes = list(root_namespace.gen_prototypes())
 
     method_mappings = [
-        "{\"%s\", ::%s}" % (functionname, functionname)
-        for functionname in root_namespace.get_functionnames()]
+        f"{{\"{functionname}\", ::{functionname}}}"
+        for functionname in root_namespace.get_functionnames()
+    ]
 
     tmpl_path = projectdir.joinpath("libopenage/testing/testlist.cpp.template")
     with tmpl_path.open() as tmpl:

--- a/openage/convert/entity_object/conversion/CMakeLists.txt
+++ b/openage/convert/entity_object/conversion/CMakeLists.txt
@@ -4,8 +4,6 @@ add_py_modules(
 	combined_sound.py
 	combined_terrain.py
 	converter_object.py
-	dynamic_loader.py
-	genie_structure.py
 	modpack.py
 	stringresource.py
 )

--- a/openage/convert/entity_object/conversion/CMakeLists.txt
+++ b/openage/convert/entity_object/conversion/CMakeLists.txt
@@ -4,6 +4,7 @@ add_py_modules(
 	combined_sound.py
 	combined_terrain.py
 	converter_object.py
+	dynamic_loader.py
 	genie_structure.py
 	modpack.py
 	stringresource.py

--- a/openage/convert/entity_object/conversion/aoc/genie_civ.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_civ.py
@@ -85,7 +85,7 @@ class GenieCivilizationGroup(ConverterObjectGroup):
 
         self.team_bonus: CivTeamBonus = None
         if self.civ.has_member("team_bonus_id"):
-            team_bonus_id = self.civ["team_bonus_id"].get_value()
+            team_bonus_id = self.civ["team_bonus_id"].value
             if team_bonus_id == -1:
                 # Gaia civ has no team bonus
                 self.team_bonus = None
@@ -97,7 +97,7 @@ class GenieCivilizationGroup(ConverterObjectGroup):
 
         # Create an object for the tech tree bonus. We use the effect ID + 10000 to avoid
         # conflicts with techs or effects
-        tech_tree_id: int  = self.civ["tech_tree_id"].get_value()
+        tech_tree_id: int  = self.civ["tech_tree_id"].value
         self.tech_tree = CivTechTree(10000 + tech_tree_id, civ_id,
                                      tech_tree_id, full_data_set)
 

--- a/openage/convert/entity_object/conversion/aoc/genie_effect.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_effect.py
@@ -50,7 +50,7 @@ class GenieEffectObject(ConverterObject):
         """
         Returns the effect's type.
         """
-        return self["type_id"].get_value()
+        return self["type_id"].value
 
     def __repr__(self):
         return f"GenieEffectObject<{self.get_id()}>"

--- a/openage/convert/entity_object/conversion/aoc/genie_graphic.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_graphic.py
@@ -63,10 +63,10 @@ class GenieGraphic(ConverterObject):
         """
         Add references for the direct subgraphics to this object.
         """
-        graphic_deltas = self["graphic_deltas"].get_value()
+        graphic_deltas = self["graphic_deltas"].value
 
         for subgraphic in graphic_deltas:
-            graphic_id = subgraphic["graphic_id"].get_value()
+            graphic_id = subgraphic["graphic_id"].value
 
             # Ignore invalid IDs
             if graphic_id not in self.data.genie_graphics.keys():
@@ -82,7 +82,7 @@ class GenieGraphic(ConverterObject):
         Returns the time taken to display all frames in this graphic.
         """
         head_graphic = self.data.genie_graphics[self.get_id()]
-        return head_graphic["frame_rate"].get_value() * head_graphic["frame_count"].get_value()
+        return head_graphic["frame_rate"].value * head_graphic["frame_count"].value
 
     def get_subgraphics(self) -> list[GenieGraphic]:
         """
@@ -95,7 +95,7 @@ class GenieGraphic(ConverterObject):
         Returns the time taken to display a single frame in this graphic.
         """
         head_graphic = self.data.genie_graphics[self.get_id()]
-        return head_graphic["frame_rate"].get_value()
+        return head_graphic["frame_rate"].value
 
     def is_shared(self) -> bool:
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_sound.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_sound.py
@@ -49,13 +49,13 @@ class GenieSound(ConverterObject):
         :type civ_id: int
         """
         sound_ids = []
-        sound_items = self["sound_items"].get_value()
+        sound_items = self["sound_items"].value
         for item in sound_items:
-            item_civ_id = item["civilization_id"].get_value()
+            item_civ_id = item["civilization_id"].value
             if not item_civ_id == civ_id:
                 continue
 
-            sound_id = item["resource_id"].get_value()
+            sound_id = item["resource_id"].value
             sound_ids.append(sound_id)
 
         return sound_ids

--- a/openage/convert/entity_object/conversion/aoc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_tech.py
@@ -82,7 +82,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         self.tech = self.data.genie_techs[tech_id]
 
         # Effects of the tech
-        effect_bundle_id: int = self.tech["tech_effect_id"].get_value()
+        effect_bundle_id: int = self.tech["tech_effect_id"].value
 
         self.effects: GenieEffectBundle = None
         if effect_bundle_id > -1:
@@ -97,8 +97,8 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         :returns: True if the research time is greater than zero
                   and research location greater than -1.
         """
-        research_time = self.tech["research_time"].get_value()
-        research_location_id = self.tech["research_location_id"].get_value()
+        research_time = self.tech["research_time"].value
+        research_location_id = self.tech["research_location_id"].value
 
         return research_time > 0 and research_location_id > -1
 
@@ -108,7 +108,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
 
         :returns: True if the civilization id is greater than zero.
         """
-        civilization_id = self.tech["civilization_id"].get_value()
+        civilization_id = self.tech["civilization_id"].value
 
         # -1 = no train location
         return civilization_id > -1
@@ -118,7 +118,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         Returns the civilization id if the tech is unique, otherwise return None.
         """
         if self.is_unique():
-            return self.tech["civilization_id"].get_value()
+            return self.tech["civilization_id"].value
 
         return None
 
@@ -135,12 +135,12 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         """
         Returns the techs that are required for this tech.
         """
-        required_tech_ids = self.tech["required_techs"].get_value()
+        required_tech_ids = self.tech["required_techs"].value
 
         required_techs = []
 
         for tech_id_member in required_tech_ids:
-            tech_id = tech_id_member.get_value()
+            tech_id = tech_id_member.value
             if tech_id == -1:
                 break
 
@@ -152,7 +152,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         """
         Returns the number of required techs necessary to unlock this  tech.
         """
-        return self.tech["required_tech_count"].get_value()
+        return self.tech["required_tech_count"].value
 
     def get_research_location_id(self) -> int:
         """
@@ -160,7 +160,7 @@ class GenieTechEffectBundleGroup(ConverterObjectGroup):
         researchable, otherwise return None.
         """
         if self.is_researchable():
-            return self.tech["research_location_id"].get_value()
+            return self.tech["research_location_id"].value
 
         return None
 
@@ -502,8 +502,8 @@ class CivBonus(GenieTechEffectBundleGroup):
         """
         for tech_group in self.data.tech_groups.values():
             if tech_group.is_researchable():
-                bonus_effect_id = self.tech["tech_effect_id"].get_value()
-                tech_group_effect_id = tech_group.tech["tech_effect_id"].get_value()
+                bonus_effect_id = self.tech["tech_effect_id"].value
+                tech_group_effect_id = tech_group.tech["tech_effect_id"].value
 
                 if bonus_effect_id == tech_group_effect_id:
                     return tech_group

--- a/openage/convert/entity_object/conversion/aoc/genie_terrain.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_terrain.py
@@ -78,13 +78,13 @@ class GenieTerrainGroup(ConverterObjectGroup):
         """
         Checks if this terrain uses a subterrain for its graphics.
         """
-        return self.terrain["terrain_replacement_id"].get_value() > -1
+        return self.terrain["terrain_replacement_id"].value > -1
 
     def get_subterrain(self) -> GenieTerrainObject:
         """
         Return the subterrain used for the graphics.
         """
-        return self.data.genie_terrains[self.terrain["terrain_replacement_id"].get_value()]
+        return self.data.genie_terrains[self.terrain["terrain_replacement_id"].value]
 
     def get_terrain(self) -> GenieTerrainObject:
         """

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -275,10 +275,10 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].value
+        projectile_id_0 = head_unit["projectile_id0"].value
         projectile_id_1 = -2
-        if head_unit.has_member("attack_projectile_secondary_unit_id"):
-            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].value
+        if head_unit.has_member("projectile_id1"):
+            projectile_id_1 = head_unit["projectile_id1"].value
 
         return projectile_id in (projectile_id_0, projectile_id_1)
 
@@ -403,16 +403,16 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        if not head_unit.has_member("attack_projectile_primary_unit_id"):
+        if not head_unit.has_member("projectile_id0"):
             return False
 
         # Get the projectiles' obj_id for the first unit in the line. AoE's
         # units stay ranged with upgrades, so this should be fine.
-        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].value
+        projectile_id_0 = head_unit["projectile_id0"].value
 
         projectile_id_1 = -1
-        if head_unit.has_member("attack_projectile_secondary_unit_id"):
-            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].value
+        if head_unit.has_member("projectile_id1"):
+            projectile_id_1 = head_unit["projectile_id1"].value
 
         # -1 -> no projectile
         return projectile_id_0 > -1 or projectile_id_1 > -1
@@ -866,10 +866,10 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
 
         :returns: True if one of the projectile IDs is greater than zero.
         """
-        projectile_id_0 = self.head_unit["attack_projectile_primary_unit_id"].value
-        projectile_id_1 = self.head_unit["attack_projectile_secondary_unit_id"].value
-        projectile_id_2 = self.transform_unit["attack_projectile_primary_unit_id"].value
-        projectile_id_3 = self.transform_unit["attack_projectile_secondary_unit_id"].value
+        projectile_id_0 = self.head_unit["projectile_id0"].value
+        projectile_id_1 = self.head_unit["projectile_id1"].value
+        projectile_id_2 = self.transform_unit["projectile_id0"].value
+        projectile_id_3 = self.transform_unit["projectile_id1"].value
 
         # -1 -> no projectile
         return (projectile_id_0 > -1 or projectile_id_1 > -1

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -148,7 +148,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
                       is not present, the unit is appended at the end
                       of the line.
         """
-        unit_id = genie_unit["id0"].get_value()
+        unit_id = genie_unit["id0"].value
 
         # Only add unit if it is not already in the list
         if not self.contains_entity(unit_id):
@@ -209,9 +209,9 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         :returns: True if the train location obj_id is greater than zero.
         """
         head_unit = self.get_head_unit()
-        armors = head_unit["armors"].get_value()
+        armors = head_unit["armors"].value
         for armor in armors.values():
-            type_id = armor["type_id"].get_value()
+            type_id = armor["type_id"].value
 
             if type_id == armor_class:
                 return True
@@ -227,9 +227,9 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         :returns: True if the train location obj_id is greater than zero.
         """
         head_unit = self.get_head_unit()
-        attacks = head_unit["attacks"].get_value()
+        attacks = head_unit["attacks"].value
         for attack in attacks.values():
-            type_id = attack["type_id"].get_value()
+            type_id = attack["type_id"].value
 
             if type_id == armor_class:
                 return True
@@ -251,9 +251,9 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        commands = head_unit["unit_commands"].get_value()
+        commands = head_unit["unit_commands"].value
         for command in commands:
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id == command_id:
                 return True
@@ -275,10 +275,10 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].value
         projectile_id_1 = -2
         if head_unit.has_member("attack_projectile_secondary_unit_id"):
-            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].get_value()
+            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].value
 
         return projectile_id in (projectile_id_0, projectile_id_1)
 
@@ -296,7 +296,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        train_location_id = head_unit["train_location_id"].get_value()
+        train_location_id = head_unit["train_location_id"].value
 
         # -1 = no train location
         return train_location_id > -1
@@ -315,8 +315,8 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        for resource_storage in head_unit["resource_storage"].get_value():
-            type_id = resource_storage["type"].get_value()
+        for resource_storage in head_unit["resource_storage"].value:
+            type_id = resource_storage["type"].value
 
             if type_id in (0, 1, 2, 3, 15, 16, 17):
                 return True
@@ -344,20 +344,20 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        trait = head_unit["trait"].get_value()
+        trait = head_unit["trait"].value
 
         # Transport ship/ram
         if trait & 0x01:
             return True
 
         # Production garrison
-        type_id = head_unit["unit_type"].get_value()
+        type_id = head_unit["unit_type"].value
         if len(self.creates) > 0 and type_id == 80:
             return True
 
         # Natural garrison
         if head_unit.has_member("garrison_type"):
-            garrison_type = head_unit["garrison_type"].get_value()
+            garrison_type = head_unit["garrison_type"].value
 
             if garrison_type > 0:
                 return True
@@ -388,7 +388,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        return head_unit["obstruction_type"].get_value() == 0
+        return head_unit["obstruction_type"].value == 0
 
     def is_projectile_shooter(self, civ_id: int = -1) -> bool:
         """
@@ -408,11 +408,11 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         # Get the projectiles' obj_id for the first unit in the line. AoE's
         # units stay ranged with upgrades, so this should be fine.
-        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_id_0 = head_unit["attack_projectile_primary_unit_id"].value
 
         projectile_id_1 = -1
         if head_unit.has_member("attack_projectile_secondary_unit_id"):
-            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].get_value()
+            projectile_id_1 = head_unit["attack_projectile_secondary_unit_id"].value
 
         # -1 -> no projectile
         return projectile_id_0 > -1 or projectile_id_1 > -1
@@ -430,7 +430,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        return head_unit["weapon_range_max"].get_value() > 0
+        return head_unit["weapon_range_max"].value > 0
 
     def is_melee(self, civ_id: int = -1) -> bool:
         """
@@ -459,7 +459,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         # Get the enabling research obj_id for the first unit in the line
         head_unit = self.get_head_unit()
-        head_unit_id = head_unit["id0"].get_value()
+        head_unit_id = head_unit["id0"].value
 
         if isinstance(self, GenieUnitLineGroup):
             if head_unit_id in self.data.unit_connections.keys():
@@ -477,7 +477,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
                 # AoE1
                 return False
 
-        enabling_research_id = head_unit_connection["enabling_research"].get_value()
+        enabling_research_id = head_unit_connection["enabling_research"].value
 
         # does not need to be enabled -> not unique
         if enabling_research_id == -1:
@@ -485,7 +485,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         # Get enabling civ
         enabling_research = self.data.genie_techs[enabling_research_id]
-        enabling_civ_id = enabling_research["civilization_id"].get_value()
+        enabling_civ_id = enabling_research["civilization_id"].value
 
         # Enabling tech has no specific civ -> not unique
         return enabling_civ_id > -1
@@ -494,7 +494,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         Return the class ID for units in the group.
         """
-        return self.get_head_unit()["unit_class"].get_value()
+        return self.get_head_unit()["unit_class"].value
 
     def get_garrison_mode(self, civ_id: int = -1) -> GenieGarrisonMode:
         """
@@ -511,7 +511,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         if civ_id != -1:
             head_unit = self.data.civ_groups[civ_id]["units"][self.get_head_unit_id()]
 
-        trait = head_unit["trait"].get_value()
+        trait = head_unit["trait"].value
 
         # Ram
         if trait == 1:
@@ -523,13 +523,13 @@ class GenieGameEntityGroup(ConverterObjectGroup):
 
         # Natural garrison
         if head_unit.has_member("garrison_type"):
-            garrison_type = head_unit["garrison_type"].get_value()
+            garrison_type = head_unit["garrison_type"].value
 
             if garrison_type > 0:
                 return GenieGarrisonMode.NATURAL
 
         # Production garrison
-        type_id = head_unit["unit_type"].get_value()
+        type_id = head_unit["unit_type"].value
         if len(self.creates) > 0 and type_id == 80:
             return GenieGarrisonMode.SELF_PRODUCED
 
@@ -540,7 +540,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         Return the obj_id of the first unit in the line.
         """
         head_unit = self.get_head_unit()
-        return head_unit["id0"].get_value()
+        return head_unit["id0"].value
 
     def get_head_unit(self) -> GenieUnitObject:
         """
@@ -561,7 +561,7 @@ class GenieGameEntityGroup(ConverterObjectGroup):
         """
         if self.is_creatable():
             head_unit = self.get_head_unit()
-            return head_unit["train_location_id"].get_value()
+            return head_unit["train_location_id"].value
 
         return None
 
@@ -593,12 +593,12 @@ class GenieUnitLineGroup(GenieGameEntityGroup):
         """
         if self.is_unique():
             head_unit = self.get_head_unit()
-            head_unit_id = head_unit["id0"].get_value()
+            head_unit_id = head_unit["id0"].value
             head_unit_connection = self.data.unit_connections[head_unit_id]
-            enabling_research_id = head_unit_connection["enabling_research"].get_value()
+            enabling_research_id = head_unit_connection["enabling_research"].value
 
             enabling_research = self.data.genie_techs[enabling_research_id]
-            return enabling_research["civilization_id"].get_value()
+            return enabling_research["civilization_id"].value
 
         return None
 
@@ -612,14 +612,14 @@ class GenieUnitLineGroup(GenieGameEntityGroup):
         TODO: Move function into GeneGameEntityGroup after doing the above.
         """
         head_unit = self.get_head_unit()
-        head_unit_id = head_unit["id0"].get_value()
+        head_unit_id = head_unit["id0"].value
 
         if head_unit_id not in self.data.unit_connections.keys():
             # TODO: Remove this check, see TODOs above
             return -1
 
         head_unit_connection = self.data.unit_connections[head_unit_id]
-        enabling_research_id = head_unit_connection["enabling_research"].get_value()
+        enabling_research_id = head_unit_connection["enabling_research"].value
 
         return enabling_research_id
 
@@ -686,7 +686,7 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
         Returns True if the building has a foundation terrain.
         """
         head_unit = self.get_head_unit()
-        return head_unit["foundation_terrain_id"].get_value() > -1
+        return head_unit["foundation_terrain_id"].value > -1
 
     def is_dropsite(self) -> bool:
         """
@@ -714,10 +714,10 @@ class GenieBuildingLineGroup(GenieGameEntityGroup):
         Returns the enabling tech id of the unit
         """
         head_unit = self.get_head_unit()
-        head_unit_id = head_unit["id0"].get_value()
+        head_unit_id = head_unit["id0"].value
         if head_unit_id in self.data.building_connections.keys():
             head_unit_connection = self.data.building_connections[head_unit_id]
-            enabling_research_id = head_unit_connection["enabling_research"].get_value()
+            enabling_research_id = head_unit_connection["enabling_research"].value
 
         else:
             # Assume it is avialable from the start
@@ -769,7 +769,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
 
         :returns: True if the train location obj_id is greater than zero.
         """
-        train_location_id = self.head["train_location_id"].get_value()
+        train_location_id = self.head["train_location_id"].value
 
         # -1 = no train location
         if train_location_id == -1:
@@ -784,7 +784,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
         :returns: True if the building has obstruction class 4.
         """
         head_unit = self.get_head_unit()
-        return head_unit["obstruction_class"].get_value() == 4
+        return head_unit["obstruction_class"].value == 4
 
     def get_head_unit(self) -> GenieUnitObject:
         """
@@ -808,7 +808,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
         """
         Returns the stack unit ID.
         """
-        return self.stack["id0"].get_value()
+        return self.stack["id0"].value
 
     def get_train_location_id(self) -> int:
         """
@@ -818,7 +818,7 @@ class GenieStackBuildingGroup(GenieBuildingLineGroup):
         creatable, otherwise return None.
         """
         if self.is_creatable():
-            return self.head["train_location_id"].get_value()
+            return self.head["train_location_id"].value
 
         return None
 
@@ -856,7 +856,7 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
 
         self.head_unit = self.data.genie_units[head_unit_id]
 
-        transform_id = self.head_unit["transform_unit_id"].get_value()
+        transform_id = self.head_unit["transform_unit_id"].value
         self.transform_unit = self.data.genie_units[transform_id]
 
     def is_projectile_shooter(self, civ_id: int = -1) -> int:
@@ -866,10 +866,10 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
 
         :returns: True if one of the projectile IDs is greater than zero.
         """
-        projectile_id_0 = self.head_unit["attack_projectile_primary_unit_id"].get_value()
-        projectile_id_1 = self.head_unit["attack_projectile_secondary_unit_id"].get_value()
-        projectile_id_2 = self.transform_unit["attack_projectile_primary_unit_id"].get_value()
-        projectile_id_3 = self.transform_unit["attack_projectile_secondary_unit_id"].get_value()
+        projectile_id_0 = self.head_unit["attack_projectile_primary_unit_id"].value
+        projectile_id_1 = self.head_unit["attack_projectile_secondary_unit_id"].value
+        projectile_id_2 = self.transform_unit["attack_projectile_primary_unit_id"].value
+        projectile_id_3 = self.transform_unit["attack_projectile_secondary_unit_id"].value
 
         # -1 -> no projectile
         return (projectile_id_0 > -1 or projectile_id_1 > -1
@@ -879,7 +879,7 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
         """
         Returns the ID of the head unit.
         """
-        return self.head_unit["id0"].get_value()
+        return self.head_unit["id0"].value
 
     def get_head_unit(self) -> GenieUnitObject:
         """
@@ -891,7 +891,7 @@ class GenieUnitTransformGroup(GenieUnitLineGroup):
         """
         Returns the ID of the transform unit.
         """
-        return self.transform_unit["id0"].get_value()
+        return self.transform_unit["id0"].value
 
     def get_transform_unit(self) -> GenieUnitObject:
         """
@@ -1069,8 +1069,8 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
         after: GenieUnitObject = None
     ) -> None:
         # Force the idle/combat units at the beginning of the line
-        if genie_unit["id0"].get_value() in (GenieUnitTaskGroup.male_line_id,
-                                             GenieUnitTaskGroup.female_line_id):
+        if genie_unit["id0"].value in (GenieUnitTaskGroup.male_line_id,
+                                       GenieUnitTaskGroup.female_line_id):
             super().add_unit(genie_unit, 0, after)
 
         else:
@@ -1083,7 +1083,7 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
         :returns: True if any train location obj_id is greater than zero.
         """
         for unit in self.line:
-            train_location_id = unit["train_location_id"].get_value()
+            train_location_id = unit["train_location_id"].value
             # -1 = no train location
             if train_location_id > -1:
                 return True
@@ -1096,7 +1096,7 @@ class GenieUnitTaskGroup(GenieUnitLineGroup):
         creatable, otherwise return None.
         """
         for unit in self.line:
-            train_location_id = unit["train_location_id"].get_value()
+            train_location_id = unit["train_location_id"].value
             # -1 = no train location
             if train_location_id > -1:
                 return train_location_id
@@ -1165,10 +1165,10 @@ class GenieVillagerGroup(GenieUnitLineGroup):
     def has_command(self, command_id: int, civ_id: int = -1) -> bool:
         for variant in self.variants:
             for genie_unit in variant.line:
-                commands = genie_unit["unit_commands"].get_value()
+                commands = genie_unit["unit_commands"].value
 
                 for command in commands:
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id == command_id:
                         return True
@@ -1229,10 +1229,10 @@ class GenieVillagerGroup(GenieUnitLineGroup):
 
         for variant in self.variants:
             for genie_unit in variant.line:
-                commands = genie_unit["unit_commands"].get_value()
+                commands = genie_unit["unit_commands"].value
 
                 for command in commands:
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id == command_id:
                         matching_units.append(genie_unit)

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -47,11 +47,11 @@ class ConverterObject:
         self.members = {}
 
         if members:
-            if all(isinstance(member, ValueMember) for member in members.values()):
-                self.members.update(members)
-
-            elif isinstance(members, DynamicLoader):
+            if isinstance(members, DynamicLoader):
                 self.members = members
+
+            elif all(isinstance(member, ValueMember) for member in members.values()):
+                self.members.update(members)
 
             else:
                 raise Exception("members must be an instance of ValueMember")

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -61,8 +61,7 @@ class ConverterObject:
         """
         Adds a member to the object.
         """
-        key = member.get_name()
-        self.members.update({key: member})
+        self.members.update({member.name: member})
 
     def add_members(self, members: dict[str, ValueMember]) -> None:
         """

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import typing
 
+from openage.convert.entity_object.conversion.dynamic_loader import DynamicLoader
+
 from ....nyan.nyan_structs import NyanObject, NyanPatch, NyanPatchMember, MemberOperator
 from ...value_object.conversion.forward_ref import ForwardRef
 from ...value_object.read.value_members import NoDiffMember, ValueMember
@@ -47,6 +49,9 @@ class ConverterObject:
         if members:
             if all(isinstance(member, ValueMember) for member in members.values()):
                 self.members.update(members)
+
+            elif isinstance(members, DynamicLoader):
+                self.members = members
 
             else:
                 raise Exception("members must be an instance of ValueMember")

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -99,8 +99,7 @@ class ConverterObject:
         that are different. It does not contain NoDiffMembers.
         """
         if type(self) is not type(other):
-            raise Exception("type %s cannot be diffed with type %s"
-                            % (type(self), type(other)))
+            raise Exception(f"type {type(self)} cannot be diffed with type {type(other)}")
 
         obj_diff = {}
 
@@ -117,8 +116,7 @@ class ConverterObject:
         Returns the obj_diff between two objects as another ConverterObject.
         """
         if type(self) is not type(other):
-            raise Exception("type %s cannot be diffed with type %s"
-                            % (type(self), type(other)))
+            raise Exception(f"type {type(self)} cannot be diffed with type {type(other)}")
 
         obj_diff = {}
 
@@ -252,8 +250,8 @@ class ConverterObjectGroup:
             return self.raw_api_objects[obj_id]
 
         except KeyError as missing_raw_api_obj:
-            raise Exception("%s: Could not find raw API object with obj_id %s"
-                            % (self, obj_id)) from missing_raw_api_obj
+            raise Exception(f"{repr(self)}: Could not find raw API object "
+                            "with obj_id {obj_id}") from missing_raw_api_obj
 
     def get_raw_api_objects(self) -> dict[str, RawAPIObject]:
         """
@@ -415,8 +413,8 @@ class RawAPIObject:
                 break
 
         else:
-            raise Exception("%s: Cannot extend raw member %s with origin %s: member not found"
-                            % (self, name, origin))
+            raise Exception(f"{repr(self)}: Cannot extend raw member {name} "
+                            f"with origin {origin}: member not found")
 
     def create_nyan_object(self) -> None:
         """
@@ -439,8 +437,8 @@ class RawAPIObject:
         The nyan object has to be created before this function can be called.
         """
         if self.nyan_object is None:
-            raise Exception("%s: nyan object needs to be created before"
-                            "member values can be assigned" % (self))
+            raise Exception(f"{repr(self)}: nyan object needs to be created before "
+                            "member values can be assigned")
 
         for raw_member in self.raw_members:
             member_name = raw_member[0]

--- a/openage/convert/entity_object/conversion/converter_object.py
+++ b/openage/convert/entity_object/conversion/converter_object.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import typing
 
-from openage.convert.entity_object.conversion.dynamic_loader import DynamicLoader
+from openage.convert.value_object.read.dynamic_loader import DynamicLoader
 
 from ....nyan.nyan_structs import NyanObject, NyanPatch, NyanPatchMember, MemberOperator
 from ...value_object.conversion.forward_ref import ForwardRef

--- a/openage/convert/entity_object/conversion/dynamic_loader.py
+++ b/openage/convert/entity_object/conversion/dynamic_loader.py
@@ -1,0 +1,81 @@
+# Copyright 2014-2022 the openage authors. See copying.md for legal info.
+
+# TODO pylint: disable=C,R
+
+"""
+Dynamically load and unload data from a file at runtime.
+"""
+
+from __future__ import annotations
+import typing
+
+if typing.TYPE_CHECKING:
+    from openage.convert.entity_object.conversion.genie_structure import GenieStructure
+    from openage.convert.value_object.init.game_version import GameVersion
+    from openage.convert.value_object.read.value_members import ValueMember
+
+
+class DynamicLoader:
+    """
+    Member that can be loaded and unloaded at runtime, saving
+    memory in the process.
+    """
+
+    __slots__ = ('name', 'datacls', 'game_version', 'srcdata', 'offset', 'members', '_loaded')
+
+    def __init__(
+        self,
+        name: str,
+        datacls: type[GenieStructure],
+        game_version: GameVersion,
+        srcdata: bytes,
+        offset: int
+    ):
+        self.datacls = datacls
+        self.game_version = game_version
+
+        self.srcdata = srcdata
+        self.offset = offset
+        self._loaded = False
+
+        self.name = name
+        self.members = None
+
+    def load(self) -> dict[str, ValueMember]:
+        """
+        Read the members from the provided source data.
+        """
+        datacls = self.datacls()
+        _, members = datacls.read(self.srcdata, self.offset, self.game_version, dynamic_load=False)
+
+        self.members = {}
+        for member in members:
+            self.members[member.name] = member
+
+        self._loaded = True
+
+        return self.members
+
+    def unload(self):
+        """
+        Delete the loaded members.
+        """
+        del self.members
+        self._loaded = False
+
+    def __getitem__(self, key) -> ValueMember:
+        """
+        Retrieve submembers from the loaded members or load them temporarily
+        if they have not been loaded previously.
+        """
+        if self._loaded:
+            return self.members[key]
+
+        # else (expensive)
+        self.load()
+        item = self.members[key]
+        self.unload()
+        return item
+
+    def __repr__(self) -> str:
+        return f"DynamicLoader<{'loaded' if self._loaded else 'unloaded'}>"

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -109,6 +109,10 @@ class GenieStructure:
         # where it stops
         start_offset = offset
         for _, export, var_name, storage_type, var_type in members:
+            if export == READ_GEN and dynamic_load and self.dynamic_load:
+                # Do not create members if dynamic loading is active
+                export = READ
+
             if stop_reading_members:
                 if isinstance(var_type, ReadMember):
                     replacement_value = var_type.get_empty_value()

--- a/openage/convert/entity_object/conversion/genie_structure.py
+++ b/openage/convert/entity_object/conversion/genie_structure.py
@@ -110,411 +110,472 @@ class GenieStructure:
                 continue
 
             if isinstance(var_type, GroupMember):
-                if not issubclass(var_type.cls, GenieStructure):
-                    raise Exception("class where members should be "
-                                    "included is not exportable: %s" % (
-                                        var_type.cls.__name__))
-
-                if isinstance(var_type, IncludeMembers):
-                    # call the read function of the referenced class (cls),
-                    # but store the data to the current object (self).
-                    offset, gen_members = var_type.cls.read(self, raw, offset,
-                                                            game_version,
-                                                            cls=var_type.cls)
-
-                    if export == READ_GEN:
-                        # Push the passed members directly into the list of generated members
-                        generated_value_members.extend(gen_members)
-
-                else:
-                    # create new instance of ValueMember,
-                    # depending on the storage type.
-                    # then save the result as a reference named `var_name`
-                    grouped_data = var_type.cls()
-                    offset, gen_members = grouped_data.read(raw, offset, game_version)
-
-                    setattr(self, var_name, grouped_data)
-
-                    if export == READ_GEN:
-                        # Store the data
-                        if storage_type is StorageType.CONTAINER_MEMBER:
-                            # push the members into a ContainerMember
-                            container = ContainerMember(var_name, gen_members)
-
-                            generated_value_members.append(container)
-
-                        elif storage_type is StorageType.ARRAY_CONTAINER:
-                            # create a container for the members first, then push the
-                            # container into an array
-                            container = ContainerMember(var_name, gen_members)
-                            allowed_member_type = StorageType.CONTAINER_MEMBER
-                            array = ArrayMember(var_name, allowed_member_type, [container])
-
-                            generated_value_members.append(array)
-
-                        else:
-                            raise Exception("%s at offset %# 08x: Data read via %s "
-                                            "cannot be stored as %s;"
-                                            " expected %s or %s"
-                                            % (var_name, offset, var_type, storage_type,
-                                               StorageType.CONTAINER_MEMBER,
-                                               StorageType.ARRAY_CONTAINER))
+                offset, gen_members = self._read_group(
+                    raw, offset, game_version, export,
+                    var_name, storage_type, var_type
+                )
+                generated_value_members.extend(gen_members)
 
             elif isinstance(var_type, MultisubtypeMember):
-                # subdata reference implies recursive call for reading the
-                # binary data
+                offset, gen_members = self._read_multisubtye(
+                    raw, offset, game_version, export, var_name,
+                    storage_type, var_type, target_class
+                )
+                generated_value_members.extend(gen_members)
 
-                # arguments passed to the next-level constructor.
-                varargs = dict()
+            else:
+                offset, gen_members, stop_reading_members = self._read_primitive(
+                    raw, offset, export, var_name,
+                    storage_type, var_type
+                )
+                generated_value_members.extend(gen_members)
 
-                if var_type.passed_args:
-                    if isinstance(var_type.passed_args, str):
-                        var_type.passed_args = set(var_type.passed_args)
-                    for passed_member_name in var_type.passed_args:
-                        varargs[passed_member_name] = getattr(
-                            self, passed_member_name)
+        return offset, generated_value_members
 
-                # subdata list length has to be defined beforehand as a
-                # object member OR number.  it's name or count is specified
-                # at the subdata member definition by length.
-                list_len = var_type.get_length(self)
+    def _read_group(
+        self,
+        raw: bytes,
+        offset: int,
+        game_version: GameVersion,
+        export: MemberAccess,
+        var_name: str,
+        storage_type: StorageType,
+        var_type: GroupMember
+    ) -> tuple[int, list[ValueMember]]:
+        generated_value_members = []
 
-                # prepare result storage lists
-                if isinstance(var_type, SubdataMember):
-                    # single-subtype child data list
-                    setattr(self, var_name, list())
-                    single_type_subdata = True
+        if not issubclass(var_type.cls, GenieStructure):
+            raise Exception("class where members should be "
+                            "included is not exportable: %s" % (
+                                var_type.cls.__name__))
+
+        if isinstance(var_type, IncludeMembers):
+            # call the read function of the referenced class (cls),
+            # but store the data to the current object (self).
+            offset, gen_members = var_type.cls.read(self, raw, offset,
+                                                    game_version,
+                                                    cls=var_type.cls)
+
+            if export == READ_GEN:
+                # Push the passed members directly into the list of generated members
+                generated_value_members.extend(gen_members)
+
+        else:
+            # create new instance of ValueMember,
+            # depending on the storage type.
+            # then save the result as a reference named `var_name`
+            grouped_data = var_type.cls()
+            offset, gen_members = grouped_data.read(raw, offset, game_version)
+
+            setattr(self, var_name, grouped_data)
+
+            if export == READ_GEN:
+                # Store the data
+                if storage_type is StorageType.CONTAINER_MEMBER:
+                    # push the members into a ContainerMember
+                    container = ContainerMember(var_name, gen_members)
+
+                    generated_value_members.append(container)
+
+                elif storage_type is StorageType.ARRAY_CONTAINER:
+                    # create a container for the members first, then push the
+                    # container into an array
+                    container = ContainerMember(var_name, gen_members)
+                    allowed_member_type = StorageType.CONTAINER_MEMBER
+                    array = ArrayMember(var_name, allowed_member_type, [container])
+
+                    generated_value_members.append(array)
+
                 else:
-                    # multi-subtype child data list
-                    setattr(self, var_name, {key: []
-                                             for key in var_type.class_lookup})
-                    single_type_subdata = False
+                    raise Exception("%s at offset %# 08x: Data read via %s "
+                                    "cannot be stored as %s;"
+                                    " expected %s or %s"
+                                    % (var_name, offset, var_type, storage_type,
+                                        StorageType.CONTAINER_MEMBER,
+                                        StorageType.ARRAY_CONTAINER))
 
-                # List for storing the ValueMember instance of each subdata structure
-                subdata_value_members = []
-                allowed_member_type = StorageType.CONTAINER_MEMBER
+        return offset, generated_value_members
 
-                # check if entries need offset checking
-                if var_type.offset_to:
-                    offset_lookup = getattr(self, var_type.offset_to[0])
+    def _read_multisubtye(
+        self,
+        raw: bytes,
+        offset: int,
+        game_version: GameVersion,
+        export: MemberAccess,
+        var_name: str,
+        storage_type: StorageType,
+        var_type: GroupMember,
+        target_class: type
+    ) -> tuple[int, list[ValueMember]]:
+        generated_value_members = []
+
+        # subdata reference implies recursive call for reading the
+        # binary data
+
+        # arguments passed to the next-level constructor.
+        varargs = dict()
+
+        if var_type.passed_args:
+            if isinstance(var_type.passed_args, str):
+                var_type.passed_args = set(var_type.passed_args)
+            for passed_member_name in var_type.passed_args:
+                varargs[passed_member_name] = getattr(
+                    self, passed_member_name)
+
+        # subdata list length has to be defined beforehand as a
+        # object member OR number.  it's name or count is specified
+        # at the subdata member definition by length.
+        list_len = var_type.get_length(self)
+
+        # prepare result storage lists
+        if isinstance(var_type, SubdataMember):
+            # single-subtype child data list
+            setattr(self, var_name, list())
+            single_type_subdata = True
+        else:
+            # multi-subtype child data list
+            setattr(self, var_name, {key: []
+                                     for key in var_type.class_lookup})
+            single_type_subdata = False
+
+        # List for storing the ValueMember instance of each subdata structure
+        subdata_value_members = []
+        allowed_member_type = StorageType.CONTAINER_MEMBER
+
+        # check if entries need offset checking
+        if var_type.offset_to:
+            offset_lookup = getattr(self, var_type.offset_to[0])
+        else:
+            offset_lookup = None
+
+        for i in range(list_len):
+
+            # List of subtype members filled if there's a subtype to be read
+            sub_members = []
+
+            # if datfile offset == 0, entry has to be skipped.
+            if offset_lookup:
+                if not var_type.offset_to[1](offset_lookup[i]):
+                    continue
+                # TODO: don't read sequentially, use the lookup as
+                #       new offset?
+
+            if single_type_subdata:
+                # append single data entry to the subdata object list
+                new_data_class = var_type.class_lookup[None]
+            else:
+                # to determine the subtype class, read the binary
+                # definition. this utilizes an on-the-fly definition
+                # of the data to be read.
+                offset, sub_members = self.read(
+                    raw, offset, game_version, cls=target_class,
+                    members=(((False,) + var_type.subtype_definition),)
+                )
+
+                # read the variable set by the above read call to
+                # use the read data to determine the denominaton of
+                # the member type
+                subtype_name = getattr(
+                    self, var_type.subtype_definition[1])
+
+                # look up the subtype class
+                new_data_class = var_type.class_lookup[subtype_name]
+
+            if not issubclass(new_data_class, GenieStructure):
+                raise Exception("dumped data "
+                                "is not exportable: %s" % (
+                                    new_data_class.__name__))
+
+            # create instance of submember class
+            new_data = new_data_class(**varargs)
+
+            # recursive call, read the subdata.
+            offset, gen_members = new_data.read(raw, offset, game_version, new_data_class)
+
+            # append the new data to the appropriate list
+            if single_type_subdata:
+                getattr(self, var_name).append(new_data)
+            else:
+                getattr(self, var_name)[subtype_name].append(new_data)
+
+            if export == READ_GEN:
+                # Append the data to the ValueMember list
+                if storage_type is StorageType.ARRAY_CONTAINER:
+                    # Put the subtype members in front
+                    sub_members.extend(gen_members)
+                    gen_members = sub_members
+                    # create a container for the retrieved members
+                    container = ContainerMember(var_name, gen_members)
+
+                    # Save the container to a list
+                    # The array is created after the for-loop
+                    subdata_value_members.append(container)
+
                 else:
-                    offset_lookup = None
+                    raise Exception("%s at offset %# 08x: Data read via %s "
+                                    "cannot be stored as %s;"
+                                    " expected %s"
+                                    % (var_name, offset, var_type, storage_type,
+                                        StorageType.ARRAY_CONTAINER))
 
-                for i in range(list_len):
+        if export == READ_GEN:
+            # Create an array from the subdata structures
+            # and append it to the other generated members
+            array = ArrayMember(var_name, allowed_member_type, subdata_value_members)
+            generated_value_members.append(array)
 
-                    # List of subtype members filled if there's a subtype to be read
-                    sub_members = []
+        return offset, generated_value_members
 
-                    # if datfile offset == 0, entry has to be skipped.
-                    if offset_lookup:
-                        if not var_type.offset_to[1](offset_lookup[i]):
-                            continue
-                        # TODO: don't read sequentially, use the lookup as
-                        #       new offset?
+    def _read_primitive(
+        self,
+        raw: bytes,
+        offset: int,
+        export: MemberAccess,
+        var_name: str,
+        storage_type: StorageType,
+        var_type: GroupMember
+    ) -> tuple[int, list[ValueMember], bool]:
+        generated_value_members = []
+        # reading binary data, as this member is no reference but
+        # actual content.
 
-                    if single_type_subdata:
-                        # append single data entry to the subdata object list
-                        new_data_class = var_type.class_lookup[None]
+        stop_reading_members = False
+
+        data_count = 1
+        is_array = False
+        is_custom_member = False
+
+        if isinstance(var_type, str):
+            is_array = self.vararray_match.match(var_type)
+
+            if is_array:
+                struct_type = is_array.group(1)
+                data_count = is_array.group(2)
+                if struct_type == "char":
+                    struct_type = "char[]"
+
+                if self.integer_match.match(data_count):
+                    # integer length
+                    data_count = int(data_count)
+                else:
+                    # dynamic length specified by member name
+                    data_count = getattr(self, data_count)
+
+                if storage_type not in (StorageType.STRING_MEMBER,
+                                        StorageType.ARRAY_INT,
+                                        StorageType.ARRAY_FLOAT,
+                                        StorageType.ARRAY_BOOL,
+                                        StorageType.ARRAY_ID,
+                                        StorageType.ARRAY_STRING):
+                    raise Exception("%s at offset %# 08x: Data read via %s "
+                                    "cannot be stored as %s;"
+                                    " expected ArrayMember format"
+                                    % (var_name, offset, var_type, storage_type))
+
+            else:
+                struct_type = var_type
+                data_count = 1
+
+        elif isinstance(var_type, ReadMember):
+            # These could be EnumMember, EnumLookupMember, etc.
+
+            # special type requires having set the raw data type
+            struct_type = var_type.raw_type
+            data_count = var_type.get_length(self)
+            is_custom_member = True
+
+        else:
+            raise Exception(
+                f"unknown data member definition {var_type} for member '{var_name}'")
+
+        if data_count < 0:
+            raise Exception("invalid length %d < 0 in %s for member '%s'" % (
+                data_count, var_type, var_name))
+
+        if struct_type not in self.struct_type_lookup:
+            raise Exception("%s: member %s requests unknown data type %s" % (
+                repr(self), var_name, struct_type))
+
+        if export == READ_UNKNOWN:
+            # for unknown variables, generate uid for the unknown
+            # memory location
+            var_name = "unknown-0x%08x" % offset
+
+        # lookup c type to python struct scan type
+        symbol = self.struct_type_lookup[struct_type]
+
+        # read that stuff!!11
+        struct_format = "< %d%s" % (data_count, symbol)
+
+        if export != SKIP:
+            result = struct.unpack_from(struct_format, raw, offset)
+
+            if is_custom_member:
+                if not var_type.verify_read_data(self, result):
+                    raise Exception("invalid data when reading %s "
+                                    "at offset %# 08x" % (
+                                        var_name, offset))
+
+            # TODO: move these into a read entry hook/verification method
+            if symbol == "s":
+                # stringify char array
+                result = decode_until_null(result[0])
+
+                if export == READ_GEN:
+                    if storage_type is StorageType.STRING_MEMBER:
+                        gen_member = StringMember(var_name, result)
+
                     else:
-                        # to determine the subtype class, read the binary
-                        # definition. this utilizes an on-the-fly definition
-                        # of the data to be read.
-                        offset, sub_members = self.read(
-                            raw, offset, game_version, cls=target_class,
-                            members=(((False,) + var_type.subtype_definition),)
-                        )
+                        raise Exception("%s at offset %# 08x: Data read via %s "
+                                        "cannot be stored as %s;"
+                                        " expected %s"
+                                        % (var_name, offset, var_type, storage_type,
+                                            StorageType.STRING_MEMBER))
 
-                        # read the variable set by the above read call to
-                        # use the read data to determine the denominaton of
-                        # the member type
-                        subtype_name = getattr(
-                            self, var_type.subtype_definition[1])
+                    generated_value_members.append(gen_member)
 
-                        # look up the subtype class
-                        new_data_class = var_type.class_lookup[subtype_name]
+            elif is_array:
+                if export == READ_GEN:
+                    # Turn every element of result into a member
+                    # and put them into an array
+                    array_members = []
+                    allowed_member_type = None
 
-                    if not issubclass(new_data_class, GenieStructure):
-                        raise Exception("dumped data "
-                                        "is not exportable: %s" % (
-                                            new_data_class.__name__))
+                    for elem in result:
+                        if storage_type is StorageType.ARRAY_INT:
+                            gen_member = IntMember(var_name, elem)
+                            allowed_member_type = StorageType.INT_MEMBER
+                            array_members.append(gen_member)
 
-                    # create instance of submember class
-                    new_data = new_data_class(**varargs)
+                        elif storage_type is StorageType.ARRAY_FLOAT:
+                            gen_member = FloatMember(var_name, elem)
+                            allowed_member_type = StorageType.FLOAT_MEMBER
+                            array_members.append(gen_member)
 
-                    # recursive call, read the subdata.
-                    offset, gen_members = new_data.read(raw, offset, game_version, new_data_class)
+                        elif storage_type is StorageType.ARRAY_BOOL:
+                            gen_member = BooleanMember(var_name, elem)
+                            allowed_member_type = StorageType.BOOLEAN_MEMBER
+                            array_members.append(gen_member)
 
-                    # append the new data to the appropriate list
-                    if single_type_subdata:
-                        getattr(self, var_name).append(new_data)
-                    else:
-                        getattr(self, var_name)[subtype_name].append(new_data)
+                        elif storage_type is StorageType.ARRAY_ID:
+                            gen_member = IDMember(var_name, elem)
+                            allowed_member_type = StorageType.ID_MEMBER
+                            array_members.append(gen_member)
 
-                    if export == READ_GEN:
-                        # Append the data to the ValueMember list
-                        if storage_type is StorageType.ARRAY_CONTAINER:
-                            # Put the subtype members in front
-                            sub_members.extend(gen_members)
-                            gen_members = sub_members
-                            # create a container for the retrieved members
-                            container = ContainerMember(var_name, gen_members)
-
-                            # Save the container to a list
-                            # The array is created after the for-loop
-                            subdata_value_members.append(container)
+                        elif storage_type is StorageType.ARRAY_STRING:
+                            gen_member = StringMember(var_name, elem)
+                            allowed_member_type = StorageType.STRING_MEMBER
+                            array_members.append(gen_member)
 
                         else:
                             raise Exception("%s at offset %# 08x: Data read via %s "
                                             "cannot be stored as %s;"
-                                            " expected %s"
+                                            " expected %s, %s, %s, %s or %s"
                                             % (var_name, offset, var_type, storage_type,
-                                               StorageType.ARRAY_CONTAINER))
-
-                if export == READ_GEN:
-                    # Create an array from the subdata structures
-                    # and append it to the other generated members
-                    array = ArrayMember(var_name, allowed_member_type, subdata_value_members)
-                    generated_value_members.append(array)
-
-            else:
-                # reading binary data, as this member is no reference but
-                # actual content.
-
-                data_count = 1
-                is_array = False
-                is_custom_member = False
-
-                if isinstance(var_type, str):
-                    is_array = self.vararray_match.match(var_type)
-
-                    if is_array:
-                        struct_type = is_array.group(1)
-                        data_count = is_array.group(2)
-                        if struct_type == "char":
-                            struct_type = "char[]"
-
-                        if self.integer_match.match(data_count):
-                            # integer length
-                            data_count = int(data_count)
-                        else:
-                            # dynamic length specified by member name
-                            data_count = getattr(self, data_count)
-
-                        if storage_type not in (StorageType.STRING_MEMBER,
                                                 StorageType.ARRAY_INT,
                                                 StorageType.ARRAY_FLOAT,
                                                 StorageType.ARRAY_BOOL,
                                                 StorageType.ARRAY_ID,
-                                                StorageType.ARRAY_STRING):
-                            raise Exception("%s at offset %# 08x: Data read via %s "
-                                            "cannot be stored as %s;"
-                                            " expected ArrayMember format"
-                                            % (var_name, offset, var_type, storage_type))
+                                                StorageType.ARRAY_STRING))
 
-                    else:
-                        struct_type = var_type
-                        data_count = 1
+                    # Create the array
+                    array = ArrayMember(var_name, allowed_member_type, array_members)
+                    generated_value_members.append(array)
 
-                elif isinstance(var_type, ReadMember):
-                    # These could be EnumMember, EnumLookupMember, etc.
+            elif data_count == 1:
+                # store first tuple element
+                result = result[0]
 
-                    # special type requires having set the raw data type
-                    struct_type = var_type.raw_type
-                    data_count = var_type.get_length(self)
-                    is_custom_member = True
+                if symbol == "f":
+                    if not math.isfinite(result):
+                        raise Exception("invalid float when "
+                                        "reading %s at offset %# 08x" % (
+                                            var_name, offset))
 
-                else:
-                    raise Exception(
-                        f"unknown data member definition {var_type} for member '{var_name}'")
-
-                if data_count < 0:
-                    raise Exception("invalid length %d < 0 in %s for member '%s'" % (
-                        data_count, var_type, var_name))
-
-                if struct_type not in self.struct_type_lookup:
-                    raise Exception("%s: member %s requests unknown data type %s" % (
-                        repr(self), var_name, struct_type))
-
-                if export == READ_UNKNOWN:
-                    # for unknown variables, generate uid for the unknown
-                    # memory location
-                    var_name = "unknown-0x%08x" % offset
-
-                # lookup c type to python struct scan type
-                symbol = self.struct_type_lookup[struct_type]
-
-                # read that stuff!!11
-                struct_format = "< %d%s" % (data_count, symbol)
-
-                if export != SKIP:
-                    result = struct.unpack_from(struct_format, raw, offset)
-
+                if export == READ_GEN:
+                    # Store the member as ValueMember
                     if is_custom_member:
-                        if not var_type.verify_read_data(self, result):
-                            raise Exception("invalid data when reading %s "
-                                            "at offset %# 08x" % (
-                                                var_name, offset))
+                        lookup_result = var_type.entry_hook(result)
 
-                    # TODO: move these into a read entry hook/verification method
-                    if symbol == "s":
-                        # stringify char array
-                        result = decode_until_null(result[0])
+                        if isinstance(var_type, EnumLookupMember):
+                            # store differently depending on storage type
+                            if storage_type is StorageType.INT_MEMBER:
+                                # store as plain integer value
+                                gen_member = IntMember(var_name, result)
 
-                        if export == READ_GEN:
-                            if storage_type is StorageType.STRING_MEMBER:
-                                gen_member = StringMember(var_name, result)
+                            elif storage_type is StorageType.ID_MEMBER:
+                                # store as plain integer value
+                                gen_member = IDMember(var_name, result)
+
+                            elif storage_type is StorageType.BITFIELD_MEMBER:
+                                # store as plain integer value
+                                gen_member = BitfieldMember(var_name, result)
+
+                            elif storage_type is StorageType.STRING_MEMBER:
+                                # store by looking up value from dict
+                                gen_member = StringMember(var_name, lookup_result)
+
+                            else:
+                                raise Exception("%s at offset %# 08x: Data read via %s "
+                                                "cannot be stored as %s;"
+                                                " expected %s, %s, %s or %s"
+                                                % (var_name, offset, var_type, storage_type,
+                                                    StorageType.INT_MEMBER,
+                                                    StorageType.ID_MEMBER,
+                                                    StorageType.BITFIELD_MEMBER,
+                                                    StorageType.STRING_MEMBER))
+
+                        elif isinstance(var_type, ContinueReadMember):
+                            if storage_type is StorageType.BOOLEAN_MEMBER:
+                                gen_member = StringMember(var_name, lookup_result)
 
                             else:
                                 raise Exception("%s at offset %# 08x: Data read via %s "
                                                 "cannot be stored as %s;"
                                                 " expected %s"
                                                 % (var_name, offset, var_type, storage_type,
-                                                   StorageType.STRING_MEMBER))
+                                                    StorageType.BOOLEAN_MEMBER))
 
-                            generated_value_members.append(gen_member)
+                    else:
+                        if storage_type is StorageType.INT_MEMBER:
+                            gen_member = IntMember(var_name, result)
 
-                    elif is_array:
-                        if export == READ_GEN:
-                            # Turn every element of result into a member
-                            # and put them into an array
-                            array_members = []
-                            allowed_member_type = None
+                        elif storage_type is StorageType.FLOAT_MEMBER:
+                            gen_member = FloatMember(var_name, result)
 
-                            for elem in result:
-                                if storage_type is StorageType.ARRAY_INT:
-                                    gen_member = IntMember(var_name, elem)
-                                    allowed_member_type = StorageType.INT_MEMBER
-                                    array_members.append(gen_member)
+                        elif storage_type is StorageType.BOOLEAN_MEMBER:
+                            gen_member = BooleanMember(var_name, result)
 
-                                elif storage_type is StorageType.ARRAY_FLOAT:
-                                    gen_member = FloatMember(var_name, elem)
-                                    allowed_member_type = StorageType.FLOAT_MEMBER
-                                    array_members.append(gen_member)
+                        elif storage_type is StorageType.ID_MEMBER:
+                            gen_member = IDMember(var_name, result)
 
-                                elif storage_type is StorageType.ARRAY_BOOL:
-                                    gen_member = BooleanMember(var_name, elem)
-                                    allowed_member_type = StorageType.BOOLEAN_MEMBER
-                                    array_members.append(gen_member)
+                        else:
+                            raise Exception("%s at offset %# 08x: Data read via %s "
+                                            "cannot be stored as %s;"
+                                            " expected %s, %s, %s or %s"
+                                            % (var_name, offset, var_type, storage_type,
+                                                StorageType.INT_MEMBER,
+                                                StorageType.FLOAT_MEMBER,
+                                                StorageType.BOOLEAN_MEMBER,
+                                                StorageType.ID_MEMBER))
 
-                                elif storage_type is StorageType.ARRAY_ID:
-                                    gen_member = IDMember(var_name, elem)
-                                    allowed_member_type = StorageType.ID_MEMBER
-                                    array_members.append(gen_member)
+                    generated_value_members.append(gen_member)
 
-                                elif storage_type is StorageType.ARRAY_STRING:
-                                    gen_member = StringMember(var_name, elem)
-                                    allowed_member_type = StorageType.STRING_MEMBER
-                                    array_members.append(gen_member)
+            # run entry hook for non-primitive members
+            if is_custom_member:
+                result = var_type.entry_hook(result)
 
-                                else:
-                                    raise Exception("%s at offset %# 08x: Data read via %s "
-                                                    "cannot be stored as %s;"
-                                                    " expected %s, %s, %s, %s or %s"
-                                                    % (var_name, offset, var_type, storage_type,
-                                                       StorageType.ARRAY_INT,
-                                                       StorageType.ARRAY_FLOAT,
-                                                       StorageType.ARRAY_BOOL,
-                                                       StorageType.ARRAY_ID,
-                                                       StorageType.ARRAY_STRING))
+                if result == ContinueReadMember.result.ABORT:
+                    # don't go through all other members of this class!
+                    stop_reading_members = True
 
-                            # Create the array
-                            array = ArrayMember(var_name, allowed_member_type, array_members)
-                            generated_value_members.append(array)
+            # store member's data value
+            setattr(self, var_name, result)
 
-                    elif data_count == 1:
-                        # store first tuple element
-                        result = result[0]
+        # increase the current file position by the size we just read
+        offset += struct.calcsize(struct_format)
 
-                        if symbol == "f":
-                            if not math.isfinite(result):
-                                raise Exception("invalid float when "
-                                                "reading %s at offset %# 08x" % (
-                                                    var_name, offset))
-
-                        if export == READ_GEN:
-                            # Store the member as ValueMember
-                            if is_custom_member:
-                                lookup_result = var_type.entry_hook(result)
-
-                                if isinstance(var_type, EnumLookupMember):
-                                    # store differently depending on storage type
-                                    if storage_type is StorageType.INT_MEMBER:
-                                        # store as plain integer value
-                                        gen_member = IntMember(var_name, result)
-
-                                    elif storage_type is StorageType.ID_MEMBER:
-                                        # store as plain integer value
-                                        gen_member = IDMember(var_name, result)
-
-                                    elif storage_type is StorageType.BITFIELD_MEMBER:
-                                        # store as plain integer value
-                                        gen_member = BitfieldMember(var_name, result)
-
-                                    elif storage_type is StorageType.STRING_MEMBER:
-                                        # store by looking up value from dict
-                                        gen_member = StringMember(var_name, lookup_result)
-
-                                    else:
-                                        raise Exception("%s at offset %# 08x: Data read via %s "
-                                                        "cannot be stored as %s;"
-                                                        " expected %s, %s, %s or %s"
-                                                        % (var_name, offset, var_type, storage_type,
-                                                           StorageType.INT_MEMBER,
-                                                           StorageType.ID_MEMBER,
-                                                           StorageType.BITFIELD_MEMBER,
-                                                           StorageType.STRING_MEMBER))
-
-                                elif isinstance(var_type, ContinueReadMember):
-                                    if storage_type is StorageType.BOOLEAN_MEMBER:
-                                        gen_member = StringMember(var_name, lookup_result)
-
-                                    else:
-                                        raise Exception("%s at offset %# 08x: Data read via %s "
-                                                        "cannot be stored as %s;"
-                                                        " expected %s"
-                                                        % (var_name, offset, var_type, storage_type,
-                                                           StorageType.BOOLEAN_MEMBER))
-
-                            else:
-                                if storage_type is StorageType.INT_MEMBER:
-                                    gen_member = IntMember(var_name, result)
-
-                                elif storage_type is StorageType.FLOAT_MEMBER:
-                                    gen_member = FloatMember(var_name, result)
-
-                                elif storage_type is StorageType.BOOLEAN_MEMBER:
-                                    gen_member = BooleanMember(var_name, result)
-
-                                elif storage_type is StorageType.ID_MEMBER:
-                                    gen_member = IDMember(var_name, result)
-
-                                else:
-                                    raise Exception("%s at offset %# 08x: Data read via %s "
-                                                    "cannot be stored as %s;"
-                                                    " expected %s, %s, %s or %s"
-                                                    % (var_name, offset, var_type, storage_type,
-                                                       StorageType.INT_MEMBER,
-                                                       StorageType.FLOAT_MEMBER,
-                                                       StorageType.BOOLEAN_MEMBER,
-                                                       StorageType.ID_MEMBER))
-
-                            generated_value_members.append(gen_member)
-
-                    # run entry hook for non-primitive members
-                    if is_custom_member:
-                        result = var_type.entry_hook(result)
-
-                        if result == ContinueReadMember.result.ABORT:
-                            # don't go through all other members of this class!
-                            stop_reading_members = True
-
-                    # store member's data value
-                    setattr(self, var_name, result)
-
-                # increase the current file position by the size we just read
-                offset += struct.calcsize(struct_format)
-
-        return offset, generated_value_members
+        return offset, generated_value_members, stop_reading_members
 
     @classmethod
     def get_data_format(
@@ -583,3 +644,6 @@ class GenieStructure:
 
         """
         raise NotImplementedError("Subclass has not implemented this function")
+
+    def __repr__(self) -> str:
+        return self.__class__.name

--- a/openage/convert/entity_object/conversion/modpack.py
+++ b/openage/convert/entity_object/conversion/modpack.py
@@ -51,7 +51,7 @@ class Modpack:
             raise Exception(f"{repr(self)}: export file must be of type MediaExportRequest "
                             f"not {type(export_request)}")
 
-        if export_request.get_type() in self.media_export_files.keys():
+        if export_request.get_type() in self.media_export_files:
             self.media_export_files[export_request.get_type()].append(export_request)
 
         else:

--- a/openage/convert/entity_object/conversion/modpack.py
+++ b/openage/convert/entity_object/conversion/modpack.py
@@ -38,8 +38,8 @@ class Modpack:
         Add a data file to the modpack for exporting.
         """
         if not isinstance(export_file, DataDefinition):
-            raise Exception("%s: export file must be of type DataDefinition"
-                            "not %s" % (self, type(export_file)))
+            raise Exception(f"{repr(self)}: export file must be of type DataDefinition "
+                            f"not {type(export_file)}")
 
         self.data_export_files.append(export_file)
 
@@ -48,8 +48,8 @@ class Modpack:
         Add a media export request to the modpack.
         """
         if not isinstance(export_request, MediaExportRequest):
-            raise Exception("%s: export file must be of type MediaExportRequest"
-                            "not %s" % (self, type(export_request)))
+            raise Exception(f"{repr(self)}: export file must be of type MediaExportRequest "
+                            f"not {type(export_request)}")
 
         if export_request.get_type() in self.media_export_files.keys():
             self.media_export_files[export_request.get_type()].append(export_request)
@@ -62,8 +62,8 @@ class Modpack:
         Add a metadata file to the modpack for exporting.
         """
         if not isinstance(export_file, MetadataExport):
-            raise Exception("%s: export file must be of type MetadataExport"
-                            "not %s" % (self, type(export_file)))
+            raise Exception(f"{repr(self)}: export file must be of type MetadataExport "
+                            f"not {type(export_file)}")
 
         self.metadata_files.append(export_file)
 

--- a/openage/convert/entity_object/conversion/ror/genie_sound.py
+++ b/openage/convert/entity_object/conversion/ror/genie_sound.py
@@ -23,9 +23,9 @@ class RoRSound(GenieSound):
         a .dat entry for that.
         """
         sound_ids = []
-        sound_items = self["sound_items"].get_value()
+        sound_items = self["sound_items"].value
         for item in sound_items:
-            sound_id = item["resource_id"].get_value()
+            sound_id = item["resource_id"].value
             sound_ids.append(sound_id)
 
         return sound_ids

--- a/openage/convert/entity_object/conversion/ror/genie_unit.py
+++ b/openage/convert/entity_object/conversion/ror/genie_unit.py
@@ -63,7 +63,7 @@ class RoRUnitLineGroup(GenieUnitLineGroup):
         :returns: True if the unit class is 10.
         """
         head_unit = self.get_head_unit()
-        return head_unit["unit_class"].get_value() == 10
+        return head_unit["unit_class"].value == 10
 
     def get_garrison_mode(self, civ_id: int = -1) -> typing.Union[GenieGarrisonMode, None]:
         """
@@ -125,7 +125,7 @@ class RoRBuildingLineGroup(GenieBuildingLineGroup):
         :returns: True if the unit class is 10.
         """
         head_unit = self.get_head_unit()
-        return head_unit["unit_class"].get_value() == 10
+        return head_unit["unit_class"].value == 10
 
     def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
@@ -156,7 +156,7 @@ class RoRAmbientGroup(GenieAmbientGroup):
         :returns: True if the unit class is 10.
         """
         head_unit = self.get_head_unit()
-        return head_unit["unit_class"].get_value() == 10
+        return head_unit["unit_class"].value == 10
 
     def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
@@ -183,7 +183,7 @@ class RoRVariantGroup(GenieVariantGroup):
         :returns: True if the unit class is 10.
         """
         head_unit = self.get_head_unit()
-        return head_unit["unit_class"].get_value() == 10
+        return head_unit["unit_class"].value == 10
 
     def get_garrison_mode(self, civ_id: int = -1) -> None:
         return None
@@ -242,7 +242,7 @@ class RoRUnitTaskGroup(GenieUnitTaskGroup):
         :returns: True if the unit class is 10.
         """
         head_unit = self.get_head_unit()
-        return head_unit["unit_class"].get_value() == 10
+        return head_unit["unit_class"].value == 10
 
     def get_garrison_mode(self, civ_id: int = -1) -> typing.Union[GenieGarrisonMode, None]:
         """

--- a/openage/convert/entity_object/conversion/stringresource.py
+++ b/openage/convert/entity_object/conversion/stringresource.py
@@ -7,7 +7,7 @@ import typing
 
 from collections import defaultdict
 
-from ...entity_object.conversion.genie_structure import GenieStructure
+from ...value_object.read.genie_structure import GenieStructure
 
 if typing.TYPE_CHECKING:
     from openage.convert.value_object.init.game_version import GameVersion

--- a/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_tech.py
@@ -49,7 +49,7 @@ class SWGBUnitLineUpgrade(UnitLineUpgrade):
         Adds a reference to an alternative unlock tech for another civ
         to this tech group.
         """
-        other_civ_id = other_unlock.tech["civilization_id"].get_value()
+        other_civ_id = other_unlock.tech["civilization_id"].value
         self.civ_unlocks[other_civ_id] = other_unlock
 
     def is_unique(self) -> bool:
@@ -94,7 +94,7 @@ class SWGBUnitUnlock(UnitUnlock):
         Adds a reference to an alternative unlock tech for another civ
         to this tech group.
         """
-        other_civ_id = other_unlock.tech["civilization_id"].get_value()
+        other_civ_id = other_unlock.tech["civilization_id"].value
         self.civ_unlocks[other_civ_id] = other_unlock
 
     def is_unique(self) -> bool:

--- a/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/swgbcc/genie_unit.py
@@ -60,7 +60,7 @@ class SWGBUnitLineGroup(GenieUnitLineGroup):
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
-        return head_unit["civilization_id"].get_value()
+        return head_unit["civilization_id"].value
 
     def is_civ_unique(self) -> bool:
         """
@@ -98,9 +98,9 @@ class SWGBStackBuildingGroup(GenieStackBuildingGroup):
         Returns the enabling tech id of the unit
         """
         stack_unit = self.get_stack_unit()
-        stack_unit_id = stack_unit["id0"].get_value()
+        stack_unit_id = stack_unit["id0"].value
         stack_unit_connection = self.data.building_connections[stack_unit_id]
-        enabling_research_id = stack_unit_connection["enabling_research"].get_value()
+        enabling_research_id = stack_unit_connection["enabling_research"].value
 
         return enabling_research_id
 
@@ -154,7 +154,7 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
-        return head_unit["civilization_id"].get_value()
+        return head_unit["civilization_id"].value
 
     def is_civ_unique(self) -> bool:
         """
@@ -178,7 +178,7 @@ class SWGBUnitTransformGroup(GenieUnitTransformGroup):
         Returns the enabling tech id of the unit
         """
         head_unit_connection = self.data.unit_connections[self.get_transform_unit_id()]
-        enabling_research_id = head_unit_connection["enabling_research"].get_value()
+        enabling_research_id = head_unit_connection["enabling_research"].value
 
         return enabling_research_id
 
@@ -233,7 +233,7 @@ class SWGBMonkGroup(GenieMonkGroup):
         Returns the ID of the civ that the line belongs to.
         """
         head_unit = self.get_head_unit()
-        return head_unit["civilization_id"].get_value()
+        return head_unit["civilization_id"].value
 
     def is_civ_unique(self) -> bool:
         """

--- a/openage/convert/entity_object/export/formats/media_cache.py
+++ b/openage/convert/entity_object/export/formats/media_cache.py
@@ -80,7 +80,7 @@ class MediaCacheFile(DataDefinition):
         :param packer_settings: Settings for the packing algorithm.
         :type packer_settings: tuple
         """
-        if media_type not in self.cache.keys():
+        if media_type not in self.cache:
             self.cache[media_type] = []
 
         self.cache[media_type].append(

--- a/openage/convert/entity_object/export/texture.py
+++ b/openage/convert/entity_object/export/texture.py
@@ -14,7 +14,7 @@ import numpy
 from ....log import spam
 from ...value_object.read.media.blendomatic import BlendingMode
 from ...value_object.read.media.hardcoded.terrain_tile_size import TILE_HALFSIZE
-from ..conversion.genie_structure import GenieStructure
+from ...value_object.read.genie_structure import GenieStructure
 
 if typing.TYPE_CHECKING:
     from openage.convert.value_object.read.media.colortable import ColorTable

--- a/openage/convert/main.py
+++ b/openage/convert/main.py
@@ -203,6 +203,10 @@ def init_subparser(cli: ArgumentParser):
         "--debug-info", type=int, choices=[0, 1, 2, 3, 4, 5, 6],
         help="create debug output for the converter run; verbosity levels 0-6")
 
+    cli.add_argument(
+        "--low-memory", action='store_true',
+        help="Activate low memory mode")
+
 
 def main(args, error):
     """ CLI entry point """

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -103,14 +103,14 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Get animation from commands proceed sprite
-        unit_commands = current_unit["unit_commands"].get_value()
+        unit_commands = current_unit["unit_commands"].value
         for command in unit_commands:
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id != command_id:
                 continue
 
-            ability_animation_id = command["proceed_sprite_id"].get_value()
+            ability_animation_id = command["proceed_sprite_id"].value
             break
 
         else:
@@ -150,10 +150,10 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -180,7 +180,7 @@ class AoCAbilitySubprocessor:
                                                                 obj_exists)
 
         # Command Sound
-        ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+        ability_comm_sound_id = current_unit["command_sound_id"].value
         if ability_comm_sound_id > -1:
             property_ref = f"{ability_ref}.CommandSound"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -232,7 +232,7 @@ class AoCAbilitySubprocessor:
 
         if ranged:
             # Min range
-            min_range = current_unit["weapon_range_min"].get_value()
+            min_range = current_unit["weapon_range_min"].value
             ability_raw_api_object.add_raw_member("min_range",
                                                   min_range,
                                                   "engine.ability.type.RangedContinuousEffect")
@@ -243,7 +243,7 @@ class AoCAbilitySubprocessor:
                 max_range = 4
 
             else:
-                max_range = current_unit["weapon_range_max"].get_value()
+                max_range = current_unit["weapon_range_max"].value
 
             ability_raw_api_object.add_raw_member("max_range",
                                                   max_range,
@@ -280,7 +280,7 @@ class AoCAbilitySubprocessor:
         # Application delay
         apply_graphic = dataset.genie_graphics[ability_animation_id]
         frame_rate = apply_graphic.get_frame_rate()
-        frame_delay = current_unit["frame_delay"].get_value()
+        frame_delay = current_unit["frame_delay"].value
         application_delay = frame_rate * frame_delay
         ability_raw_api_object.add_raw_member("application_delay",
                                               application_delay,
@@ -315,7 +315,7 @@ class AoCAbilitySubprocessor:
         """
         if isinstance(line, GenieVillagerGroup):
             current_unit = line.get_units_with_command(command_id)[0]
-            current_unit_id = current_unit["id0"].get_value()
+            current_unit_id = current_unit["id0"].value
 
         else:
             current_unit = line.get_head_unit()
@@ -348,7 +348,7 @@ class AoCAbilitySubprocessor:
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
 
-            ability_animation_id = current_unit["attack_sprite_id"].get_value()
+            ability_animation_id = current_unit["attack_sprite_id"].value
 
         else:
             ability_ref = "%s.ShootProjectile.Projectile%s.%s" % (game_entity_name,
@@ -404,10 +404,10 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -435,7 +435,7 @@ class AoCAbilitySubprocessor:
 
         # Command Sound
         if projectile == -1:
-            ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+            ability_comm_sound_id = current_unit["command_sound_id"].value
 
         else:
             ability_comm_sound_id = -1
@@ -498,13 +498,13 @@ class AoCAbilitySubprocessor:
 
         if ranged:
             # Min range
-            min_range = current_unit["weapon_range_min"].get_value()
+            min_range = current_unit["weapon_range_min"].value
             ability_raw_api_object.add_raw_member("min_range",
                                                   min_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
 
             # Max range
-            max_range = current_unit["weapon_range_max"].get_value()
+            max_range = current_unit["weapon_range_max"].value
             ability_raw_api_object.add_raw_member("max_range",
                                                   max_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
@@ -541,7 +541,7 @@ class AoCAbilitySubprocessor:
 
         # Reload time
         if projectile == -1:
-            reload_time = current_unit["attack_speed"].get_value()
+            reload_time = current_unit["attack_speed"].value
 
         else:
             reload_time = 0
@@ -552,10 +552,10 @@ class AoCAbilitySubprocessor:
 
         # Application delay
         if projectile == -1:
-            attack_graphic_id = current_unit["attack_sprite_id"].get_value()
+            attack_graphic_id = current_unit["attack_sprite_id"].value
             attack_graphic = dataset.genie_graphics[attack_graphic_id]
             frame_rate = attack_graphic.get_frame_rate()
-            frame_delay = current_unit["frame_delay"].get_value()
+            frame_delay = current_unit["frame_delay"].value
             application_delay = frame_rate * frame_delay
 
         else:
@@ -644,13 +644,13 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.AttributeChangeTracker")
 
         # Change progress
-        damage_graphics = current_unit["damage_graphics"].get_value()
+        damage_graphics = current_unit["damage_graphics"].value
         progress_forward_refs = []
 
         # Damage graphics are ordered ascending, so we start from 0
         interval_left_bound = 0
         for damage_graphic_member in damage_graphics:
-            interval_right_bound = damage_graphic_member["damage_percent"].get_value()
+            interval_right_bound = damage_graphic_member["damage_percent"].value
             progress_ref = f"{ability_ref}.ChangeProgress{interval_right_bound}"
             progress_raw_api_object = RawAPIObject(progress_ref,
                                                    f"ChangeProgress{interval_right_bound}",
@@ -679,7 +679,7 @@ class AoCAbilitySubprocessor:
             # =====================================================================================
             # AnimationOverlay property
             # =====================================================================================
-            progress_animation_id = damage_graphic_member["graphic_id"].get_value()
+            progress_animation_id = damage_graphic_member["graphic_id"].value
             if progress_animation_id > -1:
                 property_ref = f"{progress_ref}.AnimationOverlay"
                 property_raw_api_object = RawAPIObject(property_ref,
@@ -808,7 +808,7 @@ class AoCAbilitySubprocessor:
                                               0,
                                               "engine.ability.type.Constructable")
 
-        construction_animation_id = current_unit["construction_graphic_id"].get_value()
+        construction_animation_id = current_unit["construction_graphic_id"].value
 
         # Construction progress
         progress_forward_refs = []
@@ -2192,7 +2192,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["dying_graphic"].get_value()
+        ability_animation_id = current_unit["dying_graphic"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -2226,10 +2226,10 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["dying_graphic"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["dying_graphic"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -2471,7 +2471,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["dying_graphic"].get_value()
+        ability_animation_id = current_unit["dying_graphic"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -2569,8 +2569,8 @@ class AoCAbilitySubprocessor:
         api_objects = dataset.nyan_api_objects
 
         # Animation and time come from dead unit
-        death_animation_id = current_unit["dying_graphic"].get_value()
-        dead_unit_id = current_unit["dead_unit_id"].get_value()
+        death_animation_id = current_unit["dying_graphic"].value
+        dead_unit_id = current_unit["dead_unit_id"].value
         dead_unit = None
         if dead_unit_id > -1:
             dead_unit = dataset.genie_units[dead_unit_id]
@@ -2594,7 +2594,7 @@ class AoCAbilitySubprocessor:
         # Animation
         ability_animation_id = -1
         if dead_unit:
-            ability_animation_id = dead_unit["idle_graphic0"].get_value()
+            ability_animation_id = dead_unit["idle_graphic0"].value
 
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
@@ -2630,16 +2630,16 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
                 civ_unit = civ["units"][current_unit_id]
-                civ_dead_unit_id = civ_unit["dead_unit_id"].get_value()
+                civ_dead_unit_id = civ_unit["dead_unit_id"].value
                 civ_dead_unit = None
                 if civ_dead_unit_id > -1:
                     civ_dead_unit = dataset.genie_units[civ_dead_unit_id]
 
-                civ_animation_id = civ_dead_unit["idle_graphic0"].get_value()
+                civ_animation_id = civ_dead_unit["idle_graphic0"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -2686,12 +2686,12 @@ class AoCAbilitySubprocessor:
         # Despawn time = corpse decay time (dead unit) or Death animation time (if no dead unit exist)
         despawn_time = 0
         if dead_unit:
-            resource_storage = dead_unit["resource_storage"].get_value()
+            resource_storage = dead_unit["resource_storage"].value
             for storage in resource_storage:
-                resource_id = storage["type"].get_value()
+                resource_id = storage["type"].value
 
                 if resource_id == 12:
-                    despawn_time = storage["amount"].get_value()
+                    despawn_time = storage["amount"].value
 
         elif death_animation_id > -1:
             despawn_time = dataset.genie_graphics[death_animation_id].get_animation_length()
@@ -2742,12 +2742,12 @@ class AoCAbilitySubprocessor:
         # Resource containers
         containers = []
         for gatherer in gatherers:
-            unit_commands = gatherer["unit_commands"].get_value()
+            unit_commands = gatherer["unit_commands"].value
 
             for command in unit_commands:
                 # Find a gather ability. It doesn't matter which one because
                 # they should all produce the same resource for one genie unit.
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id in (5, 110):
                     break
@@ -3103,7 +3103,7 @@ class AoCAbilitySubprocessor:
         ability_raw_api_object.set_location(ability_location)
 
         # Stances
-        search_range = current_unit["search_radius"].get_value()
+        search_range = current_unit["search_radius"].value
         stance_names = ["Aggressive", "Defensive", "StandGround", "Passive"]
 
         # Attacking is prefered
@@ -3278,7 +3278,7 @@ class AoCAbilitySubprocessor:
 
         # Terrain
         if terrain_id == -1:
-            terrain_id = current_unit["foundation_terrain_id"].get_value()
+            terrain_id = current_unit["foundation_terrain_id"].value
 
         terrain = dataset.terrain_groups[terrain_id]
         terrain_forward_ref = ForwardRef(terrain, terrain_lookup_dict[terrain_id][1])
@@ -3318,7 +3318,7 @@ class AoCAbilitySubprocessor:
 
         abilities = []
         for gatherer in gatherers:
-            unit_commands = gatherer["unit_commands"].get_value()
+            unit_commands = gatherer["unit_commands"].value
             resource = None
             ability_animation_id = -1
             harvestable_class_ids = OrderedSet()
@@ -3327,24 +3327,24 @@ class AoCAbilitySubprocessor:
             for command in unit_commands:
                 # Find a gather ability. It doesn't matter which one because
                 # they should all produce the same resource for one genie unit.
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id not in (5, 110):
                     continue
 
-                target_class_id = command["class_id"].get_value()
+                target_class_id = command["class_id"].value
                 if target_class_id > -1:
                     harvestable_class_ids.add(target_class_id)
 
-                target_unit_id = command["unit_id"].get_value()
+                target_unit_id = command["unit_id"].value
                 if target_unit_id > -1:
                     harvestable_unit_ids.add(target_unit_id)
 
-                resource_id = command["resource_out"].get_value()
+                resource_id = command["resource_out"].value
 
                 # If resource_out is not specified, the gatherer harvests resource_in
                 if resource_id == -1:
-                    resource_id = command["resource_in"].get_value()
+                    resource_id = command["resource_in"].value
 
                 if resource_id == 0:
                     resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
@@ -3366,10 +3366,10 @@ class AoCAbilitySubprocessor:
                     continue
 
                 if type_id == 110:
-                    ability_animation_id = command["work_sprite_id"].get_value()
+                    ability_animation_id = command["work_sprite_id"].value
 
                 else:
-                    ability_animation_id = command["proceed_sprite_id"].get_value()
+                    ability_animation_id = command["proceed_sprite_id"].value
 
             # Look for the harvestable groups that match the class IDs and unit IDs
             check_groups = []
@@ -3487,7 +3487,7 @@ class AoCAbilitySubprocessor:
             rate_raw_api_object.add_raw_member(
                 "type", resource, "engine.util.resource.ResourceRate")
 
-            gather_rate = gatherer["work_rate"].get_value()
+            gather_rate = gatherer["work_rate"].value
             rate_raw_api_object.add_raw_member(
                 "rate", gather_rate, "engine.util.resource.ResourceRate")
 
@@ -3553,10 +3553,10 @@ class AoCAbilitySubprocessor:
         ability_raw_api_object.set_location(ability_location)
 
         # Resource spot
-        resource_storage = current_unit["resource_storage"].get_value()
+        resource_storage = current_unit["resource_storage"].value
 
         for storage in resource_storage:
-            resource_id = storage["type"].get_value()
+            resource_id = storage["type"].value
 
             # IDs 15, 16, 17 are other types of food (meat, berries, fish)
             if resource_id in (0, 15, 16, 17):
@@ -3591,15 +3591,15 @@ class AoCAbilitySubprocessor:
             # Start amount (equals max amount)
             if line.get_id() == 50:
                 # Farm food amount (hardcoded in civ)
-                starting_amount = dataset.genie_civs[1]["resources"][36].get_value()
+                starting_amount = dataset.genie_civs[1]["resources"][36].value
 
             elif line.get_id() == 199:
                 # Fish trap food amount (hardcoded in civ)
-                starting_amount = storage["amount"].get_value()
-                starting_amount += dataset.genie_civs[1]["resources"][88].get_value()
+                starting_amount = storage["amount"].value
+                starting_amount += dataset.genie_civs[1]["resources"][88].value
 
             else:
-                starting_amount = storage["amount"].get_value()
+                starting_amount = storage["amount"].value
 
             spot_raw_api_object.add_raw_member("starting_amount",
                                                starting_amount,
@@ -3611,7 +3611,7 @@ class AoCAbilitySubprocessor:
                                                "engine.util.resource_spot.ResourceSpot")
 
             # Decay rate
-            decay_rate = current_unit["resource_decay"].get_value()
+            decay_rate = current_unit["resource_decay"].value
             spot_raw_api_object.add_raw_member("decay_rate",
                                                decay_rate,
                                                "engine.util.resource_spot.ResourceSpot")
@@ -3894,7 +3894,7 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.Harvestable")
 
         # Unit have to die before they are harvestable (except for farms)
-        harvestable_by_default = current_unit["hit_points"].get_value() == 0
+        harvestable_by_default = current_unit["hit_points"].value == 0
         if line.get_class_id() == 49:
             harvestable_by_default = True
 
@@ -4033,9 +4033,9 @@ class AoCAbilitySubprocessor:
         hitbox_location = ForwardRef(line, ability_ref)
         hitbox_raw_api_object.set_location(hitbox_location)
 
-        radius_x = current_unit["radius_x"].get_value()
-        radius_y = current_unit["radius_y"].get_value()
-        radius_z = current_unit["radius_z"].get_value()
+        radius_x = current_unit["radius_x"].value
+        radius_y = current_unit["radius_y"].value
+        radius_z = current_unit["radius_z"].value
 
         hitbox_raw_api_object.add_raw_member("radius_x",
                                              radius_x,
@@ -4091,7 +4091,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["idle_graphic0"].get_value()
+        ability_animation_id = current_unit["idle_graphic0"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -4126,10 +4126,10 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["idle_graphic0"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["idle_graphic0"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -4210,7 +4210,7 @@ class AoCAbilitySubprocessor:
                                              "engine.util.attribute.AttributeSetting")
 
         # Max HP and starting HP
-        max_hp_value = current_unit["hit_points"].get_value()
+        max_hp_value = current_unit["hit_points"].value
         health_raw_api_object.add_raw_member("max_value",
                                              max_hp_value,
                                              "engine.util.attribute.AttributeSetting")
@@ -4298,7 +4298,7 @@ class AoCAbilitySubprocessor:
         line.add_raw_api_object(ability_raw_api_object)
 
         # Line of sight
-        line_of_sight = current_unit["line_of_sight"].get_value()
+        line_of_sight = current_unit["line_of_sight"].value
         ability_raw_api_object.add_raw_member("range", line_of_sight,
                                               "engine.ability.type.LineOfSight")
 
@@ -4361,7 +4361,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["move_graphics"].get_value()
+        ability_animation_id = current_unit["move_graphics"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -4400,10 +4400,10 @@ class AoCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["move_graphics"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["move_graphics"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -4429,7 +4429,7 @@ class AoCAbilitySubprocessor:
                                                                 obj_exists)
 
         # Command Sound
-        ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+        ability_comm_sound_id = current_unit["command_sound_id"].value
         if ability_comm_sound_id > -1:
             property_ref = f"{ability_ref}.CommandSound"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -4483,7 +4483,7 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.Ability")
 
         # Speed
-        speed = current_unit["speed"].get_value()
+        speed = current_unit["speed"].value
         ability_raw_api_object.add_raw_member("speed", speed, "engine.ability.type.Move")
 
         # Standard move modes
@@ -4500,7 +4500,7 @@ class AoCAbilitySubprocessor:
         follow_location = ForwardRef(line, f"{game_entity_name}.Move")
         follow_raw_api_object.set_location(follow_location)
 
-        follow_range = current_unit["line_of_sight"].get_value() - 1
+        follow_range = current_unit["line_of_sight"].value - 1
         follow_raw_api_object.add_raw_member("range",
                                              follow_range,
                                              "engine.util.move_mode.type.Follow")
@@ -4530,12 +4530,12 @@ class AoCAbilitySubprocessor:
 
         if position == 0:
             current_unit_id = line.get_head_unit_id()
-            projectile_id = line.get_head_unit()["attack_projectile_primary_unit_id"].get_value()
+            projectile_id = line.get_head_unit()["attack_projectile_primary_unit_id"].value
             current_unit = dataset.genie_units[projectile_id]
 
         elif position == 1:
             current_unit_id = line.get_head_unit_id()
-            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].get_value()
+            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].value
             current_unit = dataset.genie_units[projectile_id]
 
         else:
@@ -4559,7 +4559,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["move_graphics"].get_value()
+        ability_animation_id = current_unit["move_graphics"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -4596,7 +4596,7 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.Ability")
 
         # Speed
-        speed = current_unit["speed"].get_value()
+        speed = current_unit["speed"].value
         ability_raw_api_object.add_raw_member("speed", speed, "engine.ability.type.Move")
 
         # Move modes
@@ -4642,7 +4642,7 @@ class AoCAbilitySubprocessor:
         name_location = ForwardRef(line, ability_ref)
         name_raw_api_object.set_location(name_location)
 
-        name_string_id = current_unit["language_dll_name"].get_value()
+        name_string_id = current_unit["language_dll_name"].value
         translations = AoCAbilitySubprocessor.create_language_strings(line,
                                                                       name_string_id,
                                                                       name_ref,
@@ -4730,7 +4730,7 @@ class AoCAbilitySubprocessor:
         ability_raw_api_object.set_location(ability_location)
 
         # Terrain (Use foundation terrain)
-        terrain_id = current_unit["foundation_terrain_id"].get_value()
+        terrain_id = current_unit["foundation_terrain_id"].value
         terrain = dataset.terrain_groups[terrain_id]
         terrain_forward_ref = ForwardRef(terrain, terrain_lookup_dict[terrain_id][1])
         ability_raw_api_object.add_raw_member("terrain_overlay",
@@ -4922,16 +4922,16 @@ class AoCAbilitySubprocessor:
 
         # Arc
         if position == 0:
-            projectile_id = current_unit["attack_projectile_primary_unit_id"].get_value()
+            projectile_id = current_unit["attack_projectile_primary_unit_id"].value
 
         elif position == 1:
-            projectile_id = current_unit["attack_projectile_secondary_unit_id"].get_value()
+            projectile_id = current_unit["attack_projectile_secondary_unit_id"].value
 
         else:
             raise Exception("Invalid position")
 
         projectile = dataset.genie_units[projectile_id]
-        arc = degrees(projectile["projectile_arc"].get_value())
+        arc = degrees(projectile["projectile_arc"].value)
         ability_raw_api_object.add_raw_member("arc",
                                               arc,
                                               "engine.ability.type.Projectile")
@@ -4946,12 +4946,12 @@ class AoCAbilitySubprocessor:
         accuracy_location = ForwardRef(line, ability_ref)
         accuracy_raw_api_object.set_location(accuracy_location)
 
-        accuracy_value = current_unit["accuracy"].get_value()
+        accuracy_value = current_unit["accuracy"].value
         accuracy_raw_api_object.add_raw_member("accuracy",
                                                accuracy_value,
                                                "engine.util.accuracy.Accuracy")
 
-        accuracy_dispersion = current_unit["accuracy_dispersion"].get_value()
+        accuracy_dispersion = current_unit["accuracy_dispersion"].value
         accuracy_raw_api_object.add_raw_member("accuracy_dispersion",
                                                accuracy_dispersion,
                                                "engine.util.accuracy.Accuracy")
@@ -5023,11 +5023,11 @@ class AoCAbilitySubprocessor:
         ability_ref = f"{game_entity_name}.ProvideContingent"
 
         # Stores the pop space
-        resource_storage = current_unit["resource_storage"].get_value()
+        resource_storage = current_unit["resource_storage"].value
 
         contingents = []
         for storage in resource_storage:
-            type_id = storage["type"].get_value()
+            type_id = storage["type"].value
 
             if type_id == 4:
                 resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object(
@@ -5037,7 +5037,7 @@ class AoCAbilitySubprocessor:
             else:
                 continue
 
-            amount = storage["amount"].get_value()
+            amount = storage["amount"].value
 
             contingent_amount_name = f"{game_entity_name}.ProvideContingent.{resource_name}"
             contingent_amount = RawAPIObject(contingent_amount_name, resource_name,
@@ -5165,11 +5165,11 @@ class AoCAbilitySubprocessor:
         attribute_rate = 0
         if current_unit_id == 125:
             # stored in civ resources
-            attribute_rate = dataset.genie_civs[0]["resources"][35].get_value()
+            attribute_rate = dataset.genie_civs[0]["resources"][35].value
 
         elif current_unit_id == 692:
             # stored in civ resources, but has to get converted to amount/second
-            heal_timer = dataset.genie_civs[0]["resources"][96].get_value()
+            heal_timer = dataset.genie_civs[0]["resources"][96].value
             attribute_rate = 1 / heal_timer
 
         rate_raw_api_object.add_raw_member("rate",
@@ -5295,12 +5295,12 @@ class AoCAbilitySubprocessor:
         if isinstance(line, GenieVillagerGroup) and restock_target_id == 50:
             # Search for the build graphic of farms
             restock_unit = line.get_units_with_command(101)[0]
-            commands = restock_unit["unit_commands"].get_value()
+            commands = restock_unit["unit_commands"].value
             for command in commands:
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id == 101:
-                    ability_animation_id = command["work_sprite_id"].get_value()
+                    ability_animation_id = command["work_sprite_id"].value
 
         if ability_animation_id > -1:
             # Make the ability animated
@@ -5353,7 +5353,7 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.Restock")
 
         # restock time
-        restock_time = restock_target.get_head_unit()["creation_time"].get_value()
+        restock_time = restock_target.get_head_unit()["creation_time"].value
         ability_raw_api_object.add_raw_member("restock_time",
                                               restock_time,
                                               "engine.ability.type.Restock")
@@ -5371,14 +5371,14 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.Restock")
 
         # Amount
-        restock_amount = restock_target.get_head_unit()["resource_capacity"].get_value()
+        restock_amount = restock_target.get_head_unit()["resource_capacity"].value
         if restock_target_id == 50:
             # Farm food amount (hardcoded in civ)
-            restock_amount = dataset.genie_civs[1]["resources"][36].get_value()
+            restock_amount = dataset.genie_civs[1]["resources"][36].value
 
         elif restock_target_id == 199:
             # Fish trap added food amount (hardcoded in civ)
-            restock_amount += dataset.genie_civs[1]["resources"][88].get_value()
+            restock_amount += dataset.genie_civs[1]["resources"][88].value
 
         ability_raw_api_object.add_raw_member("amount",
                                               restock_amount,
@@ -5552,23 +5552,23 @@ class AoCAbilitySubprocessor:
         # Create containers
         containers = []
         for gatherer in gatherers:
-            unit_commands = gatherer["unit_commands"].get_value()
+            unit_commands = gatherer["unit_commands"].value
             resource = None
 
             used_command = None
             for command in unit_commands:
                 # Find a gather ability. It doesn't matter which one because
                 # they should all produce the same resource for one genie unit.
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id not in (5, 110, 111):
                     continue
 
-                resource_id = command["resource_out"].get_value()
+                resource_id = command["resource_out"].value
 
                 # If resource_out is not specified, the gatherer harvests resource_in
                 if resource_id == -1:
-                    resource_id = command["resource_in"].get_value()
+                    resource_id = command["resource_in"].value
 
                 if resource_id == 0:
                     resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
@@ -5587,7 +5587,7 @@ class AoCAbilitySubprocessor:
                     )
 
                 elif type_id == 111:
-                    target_id = command["unit_id"].get_value()
+                    target_id = command["unit_id"].value
                     if target_id not in dataset.building_lines.keys():
                         # Skips the trade workshop trading which is never used
                         continue
@@ -5613,7 +5613,7 @@ class AoCAbilitySubprocessor:
 
                 container_name = f"{gather_lookup_dict[gatherer_unit_id][0]}Container"
 
-            elif used_command["type"].get_value() == 111:
+            elif used_command["type"].value == 111:
                 # Trading
                 container_name = "TradeContainer"
 
@@ -5632,9 +5632,9 @@ class AoCAbilitySubprocessor:
 
             # Carry capacity
             if line.is_gatherer():
-                carry_capacity = gatherer["resource_capacity"].get_value()
+                carry_capacity = gatherer["resource_capacity"].value
 
-            elif used_command["type"].get_value() == 111:
+            elif used_command["type"].value == 111:
                 # No restriction for trading
                 carry_capacity = MemberSpecialValue.NYAN_INF
 
@@ -5644,7 +5644,7 @@ class AoCAbilitySubprocessor:
 
             # Carry progress
             carry_progress = []
-            carry_move_animation_id = used_command["carry_sprite_id"].get_value()
+            carry_move_animation_id = used_command["carry_sprite_id"].value
             if carry_move_animation_id > -1:
                 # =================================================================================
                 progress_ref = f"{ability_ref}.{container_name}CarryProgress"
@@ -5868,7 +5868,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Command Sound
-        ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+        ability_comm_sound_id = current_unit["command_sound_id"].value
         if ability_comm_sound_id > -1:
             property_ref = f"{ability_ref}.CommandSound"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -5927,12 +5927,12 @@ class AoCAbilitySubprocessor:
         box_location = ForwardRef(line, ability_ref)
         box_raw_api_object.set_location(box_location)
 
-        width = current_unit["selection_shape_x"].get_value()
+        width = current_unit["selection_shape_x"].value
         box_raw_api_object.add_raw_member("width",
                                           width,
                                           "engine.util.selection_box.type.Rectangle")
 
-        height = current_unit["selection_shape_y"].get_value()
+        height = current_unit["selection_shape_y"].value
         box_raw_api_object.add_raw_member("height",
                                           height,
                                           "engine.util.selection_box.type.Rectangle")
@@ -6028,7 +6028,7 @@ class AoCAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["attack_sprite_id"].get_value()
+        ability_animation_id = current_unit["attack_sprite_id"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -6058,7 +6058,7 @@ class AoCAbilitySubprocessor:
             })
 
         # Command Sound
-        ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+        ability_comm_sound_id = current_unit["command_sound_id"].value
         if ability_comm_sound_id > -1:
             property_ref = f"{ability_ref}.CommandSound"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -6112,12 +6112,12 @@ class AoCAbilitySubprocessor:
 
         # Projectile
         projectiles = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
         if projectile_primary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile0"))
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].get_value()
+        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
         if projectile_secondary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile1"))
@@ -6127,8 +6127,8 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Projectile count
-        min_projectiles = current_unit["attack_projectile_count"].get_value()
-        max_projectiles = current_unit["attack_projectile_max_count"].get_value()
+        min_projectiles = current_unit["attack_projectile_count"].value
+        max_projectiles = current_unit["attack_projectile_max_count"].value
 
         if projectile_primary == -1:
             # Special case where only the second projectile is defined (town center)
@@ -6154,18 +6154,18 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Range
-        min_range = current_unit["weapon_range_min"].get_value()
+        min_range = current_unit["weapon_range_min"].value
         ability_raw_api_object.add_raw_member("min_range",
                                               min_range,
                                               "engine.ability.type.ShootProjectile")
 
-        max_range = current_unit["weapon_range_max"].get_value()
+        max_range = current_unit["weapon_range_max"].value
         ability_raw_api_object.add_raw_member("max_range",
                                               max_range,
                                               "engine.ability.type.ShootProjectile")
 
         # Reload time and delay
-        reload_time = current_unit["attack_speed"].get_value()
+        reload_time = current_unit["attack_speed"].value
         ability_raw_api_object.add_raw_member("reload_time",
                                               reload_time,
                                               "engine.ability.type.ShootProjectile")
@@ -6177,7 +6177,7 @@ class AoCAbilitySubprocessor:
         else:
             frame_rate = 0
 
-        spawn_delay_frames = current_unit["frame_delay"].get_value()
+        spawn_delay_frames = current_unit["frame_delay"].value
         spawn_delay = frame_rate * spawn_delay_frames
         ability_raw_api_object.add_raw_member("spawn_delay",
                                               spawn_delay,
@@ -6207,9 +6207,9 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Spawning area
-        spawning_area_offset_x = current_unit["weapon_offset"][0].get_value()
-        spawning_area_offset_y = current_unit["weapon_offset"][1].get_value()
-        spawning_area_offset_z = current_unit["weapon_offset"][2].get_value()
+        spawning_area_offset_x = current_unit["weapon_offset"][0].value
+        spawning_area_offset_y = current_unit["weapon_offset"][1].value
+        spawning_area_offset_z = current_unit["weapon_offset"][2].value
 
         ability_raw_api_object.add_raw_member("spawning_area_offset_x",
                                               spawning_area_offset_x,
@@ -6221,10 +6221,9 @@ class AoCAbilitySubprocessor:
                                               spawning_area_offset_z,
                                               "engine.ability.type.ShootProjectile")
 
-        spawning_area_width = current_unit["attack_projectile_spawning_area_width"].get_value()
-        spawning_area_height = current_unit["attack_projectile_spawning_area_length"].get_value()
-        spawning_area_randomness = current_unit["attack_projectile_spawning_area_randomness"].get_value(
-        )
+        spawning_area_width = current_unit["attack_projectile_spawning_area_width"].value
+        spawning_area_height = current_unit["attack_projectile_spawning_area_length"].value
+        spawning_area_randomness = current_unit["attack_projectile_spawning_area_randomness"].value
 
         ability_raw_api_object.add_raw_member("spawning_area_width",
                                               spawning_area_width,
@@ -6401,7 +6400,7 @@ class AoCAbilitySubprocessor:
                                                 "engine.util.storage.EntityContainer")
 
         # Container slots
-        slots = current_unit["garrison_capacity"].get_value()
+        slots = current_unit["garrison_capacity"].value
         if garrison_mode is GenieGarrisonMode.MONK:
             slots = 1
 
@@ -6413,8 +6412,8 @@ class AoCAbilitySubprocessor:
         carry_progress = []
         if garrison_mode is GenieGarrisonMode.MONK and isinstance(line, GenieMonkGroup):
             switch_unit = line.get_switch_unit()
-            carry_idle_animation_id = switch_unit["idle_graphic0"].get_value()
-            carry_move_animation_id = switch_unit["move_graphics"].get_value()
+            carry_idle_animation_id = switch_unit["idle_graphic0"].value
+            carry_move_animation_id = switch_unit["move_graphics"].value
 
             progress_ref = f"{ability_ref}.CarryProgress"
             progress_raw_api_object = RawAPIObject(progress_ref,
@@ -6615,7 +6614,7 @@ class AoCAbilitySubprocessor:
         else:
             # Garrison graphics
             if current_unit.has_member("garrison_graphic"):
-                garrison_animation_id = current_unit["garrison_graphic"].get_value()
+                garrison_animation_id = current_unit["garrison_graphic"].value
 
             else:
                 garrison_animation_id = -1
@@ -6773,7 +6772,7 @@ class AoCAbilitySubprocessor:
 
         # Allowed types
         allowed_types = []
-        terrain_restriction = current_unit["terrain_restriction"].get_value()
+        terrain_restriction = current_unit["terrain_restriction"].value
         for terrain_type in terrain_type_lookup_dict.values():
             # Check if terrain type is covered by terrain restriction
             if terrain_restriction in terrain_type[1]:
@@ -6823,15 +6822,15 @@ class AoCAbilitySubprocessor:
         # Trade route (use the trade route to the market)
         trade_routes = []
 
-        unit_commands = current_unit["unit_commands"].get_value()
+        unit_commands = current_unit["unit_commands"].value
         for command in unit_commands:
             # Find the trade command and the trade post id
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id != 111:
                 continue
 
-            trade_post_id = command["unit_id"].get_value()
+            trade_post_id = command["unit_id"].value
             if trade_post_id not in dataset.building_lines.keys():
                 # Skips trade workshop
                 continue
@@ -6956,7 +6955,7 @@ class AoCAbilitySubprocessor:
         storage_entity = None
         garrisoned_forward_ref = None
         for garrisoned in line.garrison_entities:
-            creatable_type = garrisoned.get_head_unit()["creatable_type"].get_value()
+            creatable_type = garrisoned.get_head_unit()["creatable_type"].value
 
             if creatable_type == 4:
                 storage_name = name_lookup_dict[garrisoned.get_id()][0]
@@ -6978,13 +6977,13 @@ class AoCAbilitySubprocessor:
 
         # Target container
         target = None
-        unit_commands = line.get_switch_unit()["unit_commands"].get_value()
+        unit_commands = line.get_switch_unit()["unit_commands"].value
         for command in unit_commands:
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             # Deposit
             if type_id == 136:
-                target_id = command["unit_id"].get_value()
+                target_id = command["unit_id"].value
                 target = dataset.building_lines[target_id]
 
         target_name = name_lookup_dict[target.get_id()][0]
@@ -7029,14 +7028,14 @@ class AoCAbilitySubprocessor:
         line.add_raw_api_object(ability_raw_api_object)
 
         # Speed
-        turn_speed_unmodified = current_unit["turn_speed"].get_value()
+        turn_speed_unmodified = current_unit["turn_speed"].value
 
         # Default case: Instant turning
         turn_speed = MemberSpecialValue.NYAN_INF
 
         # Ships/Trebuchets turn slower
         if turn_speed_unmodified > 0:
-            turn_yaw = current_unit["max_yaw_per_sec_moving"].get_value()
+            turn_yaw = current_unit["max_yaw_per_sec_moving"].value
             turn_speed = degrees(turn_yaw)
 
         ability_raw_api_object.add_raw_member("turn_speed",
@@ -7093,10 +7092,10 @@ class AoCAbilitySubprocessor:
         # Check if contingents are stored in the unit before creating the ability
 
         # Stores the pop space
-        resource_storage = current_unit["resource_storage"].get_value()
+        resource_storage = current_unit["resource_storage"].value
         contingents = []
         for storage in resource_storage:
-            type_id = storage["type"].get_value()
+            type_id = storage["type"].value
 
             if type_id == 11:
                 resource = dataset.pregen_nyan_objects["util.resource.types.PopulationSpace"].get_nyan_object(
@@ -7106,7 +7105,7 @@ class AoCAbilitySubprocessor:
             else:
                 continue
 
-            amount = storage["amount"].get_value()
+            amount = storage["amount"].value
 
             contingent_amount_name = f"{game_entity_name}.UseContingent.{resource_name}"
             contingent_amount = RawAPIObject(contingent_amount_name, resource_name,

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -4503,12 +4503,12 @@ class AoCAbilitySubprocessor:
 
         if position == 0:
             current_unit_id = line.get_head_unit_id()
-            projectile_id = line.get_head_unit()["attack_projectile_primary_unit_id"].value
+            projectile_id = line.get_head_unit()["projectile_id0"].value
             current_unit = dataset.genie_units[projectile_id]
 
         elif position == 1:
             current_unit_id = line.get_head_unit_id()
-            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].value
+            projectile_id = line.get_head_unit()["projectile_id1"].value
             current_unit = dataset.genie_units[projectile_id]
 
         else:
@@ -4892,10 +4892,10 @@ class AoCAbilitySubprocessor:
 
         # Arc
         if position == 0:
-            projectile_id = current_unit["attack_projectile_primary_unit_id"].value
+            projectile_id = current_unit["projectile_id0"].value
 
         elif position == 1:
-            projectile_id = current_unit["attack_projectile_secondary_unit_id"].value
+            projectile_id = current_unit["projectile_id1"].value
 
         else:
             raise Exception("Invalid position")
@@ -6082,12 +6082,12 @@ class AoCAbilitySubprocessor:
 
         # Projectile
         projectiles = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
+        projectile_primary = current_unit["projectile_id0"].value
         if projectile_primary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile0"))
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
+        projectile_secondary = current_unit["projectile_id1"].value
         if projectile_secondary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile1"))
@@ -6097,8 +6097,8 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Projectile count
-        min_projectiles = current_unit["attack_projectile_count"].value
-        max_projectiles = current_unit["attack_projectile_max_count"].value
+        min_projectiles = current_unit["projectile_min_count"].value
+        max_projectiles = current_unit["projectile_max_count"].value
 
         if projectile_primary == -1:
             # Special case where only the second projectile is defined (town center)
@@ -6191,9 +6191,9 @@ class AoCAbilitySubprocessor:
                                               spawning_area_offset_z,
                                               "engine.ability.type.ShootProjectile")
 
-        spawning_area_width = current_unit["attack_projectile_spawning_area_width"].value
-        spawning_area_height = current_unit["attack_projectile_spawning_area_length"].value
-        spawning_area_randomness = current_unit["attack_projectile_spawning_area_randomness"].value
+        spawning_area_width = current_unit["projectile_spawning_area_width"].value
+        spawning_area_height = current_unit["projectile_spawning_area_length"].value
+        spawning_area_randomness = current_unit["projectile_spawning_area_randomness"].value
 
         ability_raw_api_object.add_raw_member("spawning_area_width",
                                               spawning_area_width,

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -128,12 +128,13 @@ class AoCAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations", animations_set,
                                                    "engine.ability.property.type.Animated")
@@ -169,8 +170,8 @@ class AoCAbilitySubprocessor:
                         handled_graphics_set_ids.add(graphics_set_id)
 
                     obj_prefix = f"{gset_lookup_dict[graphics_set_id][1]}{ability_name}"
-                    filename_prefix = "%s_%s_" % (command_lookup_dict[command_id][1],
-                                                  gset_lookup_dict[graphics_set_id][2],)
+                    filename_prefix = (f"{command_lookup_dict[command_id][1]}_"
+                                       f"{gset_lookup_dict[graphics_set_id][2]}_")
                     AoCAbilitySubprocessor.create_civ_animation(line,
                                                                 civ_group,
                                                                 civ_animation_id,
@@ -351,15 +352,15 @@ class AoCAbilitySubprocessor:
             ability_animation_id = current_unit["attack_sprite_id"].value
 
         else:
-            ability_ref = "%s.ShootProjectile.Projectile%s.%s" % (game_entity_name,
-                                                                  str(projectile),
-                                                                  ability_name)
+            ability_ref = (f"{game_entity_name}.ShootProjectile.Projectile{projectile}."
+                           f"{ability_name}")
             ability_raw_api_object = RawAPIObject(
                 ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
-            ability_location = ForwardRef(line,
-                                          "%s.ShootProjectile.Projectile%s"
-                                          % (game_entity_name, str(projectile)))
+            ability_location = ForwardRef(
+                line,
+                f"{game_entity_name}.ShootProjectile.Projectile{projectile}"
+            )
             ability_raw_api_object.set_location(ability_location)
 
             ability_animation_id = -1
@@ -382,12 +383,13 @@ class AoCAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations", animations_set,
                                                    "engine.ability.property.type.Animated")
@@ -423,8 +425,8 @@ class AoCAbilitySubprocessor:
                         handled_graphics_set_ids.add(graphics_set_id)
 
                     obj_prefix = f"{gset_lookup_dict[graphics_set_id][1]}{ability_name}"
-                    filename_prefix = "%s_%s_" % (command_lookup_dict[command_id][1],
-                                                  gset_lookup_dict[graphics_set_id][2],)
+                    filename_prefix = (f"{command_lookup_dict[command_id][1]}_"
+                                       f"{gset_lookup_dict[graphics_set_id][2]}_")
                     AoCAbilitySubprocessor.create_civ_animation(line,
                                                                 civ_group,
                                                                 civ_animation_id,
@@ -694,12 +696,13 @@ class AoCAbilitySubprocessor:
 
                 # Animation
                 animations_set = []
-                animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                                progress_animation_id,
-                                                                                property_ref,
-                                                                                "Idle",
-                                                                                "idle_damage_override_%s_"
-                                                                                % (interval_right_bound))
+                animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                    line,
+                    progress_animation_id,
+                    property_ref,
+                    "Idle",
+                    f"idle_damage_override_{interval_right_bound}_"
+                )
                 animations_set.append(animation_forward_ref)
                 property_raw_api_object.add_raw_member("overlays",
                                                        animations_set,
@@ -918,8 +921,8 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Create"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.ProductionQueue"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.ProductionQueue"))
+
             if len(line.researches) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Research"))
@@ -932,25 +935,21 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Storage"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.RemoveStorage"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.RemoveStorage"))
 
                 garrison_mode = line.get_garrison_mode()
 
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.SendBackToTask"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.SendBackToTask"))
 
                 if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.RallyPoint"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.RallyPoint"))
 
             if line.is_harvestable():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.Harvestable"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.Harvestable"))
 
             if line.is_dropsite():
                 disabled_forward_refs.append(ForwardRef(line,
@@ -958,8 +957,7 @@ class AoCAbilitySubprocessor:
 
             if line.is_trade_post():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.TradePost"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.TradePost"))
 
             init_state_raw_api_object.add_raw_member("disable_abilities",
                                                      disabled_forward_refs,
@@ -1079,14 +1077,12 @@ class AoCAbilitySubprocessor:
 
             # Disabled abilities
             disabled_forward_refs = [ForwardRef(line,
-                                                "%s.AttributeChangeTracker"
-                                                % (game_entity_name))]
+                                                f"{game_entity_name}.AttributeChangeTracker")]
             if len(line.creates) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Create"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.ProductionQueue"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.ProductionQueue"))
             if len(line.researches) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Research"))
@@ -1099,25 +1095,21 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Storage"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.RemoveStorage"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.RemoveStorage"))
 
                 garrison_mode = line.get_garrison_mode()
 
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.SendBackToTask"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.SendBackToTask"))
 
                 if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.RallyPoint"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.RallyPoint"))
 
             if line.is_harvestable():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.Harvestable"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.Harvestable"))
 
             if line.is_dropsite():
                 disabled_forward_refs.append(ForwardRef(line,
@@ -1125,8 +1117,7 @@ class AoCAbilitySubprocessor:
 
             if line.is_trade_post():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.TradePost"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.TradePost"))
 
             construct_state_raw_api_object.add_raw_member("disable_abilities",
                                                           disabled_forward_refs,
@@ -1458,8 +1449,7 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Create"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.ProductionQueue"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.ProductionQueue"))
             if len(line.researches) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Research"))
@@ -1472,25 +1462,21 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Storage"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.RemoveStorage"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.RemoveStorage"))
 
                 garrison_mode = line.get_garrison_mode()
 
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.SendBackToTask"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.SendBackToTask"))
 
                 if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.RallyPoint"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.RallyPoint"))
 
             if line.is_harvestable():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.Harvestable"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.Harvestable"))
 
             if line.is_dropsite():
                 disabled_forward_refs.append(ForwardRef(line,
@@ -1498,8 +1484,7 @@ class AoCAbilitySubprocessor:
 
             if line.is_trade_post():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.TradePost"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.TradePost"))
 
             init_state_raw_api_object.add_raw_member("disable_abilities",
                                                      disabled_forward_refs,
@@ -1654,14 +1639,12 @@ class AoCAbilitySubprocessor:
 
             # Disabled abilities
             disabled_forward_refs = [ForwardRef(line,
-                                                "%s.AttributeChangeTracker"
-                                                % (game_entity_name))]
+                                                f"{game_entity_name}.AttributeChangeTracker")]
             if len(line.creates) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Create"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.ProductionQueue"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.ProductionQueue"))
             if len(line.researches) > 0:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Research"))
@@ -1674,25 +1657,21 @@ class AoCAbilitySubprocessor:
                 disabled_forward_refs.append(ForwardRef(line,
                                                         f"{game_entity_name}.Storage"))
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.RemoveStorage"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.RemoveStorage"))
 
                 garrison_mode = line.get_garrison_mode()
 
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.SendBackToTask"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.SendBackToTask"))
 
                 if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                     disabled_forward_refs.append(ForwardRef(line,
-                                                            "%s.RallyPoint"
-                                                            % (game_entity_name)))
+                                                            f"{game_entity_name}.RallyPoint"))
 
             if line.is_harvestable():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.Harvestable"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.Harvestable"))
 
             if line.is_dropsite():
                 disabled_forward_refs.append(ForwardRef(line,
@@ -1700,8 +1679,7 @@ class AoCAbilitySubprocessor:
 
             if line.is_trade_post():
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.TradePost"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.TradePost"))
 
             construct_state_raw_api_object.add_raw_member("disable_abilities",
                                                           disabled_forward_refs,
@@ -2086,7 +2064,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def create_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Create ability to a line.
@@ -2160,7 +2138,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def death_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds a PassiveTransformTo ability to a line that is used to make entities die.
@@ -2308,8 +2286,7 @@ class AoCAbilitySubprocessor:
 
         if isinstance(line, GenieBuildingLineGroup):
             disabled_forward_refs.append(ForwardRef(line,
-                                                    "%s.AttributeChangeTracker"
-                                                    % (game_entity_name)))
+                                                    f"{game_entity_name}.AttributeChangeTracker"))
 
         if len(line.creates) > 0:
             disabled_forward_refs.append(ForwardRef(line,
@@ -2317,8 +2294,7 @@ class AoCAbilitySubprocessor:
 
             if isinstance(line, GenieBuildingLineGroup):
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.ProductionQueue"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.ProductionQueue"))
         if len(line.researches) > 0:
             disabled_forward_refs.append(ForwardRef(line,
                                                     f"{game_entity_name}.Research"))
@@ -2331,20 +2307,17 @@ class AoCAbilitySubprocessor:
             disabled_forward_refs.append(ForwardRef(line,
                                                     f"{game_entity_name}.Storage"))
             disabled_forward_refs.append(ForwardRef(line,
-                                                    "%s.RemoveStorage"
-                                                    % (game_entity_name)))
+                                                    f"{game_entity_name}.RemoveStorage"))
 
             garrison_mode = line.get_garrison_mode()
 
             if garrison_mode == GenieGarrisonMode.NATURAL:
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.SendBackToTask"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.SendBackToTask"))
 
             if garrison_mode in (GenieGarrisonMode.NATURAL, GenieGarrisonMode.SELF_PRODUCED):
                 disabled_forward_refs.append(ForwardRef(line,
-                                                        "%s.RallyPoint"
-                                                        % (game_entity_name)))
+                                                        f"{game_entity_name}.RallyPoint"))
 
         if line.is_harvestable():
             disabled_forward_refs.append(ForwardRef(line,
@@ -2442,7 +2415,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def delete_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds a PassiveTransformTo ability to a line that is used to make entities die.
@@ -2553,7 +2526,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def despawn_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Despawn ability to a line.
@@ -2704,7 +2677,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def drop_resources_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the DropResources ability to a line.
@@ -2757,8 +2730,8 @@ class AoCAbilitySubprocessor:
                 # Skips hunting wolves
                 continue
 
-            container_ref = "%s.ResourceStorage.%sContainer" % (game_entity_name,
-                                                                gather_lookup_dict[gatherer_unit_id][0])
+            container_ref = (f"{game_entity_name}.ResourceStorage."
+                             f"{gather_lookup_dict[gatherer_unit_id][0]}Container")
             container_forward_ref = ForwardRef(line, container_ref)
             containers.append(container_forward_ref)
 
@@ -2811,7 +2784,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def drop_site_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the DropSite ability to a line.
@@ -2851,8 +2824,8 @@ class AoCAbilitySubprocessor:
             gatherer_head_unit_id = gatherer_line.get_head_unit_id()
             gatherer_name = name_lookup_dict[gatherer_head_unit_id][0]
 
-            container_ref = "%s.ResourceStorage.%sContainer" % (gatherer_name,
-                                                                gather_lookup_dict[gatherer_id][0])
+            container_ref = (f"{gatherer_name}.ResourceStorage."
+                             f"{gather_lookup_dict[gatherer_id][0]}Container")
             container_forward_ref = ForwardRef(gatherer_line, container_ref)
             containers.append(container_forward_ref)
 
@@ -2888,7 +2861,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def enter_container_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the EnterContainer ability to a line.
@@ -2955,7 +2928,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def exchange_resources_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ExchangeResources ability to a line.
@@ -3000,18 +2973,18 @@ class AoCAbilitySubprocessor:
                                                   "engine.ability.type.ExchangeResources")
 
             # Exchange rate
-            exchange_rate = dataset.pregen_nyan_objects[("util.resource.market_trading.Market%sExchangeRate"
-                                                         % (resource_name))].get_nyan_object()
+            exchange_rate_ref = f"util.resource.market_trading.Market{resource_name}ExchangeRate"
+            exchange_rate = dataset.pregen_nyan_objects[exchange_rate_ref].get_nyan_object()
             ability_raw_api_object.add_raw_member("exchange_rate",
                                                   exchange_rate,
                                                   "engine.ability.type.ExchangeResources")
 
             # Exchange modes
+            buy_exchange_ref = "util.resource.market_trading.MarketBuyExchangeMode"
+            sell_exchange_ref = "util.resource.market_trading.MarketSellExchangeMode"
             exchange_modes = [
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(
-                ),
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(
-                ),
+                dataset.pregen_nyan_objects[buy_exchange_ref].get_nyan_object(),
+                dataset.pregen_nyan_objects[sell_exchange_ref].get_nyan_object(),
             ]
             ability_raw_api_object.add_raw_member("exchange_modes",
                                                   exchange_modes,
@@ -3022,7 +2995,7 @@ class AoCAbilitySubprocessor:
 
         return abilities
 
-    @staticmethod
+    @ staticmethod
     def exit_container_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ExitContainer ability to a line.
@@ -3076,7 +3049,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def game_entity_stance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the GameEntityStance ability to a line.
@@ -3163,7 +3136,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def formation_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Formation ability to a line.
@@ -3246,7 +3219,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def foundation_ability(line: GenieGameEntityGroup, terrain_id: int = -1) -> ForwardRef:
         """
         Adds the Foundation abilities to a line. Optionally chooses the specified
@@ -3290,7 +3263,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def gather_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Gather abilities to a line. Unlike the other methods, this
@@ -3427,12 +3400,13 @@ class AoCAbilitySubprocessor:
                 line.add_raw_api_object(property_raw_api_object)
 
                 animations_set = []
-                animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                                ability_animation_id,
-                                                                                property_ref,
-                                                                                ability_name,
-                                                                                "%s_"
-                                                                                % gather_lookup_dict[gatherer_unit_id][1])
+                animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                    line,
+                    ability_animation_id,
+                    property_ref,
+                    ability_name,
+                    f"{gather_lookup_dict[gatherer_unit_id][1]}_"
+                )
                 animations_set.append(animation_forward_ref)
                 property_raw_api_object.add_raw_member("animations", animations_set,
                                                        "engine.ability.property.type.Animated")
@@ -3499,8 +3473,8 @@ class AoCAbilitySubprocessor:
                                                   "engine.ability.type.Gather")
 
             # Resource container
-            container_ref = "%s.ResourceStorage.%sContainer" % (game_entity_name,
-                                                                gather_lookup_dict[gatherer_unit_id][0])
+            container_ref = (f"{game_entity_name}.ResourceStorage."
+                             f"{gather_lookup_dict[gatherer_unit_id][0]}Container")
             container_forward_ref = ForwardRef(line, container_ref)
             ability_raw_api_object.add_raw_member("container",
                                                   container_forward_ref,
@@ -3514,8 +3488,7 @@ class AoCAbilitySubprocessor:
                 group_name = entity_lookups[group_id][0]
 
                 spot_forward_ref = ForwardRef(group,
-                                              "%s.Harvestable.%sResourceSpot"
-                                              % (group_name, group_name))
+                                              f"{group_name}.Harvestable.{group_name}ResourceSpot")
                 spot_forward_refs.append(spot_forward_ref)
 
             ability_raw_api_object.add_raw_member("targets",
@@ -3527,7 +3500,7 @@ class AoCAbilitySubprocessor:
 
         return abilities
 
-    @staticmethod
+    @ staticmethod
     def harvestable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Harvestable ability to a line.
@@ -3908,7 +3881,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def herd_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Herd ability to a line.
@@ -3960,7 +3933,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def herdable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Herdable ability to a line.
@@ -4000,7 +3973,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def hitbox_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Hitbox ability to a line.
@@ -4059,7 +4032,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def idle_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Idle ability to a line.
@@ -4164,7 +4137,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def live_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Live ability to a line.
@@ -4270,7 +4243,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def los_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the LineOfSight ability to a line.
@@ -4329,7 +4302,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def move_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Move ability to a line.
@@ -4515,7 +4488,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def move_projectile_ability(line: GenieGameEntityGroup, position: int = -1) -> ForwardRef:
         """
         Adds the Move ability to a projectile of the specified line.
@@ -4549,8 +4522,7 @@ class AoCAbilitySubprocessor:
         ability_raw_api_object = RawAPIObject(ability_ref, "Move", dataset.nyan_api_objects)
         ability_raw_api_object.add_raw_parent("engine.ability.type.Move")
         ability_location = ForwardRef(line,
-                                      "%s.ShootProjectile.Projectile%s"
-                                      % (game_entity_name, position))
+                                      f"{game_entity_name}.ShootProjectile.Projectile{position}")
         ability_raw_api_object.set_location(ability_location)
 
         line.add_raw_api_object(ability_raw_api_object)
@@ -4609,7 +4581,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def named_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Named ability to a line.
@@ -4646,8 +4618,7 @@ class AoCAbilitySubprocessor:
         translations = AoCAbilitySubprocessor.create_language_strings(line,
                                                                       name_string_id,
                                                                       name_ref,
-                                                                      "%sName"
-                                                                      % (game_entity_name))
+                                                                      f"{game_entity_name}Name")
         name_raw_api_object.add_raw_member("translations",
                                            translations,
                                            "engine.util.language.translated.type.TranslatedString")
@@ -4702,7 +4673,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def overlay_terrain_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the OverlayTerrain to a line.
@@ -4743,7 +4714,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def passable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Passable ability to a line.
@@ -4828,7 +4799,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def production_queue_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProductionQueue ability to a line.
@@ -4888,7 +4859,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def projectile_ability(line: GenieGameEntityGroup, position: int = 0) -> ForwardRef:
         """
         Adds a Projectile ability to projectiles in a line. Which projectile should
@@ -4911,8 +4882,7 @@ class AoCAbilitySubprocessor:
 
         # First projectile is mandatory
         obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{str(position)}"
-        ability_ref = "%s.ShootProjectile.Projectile%s.Projectile"\
-            % (game_entity_name, str(position))
+        ability_ref = f"{game_entity_name}.ShootProjectile.Projectile{position}.Projectile"
         ability_raw_api_object = RawAPIObject(ability_ref,
                                               "Projectile",
                                               dataset.nyan_api_objects)
@@ -4937,8 +4907,8 @@ class AoCAbilitySubprocessor:
                                               "engine.ability.type.Projectile")
 
         # Accuracy
-        accuracy_name = "%s.ShootProjectile.Projectile%s.Projectile.Accuracy"\
-                        % (game_entity_name, str(position))
+        accuracy_name = (f"{game_entity_name}.ShootProjectile."
+                         f"Projectile{position}.Projectile.Accuracy")
         accuracy_raw_api_object = RawAPIObject(accuracy_name,
                                                "Accuracy",
                                                dataset.nyan_api_objects)
@@ -5000,7 +4970,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def provide_contingent_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ProvideContingent ability to a line.
@@ -5079,7 +5049,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def rally_point_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RallyPoint ability to a line.
@@ -5108,7 +5078,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def regenerate_attribute_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the RegenerateAttribute ability to a line.
@@ -5189,7 +5159,7 @@ class AoCAbilitySubprocessor:
 
         return [ability_forward_ref]
 
-    @staticmethod
+    @ staticmethod
     def regenerate_resource_spot_ability(line: GenieGameEntityGroup) -> None:
         """
         Adds the RegenerateResourceSpot ability to a line.
@@ -5201,7 +5171,7 @@ class AoCAbilitySubprocessor:
         """
         # Unused in AoC
 
-    @staticmethod
+    @ staticmethod
     def remove_storage_ability(line) -> ForwardRef:
         """
         Adds the RemoveStorage ability to a line.
@@ -5251,7 +5221,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def restock_ability(line: GenieGameEntityGroup, restock_target_id: int) -> ForwardRef:
         """
         Adds the Restock ability to a line.
@@ -5315,13 +5285,13 @@ class AoCAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            restock_lookup_dict[restock_target_id][0],
-                                                                            "%s_"
-                                                                            % restock_lookup_dict[restock_target_id][1])
-
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                restock_lookup_dict[restock_target_id][0],
+                f"{restock_lookup_dict[restock_target_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations",
                                                    animations_set,
@@ -5345,9 +5315,8 @@ class AoCAbilitySubprocessor:
         restock_target_lookup_dict = internal_name_lookups.get_entity_lookups(dataset.game_version)
         restock_target_name = restock_target_lookup_dict[restock_target_id][0]
         spot_forward_ref = ForwardRef(restock_target,
-                                      "%s.Harvestable.%sResourceSpot"
-                                      % (restock_target_name,
-                                         restock_target_name))
+                                      (f"{restock_target_name}.Harvestable."
+                                       f"{restock_target_name}ResourceSpot"))
         ability_raw_api_object.add_raw_member("target",
                                               spot_forward_ref,
                                               "engine.ability.type.Restock")
@@ -5361,8 +5330,8 @@ class AoCAbilitySubprocessor:
         # Manual/Auto Cost
         # Link to the same Cost object as Create
         cost_forward_ref = ForwardRef(restock_target,
-                                      "%s.CreatableGameEntity.%sCost"
-                                      % (restock_target_name, restock_target_name))
+                                      (f"{restock_target_name}.CreatableGameEntity."
+                                       f"{restock_target_name}Cost"))
         ability_raw_api_object.add_raw_member("manual_cost",
                                               cost_forward_ref,
                                               "engine.ability.type.Restock")
@@ -5390,7 +5359,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def research_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Research ability to a line.
@@ -5466,7 +5435,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def resistance_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Resistance ability to a line.
@@ -5516,7 +5485,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def resource_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the ResourceStorage ability to a line.
@@ -5765,7 +5734,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def selectable_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds Selectable abilities to a line. Units will get two of these,
@@ -5952,7 +5921,7 @@ class AoCAbilitySubprocessor:
 
         return abilities
 
-    @staticmethod
+    @ staticmethod
     def send_back_to_task_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the SendBackToTask ability to a line.
@@ -5993,7 +5962,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def shoot_projectile_ability(line: GenieGameEntityGroup, command_id: int) -> ForwardRef:
         """
         Adds the ShootProjectile ability to a line.
@@ -6041,12 +6010,13 @@ class AoCAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations",
                                                    animations_set,
@@ -6251,7 +6221,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def stop_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Stop ability to a line.
@@ -6305,7 +6275,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Storage ability to a line.
@@ -6362,9 +6332,9 @@ class AoCAbilitySubprocessor:
         if garrison_mode is GenieGarrisonMode.UNIT_GARRISON:
             for storage_element in line.garrison_entities:
                 storage_element_name = name_lookup_dict[storage_element.get_head_unit_id()][0]
-                storage_def_ref = "%s.Storage.%sContainer.%sStorageDef" % (game_entity_name,
-                                                                           game_entity_name,
-                                                                           storage_element_name)
+                storage_def_ref = (f"{game_entity_name}.Storage."
+                                   f"{game_entity_name}Container."
+                                   f"{storage_element_name}StorageDef")
                 storage_def_raw_api_object = RawAPIObject(storage_def_ref,
                                                           f"{storage_element_name}StorageDef",
                                                           dataset.nyan_api_objects)
@@ -6742,7 +6712,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def terrain_requirement_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TerrainRequirement to a line.
@@ -6795,7 +6765,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def trade_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Trade ability to a line.
@@ -6859,7 +6829,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def trade_post_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TradePost ability to a line.
@@ -6926,7 +6896,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def transfer_storage_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the TransferStorage ability to a line.
@@ -6999,7 +6969,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def turn_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Turn ability to a line.
@@ -7071,7 +7041,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def use_contingent_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the UseContingent ability to a line.
@@ -7147,7 +7117,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def visibility_ability(line: GenieGameEntityGroup) -> ForwardRef:
         """
         Adds the Visibility ability to a line.
@@ -7266,7 +7236,7 @@ class AoCAbilitySubprocessor:
 
         return ability_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def create_animation(
         line: GenieGameEntityGroup,
         animation_id: int,
@@ -7306,8 +7276,8 @@ class AoCAbilitySubprocessor:
 
         else:
             ability_sprite = CombinedSprite(animation_id,
-                                            "%s%s" % (filename_prefix,
-                                                      name_lookup_dict[head_unit_id][1]),
+                                            (f"{filename_prefix}"
+                                             f"{name_lookup_dict[head_unit_id][1]}"),
                                             dataset)
             dataset.combined_sprites.update({ability_sprite.get_id(): ability_sprite})
 
@@ -7322,7 +7292,7 @@ class AoCAbilitySubprocessor:
 
         return animation_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def create_civ_animation(
         line: GenieGameEntityGroup,
         civ_group: GenieCivilizationGroup,
@@ -7432,7 +7402,7 @@ class AoCAbilitySubprocessor:
                                     [wrapper_forward_ref])
         civ_group.add_raw_member_push(push_object)
 
-    @staticmethod
+    @ staticmethod
     def create_sound(
         line: GenieGameEntityGroup,
         sound_id: int,
@@ -7497,7 +7467,7 @@ class AoCAbilitySubprocessor:
 
         return sound_forward_ref
 
-    @staticmethod
+    @ staticmethod
     def create_language_strings(
         line: GenieGameEntityGroup,
         string_id: int,

--- a/openage/convert/processor/conversion/aoc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/ability_subprocessor.py
@@ -2726,7 +2726,7 @@ class AoCAbilitySubprocessor:
                     break
 
             gatherer_unit_id = gatherer.get_id()
-            if gatherer_unit_id not in gather_lookup_dict.keys():
+            if gatherer_unit_id not in gather_lookup_dict:
                 # Skips hunting wolves
                 continue
 
@@ -2816,7 +2816,7 @@ class AoCAbilitySubprocessor:
 
         containers = []
         for gatherer_id in gatherer_ids:
-            if gatherer_id not in gather_lookup_dict.keys():
+            if gatherer_id not in gather_lookup_dict:
                 # Skips hunting wolves
                 continue
 
@@ -3369,7 +3369,7 @@ class AoCAbilitySubprocessor:
                 continue
 
             gatherer_unit_id = gatherer.get_id()
-            if gatherer_unit_id not in gather_lookup_dict.keys():
+            if gatherer_unit_id not in gather_lookup_dict:
                 # Skips hunting wolves
                 continue
 
@@ -5576,7 +5576,7 @@ class AoCAbilitySubprocessor:
 
             if line.is_gatherer():
                 gatherer_unit_id = gatherer.get_id()
-                if gatherer_unit_id not in gather_lookup_dict.keys():
+                if gatherer_unit_id not in gather_lookup_dict:
                     # Skips hunting wolves
                     continue
 

--- a/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
@@ -70,7 +70,7 @@ class AoCAuxiliarySubprocessor:
             # Add object to the Civ object
             enabling_research_id = line.get_enabling_research_id()
             enabling_research = dataset.genie_techs[enabling_research_id]
-            enabling_civ_id = enabling_research["civilization_id"].get_value()
+            enabling_civ_id = enabling_research["civilization_id"].value
 
             civ = dataset.civ_groups[enabling_civ_id]
             civ_name = civ_lookup_dict[enabling_civ_id][0]
@@ -129,8 +129,8 @@ class AoCAuxiliarySubprocessor:
 
         cost_amounts = []
         cost_repair_amounts = []
-        for resource_amount in current_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in current_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             resource = None
             resource_name = ""
@@ -160,10 +160,10 @@ class AoCAuxiliarySubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
-            amount = resource_amount["amount"].get_value()
+            amount = resource_amount["amount"].value
 
             cost_amount_name = f"{cost_name}.{resource_name}Amount"
             cost_amount = RawAPIObject(cost_amount_name,
@@ -220,7 +220,7 @@ class AoCAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
         # Creation time
         if isinstance(line, GenieUnitLineGroup):
-            creation_time = current_unit["creation_time"].get_value()
+            creation_time = current_unit["creation_time"].value
 
         else:
             # Buildings are created immediately
@@ -231,7 +231,7 @@ class AoCAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
 
         # Creation sound
-        creation_sound_id = current_unit["train_sound_id"].get_value()
+        creation_sound_id = current_unit["train_sound_id"].value
 
         # Create sound object
         obj_name = f"{game_entity_name}.CreatableGameEntity.Sound"
@@ -307,8 +307,8 @@ class AoCAuxiliarySubprocessor:
                                                 1.0,
                                                 "engine.util.placement_mode.type.Place")
             # Clearance size
-            clearance_size_x = current_unit["clearance_size_x"].get_value()
-            clearance_size_y = current_unit["clearance_size_y"].get_value()
+            clearance_size_x = current_unit["clearance_size_x"].value
+            clearance_size_y = current_unit["clearance_size_y"].value
             place_raw_api_object.add_raw_member("clearance_size_x",
                                                 clearance_size_x,
                                                 "engine.util.placement_mode.type.Place")
@@ -322,7 +322,7 @@ class AoCAuxiliarySubprocessor:
                                                 "engine.util.placement_mode.type.Place")
 
             # Max elevation difference
-            elevation_mode = current_unit["elevation_mode"].get_value()
+            elevation_mode = current_unit["elevation_mode"].value
             if elevation_mode == 2:
                 max_elevation_difference = 0
 
@@ -460,9 +460,8 @@ class AoCAuxiliarySubprocessor:
                                            "engine.util.cost.Cost")
 
         cost_amounts = []
-        for resource_amount in tech_group.tech["research_resource_costs"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
-
+        for resource_amount in tech_group.tech["research_resource_costs"].value:
+            resource_id = resource_amount["type_id"].value
             resource = None
             resource_name = ""
             if resource_id == -1:
@@ -491,10 +490,10 @@ class AoCAuxiliarySubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
-            amount = resource_amount["amount"].get_value()
+            amount = resource_amount["amount"].value
 
             cost_amount_ref = f"{cost_ref}.{resource_name}Amount"
             cost_amount = RawAPIObject(cost_amount_ref,
@@ -524,8 +523,7 @@ class AoCAuxiliarySubprocessor:
                                                    cost_forward_ref,
                                                    "engine.util.research.ResearchableTech")
 
-        research_time = tech_group.tech["research_time"].get_value()
-
+        research_time = tech_group.tech["research_time"].value
         researchable_raw_api_object.add_raw_member("research_time",
                                                    research_time,
                                                    "engine.util.research.ResearchableTech")
@@ -703,13 +701,13 @@ class AoCAuxiliarySubprocessor:
 
             # Find required techs for the current tech
             assoc_tech_id_members = []
-            assoc_tech_id_members.extend(tech["required_techs"].get_value())
-            required_tech_count = tech["required_tech_count"].get_value()
+            assoc_tech_id_members.extend(tech["required_techs"].value)
+            required_tech_count = tech["required_tech_count"].value
 
             # Remove tech ids that are invalid or those we don't use
             relevant_ids = []
             for tech_id_member in assoc_tech_id_members:
-                required_tech_id = tech_id_member.get_value()
+                required_tech_id = tech_id_member.value
                 if required_tech_id == -1:
                     continue
 

--- a/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/auxiliary_subprocessor.py
@@ -112,8 +112,8 @@ class AoCAuxiliarySubprocessor:
 
         if line.is_repairable():
             # Cost (repair) for buildings
-            cost_repair_name = "%s.CreatableGameEntity.%sRepairCost" % (game_entity_name,
-                                                                        game_entity_name)
+            cost_repair_name = (f"{game_entity_name}.CreatableGameEntity."
+                                f"{game_entity_name}RepairCost")
             cost_repair_raw_api_object = RawAPIObject(cost_repair_name,
                                                       f"{game_entity_name}RepairCost",
                                                       dataset.nyan_api_objects)
@@ -381,8 +381,8 @@ class AoCAuxiliarySubprocessor:
 
             # Container
             container_forward_ref = ForwardRef(train_location,
-                                               "%s.Storage.%sContainer"
-                                               % (train_location_name, train_location_name))
+                                               (f"{train_location_name}.Storage."
+                                                f"{train_location_name}Container"))
             own_storage_raw_api_object.add_raw_member("container",
                                                       container_forward_ref,
                                                       "engine.util.placement_mode.type.OwnStorage")
@@ -608,8 +608,7 @@ class AoCAuxiliarySubprocessor:
                 literal_parent = "engine.util.logic.literal.type.TechResearched"
 
             else:
-                raise Exception("Required tech id %s is neither intiated nor researchable"
-                                % (tech_id))
+                raise Exception("Required tech id {tech_id} is neither intiated nor researchable")
 
             literal_ref = f"{obj_ref}.{literal_name}"
             literal_raw_api_object = RawAPIObject(literal_ref,

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -627,9 +627,7 @@ class AoCCivSubprocessor:
             animation_sprite = dataset.combined_sprites[animation_id]
 
         else:
-            animation_filename = "%s%s" % (filename_prefix,
-                                           name_lookup_dict[line.get_head_unit_id()][1])
-
+            animation_filename = f"{filename_prefix}{name_lookup_dict[line.get_head_unit_id()][1]}"
             animation_sprite = CombinedSprite(animation_id,
                                               animation_filename,
                                               dataset)

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -73,10 +73,10 @@ class AoCCivSubprocessor:
         civ_name = civ_lookup_dict[civ_id][0]
 
         # Find starting resource amounts
-        food_amount = civ_group.civ["resources"][91].get_value()
-        wood_amount = civ_group.civ["resources"][92].get_value()
-        gold_amount = civ_group.civ["resources"][93].get_value()
-        stone_amount = civ_group.civ["resources"][94].get_value()
+        food_amount = civ_group.civ["resources"][91].value
+        wood_amount = civ_group.civ["resources"][92].value
+        gold_amount = civ_group.civ["resources"][93].value
+        stone_amount = civ_group.civ["resources"][94].value
 
         # Find civ unique starting resources
         tech_tree = civ_group.get_tech_tree_effects()
@@ -86,8 +86,8 @@ class AoCCivSubprocessor:
             if type_id != 1:
                 continue
 
-            resource_id = effect["attr_a"].get_value()
-            amount = effect["attr_d"].get_value()
+            resource_id = effect["attr_a"].value
+            amount = effect["attr_d"].value
             if resource_id == 91:
                 food_amount += amount
 
@@ -207,13 +207,13 @@ class AoCCivSubprocessor:
 
                 # civ boni might be unlocked by age ups. if so, patch them into the age up
                 # patches are queued here
-                required_tech_count = civ_bonus.tech["required_tech_count"].get_value()
+                required_tech_count = civ_bonus.tech["required_tech_count"].value
                 if required_tech_count > 0 and len(bonus_patches) > 0:
                     if required_tech_count == 1:
-                        tech_id = civ_bonus.tech["required_techs"][0].get_value()
+                        tech_id = civ_bonus.tech["required_techs"][0].value
 
                     elif required_tech_count == 2:
-                        tech_id = civ_bonus.tech["required_techs"][1].get_value()
+                        tech_id = civ_bonus.tech["required_techs"][1].value
 
                     if tech_id == 104:
                         # Skip Dark Age; it is not a tech in openage
@@ -453,7 +453,7 @@ class AoCCivSubprocessor:
                 continue
 
             # Get tech id
-            tech_id = int(effect["attr_d"].get_value())
+            tech_id = int(effect["attr_d"].value)
 
             # Check what the purpose of the tech is
             if tech_id in dataset.unit_unlocks.keys():

--- a/openage/convert/processor/conversion/aoc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/civ_subprocessor.py
@@ -219,7 +219,7 @@ class AoCCivSubprocessor:
                         # Skip Dark Age; it is not a tech in openage
                         patches.extend(bonus_patches)
 
-                    elif tech_id in tech_patches.keys():
+                    elif tech_id in tech_patches:
                         tech_patches[tech_id].extend(bonus_patches)
 
                     else:
@@ -467,7 +467,7 @@ class AoCCivSubprocessor:
                 else:
                     train_location = dataset.building_lines[train_location_id]
 
-                if train_location in disabled_entities.keys():
+                if train_location in disabled_entities:
                     disabled_entities[train_location].append(unlocked_line)
 
                 else:
@@ -483,7 +483,7 @@ class AoCCivSubprocessor:
                     research_location_id = tech_group.get_research_location_id()
                     research_location = dataset.building_lines[research_location_id]
 
-                    if research_location in disabled_techs.keys():
+                    if research_location in disabled_techs:
                         disabled_techs[research_location].append(tech_group)
 
                     else:

--- a/openage/convert/processor/conversion/aoc/effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/effect_subprocessor.py
@@ -49,7 +49,7 @@ class AoCEffectSubprocessor:
             current_unit = line.get_head_unit()
 
         else:
-            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].get_value()
+            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].value
             current_unit = dataset.genie_units[projectile_id]
 
         effects = []
@@ -60,11 +60,11 @@ class AoCEffectSubprocessor:
         effect_parent = "engine.effect.discrete.flat_attribute_change.FlatAttributeChange"
         attack_parent = "engine.effect.discrete.flat_attribute_change.type.FlatAttributeChangeDecrease"
 
-        attacks = current_unit["attacks"].get_value()
+        attacks = current_unit["attacks"].value
 
         for attack in attacks.values():
-            armor_class = attack["type_id"].get_value()
-            attack_amount = attack["amount"].get_value()
+            armor_class = attack["type_id"].value
+            attack_amount = attack["amount"].value
             class_name = armor_lookup_dict[armor_class]
 
             attack_ref = f"{location_ref}.{class_name}"
@@ -154,14 +154,14 @@ class AoCEffectSubprocessor:
         effect_parent = "engine.effect.discrete.convert.Convert"
         convert_parent = "engine.effect.discrete.convert.type.AoE2Convert"
 
-        unit_commands = current_unit["unit_commands"].get_value()
+        unit_commands = current_unit["unit_commands"].value
         for command in unit_commands:
             # Find the Heal command.
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id == 104:
-                skip_guaranteed_rounds = -1 * command["work_value1"].get_value()
-                skip_protected_rounds = -1 * command["work_value2"].get_value()
+                skip_guaranteed_rounds = -1 * command["work_value1"].value
+                skip_protected_rounds = -1 * command["work_value2"].value
                 break
 
         else:
@@ -189,7 +189,7 @@ class AoCEffectSubprocessor:
 
         # Chance
         # hardcoded resource
-        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100
+        chance_success = dataset.genie_civs[0]["resources"][182].value / 100
         convert_raw_api_object.add_raw_member("chance_success",
                                               chance_success,
                                               effect_parent)
@@ -231,7 +231,7 @@ class AoCEffectSubprocessor:
 
         # Chance
         # hardcoded resource
-        chance_success = dataset.genie_civs[0]["resources"][182].get_value() / 100
+        chance_success = dataset.genie_civs[0]["resources"][182].value / 100
         convert_raw_api_object.add_raw_member("chance_success",
                                               chance_success,
                                               effect_parent)
@@ -277,12 +277,12 @@ class AoCEffectSubprocessor:
         effect_parent = "engine.effect.continuous.flat_attribute_change.FlatAttributeChange"
         heal_parent = "engine.effect.continuous.flat_attribute_change.type.FlatAttributeChangeIncrease"
 
-        unit_commands = current_unit["unit_commands"].get_value()
+        unit_commands = current_unit["unit_commands"].value
         heal_command = None
 
         for command in unit_commands:
             # Find the Heal command.
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id == 105:
                 heal_command = command
@@ -292,7 +292,7 @@ class AoCEffectSubprocessor:
             # Return the empty set
             return effects
 
-        heal_rate = heal_command["work_value1"].get_value()
+        heal_rate = heal_command["work_value1"].value
 
         heal_ref = f"{location_ref}.HealEffect"
         heal_raw_api_object = RawAPIObject(heal_ref,
@@ -527,7 +527,7 @@ class AoCEffectSubprocessor:
                                                             progress_effect_parent)
 
             # Total change time
-            change_time = constructable_line.get_head_unit()["creation_time"].get_value()
+            change_time = constructable_line.get_head_unit()["creation_time"].value
             contruct_progress_raw_api_object.add_raw_member("total_change_time",
                                                             change_time,
                                                             progress_effect_parent)
@@ -554,7 +554,7 @@ class AoCEffectSubprocessor:
                                                       attr_effect_parent)
 
             # Total change time
-            change_time = constructable_line.get_head_unit()["creation_time"].get_value()
+            change_time = constructable_line.get_head_unit()["creation_time"].value
             contruct_hp_raw_api_object.add_raw_member("total_change_time",
                                                       change_time,
                                                       attr_effect_parent)
@@ -597,15 +597,15 @@ class AoCEffectSubprocessor:
         armor_parent = "engine.resistance.discrete.flat_attribute_change.type.FlatAttributeChangeDecrease"
 
         if current_unit.has_member("armors"):
-            armors = current_unit["armors"].get_value()
+            armors = current_unit["armors"].value
 
         else:
             # TODO: Trees and blast defense
             armors = {}
 
         for armor in armors.values():
-            armor_class = armor["type_id"].get_value()
-            armor_amount = armor["amount"].get_value()
+            armor_class = armor["type_id"].value
+            armor_amount = armor["amount"].value
             class_name = armor_lookup_dict[armor_class]
 
             armor_ref = f"{ability_ref}.{class_name}"
@@ -700,18 +700,18 @@ class AoCEffectSubprocessor:
 
         # Chance resist
         # hardcoded resource
-        chance_resist = dataset.genie_civs[0]["resources"][77].get_value() / 100
+        chance_resist = dataset.genie_civs[0]["resources"][77].value / 100
         resistance_raw_api_object.add_raw_member("chance_resist",
                                                  chance_resist,
                                                  resistance_parent)
 
         if isinstance(line, GenieUnitLineGroup):
-            guaranteed_rounds = dataset.genie_civs[0]["resources"][178].get_value()
-            protected_rounds = dataset.genie_civs[0]["resources"][179].get_value()
+            guaranteed_rounds = dataset.genie_civs[0]["resources"][178].value
+            protected_rounds = dataset.genie_civs[0]["resources"][179].value
 
         else:
-            guaranteed_rounds = dataset.genie_civs[0]["resources"][180].get_value()
-            protected_rounds = dataset.genie_civs[0]["resources"][181].get_value()
+            guaranteed_rounds = dataset.genie_civs[0]["resources"][180].value
+            protected_rounds = dataset.genie_civs[0]["resources"][181].value
 
         # Guaranteed rounds
         resistance_raw_api_object.add_raw_member("guaranteed_resist_rounds",

--- a/openage/convert/processor/conversion/aoc/effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/effect_subprocessor.py
@@ -49,7 +49,7 @@ class AoCEffectSubprocessor:
             current_unit = line.get_head_unit()
 
         else:
-            projectile_id = line.get_head_unit()["attack_projectile_secondary_unit_id"].value
+            projectile_id = line.get_head_unit()["projectile_id1"].value
             current_unit = dataset.genie_units[projectile_id]
 
         effects = []

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -56,9 +56,9 @@ class AoCMediaSubprocessor:
                     continue
 
                 targetdir = graphic_targetdirs[graphic_id]
-                source_filename = f"{str(graphic['slp_id'].get_value())}.slp"
+                source_filename = f"{str(graphic['slp_id'].value)}.slp"
                 target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].get_value()))
+                                                 str(graphic["slp_id"].value))
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,
@@ -67,7 +67,7 @@ class AoCMediaSubprocessor:
                 full_data_set.graphics_exports.update({graphic_id: export_request})
 
                 # Metadata from graphics
-                sequence_type = graphic["sequence_type"].get_value()
+                sequence_type = graphic["sequence_type"].value
                 if sequence_type == 0x00:
                     layer_mode = LayerMode.OFF
 
@@ -77,18 +77,18 @@ class AoCMediaSubprocessor:
                 else:
                     layer_mode = LayerMode.LOOP
 
-                layer_pos = graphic["layer"].get_value()
-                frame_rate = round(graphic["frame_rate"].get_value(), ndigits=6)
+                layer_pos = graphic["layer"].value
+                frame_rate = round(graphic["frame_rate"].value, ndigits=6)
                 if frame_rate < 0.000001:
                     frame_rate = None
 
-                replay_delay = round(graphic["replay_delay"].get_value(), ndigits=6)
+                replay_delay = round(graphic["replay_delay"].value, ndigits=6)
                 if replay_delay < 0.000001:
                     replay_delay = None
 
-                frame_count = graphic["frame_count"].get_value()
-                angle_count = graphic["angle_count"].get_value()
-                mirror_mode = graphic["mirroring_mode"].get_value()
+                frame_count = graphic["frame_count"].value
+                angle_count = graphic["angle_count"].value
+                mirror_mode = graphic["mirroring_mode"].value
                 metadata_export.add_graphics_metadata(target_filename,
                                                       layer_mode,
                                                       layer_pos,
@@ -105,7 +105,7 @@ class AoCMediaSubprocessor:
 
         combined_terrains = full_data_set.combined_terrains.values()
         for texture in combined_terrains:
-            slp_id = texture.get_terrain()["slp_id"].get_value()
+            slp_id = texture.get_terrain()["slp_id"].value
 
             targetdir = texture.resolve_graphics_location()
             source_filename = f"{str(slp_id)}.slp"

--- a/openage/convert/processor/conversion/aoc/media_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/media_subprocessor.py
@@ -57,8 +57,7 @@ class AoCMediaSubprocessor:
 
                 targetdir = graphic_targetdirs[graphic_id]
                 source_filename = f"{str(graphic['slp_id'].value)}.slp"
-                target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].value))
+                target_filename = f"{sprite.get_filename()}_{str(graphic['slp_id'].value)}.png"
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,

--- a/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
@@ -144,8 +144,7 @@ class AoCModifierSubprocessor:
                         elif isinstance(resource_line, GenieVariantGroup):
                             resource_line_name = name_lookup_dict[head_unit_id][1]
 
-                        modifier_ref = "%s.%sGatheringRate" % (target_obj_name,
-                                                               resource_line_name)
+                        modifier_ref = f"{target_obj_name}.{resource_line_name}GatheringRate"
                         modifier_raw_api_object = RawAPIObject(modifier_ref,
                                                                "%sGatheringRate",
                                                                dataset.nyan_api_objects)
@@ -162,8 +161,8 @@ class AoCModifierSubprocessor:
                         )
 
                         # Resource spot
-                        spot_ref = "%s.Harvestable.%sResourceSpot" % (resource_line_name,
-                                                                      resource_line_name)
+                        spot_ref = (f"{resource_line_name}.Harvestable."
+                                    f"{resource_line_name}ResourceSpot")
                         spot_forward_ref = ForwardRef(resource_line, spot_ref)
                         modifier_raw_api_object.add_raw_member(
                             "resource_spot",

--- a/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modifier_subprocessor.py
@@ -92,18 +92,18 @@ class AoCModifierSubprocessor:
             target_obj_name = name_lookup_dict[head_unit_id][0]
 
             for gatherer in gatherers:
-                unit_commands = gatherer["unit_commands"].get_value()
+                unit_commands = gatherer["unit_commands"].value
 
                 for command in unit_commands:
                     # Find a gather ability.
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     gather_task_ids = internal_name_lookups.get_gather_lookups(
                         dataset.game_version).keys()
                     if type_id not in gather_task_ids:
                         continue
 
-                    work_value = command["work_value1"].get_value()
+                    work_value = command["work_value1"].value
 
                     # Check if the work value is 1 (with some rounding error margin)
                     # if not, we have to create a modifier
@@ -111,8 +111,8 @@ class AoCModifierSubprocessor:
                         continue
 
                     # Search for the lines with the matching class/unit id
-                    class_id = command["class_id"].get_value()
-                    unit_id = command["unit_id"].get_value()
+                    class_id = command["class_id"].value
+                    unit_id = command["unit_id"].value
 
                     entity_lines = {}
                     entity_lines.update(dataset.unit_lines)

--- a/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/modpack_subprocessor.py
@@ -97,7 +97,7 @@ class AoCModpackSubprocessor:
             obj_filename = raw_api_object.get_filename()
             nyan_file_path = f"{modpack.name}/{obj_location}{obj_filename}"
 
-            if nyan_file_path in created_nyan_files.keys():
+            if nyan_file_path in created_nyan_files:
                 nyan_file = created_nyan_files[nyan_file_path]
 
             else:

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -1210,11 +1210,11 @@ class AoCNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
+        projectile_primary = current_unit["projectile_id0"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
+        projectile_secondary = current_unit["projectile_id1"].value
         if projectile_secondary > -1:
             projectile_indices.append(1)
 

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -199,14 +199,14 @@ class AoCNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_unit["unit_type"].get_value()
+        unit_type = current_unit["unit_type"].value
 
         if unit_type >= 70:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_unit["unit_class"].get_value()
+        unit_class = current_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -405,14 +405,14 @@ class AoCNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_building["unit_type"].get_value()
+        unit_type = current_building["unit_type"].value
 
         if unit_type >= 80:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_building["unit_class"].get_value()
+        unit_class = current_building["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -568,7 +568,7 @@ class AoCNyanSubprocessor:
         )
         types_set.append(type_obj)
 
-        unit_class = ambient_unit["unit_class"].get_value()
+        unit_class = ambient_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -581,7 +581,7 @@ class AoCNyanSubprocessor:
         # =======================================================================
         abilities_set = []
 
-        interaction_mode = ambient_unit["interaction_mode"].get_value()
+        interaction_mode = ambient_unit["interaction_mode"].value
 
         if interaction_mode >= 0:
             abilities_set.append(AoCAbilitySubprocessor.death_ability(ambient_group))
@@ -660,7 +660,7 @@ class AoCNyanSubprocessor:
         )
         types_set.append(type_obj)
 
-        unit_class = variant_main_unit["unit_class"].get_value()
+        unit_class = variant_main_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -681,7 +681,7 @@ class AoCNyanSubprocessor:
         abilities_set.append(AoCAbilitySubprocessor.terrain_requirement_ability(variant_group))
         abilities_set.append(AoCAbilitySubprocessor.visibility_ability(variant_group))
 
-        if variant_main_unit.has_member("speed") and variant_main_unit["speed"].get_value() > 0.0001\
+        if variant_main_unit.has_member("speed") and variant_main_unit["speed"].value > 0.0001\
                 and variant_main_unit.has_member("command_sound_id"):
             # TODO: Let variant groups be converted without having command_sound_id member
             abilities_set.append(AoCAbilitySubprocessor.move_ability(variant_group))
@@ -750,7 +750,7 @@ class AoCNyanSubprocessor:
                                                                        variant_ref,
                                                                        diff_variant))
 
-            if variant_main_unit.has_member("speed") and variant_main_unit["speed"].get_value() > 0.0001\
+            if variant_main_unit.has_member("speed") and variant_main_unit["speed"].value > 0.0001\
                     and variant_main_unit.has_member("command_sound_id"):
                 # TODO: Let variant groups be converted without having command_sound_id member:
                 patches.extend(AoCUpgradeAbilitySubprocessor.move_ability(variant_group,
@@ -995,11 +995,11 @@ class AoCNyanSubprocessor:
         # Ambience
         # =======================================================================
         terrain = terrain_group.get_terrain()
-        ambients_count = terrain["terrain_units_used_count"].get_value()
+        ambients_count = terrain["terrain_units_used_count"].value
 
         ambience = []
         for ambient_index in range(ambients_count):
-            ambient_id = terrain["terrain_unit_id"][ambient_index].get_value()
+            ambient_id = terrain["terrain_unit_id"][ambient_index].value
 
             if ambient_id == -1:
                 continue
@@ -1022,7 +1022,7 @@ class AoCNyanSubprocessor:
                                                   "engine.util.terrain.TerrainAmbient")
 
             # Max density
-            max_density = terrain["terrain_unit_density"][ambient_index].get_value()
+            max_density = terrain["terrain_unit_density"][ambient_index].value
             ambient_raw_api_object.add_raw_member("max_density",
                                                   max_density,
                                                   "engine.util.terrain.TerrainAmbient")
@@ -1210,11 +1210,11 @@ class AoCNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].get_value()
+        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
         if projectile_secondary > -1:
             projectile_indices.append(1)
 

--- a/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/nyan_subprocessor.py
@@ -1219,9 +1219,8 @@ class AoCNyanSubprocessor:
             projectile_indices.append(1)
 
         for projectile_num in projectile_indices:
-            obj_ref = "%s.ShootProjectile.Projectile%s" % (game_entity_name,
-                                                           str(projectile_num))
-            obj_name = f"Projectile{str(projectile_num)}"
+            obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{projectile_num}"
+            obj_name = f"Projectile{projectile_num}"
             proj_raw_api_object = RawAPIObject(obj_ref, obj_name, dataset.nyan_api_objects)
             proj_raw_api_object.add_raw_parent("engine.util.game_entity.GameEntity")
             proj_raw_api_object.set_location(projectiles_location)

--- a/openage/convert/processor/conversion/aoc/pregen_processor.py
+++ b/openage/convert/processor/conversion/aoc/pregen_processor.py
@@ -59,8 +59,8 @@ class AoCPregenSubprocessor:
             pregen_object.create_nyan_members()
 
             if not pregen_object.is_ready():
-                raise Exception("%s: Pregenerated object is not ready for export. "
-                                "Member or object not initialized." % (pregen_object))
+                raise Exception(f"{repr(pregen_object)}: Pregenerated object is not ready "
+                                "for export. Member or object not initialized.")
 
     @staticmethod
     def generate_attributes(

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -557,8 +557,8 @@ class AoCProcessor:
                     break
 
             else:
-                raise Exception("Unit %s is not first in line, but no previous unit can"
-                                " be found in other_connections" % (unit_id))
+                raise Exception(f"Unit {unit_id} is not first in line, but no previous unit can "
+                                "be found in other_connections")
 
             connected_ids = connection["other_connected_ids"].value
             previous_unit_id = connected_ids[connected_index].value
@@ -690,9 +690,8 @@ class AoCProcessor:
                         break
 
                 else:
-                    raise Exception("Building %s is not first in line, but no previous "
-                                    "building could be found in other_connections"
-                                    % (building_id))
+                    raise Exception(f"Building {building_id} is not first in line, but no "
+                                    "previous building could be found in other_connections")
 
                 previous_building_id = connected_ids[connected_index].value
                 break

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -212,14 +212,14 @@ class AoCProcessor:
         # Gaia also seems to have the most units, so we only read from Gaia
         #
         # call hierarchy: wrapper[0]->civs[0]->units
-        raw_units = gamespec[0]["civs"][0]["units"].get_value()
+        raw_units = gamespec[0]["civs"][0]["units"].value
 
         # Unit headers store the things units can do
-        raw_unit_headers = gamespec[0]["unit_headers"].get_value()
+        raw_unit_headers = gamespec[0]["unit_headers"].value
 
         for raw_unit in raw_units:
-            unit_id = raw_unit["id0"].get_value()
-            unit_members = raw_unit.get_value()
+            unit_id = raw_unit["id0"].value
+            unit_members = raw_unit.value
 
             # Turn attack and armor into containers to make diffing work
             if "attacks" in unit_members.keys():
@@ -249,12 +249,12 @@ class AoCProcessor:
         # Techs are stored as "researches".
         #
         # call hierarchy: wrapper[0]->researches
-        raw_techs = gamespec[0]["researches"].get_value()
+        raw_techs = gamespec[0]["researches"].value
 
         index = 0
         for raw_tech in raw_techs:
             tech_id = index
-            tech_members = raw_tech.get_value()
+            tech_members = raw_tech.value
 
             tech = GenieTechObject(tech_id, full_data_set, members=tech_members)
             full_data_set.genie_techs.update({tech.get_id(): tech})
@@ -273,21 +273,21 @@ class AoCProcessor:
         :type gamespec: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->effect_bundles
-        raw_effect_bundles = gamespec[0]["effect_bundles"].get_value()
+        raw_effect_bundles = gamespec[0]["effect_bundles"].value
 
         index_bundle = 0
         for raw_effect_bundle in raw_effect_bundles:
             bundle_id = index_bundle
 
             # call hierarchy: effect_bundle->effects
-            raw_effects = raw_effect_bundle["effects"].get_value()
+            raw_effects = raw_effect_bundle["effects"].value
 
             effects = {}
 
             index_effect = 0
             for raw_effect in raw_effects:
                 effect_id = index_effect
-                effect_members = raw_effect.get_value()
+                effect_members = raw_effect.value
 
                 effect = GenieEffectObject(effect_id, bundle_id, full_data_set,
                                            members=effect_members)
@@ -297,7 +297,7 @@ class AoCProcessor:
                 index_effect += 1
 
             # Pass everything to the bundle
-            effect_bundle_members = raw_effect_bundle.get_value()
+            effect_bundle_members = raw_effect_bundle.value
             # Remove effects we store them as separate objects
             effect_bundle_members.pop("effects")
 
@@ -319,13 +319,13 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->civs
-        raw_civs = gamespec[0]["civs"].get_value()
+        raw_civs = gamespec[0]["civs"].value
 
         index = 0
         for raw_civ in raw_civs:
             civ_id = index
 
-            civ_members = raw_civ.get_value()
+            civ_members = raw_civ.value
             units_member = civ_members.pop("units")
             units_member = units_member.get_container("id0")
 
@@ -345,11 +345,11 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->age_connections
-        raw_connections = gamespec[0]["age_connections"].get_value()
+        raw_connections = gamespec[0]["age_connections"].value
 
         for raw_connection in raw_connections:
-            age_id = raw_connection["id"].get_value()
-            connection_members = raw_connection.get_value()
+            age_id = raw_connection["id"].value
+            connection_members = raw_connection.value
 
             connection = GenieAgeConnection(age_id, full_data_set, members=connection_members)
             full_data_set.age_connections.update({connection.get_id(): connection})
@@ -366,11 +366,11 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->building_connections
-        raw_connections = gamespec[0]["building_connections"].get_value()
+        raw_connections = gamespec[0]["building_connections"].value
 
         for raw_connection in raw_connections:
-            building_id = raw_connection["id"].get_value()
-            connection_members = raw_connection.get_value()
+            building_id = raw_connection["id"].value
+            connection_members = raw_connection.value
 
             connection = GenieBuildingConnection(building_id, full_data_set,
                                                  members=connection_members)
@@ -388,11 +388,11 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->unit_connections
-        raw_connections = gamespec[0]["unit_connections"].get_value()
+        raw_connections = gamespec[0]["unit_connections"].value
 
         for raw_connection in raw_connections:
-            unit_id = raw_connection["id"].get_value()
-            connection_members = raw_connection.get_value()
+            unit_id = raw_connection["id"].value
+            connection_members = raw_connection.value
 
             connection = GenieUnitConnection(unit_id, full_data_set, members=connection_members)
             full_data_set.unit_connections.update({connection.get_id(): connection})
@@ -409,11 +409,11 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->tech_connections
-        raw_connections = gamespec[0]["tech_connections"].get_value()
+        raw_connections = gamespec[0]["tech_connections"].value
 
         for raw_connection in raw_connections:
-            tech_id = raw_connection["id"].get_value()
-            connection_members = raw_connection.get_value()
+            tech_id = raw_connection["id"].value
+            connection_members = raw_connection.value
 
             connection = GenieTechConnection(tech_id, full_data_set, members=connection_members)
             full_data_set.tech_connections.update({connection.get_id(): connection})
@@ -427,19 +427,19 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->graphics
-        raw_graphics = gamespec[0]["graphics"].get_value()
+        raw_graphics = gamespec[0]["graphics"].value
 
         for raw_graphic in raw_graphics:
             # Can be ignored if there is no filename associated
-            filename = raw_graphic["filename"].get_value()
+            filename = raw_graphic["filename"].value
             if not filename:
                 continue
 
-            graphic_id = raw_graphic["graphic_id"].get_value()
-            graphic_members = raw_graphic.get_value()
+            graphic_id = raw_graphic["graphic_id"].value
+            graphic_members = raw_graphic.value
 
             graphic = GenieGraphic(graphic_id, full_data_set, members=graphic_members)
-            slp_id = raw_graphic["slp_id"].get_value()
+            slp_id = raw_graphic["slp_id"].value
             if str(slp_id) not in full_data_set.existing_graphics:
                 graphic.exists = False
 
@@ -458,11 +458,11 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->sounds
-        raw_sounds = gamespec[0]["sounds"].get_value()
+        raw_sounds = gamespec[0]["sounds"].value
 
         for raw_sound in raw_sounds:
-            sound_id = raw_sound["sound_id"].get_value()
-            sound_members = raw_sound.get_value()
+            sound_id = raw_sound["sound_id"].value
+            sound_members = raw_sound.value
 
             sound = GenieSound(sound_id, full_data_set, members=sound_members)
             full_data_set.genie_sounds.update({sound.get_id(): sound})
@@ -476,12 +476,12 @@ class AoCProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->terrains
-        raw_terrains = gamespec[0]["terrains"].get_value()
+        raw_terrains = gamespec[0]["terrains"].value
 
         index = 0
         for raw_terrain in raw_terrains:
             terrain_index = index
-            terrain_members = raw_terrain.get_value()
+            terrain_members = raw_terrain.value
 
             terrain = GenieTerrainObject(terrain_index, full_data_set, members=terrain_members)
             full_data_set.genie_terrains.update({terrain.get_id(): terrain})
@@ -502,9 +502,9 @@ class AoCProcessor:
 
         # First only handle the line heads (firstunits in a line)
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
+            unit_id = connection["id"].value
             unit = full_data_set.genie_units[unit_id]
-            line_mode = connection["line_mode"].get_value()
+            line_mode = connection["line_mode"].value
 
             if line_mode != 2:
                 # It's an upgrade. Skip and handle later
@@ -512,7 +512,7 @@ class AoCProcessor:
 
             # Check for special cases first
             if unit.has_member("transform_unit_id")\
-                    and unit["transform_unit_id"].get_value() > -1:
+                    and unit["transform_unit_id"].value > -1:
                 # Trebuchet
                 unit_line = GenieUnitTransformGroup(unit_id, unit_id, full_data_set)
                 full_data_set.transform_groups.update({unit_line.get_id(): unit_line})
@@ -524,7 +524,7 @@ class AoCProcessor:
                 full_data_set.monk_groups.update({unit_line.get_id(): unit_line})
 
             elif unit.has_member("task_group")\
-                    and unit["task_group"].get_value() > 0:
+                    and unit["task_group"].value > 0:
                 # Villager
                 # done somewhere else because they are special^TM
                 continue
@@ -539,18 +539,18 @@ class AoCProcessor:
 
         # Second, handle all upgraded units
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
+            unit_id = connection["id"].value
             unit = full_data_set.genie_units[unit_id]
-            line_mode = connection["line_mode"].get_value()
+            line_mode = connection["line_mode"].value
 
             if line_mode != 3:
                 # This unit is not an upgrade and was handled in the last for-loop
                 continue
 
             # Search other_connections for the previous unit in line
-            connected_types = connection["other_connections"].get_value()
+            connected_types = connection["other_connections"].value
             for index, _ in enumerate(connected_types):
-                connected_type = connected_types[index]["other_connection"].get_value()
+                connected_type = connected_types[index]["other_connection"].value
                 if connected_type == 2:
                     # 2 == Unit
                     connected_index = index
@@ -560,8 +560,8 @@ class AoCProcessor:
                 raise Exception("Unit %s is not first in line, but no previous unit can"
                                 " be found in other_connections" % (unit_id))
 
-            connected_ids = connection["other_connected_ids"].get_value()
-            previous_unit_id = connected_ids[connected_index].get_value()
+            connected_ids = connection["other_connected_ids"].value
+            previous_unit_id = connected_ids[connected_index].value
 
             # Search for the first unit ID in the line recursively
             previous_id = previous_unit_id
@@ -571,17 +571,17 @@ class AoCProcessor:
                     # Short-circuit here, if we the previous unit was already handled
                     break
 
-                connected_types = previous_connection["other_connections"].get_value()
+                connected_types = previous_connection["other_connections"].value
                 connected_index = -1
                 for index, _ in enumerate(connected_types):
-                    connected_type = connected_types[index]["other_connection"].get_value()
+                    connected_type = connected_types[index]["other_connection"].value
                     if connected_type == 2:
                         # 2 == Unit
                         connected_index = index
                         break
 
-                connected_ids = previous_connection["other_connected_ids"].get_value()
-                previous_id = connected_ids[connected_index].get_value()
+                connected_ids = previous_connection["other_connected_ids"].value
+                previous_id = connected_ids[connected_index].value
                 previous_connection = unit_connections[previous_id]
 
             unit_line = full_data_set.unit_ref[previous_id]
@@ -622,7 +622,7 @@ class AoCProcessor:
         building_connections = full_data_set.building_connections
 
         for connection in building_connections.values():
-            building_id = connection["id"].get_value()
+            building_id = connection["id"].value
             building = full_data_set.genie_units[building_id]
             previous_building_id = None
             stack_building = False
@@ -633,11 +633,11 @@ class AoCProcessor:
 
             # Check if we have to create a GenieStackBuildingGroup
             if building.has_member("stack_unit_id") and \
-                    building["stack_unit_id"].get_value() > -1:
+                    building["stack_unit_id"].value > -1:
                 stack_building = True
 
             if building.has_member("head_unit_id") and \
-                    building["head_unit_id"].get_value() > -1:
+                    building["head_unit_id"].value > -1:
                 # we don't care about head units because we process
                 # them with their stack unit
                 continue
@@ -645,20 +645,20 @@ class AoCProcessor:
             # Check if the building is part of an existing line.
             # To do this, we look for connected techs and
             # check if any tech has an upgrade effect.
-            connected_types = connection["other_connections"].get_value()
+            connected_types = connection["other_connections"].value
             connected_tech_indices = []
             for index, _ in enumerate(connected_types):
-                connected_type = connected_types[index]["other_connection"].get_value()
+                connected_type = connected_types[index]["other_connection"].value
                 if connected_type == 3:
                     # 3 == Tech
                     connected_tech_indices.append(index)
 
-            connected_ids = connection["other_connected_ids"].get_value()
+            connected_ids = connection["other_connected_ids"].value
 
             for index in connected_tech_indices:
-                connected_tech_id = connected_ids[index].get_value()
+                connected_tech_id = connected_ids[index].value
                 connected_tech = full_data_set.genie_techs[connected_tech_id]
-                effect_bundle_id = connected_tech["tech_effect_id"].get_value()
+                effect_bundle_id = connected_tech["tech_effect_id"].value
                 effect_bundle = full_data_set.genie_effect_bundles[effect_bundle_id]
 
                 upgrade_effects = effect_bundle.get_effects(effect_type=3)
@@ -668,8 +668,8 @@ class AoCProcessor:
 
                 # Search upgrade effects for the line_id
                 for upgrade in upgrade_effects:
-                    upgrade_source = upgrade["attr_a"].get_value()
-                    upgrade_target = upgrade["attr_b"].get_value()
+                    upgrade_source = upgrade["attr_a"].value
+                    upgrade_target = upgrade["attr_b"].value
 
                     # Check if the upgrade target is correct
                     if upgrade_target == building_id:
@@ -683,7 +683,7 @@ class AoCProcessor:
 
                 # Find the previous building
                 for c_index, _ in enumerate(connected_types):
-                    connected_type = connected_types[c_index]["other_connection"].get_value()
+                    connected_type = connected_types[c_index]["other_connection"].value
                     if connected_type == 1:
                         # 1 == Building
                         connected_index = c_index
@@ -694,13 +694,13 @@ class AoCProcessor:
                                     "building could be found in other_connections"
                                     % (building_id))
 
-                previous_building_id = connected_ids[connected_index].get_value()
+                previous_building_id = connected_ids[connected_index].value
                 break
 
             if line_id == building_id:
                 # First building in line
                 if stack_building:
-                    stack_unit_id = building["stack_unit_id"].get_value()
+                    stack_unit_id = building["stack_unit_id"].value
                     building_line = GenieStackBuildingGroup(stack_unit_id, line_id, full_data_set)
 
                 else:
@@ -735,18 +735,18 @@ class AoCProcessor:
 
             index = 0
             for effect in effects:
-                effect_type = effect["type_id"].get_value()
+                effect_type = effect["type_id"].value
                 if effect_type < 0:
                     # Effect has no type
                     continue
 
                 if effect_type == 3:
-                    if effect["attr_b"].get_value() < 0:
+                    if effect["attr_b"].value < 0:
                         # Upgrade to invalid unit
                         continue
 
                 if effect_type == 102:
-                    if effect["attr_d"].get_value() < 0:
+                    if effect["attr_d"].value < 0:
                         # Tech disable effect with no tech id specified
                         continue
 
@@ -771,11 +771,11 @@ class AoCProcessor:
 
         # In tech connection are age ups, building unlocks/upgrades and stat upgrades
         for connection in tech_connections.values():
-            connected_buildings = connection["buildings"].get_value()
-            tech_id = connection["id"].get_value()
+            connected_buildings = connection["buildings"].value
+            tech_id = connection["id"].value
             tech = full_data_set.genie_techs[tech_id]
 
-            effect_id = tech["tech_effect_id"].get_value()
+            effect_id = tech["tech_effect_id"].value
             if effect_id < 0:
                 continue
 
@@ -786,10 +786,10 @@ class AoCProcessor:
             resource_effects = tech_effects.get_effects(effect_type=1)
             for effect in resource_effects:
                 # Resource ID 6: Current Age
-                if effect["attr_a"].get_value() != 6:
+                if effect["attr_a"].value != 6:
                     continue
 
-                age_id = effect["attr_b"].get_value()
+                age_id = effect["attr_b"].value
                 age_up = AgeUpgrade(tech_id, age_id, full_data_set)
                 full_data_set.tech_groups.update({age_up.get_id(): age_up})
                 full_data_set.age_upgrades.update({age_up.get_id(): age_up})
@@ -805,7 +805,7 @@ class AoCProcessor:
                 upgrade_effects = tech_effects.get_effects(effect_type=2)
                 if len(unlock_effects) > 0:
                     unlock = unlock_effects[0]
-                    unlock_id = unlock["attr_a"].get_value()
+                    unlock_id = unlock["attr_a"].value
 
                     building_unlock = BuildingUnlock(tech_id, unlock_id, full_data_set)
                     full_data_set.tech_groups.update(
@@ -818,8 +818,8 @@ class AoCProcessor:
 
                 if len(upgrade_effects) > 0:
                     upgrade = upgrade_effects[0]
-                    line_id = upgrade["attr_a"].get_value()
-                    upgrade_id = upgrade["attr_b"].get_value()
+                    line_id = upgrade["attr_a"].value
+                    upgrade_id = upgrade["attr_b"].value
 
                     building_upgrade = BuildingLineUpgrade(
                         tech_id,
@@ -843,10 +843,10 @@ class AoCProcessor:
         # Unit upgrades and unlocks are stored in unit connections
         unit_connections = full_data_set.unit_connections
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
-            required_research_id = connection["required_research"].get_value()
-            enabling_research_id = connection["enabling_research"].get_value()
-            line_mode = connection["line_mode"].get_value()
+            unit_id = connection["id"].value
+            required_research_id = connection["required_research"].value
+            enabling_research_id = connection["enabling_research"].value
+            line_mode = connection["line_mode"].value
             line_id = full_data_set.unit_ref[unit_id].get_id()
 
             if required_research_id == -1 and enabling_research_id == -1:
@@ -879,8 +879,8 @@ class AoCProcessor:
             if not genie_unit.has_member("research_id"):
                 continue
 
-            building_id = genie_unit["id0"].get_value()
-            initiated_tech_id = genie_unit["research_id"].get_value()
+            building_id = genie_unit["id0"].value
+            initiated_tech_id = genie_unit["research_id"].value
 
             if initiated_tech_id == -1:
                 continue
@@ -901,17 +901,17 @@ class AoCProcessor:
             tech_id = index
 
             # Civ ID must be positive and non-zero
-            civ_id = genie_techs[index]["civilization_id"].get_value()
+            civ_id = genie_techs[index]["civilization_id"].value
             if civ_id <= 0:
                 continue
 
             # Passive boni are not researched anywhere
-            research_location_id = genie_techs[index]["research_location_id"].get_value()
+            research_location_id = genie_techs[index]["research_location_id"].value
             if research_location_id > 0:
                 continue
 
             # Passive boni are not available in full tech mode
-            full_tech_mode = genie_techs[index]["full_tech_mode"].get_value()
+            full_tech_mode = genie_techs[index]["full_tech_mode"].value
             if full_tech_mode:
                 continue
 
@@ -957,7 +957,7 @@ class AoCProcessor:
         # Find task groups in the dataset
         for unit in units.values():
             if unit.has_member("task_group"):
-                task_group_id = unit["task_group"].get_value()
+                task_group_id = unit["task_group"].value
 
             else:
                 task_group_id = 0
@@ -982,7 +982,7 @@ class AoCProcessor:
                 full_data_set.task_groups.update({task_group_id: task_group})
 
             task_group_ids.add(task_group_id)
-            unit_ids.add(unit["id0"].get_value())
+            unit_ids.add(unit["id0"].value)
 
         # Create the villager task group
         villager = GenieVillagerGroup(118, task_group_ids, full_data_set)
@@ -1043,14 +1043,14 @@ class AoCProcessor:
         terrains = full_data_set.genie_terrains.values()
 
         for terrain in terrains:
-            slp_id = terrain["slp_id"].get_value()
-            replacement_id = terrain["terrain_replacement_id"].get_value()
+            slp_id = terrain["slp_id"].value
+            replacement_id = terrain["terrain_replacement_id"].value
 
             if slp_id == -1 and replacement_id == -1:
                 # No graphics and no graphics replacement means this terrain is unused
                 continue
 
-            enabled = terrain["enabled"].get_value()
+            enabled = terrain["enabled"].value
 
             if enabled:
                 terrain_group = GenieTerrainGroup(terrain.get_id(), full_data_set)
@@ -1076,8 +1076,8 @@ class AoCProcessor:
                 if type_id != 3:
                     continue
 
-                upgrade_source_id = effect["attr_a"].get_value()
-                upgrade_target_id = effect["attr_b"].get_value()
+                upgrade_source_id = effect["attr_a"].value
+                upgrade_target_id = effect["attr_b"].value
 
                 if upgrade_source_id not in full_data_set.building_lines.keys():
                     continue
@@ -1157,9 +1157,9 @@ class AoCProcessor:
             if unit_line.is_unique():
                 head_unit_id = unit_line.get_head_unit_id()
                 head_unit_connection = full_data_set.unit_connections[head_unit_id]
-                enabling_research_id = head_unit_connection["enabling_research"].get_value()
+                enabling_research_id = head_unit_connection["enabling_research"].value
                 enabling_research = full_data_set.genie_techs[enabling_research_id]
-                enabling_civ_id = enabling_research["civilization_id"].get_value()
+                enabling_civ_id = enabling_research["civilization_id"].value
 
                 full_data_set.civ_groups[enabling_civ_id].add_unique_entity(unit_line)
 
@@ -1167,9 +1167,9 @@ class AoCProcessor:
             if building_line.is_unique():
                 head_unit_id = building_line.get_head_unit_id()
                 head_building_connection = full_data_set.building_connections[head_unit_id]
-                enabling_research_id = head_building_connection["enabling_research"].get_value()
+                enabling_research_id = head_building_connection["enabling_research"].value
                 enabling_research = full_data_set.genie_techs[enabling_research_id]
-                enabling_civ_id = enabling_research["civilization_id"].get_value()
+                enabling_civ_id = enabling_research["civilization_id"].value
 
                 full_data_set.civ_groups[enabling_civ_id].add_unique_entity(building_line)
 
@@ -1193,11 +1193,11 @@ class AoCProcessor:
 
         for villager in villager_groups.values():
             for unit in villager.variants[0].line:
-                drop_site_members = unit["drop_sites"].get_value()
-                unit_id = unit["id0"].get_value()
+                drop_site_members = unit["drop_sites"].value
+                unit_id = unit["id0"].value
 
                 for drop_site_member in drop_site_members:
-                    drop_site_id = drop_site_member.get_value()
+                    drop_site_id = drop_site_member.value
 
                     if drop_site_id > -1:
                         drop_site = full_data_set.building_lines[drop_site_id]
@@ -1228,14 +1228,14 @@ class AoCProcessor:
             garrison_units = []
 
             if unit_line.has_command(3):
-                unit_commands = unit_line.get_head_unit()["unit_commands"].get_value()
+                unit_commands = unit_line.get_head_unit()["unit_commands"].value
                 for command in unit_commands:
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id != 3:
                         continue
 
-                    class_id = command["class_id"].get_value()
+                    class_id = command["class_id"].value
                     if class_id > -1:
                         garrison_classes.append(class_id)
 
@@ -1243,7 +1243,7 @@ class AoCProcessor:
                             # Towers because Ensemble didn't like consistent rules
                             garrison_classes.append(52)
 
-                    unit_id = command["unit_id"].get_value()
+                    unit_id = command["unit_id"].value
                     if unit_id > -1:
                         garrison_units.append(unit_id)
 
@@ -1255,13 +1255,13 @@ class AoCProcessor:
                 garrison_mode = garrison_line.get_garrison_mode()
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     if unit_line.get_head_unit().has_member("creatable_type"):
-                        creatable_type = unit_line.get_head_unit()["creatable_type"].get_value()
+                        creatable_type = unit_line.get_head_unit()["creatable_type"].value
 
                     else:
                         creatable_type = 0
 
                     if garrison_line.get_head_unit().has_member("garrison_type"):
-                        garrison_type = garrison_line.get_head_unit()["garrison_type"].get_value()
+                        garrison_type = garrison_line.get_head_unit()["garrison_type"].value
 
                     else:
                         garrison_type = 0
@@ -1304,14 +1304,14 @@ class AoCProcessor:
                 # Monk inventories
                 elif garrison_mode == GenieGarrisonMode.MONK:
                     # Search for a pickup command
-                    unit_commands = garrison_line.get_head_unit()["unit_commands"].get_value()
+                    unit_commands = garrison_line.get_head_unit()["unit_commands"].value
                     for command in unit_commands:
-                        type_id = command["type"].get_value()
+                        type_id = command["type"].value
 
                         if type_id != 132:
                             continue
 
-                        unit_id = command["unit_id"].get_value()
+                        unit_id = command["unit_id"].value
                         if unit_id == unit_line.get_head_unit_id():
                             unit_line.garrison_locations.append(garrison_line)
                             garrison_line.garrison_entities.append(unit_line)
@@ -1331,16 +1331,16 @@ class AoCProcessor:
         for unit_line in unit_lines:
             if unit_line.has_command(111):
                 head_unit = unit_line.get_head_unit()
-                unit_commands = head_unit["unit_commands"].get_value()
+                unit_commands = head_unit["unit_commands"].value
                 trade_post_id = -1
                 for command in unit_commands:
                     # Find the trade command and the trade post id
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id != 111:
                         continue
 
-                    trade_post_id = command["unit_id"].get_value()
+                    trade_post_id = command["unit_id"].value
                     break
 
                 # Notify buiding
@@ -1365,14 +1365,14 @@ class AoCProcessor:
         repair_classes = []
         for villager in villager_groups.values():
             repair_unit = villager.get_units_with_command(106)[0]
-            unit_commands = repair_unit["unit_commands"].get_value()
+            unit_commands = repair_unit["unit_commands"].value
             for command in unit_commands:
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id != 106:
                     continue
 
-                class_id = command["class_id"].get_value()
+                class_id = command["class_id"].value
                 if class_id == -1:
                     # Buildings/Siege
                     repair_classes.append(3)

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -408,7 +408,7 @@ class AoCTechSubprocessor:
         mode = effect["attr_c"].value
         amount = int(effect["attr_d"].value)
 
-        if tech_id not in tech_lookup_dict.keys():
+        if tech_id not in tech_lookup_dict:
             # Skips some legacy techs from AoK such as the tech for bombard cannon
             return patches
 
@@ -525,7 +525,7 @@ class AoCTechSubprocessor:
         mode = effect["attr_c"].value
         research_time = effect["attr_d"].value
 
-        if tech_id not in tech_lookup_dict.keys():
+        if tech_id not in tech_lookup_dict:
             # Skips some legacy techs from AoK such as the tech for bombard cannon
             return patches
 

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -206,10 +206,10 @@ class AoCTechSubprocessor:
             raise Exception("Effect type %s is not a valid attribute effect"
                             % str(effect_type))
 
-        unit_id = effect["attr_a"].get_value()
-        class_id = effect["attr_b"].get_value()
-        attribute_type = effect["attr_c"].get_value()
-        value = effect["attr_d"].get_value()
+        unit_id = effect["attr_a"].value
+        class_id = effect["attr_b"].value
+        attribute_type = effect["attr_c"].value
+        value = effect["attr_d"].value
 
         if attribute_type == -1:
             return patches
@@ -262,7 +262,7 @@ class AoCTechSubprocessor:
         effect_type = effect.get_type()
         operator = None
         if effect_type in (1, 11):
-            mode = effect["attr_b"].get_value()
+            mode = effect["attr_b"].value
 
             if mode == 0:
                 operator = MemberOperator.ASSIGN
@@ -277,8 +277,8 @@ class AoCTechSubprocessor:
             raise Exception("Effect type %s is not a valid resource effect"
                             % str(effect_type))
 
-        resource_id = effect["attr_a"].get_value()
-        value = effect["attr_d"].get_value()
+        resource_id = effect["attr_a"].value
+        value = effect["attr_d"].value
 
         if resource_id in (-1, 6, 21):
             # -1 = invalid ID
@@ -305,8 +305,8 @@ class AoCTechSubprocessor:
 
         tech_lookup_dict = internal_name_lookups.get_tech_lookups(dataset.game_version)
 
-        upgrade_source_id = effect["attr_a"].get_value()
-        upgrade_target_id = effect["attr_b"].get_value()
+        upgrade_source_id = effect["attr_a"].value
+        upgrade_target_id = effect["attr_b"].value
 
         if upgrade_source_id not in dataset.unit_ref.keys() or\
                 upgrade_target_id not in dataset.unit_ref.keys():
@@ -405,10 +405,10 @@ class AoCTechSubprocessor:
         else:
             obj_name = civ_lookup_dict[obj_id][0]
 
-        tech_id = effect["attr_a"].get_value()
-        resource_id = effect["attr_b"].get_value()
-        mode = effect["attr_c"].get_value()
-        amount = int(effect["attr_d"].get_value())
+        tech_id = effect["attr_a"].value
+        resource_id = effect["attr_b"].value
+        mode = effect["attr_c"].value
+        amount = int(effect["attr_d"].value)
 
         if tech_id not in tech_lookup_dict.keys():
             # Skips some legacy techs from AoK such as the tech for bombard cannon
@@ -433,8 +433,8 @@ class AoCTechSubprocessor:
             raise Exception("no valid resource ID found")
 
         # Check if the tech actually costs an amount of the defined resource
-        for resource_amount in tech_group.tech["research_resource_costs"].get_value():
-            cost_resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in tech_group.tech["research_resource_costs"].value:
+            cost_resource_id = resource_amount["type_id"].value
 
             if cost_resource_id == resource_id:
                 break
@@ -525,9 +525,9 @@ class AoCTechSubprocessor:
         else:
             obj_name = civ_lookup_dict[obj_id][0]
 
-        tech_id = effect["attr_a"].get_value()
-        mode = effect["attr_c"].get_value()
-        research_time = effect["attr_d"].get_value()
+        tech_id = effect["attr_a"].value
+        mode = effect["attr_c"].value
+        research_time = effect["attr_d"].value
 
         if tech_id not in tech_lookup_dict.keys():
             # Skips some legacy techs from AoK such as the tech for bombard cannon

--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -203,8 +203,7 @@ class AoCTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid attribute effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid attribute effect")
 
         unit_id = effect["attr_a"].value
         class_id = effect["attr_b"].value
@@ -274,8 +273,7 @@ class AoCTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid resource effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid resource effect")
 
         resource_id = effect["attr_a"].value
         value = effect["attr_d"].value
@@ -449,9 +447,7 @@ class AoCTechSubprocessor:
         else:
             operator = MemberOperator.ADD
 
-        patch_target_ref = "%s.ResearchableTech.%sCost.%sAmount" % (tech_name,
-                                                                    tech_name,
-                                                                    resource_name)
+        patch_target_ref = f"{tech_name}.ResearchableTech.{tech_name}Cost.{resource_name}Amount"
         patch_target_forward_ref = ForwardRef(tech_group, patch_target_ref)
 
         # Wrapper

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -170,7 +170,7 @@ class AoCUpgradeAbilitySubprocessor:
                     attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.value
+                    attack_graphic_id = diff_animation.ref.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
@@ -351,7 +351,7 @@ class AoCUpgradeAbilitySubprocessor:
                     attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.value
+                    attack_graphic_id = diff_animation.ref.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
@@ -457,7 +457,7 @@ class AoCUpgradeAbilitySubprocessor:
                 continue
 
             # This should be a NoDiffMember
-            percentage = diff_damage_animation["damage_percent"].value.value
+            percentage = diff_damage_animation["damage_percent"].ref.value
 
             patch_target_ref = "%s.AttributeChangeTracker.ChangeProgress%s" % (game_entity_name,
                                                                                str(percentage))
@@ -1675,7 +1675,7 @@ class AoCUpgradeAbilitySubprocessor:
                     attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.value
+                    attack_graphic_id = diff_animation.ref.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -129,7 +129,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             if not isinstance(diff_animation, NoDiffMember):
-                diff_animation_id = diff_animation.get_value()
+                diff_animation_id = diff_animation.value
                 animations_set = []
                 if diff_animation_id > -1:
                     # Patch the new animation in
@@ -149,7 +149,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_comm_sound, NoDiffMember):
                 sounds_set = []
-                diff_comm_sound_id = diff_comm_sound.get_value()
+                diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
                     sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
@@ -167,14 +167,14 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_frame_delay, NoDiffMember):
                 if not isinstance(diff_animation, NoDiffMember):
-                    attack_graphic_id = diff_animation.get_value()
+                    attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.get_value()
+                    attack_graphic_id = diff_animation.value.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
-                frame_delay = diff_frame_delay.get_value()
+                frame_delay = diff_frame_delay.value
                 application_delay = frame_rate * frame_delay
 
                 nyan_patch_raw_api_object.add_raw_patch_member("application_delay",
@@ -184,7 +184,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if ranged:
                 if not isinstance(diff_min_range, NoDiffMember):
-                    min_range = diff_min_range.get_value()
+                    min_range = diff_min_range.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("min_range",
                                                                    min_range,
@@ -192,7 +192,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_max_range, NoDiffMember):
-                    max_range = diff_max_range.get_value()
+                    max_range = diff_max_range.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("max_range",
                                                                    max_range,
@@ -302,7 +302,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             if not isinstance(diff_animation, NoDiffMember):
-                diff_animation_id = diff_animation.get_value()
+                diff_animation_id = diff_animation.value
                 animations_set = []
                 if diff_animation_id > -1:
                     # Patch the new animation in
@@ -322,7 +322,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_comm_sound, NoDiffMember):
                 sounds_set = []
-                diff_comm_sound_id = diff_comm_sound.get_value()
+                diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
                     sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
@@ -339,7 +339,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ASSIGN)
 
             if not isinstance(diff_reload_time, NoDiffMember):
-                reload_time = diff_reload_time.get_value()
+                reload_time = diff_reload_time.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("reload_time",
                                                                reload_time,
@@ -348,14 +348,14 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_frame_delay, NoDiffMember):
                 if not isinstance(diff_animation, NoDiffMember):
-                    attack_graphic_id = diff_animation.get_value()
+                    attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.get_value()
+                    attack_graphic_id = diff_animation.value.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
-                frame_delay = diff_frame_delay.get_value()
+                frame_delay = diff_frame_delay.value
                 application_delay = frame_rate * frame_delay
 
                 nyan_patch_raw_api_object.add_raw_patch_member("application_delay",
@@ -365,7 +365,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if ranged:
                 if not isinstance(diff_min_range, NoDiffMember):
-                    min_range = diff_min_range.get_value()
+                    min_range = diff_min_range.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("min_range",
                                                                    min_range,
@@ -373,7 +373,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_max_range, NoDiffMember):
-                    max_range = diff_max_range.get_value()
+                    max_range = diff_max_range.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("max_range",
                                                                    max_range,
@@ -445,7 +445,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_damage_graphics, NoDiffMember):
                 return patches
 
-            diff_damage_animations = diff_damage_graphics.get_value()
+            diff_damage_animations = diff_damage_graphics.value
 
         else:
             return patches
@@ -457,7 +457,7 @@ class AoCUpgradeAbilitySubprocessor:
                 continue
 
             # This should be a NoDiffMember
-            percentage = diff_damage_animation["damage_percent"].value.get_value()
+            percentage = diff_damage_animation["damage_percent"].value.value
 
             patch_target_ref = "%s.AttributeChangeTracker.ChangeProgress%s" % (game_entity_name,
                                                                                str(percentage))
@@ -494,7 +494,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             animations_set = []
-            diff_animation_id = diff_damage_animation["graphic_id"].get_value()
+            diff_animation_id = diff_damage_animation["graphic_id"].value
             if diff_animation_id > -1:
                 # Patch the new animation in
                 animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
@@ -561,7 +561,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_animation, NoDiffMember):
                 return patches
 
-            diff_animation_id = diff_animation.get_value()
+            diff_animation_id = diff_animation.value
 
         else:
             return patches
@@ -664,8 +664,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_dead_unit, NoDiffMember):
                 return patches
 
-            diff_animation_id = dataset.genie_units[diff_dead_unit.get_value(
-            )]["idle_graphic0"].get_value()
+            diff_animation_id = dataset.genie_units[diff_dead_unit.value]["idle_graphic0"].value
 
         else:
             return patches
@@ -768,7 +767,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_animation, NoDiffMember):
                 return patches
 
-            diff_animation_id = diff_animation.get_value()
+            diff_animation_id = diff_animation.value
 
         else:
             return patches
@@ -871,7 +870,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_hp, NoDiffMember):
                 return patches
 
-            diff_hp_value = diff_hp.get_value()
+            diff_hp_value = diff_hp.value
 
         else:
             return patches
@@ -970,7 +969,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_line_of_sight, NoDiffMember):
                 return patches
 
-            diff_los_range = diff_line_of_sight.get_value()
+            diff_los_range = diff_line_of_sight.value
 
         else:
             return patches
@@ -1102,7 +1101,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_move_animation, NoDiffMember):
                 animations_set = []
-                diff_animation_id = diff_move_animation.get_value()
+                diff_animation_id = diff_move_animation.value
                 if diff_animation_id > -1:
                     # Patch the new animation in
                     animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
@@ -1120,7 +1119,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_comm_sound, NoDiffMember):
                 sounds_set = []
-                diff_comm_sound_id = diff_comm_sound.get_value()
+                diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
                     sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
@@ -1136,7 +1135,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ASSIGN)
 
             if not isinstance(diff_move_speed, NoDiffMember):
-                diff_speed_value = diff_move_speed.get_value()
+                diff_speed_value = diff_move_speed.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("speed",
                                                                diff_speed_value,
@@ -1227,7 +1226,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.add_raw_parent("engine.util.patch.NyanPatch")
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
-            name_string_id = diff_name.get_value()
+            name_string_id = diff_name.value
             translations = AoCUpgradeAbilitySubprocessor.create_language_strings(converter_group,
                                                                                  name_string_id,
                                                                                  nyan_patch_ref,
@@ -1371,7 +1370,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             # Change sound
-            diff_selection_sound_id = diff_selection_sound.get_value()
+            diff_selection_sound_id = diff_selection_sound.value
             sounds_set = []
             if diff_selection_sound_id > -1:
                 # Patch the new sound in
@@ -1441,7 +1440,7 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             if not isinstance(diff_radius_x, NoDiffMember):
-                diff_width_value = diff_radius_x.get_value()
+                diff_width_value = diff_radius_x.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("width",
                                                                diff_width_value,
@@ -1449,7 +1448,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_radius_y, NoDiffMember):
-                diff_height_value = diff_radius_y.get_value()
+                diff_height_value = diff_radius_y.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("height",
                                                                diff_height_value,
@@ -1571,7 +1570,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_animation, NoDiffMember):
                 animations_set = []
-                diff_animation_id = diff_animation.get_value()
+                diff_animation_id = diff_animation.value
                 if diff_animation_id > -1:
                     # Patch the new animation in
                     animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
@@ -1590,7 +1589,7 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_comm_sound, NoDiffMember):
                 sounds_set = []
-                diff_comm_sound_id = diff_comm_sound.get_value()
+                diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
                     sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
@@ -1607,11 +1606,11 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ASSIGN)
 
             if not isinstance(diff_min_projectiles, NoDiffMember):
-                min_projectiles = diff_min_projectiles.get_value()
-                source_min_count = upgrade_source["attack_projectile_count"].get_value()
-                source_max_count = upgrade_source["attack_projectile_max_count"].get_value()
-                target_min_count = upgrade_target["attack_projectile_count"].get_value()
-                target_max_count = upgrade_target["attack_projectile_max_count"].get_value()
+                min_projectiles = diff_min_projectiles.value
+                source_min_count = upgrade_source["attack_projectile_count"].value
+                source_max_count = upgrade_source["attack_projectile_max_count"].value
+                target_min_count = upgrade_target["attack_projectile_count"].value
+                target_max_count = upgrade_target["attack_projectile_max_count"].value
 
                 # Account for a special case where the number of projectiles are 0
                 # in the .dat, but the game still counts this as 1 when a projectile
@@ -1629,11 +1628,11 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
             if not isinstance(diff_max_projectiles, NoDiffMember):
-                max_projectiles = diff_max_projectiles.get_value()
-                source_min_count = upgrade_source["attack_projectile_count"].get_value()
-                source_max_count = upgrade_source["attack_projectile_max_count"].get_value()
-                target_min_count = upgrade_target["attack_projectile_count"].get_value()
-                target_max_count = upgrade_target["attack_projectile_max_count"].get_value()
+                max_projectiles = diff_max_projectiles.value
+                source_min_count = upgrade_source["attack_projectile_count"].value
+                source_max_count = upgrade_source["attack_projectile_max_count"].value
+                target_min_count = upgrade_target["attack_projectile_count"].value
+                target_max_count = upgrade_target["attack_projectile_max_count"].value
 
                 # Account for a special case where the number of projectiles are 0
                 # in the .dat, but the game still counts this as 1 when a projectile
@@ -1651,24 +1650,21 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
             if not isinstance(diff_min_range, NoDiffMember):
-                min_range = diff_min_range.get_value()
-
+                min_range = diff_min_range.value
                 nyan_patch_raw_api_object.add_raw_patch_member("min_range",
                                                                min_range,
                                                                "engine.ability.type.ShootProjectile",
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_max_range, NoDiffMember):
-                max_range = diff_max_range.get_value()
-
+                max_range = diff_max_range.value
                 nyan_patch_raw_api_object.add_raw_patch_member("max_range",
                                                                max_range,
                                                                "engine.ability.type.ShootProjectile",
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_reload_time, NoDiffMember):
-                reload_time = diff_reload_time.get_value()
-
+                reload_time = diff_reload_time.value
                 nyan_patch_raw_api_object.add_raw_patch_member("reload_time",
                                                                reload_time,
                                                                "engine.ability.type.ShootProjectile",
@@ -1676,14 +1672,14 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_spawn_delay, NoDiffMember):
                 if not isinstance(diff_animation, NoDiffMember):
-                    attack_graphic_id = diff_animation.get_value()
+                    attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.get_value()
+                    attack_graphic_id = diff_animation.value.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
-                frame_delay = diff_spawn_delay.get_value()
+                frame_delay = diff_spawn_delay.value
                 spawn_delay = frame_rate * frame_delay
 
                 nyan_patch_raw_api_object.add_raw_patch_member("spawn_delay",
@@ -1697,7 +1693,7 @@ class AoCUpgradeAbilitySubprocessor:
                 diff_spawn_area_z = diff_spawn_area_offsets[2]
 
                 if not isinstance(diff_spawn_area_x, NoDiffMember):
-                    spawn_area_x = diff_spawn_area_x.get_value()
+                    spawn_area_x = diff_spawn_area_x.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_x",
                                                                    spawn_area_x,
@@ -1705,7 +1701,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_spawn_area_y, NoDiffMember):
-                    spawn_area_y = diff_spawn_area_y.get_value()
+                    spawn_area_y = diff_spawn_area_y.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_y",
                                                                    spawn_area_y,
@@ -1713,7 +1709,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_spawn_area_z, NoDiffMember):
-                    spawn_area_z = diff_spawn_area_z.get_value()
+                    spawn_area_z = diff_spawn_area_z.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_z",
                                                                    spawn_area_z,
@@ -1721,7 +1717,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
             if not isinstance(diff_spawn_area_width, NoDiffMember):
-                spawn_area_width = diff_spawn_area_width.get_value()
+                spawn_area_width = diff_spawn_area_width.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_width",
                                                                spawn_area_width,
@@ -1729,7 +1725,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_spawn_area_height, NoDiffMember):
-                spawn_area_height = diff_spawn_area_height.get_value()
+                spawn_area_height = diff_spawn_area_height.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_height",
                                                                spawn_area_height,
@@ -1737,7 +1733,7 @@ class AoCUpgradeAbilitySubprocessor:
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_spawn_area_randomness, NoDiffMember):
-                spawn_area_randomness = diff_spawn_area_randomness.get_value()
+                spawn_area_randomness = diff_spawn_area_randomness.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_randomness",
                                                                spawn_area_randomness,
@@ -1794,7 +1790,7 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(diff_turn_speed, NoDiffMember):
                 return patches
 
-            diff_turn_speed_value = diff_turn_speed.get_value()
+            diff_turn_speed_value = diff_turn_speed.value
 
         else:
             return patches
@@ -1836,7 +1832,7 @@ class AoCUpgradeAbilitySubprocessor:
         turn_speed = MemberSpecialValue.NYAN_INF
         # Ships/Trebuchets turn slower
         if turn_speed_unmodified > 0:
-            turn_yaw = diff["max_yaw_per_sec_moving"].get_value()
+            turn_yaw = diff["max_yaw_per_sec_moving"].value
             turn_speed = degrees(turn_yaw)
 
         nyan_patch_raw_api_object.add_raw_patch_member("turn_speed",

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -110,8 +110,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -133,13 +133,14 @@ class AoCUpgradeAbilitySubprocessor:
                 animations_set = []
                 if diff_animation_id > -1:
                     # Patch the new animation in
-                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
-                                                                                           line,
-                                                                                           diff_animation_id,
-                                                                                           nyan_patch_ref,
-                                                                                           ability_name,
-                                                                                           "%s_"
-                                                                                           % command_lookup_dict[command_id][1])
+                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(
+                        converter_group,
+                        line,
+                        diff_animation_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     animations_set.append(animation_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("animations",
@@ -152,12 +153,13 @@ class AoCUpgradeAbilitySubprocessor:
                 diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
-                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
-                                                                                   diff_comm_sound_id,
-                                                                                   nyan_patch_ref,
-                                                                                   ability_name,
-                                                                                   "%s_"
-                                                                                   % command_lookup_dict[command_id][1])
+                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(
+                        converter_group,
+                        diff_comm_sound_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     sounds_set.append(sound_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("sounds",
@@ -283,8 +285,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -306,13 +308,14 @@ class AoCUpgradeAbilitySubprocessor:
                 animations_set = []
                 if diff_animation_id > -1:
                     # Patch the new animation in
-                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
-                                                                                           line,
-                                                                                           diff_animation_id,
-                                                                                           nyan_patch_ref,
-                                                                                           ability_name,
-                                                                                           "%s_"
-                                                                                           % command_lookup_dict[command_id][1])
+                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(
+                        converter_group,
+                        line,
+                        diff_animation_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     animations_set.append(animation_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("animations",
@@ -325,12 +328,13 @@ class AoCUpgradeAbilitySubprocessor:
                 diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
-                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
-                                                                                   diff_comm_sound_id,
-                                                                                   nyan_patch_ref,
-                                                                                   ability_name,
-                                                                                   "%s_"
-                                                                                   % command_lookup_dict[command_id][1])
+                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(
+                        converter_group,
+                        diff_comm_sound_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     sounds_set.append(sound_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("sounds",
@@ -459,13 +463,12 @@ class AoCUpgradeAbilitySubprocessor:
             # This should be a NoDiffMember
             percentage = diff_damage_animation["damage_percent"].ref.value
 
-            patch_target_ref = "%s.AttributeChangeTracker.ChangeProgress%s" % (game_entity_name,
-                                                                               str(percentage))
+            patch_target_ref = (f"{game_entity_name}.AttributeChangeTracker."
+                                f"ChangeProgress{percentage}")
             patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
             # Wrapper
-            wrapper_name = "Change%sDamageGraphic%sWrapper" % (game_entity_name,
-                                                               str(percentage))
+            wrapper_name = (f"Change{game_entity_name}DamageGraphic{percentage}Wrapper")
             wrapper_ref = f"{container_obj_ref}.{wrapper_name}"
             wrapper_raw_api_object = RawAPIObject(wrapper_ref,
                                                   wrapper_name,
@@ -475,8 +478,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -497,13 +500,14 @@ class AoCUpgradeAbilitySubprocessor:
             diff_animation_id = diff_damage_animation["graphic_id"].value
             if diff_animation_id > -1:
                 # Patch the new animation in
-                animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
-                                                                                       line,
-                                                                                       diff_animation_id,
-                                                                                       nyan_patch_ref,
-                                                                                       "Idle",
-                                                                                       "idle_damage_override_%s_"
-                                                                                       % (str(percentage)))
+                animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(
+                    converter_group,
+                    line,
+                    diff_animation_id,
+                    nyan_patch_ref,
+                    "Idle",
+                    f"idle_damage_override_{percentage}_"
+                )
                 animations_set.append(animation_forward_ref)
 
             nyan_patch_raw_api_object.add_raw_patch_member("overlays",
@@ -580,8 +584,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -683,8 +687,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -786,8 +790,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -889,8 +893,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -988,8 +992,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -1081,8 +1085,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -1208,8 +1212,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[group_id][1]}_upgrade")
 
             else:
@@ -1227,11 +1231,12 @@ class AoCUpgradeAbilitySubprocessor:
             nyan_patch_raw_api_object.set_patch_target(patch_target_forward_ref)
 
             name_string_id = diff_name.value
-            translations = AoCUpgradeAbilitySubprocessor.create_language_strings(converter_group,
-                                                                                 name_string_id,
-                                                                                 nyan_patch_ref,
-                                                                                 "%sName"
-                                                                                 % (obj_prefix))
+            translations = AoCUpgradeAbilitySubprocessor.create_language_strings(
+                converter_group,
+                name_string_id,
+                nyan_patch_ref,
+                f"{obj_prefix}Name"
+            )
             nyan_patch_raw_api_object.add_raw_patch_member("translations",
                                                            translations,
                                                            "engine.util.language.translated.type.TranslatedString",
@@ -1351,8 +1356,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -1421,8 +1426,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -1550,8 +1555,8 @@ class AoCUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -1573,13 +1578,14 @@ class AoCUpgradeAbilitySubprocessor:
                 diff_animation_id = diff_animation.value
                 if diff_animation_id > -1:
                     # Patch the new animation in
-                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
-                                                                                           line,
-                                                                                           diff_animation_id,
-                                                                                           nyan_patch_ref,
-                                                                                           ability_name,
-                                                                                           "%s_"
-                                                                                           % command_lookup_dict[command_id][1])
+                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(
+                        converter_group,
+                        line,
+                        diff_animation_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     animations_set.append(animation_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("animations",
@@ -1592,12 +1598,13 @@ class AoCUpgradeAbilitySubprocessor:
                 diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
-                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
-                                                                                   diff_comm_sound_id,
-                                                                                   nyan_patch_ref,
-                                                                                   ability_name,
-                                                                                   "%s_"
-                                                                                   % command_lookup_dict[command_id][1])
+                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(
+                        converter_group,
+                        diff_comm_sound_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     sounds_set.append(sound_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("sounds",
@@ -1809,8 +1816,8 @@ class AoCUpgradeAbilitySubprocessor:
         if isinstance(line, GenieBuildingLineGroup):
             # Store building upgrades next to their game entity definition,
             # not in the Age up techs.
-            wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                % (name_lookup_dict[head_unit_id][1]))
+            wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                 f"{name_lookup_dict[head_unit_id][1]}/"))
             wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
         else:
@@ -1890,9 +1897,9 @@ class AoCUpgradeAbilitySubprocessor:
 
         else:
             if isinstance(line, GenieBuildingLineGroup):
-                animation_filename = "%s%s_%s" % (filename_prefix,
-                                                  name_lookup_dict[line.get_head_unit_id()][1],
-                                                  group_name)
+                animation_filename = (f"{filename_prefix}"
+                                      f"{name_lookup_dict[line.get_head_unit_id()][1]}_"
+                                      f"{group_name}")
 
             else:
                 animation_filename = f"{filename_prefix}{group_name}"

--- a/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_ability_subprocessor.py
@@ -1514,17 +1514,17 @@ class AoCUpgradeAbilitySubprocessor:
         if diff:
             diff_animation = diff["attack_sprite_id"]
             diff_comm_sound = diff["command_sound_id"]
-            diff_min_projectiles = diff["attack_projectile_count"]
-            diff_max_projectiles = diff["attack_projectile_max_count"]
+            diff_min_projectiles = diff["projectile_min_count"]
+            diff_max_projectiles = diff["projectile_max_count"]
             diff_min_range = diff["weapon_range_min"]
             diff_max_range = diff["weapon_range_min"]
             diff_reload_time = diff["attack_speed"]
             # spawn delay also depends on animation
             diff_spawn_delay = diff["frame_delay"]
             diff_spawn_area_offsets = diff["weapon_offset"]
-            diff_spawn_area_width = diff["attack_projectile_spawning_area_width"]
-            diff_spawn_area_height = diff["attack_projectile_spawning_area_length"]
-            diff_spawn_area_randomness = diff["attack_projectile_spawning_area_randomness"]
+            diff_spawn_area_width = diff["projectile_spawning_area_width"]
+            diff_spawn_area_height = diff["projectile_spawning_area_length"]
+            diff_spawn_area_randomness = diff["projectile_spawning_area_randomness"]
 
             if any(not isinstance(value, NoDiffMember) for value in (diff_animation,
                                                                      diff_comm_sound,
@@ -1614,10 +1614,10 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_min_projectiles, NoDiffMember):
                 min_projectiles = diff_min_projectiles.value
-                source_min_count = upgrade_source["attack_projectile_count"].value
-                source_max_count = upgrade_source["attack_projectile_max_count"].value
-                target_min_count = upgrade_target["attack_projectile_count"].value
-                target_max_count = upgrade_target["attack_projectile_max_count"].value
+                source_min_count = upgrade_source["projectile_min_count"].value
+                source_max_count = upgrade_source["projectile_max_count"].value
+                target_min_count = upgrade_target["projectile_min_count"].value
+                target_max_count = upgrade_target["projectile_max_count"].value
 
                 # Account for a special case where the number of projectiles are 0
                 # in the .dat, but the game still counts this as 1 when a projectile
@@ -1636,10 +1636,10 @@ class AoCUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_max_projectiles, NoDiffMember):
                 max_projectiles = diff_max_projectiles.value
-                source_min_count = upgrade_source["attack_projectile_count"].value
-                source_max_count = upgrade_source["attack_projectile_max_count"].value
-                target_min_count = upgrade_target["attack_projectile_count"].value
-                target_max_count = upgrade_target["attack_projectile_max_count"].value
+                source_min_count = upgrade_source["projectile_min_count"].value
+                source_max_count = upgrade_source["projectile_max_count"].value
+                target_min_count = upgrade_target["projectile_min_count"].value
+                target_max_count = upgrade_target["projectile_max_count"].value
 
                 # Account for a special case where the number of projectiles are 0
                 # in the .dat, but the game still counts this as 1 when a projectile

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -285,7 +285,7 @@ class AoCUpgradeAttributeSubprocessor:
 
         if line.is_projectile_shooter():
             primary_projectile_id = line.get_head_unit(
-            )["attack_projectile_primary_unit_id"].get_value()
+            )["attack_projectile_primary_unit_id"].value
             if primary_projectile_id == -1:
                 # Upgrade is skipped if the primary projectile is not defined
                 return patches
@@ -406,8 +406,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].get_value()
-        projectile_id1 = head_unit["attack_projectile_secondary_unit_id"].get_value()
+        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].value
+        projectile_id1 = head_unit["attack_projectile_secondary_unit_id"].value
 
         if projectile_id0 > -1:
             patch_target_ref = f"{game_entity_name}.ShootProjectile.Projectile0.Projectile"
@@ -598,8 +598,8 @@ class AoCUpgradeAttributeSubprocessor:
         patches = []
 
         # Check if the unit line actually costs food
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             if resource_id == 0:
                 break
@@ -703,8 +703,8 @@ class AoCUpgradeAttributeSubprocessor:
         patches = []
 
         # Check if the unit line actually costs wood
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             if resource_id == 1:
                 break
@@ -808,8 +808,8 @@ class AoCUpgradeAttributeSubprocessor:
         patches = []
 
         # Check if the unit line actually costs gold
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             if resource_id == 3:
                 break
@@ -913,8 +913,8 @@ class AoCUpgradeAttributeSubprocessor:
         patches = []
 
         # Check if the unit line actually costs stone
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             if resource_id == 2:
                 break
@@ -2176,8 +2176,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             resource_name = ""
             if resource_id == -1:
@@ -2201,7 +2201,7 @@ class AoCUpgradeAttributeSubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
             patch_target_ref = "%s.CreatableGameEntity.%sCost.%sAmount" % (game_entity_name,

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -514,6 +514,34 @@ class AoCUpgradeAttributeSubprocessor:
         return patches
 
     @staticmethod
+    def attack_warning_sound_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the attack warning sound modify effect (ID: 26).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param line: Unit/Building line that has the ability.
+        :type line: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: int, float
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def blast_radius_upgrade(
         converter_group: ConverterObjectGroup,
         line: GenieGameEntityGroup,
@@ -1355,6 +1383,34 @@ class AoCUpgradeAttributeSubprocessor:
 
         wrapper_forward_ref = ForwardRef(converter_group, wrapper_ref)
         patches.append(wrapper_forward_ref)
+
+        return patches
+
+    @staticmethod
+    def ignore_armor_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the ignore armor effect (ID: 63).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param line: Unit/Building line that has the ability.
+        :type line: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: int, float
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
 
         return patches
 
@@ -2571,6 +2627,34 @@ class AoCUpgradeAttributeSubprocessor:
         patches = []
 
         # Unused in AoC
+
+        return patches
+
+    @staticmethod
+    def train_button_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the train button modify effect (ID: 43).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param line: Unit/Building line that has the ability.
+        :type line: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: int, float
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
 
         return patches
 

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -621,8 +621,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.FoodAmount" % (game_entity_name,
-                                                                         game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.FoodAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -726,8 +726,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.WoodAmount" % (game_entity_name,
-                                                                         game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.WoodAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -831,8 +831,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.GoldAmount" % (game_entity_name,
-                                                                         game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.GoldAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -936,8 +936,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.StoneAmount" % (game_entity_name,
-                                                                          game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.StoneAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -2204,9 +2204,8 @@ class AoCUpgradeAttributeSubprocessor:
             if not resource_amount["enabled"].value:
                 continue
 
-            patch_target_ref = "%s.CreatableGameEntity.%sCost.%sAmount" % (game_entity_name,
-                                                                           game_entity_name,
-                                                                           resource_name)
+            patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                                f"{game_entity_name}Cost.{resource_name}Amount")
             patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
             # Wrapper

--- a/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_attribute_subprocessor.py
@@ -285,7 +285,7 @@ class AoCUpgradeAttributeSubprocessor:
 
         if line.is_projectile_shooter():
             primary_projectile_id = line.get_head_unit(
-            )["attack_projectile_primary_unit_id"].value
+            )["projectile_id0"].value
             if primary_projectile_id == -1:
                 # Upgrade is skipped if the primary projectile is not defined
                 return patches
@@ -406,8 +406,8 @@ class AoCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].value
-        projectile_id1 = head_unit["attack_projectile_secondary_unit_id"].value
+        projectile_id0 = head_unit["projectile_id0"].value
+        projectile_id1 = head_unit["projectile_id1"].value
 
         if projectile_id0 > -1:
             patch_target_ref = f"{game_entity_name}.ShootProjectile.Projectile0.Projectile"

--- a/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
@@ -65,7 +65,7 @@ class AoCUpgradeEffectSubprocessor:
 
         tech_name = tech_lookup_dict[tech_id][0]
 
-        diff_attacks = diff["attacks"].get_value()
+        diff_attacks = diff["attacks"].value
         for diff_attack in diff_attacks.values():
             if isinstance(diff_attack, NoDiffMember):
                 continue
@@ -74,8 +74,8 @@ class AoCUpgradeEffectSubprocessor:
                 # Create a new attack effect, then patch it in
                 attack = diff_attack.get_reference()
 
-                armor_class = attack["type_id"].get_value()
-                attack_amount = attack["amount"].get_value()
+                armor_class = attack["type_id"].value
+                attack_amount = attack["amount"].value
 
                 if armor_class == -1:
                     continue
@@ -198,7 +198,7 @@ class AoCUpgradeEffectSubprocessor:
                 # Patch the effect out of the ability
                 attack = diff_attack.get_reference()
 
-                armor_class = attack["type_id"].get_value()
+                armor_class = attack["type_id"].value
                 class_name = armor_lookup_dict[armor_class]
 
                 patch_target_ref = f"{ability_ref}.Batch"
@@ -259,8 +259,8 @@ class AoCUpgradeEffectSubprocessor:
                     raise Exception("Could not create effect upgrade for line %s: Out of order"
                                     % (line))
 
-                armor_class = diff_armor_class.get_reference().get_value()
-                attack_amount = diff_attack["amount"].get_value()
+                armor_class = diff_armor_class.get_reference().value
+                attack_amount = diff_attack["amount"].value
 
                 class_name = armor_lookup_dict[armor_class]
 
@@ -347,7 +347,7 @@ class AoCUpgradeEffectSubprocessor:
 
         tech_name = tech_lookup_dict[tech_id][0]
 
-        diff_armors = diff["armors"].get_value()
+        diff_armors = diff["armors"].value
         for diff_armor in diff_armors.values():
             if isinstance(diff_armor, NoDiffMember):
                 continue
@@ -356,8 +356,8 @@ class AoCUpgradeEffectSubprocessor:
                 # Create a new attack resistance, then patch it in
                 armor = diff_armor.get_reference()
 
-                armor_class = armor["type_id"].get_value()
-                armor_amount = armor["amount"].get_value()
+                armor_class = armor["type_id"].value
+                armor_amount = armor["amount"].value
 
                 if armor_class == -1:
                     continue
@@ -466,7 +466,7 @@ class AoCUpgradeEffectSubprocessor:
                 # Patch the resistance out of the ability
                 armor = diff_armor.get_reference()
 
-                armor_class = armor["type_id"].get_value()
+                armor_class = armor["type_id"].value
                 class_name = armor_lookup_dict[armor_class]
 
                 patch_target_ref = f"{ability_ref}"
@@ -527,8 +527,8 @@ class AoCUpgradeEffectSubprocessor:
                     raise Exception("Could not create effect upgrade for line %s: Out of order"
                                     % (line))
 
-                armor_class = diff_armor_class.get_reference().get_value()
-                armor_amount = diff_armor["amount"].get_value()
+                armor_class = diff_armor_class.get_reference().value
+                armor_amount = diff_armor["amount"].value
 
                 class_name = armor_lookup_dict[armor_class]
 

--- a/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
@@ -100,8 +100,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:
@@ -215,8 +215,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:
@@ -256,8 +256,8 @@ class AoCUpgradeEffectSubprocessor:
                 if not isinstance(diff_armor_class, NoDiffMember):
                     # If this happens then the attacks are out of order
                     # and we have to try something else
-                    raise Exception("Could not create effect upgrade for line %s: Out of order"
-                                    % (line))
+                    raise Exception(f"Could not create effect upgrade for line {repr(line)}: "
+                                    "Out of order")
 
                 armor_class = diff_armor_class.ref.value
                 attack_amount = diff_attack["amount"].value
@@ -278,8 +278,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:
@@ -382,8 +382,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:
@@ -483,8 +483,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:
@@ -524,8 +524,8 @@ class AoCUpgradeEffectSubprocessor:
                 if not isinstance(diff_armor_class, NoDiffMember):
                     # If this happens then the armors are out of order
                     # and we have to try something else
-                    raise Exception("Could not create effect upgrade for line %s: Out of order"
-                                    % (line))
+                    raise Exception(f"Could not create effect upgrade for line {repr(line)}: "
+                                    "Out of order")
 
                 armor_class = diff_armor_class.ref.value
                 armor_amount = diff_armor["amount"].value
@@ -546,8 +546,8 @@ class AoCUpgradeEffectSubprocessor:
                 if isinstance(line, GenieBuildingLineGroup):
                     # Store building upgrades next to their game entity definition,
                     # not in the Age up techs.
-                    wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                        % (name_lookup_dict[head_unit_id][1]))
+                    wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                         f"{name_lookup_dict[head_unit_id][1]}/"))
                     wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
                 else:

--- a/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/upgrade_effect_subprocessor.py
@@ -72,7 +72,7 @@ class AoCUpgradeEffectSubprocessor:
 
             if isinstance(diff_attack, LeftMissingMember):
                 # Create a new attack effect, then patch it in
-                attack = diff_attack.get_reference()
+                attack = diff_attack.ref
 
                 armor_class = attack["type_id"].value
                 attack_amount = attack["amount"].value
@@ -196,7 +196,7 @@ class AoCUpgradeEffectSubprocessor:
 
             elif isinstance(diff_attack, RightMissingMember):
                 # Patch the effect out of the ability
-                attack = diff_attack.get_reference()
+                attack = diff_attack.ref
 
                 armor_class = attack["type_id"].value
                 class_name = armor_lookup_dict[armor_class]
@@ -259,7 +259,7 @@ class AoCUpgradeEffectSubprocessor:
                     raise Exception("Could not create effect upgrade for line %s: Out of order"
                                     % (line))
 
-                armor_class = diff_armor_class.get_reference().value
+                armor_class = diff_armor_class.ref.value
                 attack_amount = diff_attack["amount"].value
 
                 class_name = armor_lookup_dict[armor_class]
@@ -354,7 +354,7 @@ class AoCUpgradeEffectSubprocessor:
 
             if isinstance(diff_armor, LeftMissingMember):
                 # Create a new attack resistance, then patch it in
-                armor = diff_armor.get_reference()
+                armor = diff_armor.ref
 
                 armor_class = armor["type_id"].value
                 armor_amount = armor["amount"].value
@@ -464,7 +464,7 @@ class AoCUpgradeEffectSubprocessor:
 
             elif isinstance(diff_armor, RightMissingMember):
                 # Patch the resistance out of the ability
-                armor = diff_armor.get_reference()
+                armor = diff_armor.ref
 
                 armor_class = armor["type_id"].value
                 class_name = armor_lookup_dict[armor_class]
@@ -527,7 +527,7 @@ class AoCUpgradeEffectSubprocessor:
                     raise Exception("Could not create effect upgrade for line %s: Out of order"
                                     % (line))
 
-                armor_class = diff_armor_class.get_reference().value
+                armor_class = diff_armor_class.ref.value
                 armor_amount = diff_armor["amount"].value
 
                 class_name = armor_lookup_dict[armor_class]

--- a/openage/convert/processor/conversion/de1/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de1/media_subprocessor.py
@@ -63,8 +63,7 @@ class DE1MediaSubprocessor:
 
                 # TODO: Also convert x2 and x4 variants
                 source_filename = f"{source_str}x1.slp"
-                target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].value))
+                target_filename = f"{sprite.get_filename()}_{str(graphic['slp_id'].value)}.png"
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,

--- a/openage/convert/processor/conversion/de1/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de1/media_subprocessor.py
@@ -59,12 +59,12 @@ class DE1MediaSubprocessor:
                 # DE1 stores most graphics filenames as 'whatever_<x#>'
                 # where '<x#>' must be replaced by x1, x2 or x4
                 # which corresponds to the graphics resolution variant
-                source_str = graphic['filename'].get_value()[:-4]
+                source_str = graphic['filename'].value[:-4]
 
                 # TODO: Also convert x2 and x4 variants
                 source_filename = f"{source_str}x1.slp"
                 target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].get_value()))
+                                                 str(graphic["slp_id"].value))
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,
@@ -73,7 +73,7 @@ class DE1MediaSubprocessor:
                 full_data_set.graphics_exports.update({graphic_id: export_request})
 
                 # Metadata from graphics
-                sequence_type = graphic["sequence_type"].get_value()
+                sequence_type = graphic["sequence_type"].value
                 if sequence_type == 0x00:
                     layer_mode = LayerMode.OFF
 
@@ -83,18 +83,18 @@ class DE1MediaSubprocessor:
                 else:
                     layer_mode = LayerMode.LOOP
 
-                layer_pos = graphic["layer"].get_value()
-                frame_rate = round(graphic["frame_rate"].get_value(), ndigits=6)
+                layer_pos = graphic["layer"].value
+                frame_rate = round(graphic["frame_rate"].value, ndigits=6)
                 if frame_rate < 0.000001:
                     frame_rate = None
 
-                replay_delay = round(graphic["replay_delay"].get_value(), ndigits=6)
+                replay_delay = round(graphic["replay_delay"].value, ndigits=6)
                 if replay_delay < 0.000001:
                     replay_delay = None
 
-                frame_count = graphic["frame_count"].get_value()
-                angle_count = graphic["angle_count"].get_value()
-                mirror_mode = graphic["mirroring_mode"].get_value()
+                frame_count = graphic["frame_count"].value
+                angle_count = graphic["angle_count"].value
+                mirror_mode = graphic["mirroring_mode"].value
                 metadata_export.add_graphics_metadata(target_filename,
                                                       layer_mode,
                                                       layer_pos,

--- a/openage/convert/processor/conversion/de1/processor.py
+++ b/openage/convert/processor/conversion/de1/processor.py
@@ -181,11 +181,11 @@ class DE1Processor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->graphics
-        raw_graphics = gamespec[0]["graphics"].get_value()
+        raw_graphics = gamespec[0]["graphics"].value
 
         for raw_graphic in raw_graphics:
             # Can be ignored if there is no filename associated
-            filename = raw_graphic["filename"].get_value()
+            filename = raw_graphic["filename"].value
             if not filename:
                 continue
 
@@ -197,8 +197,8 @@ class DE1Processor:
             if filename.endswith("<x#>"):
                 filename = f"{filename[:-4]}x1"
 
-            graphic_id = raw_graphic["graphic_id"].get_value()
-            graphic_members = raw_graphic.get_value()
+            graphic_id = raw_graphic["graphic_id"].value
+            graphic_members = raw_graphic.value
 
             graphic = GenieGraphic(graphic_id, full_data_set, members=graphic_members)
             if filename not in full_data_set.existing_graphics:

--- a/openage/convert/processor/conversion/de2/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/ability_subprocessor.py
@@ -81,11 +81,11 @@ class DE2AbilitySubprocessor:
         attribute_rate = 0
         if current_unit_id == 125:
             # stored in civ resources
-            attribute_rate = dataset.genie_civs[0]["resources"][35].get_value()
+            attribute_rate = dataset.genie_civs[0]["resources"][35].value
 
         elif current_unit_id == 692:
             # stored in unit, but has to get converted to amount/second
-            heal_timer = current_unit["heal_timer"].get_value()
+            heal_timer = current_unit["heal_timer"].value
             attribute_rate = 1 / heal_timer
 
         rate_raw_api_object.add_raw_member("rate",

--- a/openage/convert/processor/conversion/de2/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/civ_subprocessor.py
@@ -99,7 +99,7 @@ class DE2CivSubprocessor:
                         # TODO: Bonus unlocked by something else
                         continue
 
-                    if tech_id in tech_patches.keys():
+                    if tech_id in tech_patches:
                         tech_patches[tech_id].extend(bonus_patches)
 
                     else:

--- a/openage/convert/processor/conversion/de2/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/civ_subprocessor.py
@@ -66,15 +66,15 @@ class DE2CivSubprocessor:
 
                 # civ boni might be unlocked by age ups. if so, patch them into the age up
                 # patches are queued here
-                required_tech_count = civ_bonus.tech["required_tech_count"].get_value()
+                required_tech_count = civ_bonus.tech["required_tech_count"].value
                 if required_tech_count > 0 and len(bonus_patches) > 0:
                     if required_tech_count == 1:
-                        tech_id = civ_bonus.tech["required_techs"][0].get_value()
+                        tech_id = civ_bonus.tech["required_techs"][0].value
 
                     elif required_tech_count == 2:
                         # Try to patch them into the second listed tech
                         # This tech is usually unlocked by an age up
-                        tech_id = civ_bonus.tech["required_techs"][1].get_value()
+                        tech_id = civ_bonus.tech["required_techs"][1].value
 
                         if tech_id == 232:
                             # Synergies with other civs (usually chinese farming bonus)
@@ -84,11 +84,11 @@ class DE2CivSubprocessor:
                         if tech_id not in dataset.tech_groups.keys():
                             # Circumvents a "funny" duplicate castle age up tech for Incas
                             # The required tech of the duplicate is the age up we are looking for
-                            tech_id = dataset.genie_techs[tech_id]["required_techs"][0].get_value()
+                            tech_id = dataset.genie_techs[tech_id]["required_techs"][0].value
 
                         if not dataset.tech_groups[tech_id].is_researchable():
                             # Fall back to the first tech if the second is not researchable
-                            tech_id = civ_bonus.tech["required_techs"][0].get_value()
+                            tech_id = civ_bonus.tech["required_techs"][0].value
 
                     if tech_id == 104:
                         # Skip Dark Age; it is not a tech in openage

--- a/openage/convert/processor/conversion/de2/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/media_subprocessor.py
@@ -55,8 +55,7 @@ class DE2MediaSubprocessor:
 
                 targetdir = graphic_targetdirs[graphic_id]
                 source_filename = f"{str(graphic['filename'].value)}.smx"
-                target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].value))
+                target_filename = f"{sprite.get_filename()}_{str(graphic['slp_id'].value)}.png"
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,

--- a/openage/convert/processor/conversion/de2/media_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/media_subprocessor.py
@@ -54,9 +54,9 @@ class DE2MediaSubprocessor:
                     continue
 
                 targetdir = graphic_targetdirs[graphic_id]
-                source_filename = f"{str(graphic['filename'].get_value())}.smx"
+                source_filename = f"{str(graphic['filename'].value)}.smx"
                 target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].get_value()))
+                                                 str(graphic["slp_id"].value))
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,
@@ -65,7 +65,7 @@ class DE2MediaSubprocessor:
                 full_data_set.graphics_exports.update({graphic_id: export_request})
 
                 # Metadata from graphics
-                sequence_type = graphic["sequence_type"].get_value()
+                sequence_type = graphic["sequence_type"].value
                 if sequence_type == 0x00:
                     layer_mode = LayerMode.OFF
 
@@ -75,18 +75,18 @@ class DE2MediaSubprocessor:
                 else:
                     layer_mode = LayerMode.LOOP
 
-                layer_pos = graphic["layer"].get_value()
-                frame_rate = round(graphic["frame_rate"].get_value(), ndigits=6)
+                layer_pos = graphic["layer"].value
+                frame_rate = round(graphic["frame_rate"].value, ndigits=6)
                 if frame_rate < 0.000001:
                     frame_rate = None
 
-                replay_delay = round(graphic["replay_delay"].get_value(), ndigits=6)
+                replay_delay = round(graphic["replay_delay"].value, ndigits=6)
                 if replay_delay < 0.000001:
                     replay_delay = None
 
-                frame_count = graphic["frame_count"].get_value()
-                angle_count = graphic["angle_count"].get_value()
-                mirror_mode = graphic["mirroring_mode"].get_value()
+                frame_count = graphic["frame_count"].value
+                angle_count = graphic["angle_count"].value
+                mirror_mode = graphic["mirroring_mode"].value
                 metadata_export.add_graphics_metadata(target_filename,
                                                       layer_mode,
                                                       layer_pos,

--- a/openage/convert/processor/conversion/de2/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/nyan_subprocessor.py
@@ -199,14 +199,14 @@ class DE2NyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_unit["unit_type"].get_value()
+        unit_type = current_unit["unit_type"].value
 
         if unit_type >= 70:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_unit["unit_class"].get_value()
+        unit_class = current_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -405,14 +405,14 @@ class DE2NyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_building["unit_type"].get_value()
+        unit_type = current_building["unit_type"].value
 
         if unit_type >= 80:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_building["unit_class"].get_value()
+        unit_class = current_building["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -742,13 +742,13 @@ class DE2NyanSubprocessor:
         # Ambience
         # =======================================================================
         terrain = terrain_group.get_terrain()
-        # ambients_count = terrain["terrain_units_used_count"].get_value()
+        # ambients_count = terrain["terrain_units_used_count"].value
 
         ambience = []
         # TODO: Ambience
 # ===============================================================================
 #         for ambient_index in range(ambients_count):
-#             ambient_id = terrain["terrain_unit_id"][ambient_index].get_value()
+#             ambient_id = terrain["terrain_unit_id"][ambient_index].value
 #
 #             if ambient_id == -1:
 #                 continue
@@ -771,7 +771,7 @@ class DE2NyanSubprocessor:
 #                                                   "engine.util.terrain.TerrainAmbient")
 #
 #             # Max density
-#             max_density = terrain["terrain_unit_density"][ambient_index].get_value()
+#             max_density = terrain["terrain_unit_density"][ambient_index].value
 #             ambient_raw_api_object.add_raw_member("max_density",
 #                                                   max_density,
 #                                                   "engine.util.terrain.TerrainAmbient")

--- a/openage/convert/processor/conversion/de2/processor.py
+++ b/openage/convert/processor/conversion/de2/processor.py
@@ -191,14 +191,14 @@ class DE2Processor:
         # Gaia also seems to have the most units, so we only read from Gaia
         #
         # call hierarchy: wrapper[0]->civs[0]->units
-        raw_units = gamespec[0]["civs"][0]["units"].get_value()
+        raw_units = gamespec[0]["civs"][0]["units"].value
 
         # Unit headers store the things units can do
-        raw_unit_headers = gamespec[0]["unit_headers"].get_value()
+        raw_unit_headers = gamespec[0]["unit_headers"].value
 
         for raw_unit in raw_units:
-            unit_id = raw_unit["id0"].get_value()
-            unit_members = raw_unit.get_value()
+            unit_id = raw_unit["id0"].value
+            unit_members = raw_unit.value
 
             # Turn attack and armor into containers to make diffing work
             if "attacks" in unit_members.keys():
@@ -216,7 +216,7 @@ class DE2Processor:
             # Commands
             if "unit_commands" not in unit_members.keys():
                 # Only ActionUnits with type >= 40 should have commands
-                unit_type = raw_unit["unit_type"].get_value()
+                unit_type = raw_unit["unit_type"].value
                 if unit_type >= 40:
                     unit_commands = raw_unit_headers[unit_id]["unit_commands"]
                     unit.add_member(unit_commands)
@@ -237,16 +237,16 @@ class DE2Processor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->graphics
-        raw_graphics = gamespec[0]["graphics"].get_value()
+        raw_graphics = gamespec[0]["graphics"].value
 
         for raw_graphic in raw_graphics:
             # Can be ignored if there is no filename associated
-            filename = raw_graphic["filename"].get_value().lower()
+            filename = raw_graphic["filename"].value.lower()
             if not filename:
                 continue
 
-            graphic_id = raw_graphic["graphic_id"].get_value()
-            graphic_members = raw_graphic.get_value()
+            graphic_id = raw_graphic["graphic_id"].value
+            graphic_members = raw_graphic.value
             graphic = GenieGraphic(graphic_id, full_data_set, members=graphic_members)
 
             if filename not in full_data_set.existing_graphics:

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -54,12 +54,16 @@ class DE2TechSubprocessor:
 
         # TODO: These refer to different atributes in DE2
         24: AoCUpgradeAttributeSubprocessor.imperial_tech_id_upgrade,
+        26: AoCUpgradeAttributeSubprocessor.attack_warning_sound_upgrade,
         42: AoCUpgradeAttributeSubprocessor.standing_wonders_upgrade,
+        43: AoCUpgradeAttributeSubprocessor.train_button_upgrade,
         46: AoCUpgradeAttributeSubprocessor.tribute_inefficiency_upgrade,
         48: AoCUpgradeAttributeSubprocessor.tc_available_upgrade,
         49: AoCUpgradeAttributeSubprocessor.gold_counter_upgrade,
         57: AoCUpgradeAttributeSubprocessor.kidnap_storage_upgrade,
 
+        30: DE2UpgradeAttributeSubprocessor.herdable_garrison_capacity_upgrade,
+        63: AoCUpgradeAttributeSubprocessor.ignore_armor_upgrade,
         100: AoCUpgradeAttributeSubprocessor.resource_cost_upgrade,
         101: AoCUpgradeAttributeSubprocessor.creation_time_upgrade,
         102: AoCUpgradeAttributeSubprocessor.min_projectiles_upgrade,
@@ -70,6 +74,7 @@ class DE2TechSubprocessor:
         107: AoCUpgradeAttributeSubprocessor.max_projectiles_upgrade,
         108: AoCUpgradeAttributeSubprocessor.garrison_heal_upgrade,
         109: DE2UpgradeAttributeSubprocessor.regeneration_rate_upgrade,
+        110: DE2UpgradeAttributeSubprocessor.villager_pop_space_upgrade,
     }
 
     upgrade_resource_funcs = {
@@ -131,6 +136,14 @@ class DE2TechSubprocessor:
         238: DE2UpgradeResourceSubprocessor.folwark_flag_upgrade,
         239: DE2UpgradeResourceSubprocessor.folwark_mill_id_upgrade,
         241: DE2UpgradeResourceSubprocessor.stone_gold_gen_upgrade,
+        242: DE2UpgradeResourceSubprocessor.workshop_food_gen_upgrade,
+        243: DE2UpgradeResourceSubprocessor.workshop_wood_gen_upgrade,
+        244: DE2UpgradeResourceSubprocessor.workshop_stone_gen_upgrade,
+        245: DE2UpgradeResourceSubprocessor.workshop_gold_gen_upgrade,
+        251: DE2UpgradeResourceSubprocessor.trade_food_bonus_upgrade,
+        254: DE2UpgradeResourceSubprocessor.herdable_garrison_upgrade,
+        262: DE2UpgradeResourceSubprocessor.bengali_conversion_resistance_upgrade,
+        266: DE2UpgradeResourceSubprocessor.doi_paper_money_upgrade,
     }
 
     @classmethod

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -62,7 +62,7 @@ class DE2TechSubprocessor:
         49: AoCUpgradeAttributeSubprocessor.gold_counter_upgrade,
         57: AoCUpgradeAttributeSubprocessor.kidnap_storage_upgrade,
 
-        30: DE2UpgradeAttributeSubprocessor.herdable_garrison_capacity_upgrade,
+        30: DE2UpgradeAttributeSubprocessor.herdable_capacity_upgrade,
         63: AoCUpgradeAttributeSubprocessor.ignore_armor_upgrade,
         100: AoCUpgradeAttributeSubprocessor.resource_cost_upgrade,
         101: AoCUpgradeAttributeSubprocessor.creation_time_upgrade,

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -230,10 +230,10 @@ class DE2TechSubprocessor:
             raise Exception("Effect type %s is not a valid attribute effect"
                             % str(effect_type))
 
-        unit_id = effect["attr_a"].get_value()
-        class_id = effect["attr_b"].get_value()
-        attribute_type = effect["attr_c"].get_value()
-        value = effect["attr_d"].get_value()
+        unit_id = effect["attr_a"].value
+        class_id = effect["attr_b"].value
+        attribute_type = effect["attr_c"].value
+        value = effect["attr_d"].value
 
         if attribute_type == -1:
             return patches
@@ -286,7 +286,7 @@ class DE2TechSubprocessor:
         effect_type = effect.get_type()
         operator = None
         if effect_type in (1, 11):
-            mode = effect["attr_b"].get_value()
+            mode = effect["attr_b"].value
 
             if mode == 0:
                 operator = MemberOperator.ASSIGN
@@ -301,8 +301,8 @@ class DE2TechSubprocessor:
             raise Exception("Effect type %s is not a valid resource effect"
                             % str(effect_type))
 
-        resource_id = effect["attr_a"].get_value()
-        value = effect["attr_d"].get_value()
+        resource_id = effect["attr_a"].value
+        value = effect["attr_d"].value
 
         if resource_id in (-1, 6, 21):
             # -1 = invalid ID

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -227,8 +227,7 @@ class DE2TechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid attribute effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid attribute effect")
 
         unit_id = effect["attr_a"].value
         class_id = effect["attr_b"].value
@@ -298,8 +297,7 @@ class DE2TechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid resource effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid attribute effect")
 
         resource_id = effect["attr_a"].value
         value = effect["attr_d"].value

--- a/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
@@ -25,6 +25,36 @@ class DE2UpgradeAttributeSubprocessor:
     """
 
     @staticmethod
+    def herdable_garrison_capacity_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the herdable garrison capacity modify effect (ID: 30).
+
+        TODO: Move into AK processor.
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param line: Unit/Building line that has the ability.
+        :type line: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: int, float
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def regeneration_rate_upgrade(
         converter_group: ConverterObjectGroup,
         line: GenieGameEntityGroup,
@@ -34,6 +64,36 @@ class DE2UpgradeAttributeSubprocessor:
     ) -> list[ForwardRef]:
         """
         Creates a patch for the regeneration rate modify effect (ID: 109).
+
+        TODO: Move into AK processor.
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param line: Unit/Building line that has the ability.
+        :type line: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: int, float
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def villager_pop_space_upgrade(
+        converter_group: ConverterObjectGroup,
+        line: GenieGameEntityGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the villager pop space modify effect (ID: 110).
 
         TODO: Move into AK processor.
 

--- a/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_attribute_subprocessor.py
@@ -25,7 +25,7 @@ class DE2UpgradeAttributeSubprocessor:
     """
 
     @staticmethod
-    def herdable_garrison_capacity_upgrade(
+    def herdable_capacity_upgrade(
         converter_group: ConverterObjectGroup,
         line: GenieGameEntityGroup,
         value: typing.Union[int, float],

--- a/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/upgrade_resource_subprocessor.py
@@ -24,6 +24,31 @@ class DE2UpgradeResourceSubprocessor:
     """
 
     @staticmethod
+    def bengali_conversion_resistance_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the bengali conversion resistance effect (ID: 262).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def burgundian_vineyards_upgrade(
         converter_group: ConverterObjectGroup,
         value: typing.Union[int, float],
@@ -342,6 +367,31 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
+    def doi_paper_money_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the Paper Money effect in Dynasties of India (ID: 266).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def elevation_attack_upgrade(
         converter_group: ConverterObjectGroup,
         value: typing.Union[int, float],
@@ -550,6 +600,31 @@ class DE2UpgradeResourceSubprocessor:
         return patches
 
     @staticmethod
+    def herdable_garrison_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the herdable garrison effect (ID: 254).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
     def relic_food_production_upgrade(
         converter_group: ConverterObjectGroup,
         value: typing.Union[int, float],
@@ -635,6 +710,131 @@ class DE2UpgradeResourceSubprocessor:
     ) -> list[ForwardRef]:
         """
         Creates a patch for the polish stone gold generation effect (ID: 241).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def trade_food_bonus_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the trade food bonus effect (ID: 251).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def workshop_food_gen_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the workshop food generation effect (ID: 242).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def workshop_wood_gen_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the workshop wood generation effect (ID: 243).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def workshop_stone_gen_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the workshop stone generation effect (ID: 244).
+
+        :param converter_group: Tech/Civ that gets the patch.
+        :type converter_group: ...dataformat.converter_object.ConverterObjectGroup
+        :param value: Value used for patching the member.
+        :type value: MemberOperator
+        :param operator: Operator used for patching the member.
+        :type operator: MemberOperator
+        :returns: The forward references for the generated patches.
+        :rtype: list
+        """
+        patches = []
+
+        # TODO: Implement
+
+        return patches
+
+    @staticmethod
+    def workshop_gold_gen_upgrade(
+        converter_group: ConverterObjectGroup,
+        value: typing.Union[int, float],
+        operator: MemberOperator,
+        team: bool = False
+    ) -> list[ForwardRef]:
+        """
+        Creates a patch for the workshop gold generation effect (ID: 245).
 
         :param converter_group: Tech/Civ that gets the patch.
         :type converter_group: ...dataformat.converter_object.ConverterObjectGroup

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -56,8 +56,7 @@ class HDMediaSubprocessor:
 
                 targetdir = graphic_targetdirs[graphic_id]
                 source_filename = f"{str(graphic['slp_id'].value)}.slp"
-                target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].value))
+                target_filename = f"{sprite.get_filename()}_{str(graphic['slp_id'].value)}.png"
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,

--- a/openage/convert/processor/conversion/hd/media_subprocessor.py
+++ b/openage/convert/processor/conversion/hd/media_subprocessor.py
@@ -55,9 +55,9 @@ class HDMediaSubprocessor:
                     continue
 
                 targetdir = graphic_targetdirs[graphic_id]
-                source_filename = f"{str(graphic['slp_id'].get_value())}.slp"
+                source_filename = f"{str(graphic['slp_id'].value)}.slp"
                 target_filename = "%s_%s.png" % (sprite.get_filename(),
-                                                 str(graphic["slp_id"].get_value()))
+                                                 str(graphic["slp_id"].value))
 
                 export_request = MediaExportRequest(MediaType.GRAPHICS,
                                                     targetdir,
@@ -66,7 +66,7 @@ class HDMediaSubprocessor:
                 full_data_set.graphics_exports.update({graphic_id: export_request})
 
                 # Metadata from graphics
-                sequence_type = graphic["sequence_type"].get_value()
+                sequence_type = graphic["sequence_type"].value
                 if sequence_type == 0x00:
                     layer_mode = LayerMode.OFF
 
@@ -76,18 +76,18 @@ class HDMediaSubprocessor:
                 else:
                     layer_mode = LayerMode.LOOP
 
-                layer_pos = graphic["layer"].get_value()
-                frame_rate = round(graphic["frame_rate"].get_value(), ndigits=6)
+                layer_pos = graphic["layer"].value
+                frame_rate = round(graphic["frame_rate"].value, ndigits=6)
                 if frame_rate < 0.000001:
                     frame_rate = None
 
-                replay_delay = round(graphic["replay_delay"].get_value(), ndigits=6)
+                replay_delay = round(graphic["replay_delay"].value, ndigits=6)
                 if replay_delay < 0.000001:
                     replay_delay = None
 
-                frame_count = graphic["frame_count"].get_value()
-                angle_count = graphic["angle_count"].get_value()
-                mirror_mode = graphic["mirroring_mode"].get_value()
+                frame_count = graphic["frame_count"].value
+                angle_count = graphic["angle_count"].value
+                mirror_mode = graphic["mirroring_mode"].value
                 metadata_export.add_graphics_metadata(target_filename,
                                                       layer_mode,
                                                       layer_pos,
@@ -104,8 +104,8 @@ class HDMediaSubprocessor:
 
         combined_terrains = full_data_set.combined_terrains.values()
         for texture in combined_terrains:
-            slp_id = texture.get_terrain()["slp_id"].get_value()
-            srcfile_prefix = texture.get_terrain()["filename"].get_value()
+            slp_id = texture.get_terrain()["slp_id"].value
+            srcfile_prefix = texture.get_terrain()["filename"].value
 
             targetdir = texture.resolve_graphics_location()
             source_filename = f"{str(srcfile_prefix)}_00_color.png"

--- a/openage/convert/processor/conversion/ror/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/ability_subprocessor.py
@@ -100,16 +100,15 @@ class RoRAbilitySubprocessor:
                 ability_animation_id = current_unit["attack_sprite_id"].value
 
         else:
-            ability_ref = "%s.ShootProjectile.Projectile%s.%s" % (game_entity_name,
-                                                                  str(projectile),
-                                                                  ability_name)
+            ability_ref = (f"{game_entity_name}.ShootProjectile."
+                           f"Projectile{projectile}.{ability_name}")
             ability_raw_api_object = RawAPIObject(ability_ref,
                                                   ability_name,
                                                   dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
             ability_location = ForwardRef(line,
-                                          "%s.ShootProjectile.Projectile%s"
-                                          % (game_entity_name, str(projectile)))
+                                          (f"{game_entity_name}.ShootProjectile."
+                                           f"Projectile{projectile}"))
             ability_raw_api_object.set_location(ability_location)
 
             ability_animation_id = -1
@@ -130,12 +129,13 @@ class RoRAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations", animations_set,
                                                    "engine.ability.property.type.Animated")
@@ -171,8 +171,8 @@ class RoRAbilitySubprocessor:
                         handled_graphics_set_ids.add(graphics_set_id)
 
                     obj_prefix = f"{gset_lookup_dict[graphics_set_id][1]}{ability_name}"
-                    filename_prefix = "%s_%s_" % (command_lookup_dict[command_id][1],
-                                                  gset_lookup_dict[graphics_set_id][2],)
+                    filename_prefix = (f"{command_lookup_dict[command_id][1]}_"
+                                       f"{gset_lookup_dict[graphics_set_id][2]}_")
                     AoCAbilitySubprocessor.create_civ_animation(line,
                                                                 civ_group,
                                                                 civ_animation_id,
@@ -523,9 +523,8 @@ class RoRAbilitySubprocessor:
         game_entity_name = name_lookup_dict[current_unit_id][0]
 
         # First projectile is mandatory
-        obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{str(position)}"
-        ability_ref = "%s.ShootProjectile.Projectile%s.Projectile" % (game_entity_name,
-                                                                      str(position))
+        obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{position}"
+        ability_ref = f"{game_entity_name}.ShootProjectile.Projectile{position}.Projectile"
         ability_raw_api_object = RawAPIObject(ability_ref,
                                               "Projectile",
                                               dataset.nyan_api_objects)
@@ -547,8 +546,8 @@ class RoRAbilitySubprocessor:
                                               "engine.ability.type.Projectile")
 
         # Accuracy
-        accuracy_name = "%s.ShootProjectile.Projectile%s.Projectile.Accuracy"\
-                        % (game_entity_name, str(position))
+        accuracy_name = (f"{game_entity_name}.ShootProjectile."
+                         f"Projectile{position}.Projectile.Accuracy")
         accuracy_raw_api_object = RawAPIObject(accuracy_name, "Accuracy", dataset.nyan_api_objects)
         accuracy_raw_api_object.add_raw_parent("engine.util.accuracy.Accuracy")
         accuracy_location = ForwardRef(line, ability_ref)
@@ -705,12 +704,13 @@ class RoRAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations",
                                                    animations_set,

--- a/openage/convert/processor/conversion/ror/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/ability_subprocessor.py
@@ -534,7 +534,7 @@ class RoRAbilitySubprocessor:
 
         # Arc
         if position == 0:
-            projectile_id = current_unit["attack_projectile_primary_unit_id"].value
+            projectile_id = current_unit["projectile_id0"].value
 
         else:
             raise Exception("Invalid position")
@@ -776,7 +776,7 @@ class RoRAbilitySubprocessor:
 
         # Projectile
         projectiles = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
+        projectile_primary = current_unit["projectile_id0"].value
         if projectile_primary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile0"))

--- a/openage/convert/processor/conversion/ror/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/ability_subprocessor.py
@@ -48,7 +48,7 @@ class RoRAbilitySubprocessor:
         """
         if isinstance(line, GenieVillagerGroup):
             current_unit = line.get_units_with_command(command_id)[0]
-            current_unit_id = current_unit["id0"].get_value()
+            current_unit_id = current_unit["id0"].value
 
         else:
             current_unit = line.get_head_unit()
@@ -83,21 +83,21 @@ class RoRAbilitySubprocessor:
 
             if command_id == 104:
                 # Get animation from commands proceed sprite
-                unit_commands = current_unit["unit_commands"].get_value()
+                unit_commands = current_unit["unit_commands"].value
                 for command in unit_commands:
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id != command_id:
                         continue
 
-                    ability_animation_id = command["proceed_sprite_id"].get_value()
+                    ability_animation_id = command["proceed_sprite_id"].value
                     break
 
                 else:
                     ability_animation_id = -1
 
             else:
-                ability_animation_id = current_unit["attack_sprite_id"].get_value()
+                ability_animation_id = current_unit["attack_sprite_id"].value
 
         else:
             ability_ref = "%s.ShootProjectile.Projectile%s.%s" % (game_entity_name,
@@ -152,10 +152,10 @@ class RoRAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -183,7 +183,7 @@ class RoRAbilitySubprocessor:
 
         # Command Sound
         if projectile == -1:
-            ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+            ability_comm_sound_id = current_unit["command_sound_id"].value
 
         else:
             ability_comm_sound_id = -1
@@ -246,13 +246,13 @@ class RoRAbilitySubprocessor:
 
         if ranged:
             # Min range
-            min_range = current_unit["weapon_range_min"].get_value()
+            min_range = current_unit["weapon_range_min"].value
             ability_raw_api_object.add_raw_member("min_range",
                                                   min_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
 
             # Max range
-            max_range = current_unit["weapon_range_max"].get_value()
+            max_range = current_unit["weapon_range_max"].value
             ability_raw_api_object.add_raw_member("max_range",
                                                   max_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
@@ -292,7 +292,7 @@ class RoRAbilitySubprocessor:
 
         # Reload time
         if projectile == -1:
-            reload_time = current_unit["attack_speed"].get_value()
+            reload_time = current_unit["attack_speed"].value
 
         else:
             reload_time = 0
@@ -305,7 +305,7 @@ class RoRAbilitySubprocessor:
         if projectile == -1:
             apply_graphic = dataset.genie_graphics[ability_animation_id]
             frame_rate = apply_graphic.get_frame_rate()
-            frame_delay = current_unit["frame_delay"].get_value()
+            frame_delay = current_unit["frame_delay"].value
             application_delay = frame_rate * frame_delay
 
         else:
@@ -383,7 +383,7 @@ class RoRAbilitySubprocessor:
         ability_raw_api_object.set_location(ability_location)
 
         # Stances
-        search_range = current_unit["search_radius"].get_value()
+        search_range = current_unit["search_radius"].value
         stance_names = ["Aggressive", "StandGround"]
 
         # Attacking is preferred
@@ -535,13 +535,13 @@ class RoRAbilitySubprocessor:
 
         # Arc
         if position == 0:
-            projectile_id = current_unit["attack_projectile_primary_unit_id"].get_value()
+            projectile_id = current_unit["attack_projectile_primary_unit_id"].value
 
         else:
             raise Exception("Invalid position")
 
         projectile = dataset.genie_units[projectile_id]
-        arc = degrees(projectile["projectile_arc"].get_value())
+        arc = degrees(projectile["projectile_arc"].value)
         ability_raw_api_object.add_raw_member("arc",
                                               arc,
                                               "engine.ability.type.Projectile")
@@ -554,7 +554,7 @@ class RoRAbilitySubprocessor:
         accuracy_location = ForwardRef(line, ability_ref)
         accuracy_raw_api_object.set_location(accuracy_location)
 
-        accuracy_value = current_unit["accuracy"].get_value()
+        accuracy_value = current_unit["accuracy"].value
         accuracy_raw_api_object.add_raw_member("accuracy",
                                                accuracy_value,
                                                "engine.util.accuracy.Accuracy")
@@ -692,7 +692,7 @@ class RoRAbilitySubprocessor:
         properties = {}
 
         # Animation
-        ability_animation_id = current_unit["attack_sprite_id"].get_value()
+        ability_animation_id = current_unit["attack_sprite_id"].value
         if ability_animation_id > -1:
             property_ref = f"{ability_ref}.Animated"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -722,7 +722,7 @@ class RoRAbilitySubprocessor:
             })
 
         # Command Sound
-        ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+        ability_comm_sound_id = current_unit["command_sound_id"].value
         if ability_comm_sound_id > -1:
             property_ref = f"{ability_ref}.CommandSound"
             property_raw_api_object = RawAPIObject(property_ref,
@@ -776,7 +776,7 @@ class RoRAbilitySubprocessor:
 
         # Projectile
         projectiles = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
         if projectile_primary > -1:
             projectiles.append(ForwardRef(line,
                                           f"{game_entity_name}.ShootProjectile.Projectile0"))
@@ -797,18 +797,18 @@ class RoRAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Range
-        min_range = current_unit["weapon_range_min"].get_value()
+        min_range = current_unit["weapon_range_min"].value
         ability_raw_api_object.add_raw_member("min_range",
                                               min_range,
                                               "engine.ability.type.ShootProjectile")
 
-        max_range = current_unit["weapon_range_max"].get_value()
+        max_range = current_unit["weapon_range_max"].value
         ability_raw_api_object.add_raw_member("max_range",
                                               max_range,
                                               "engine.ability.type.ShootProjectile")
 
         # Reload time and delay
-        reload_time = current_unit["attack_speed"].get_value()
+        reload_time = current_unit["attack_speed"].value
         ability_raw_api_object.add_raw_member("reload_time",
                                               reload_time,
                                               "engine.ability.type.ShootProjectile")
@@ -820,7 +820,7 @@ class RoRAbilitySubprocessor:
         else:
             frame_rate = 0
 
-        spawn_delay_frames = current_unit["frame_delay"].get_value()
+        spawn_delay_frames = current_unit["frame_delay"].value
         spawn_delay = frame_rate * spawn_delay_frames
         ability_raw_api_object.add_raw_member("spawn_delay",
                                               spawn_delay,
@@ -849,9 +849,9 @@ class RoRAbilitySubprocessor:
                                               "engine.ability.type.ShootProjectile")
 
         # Spawning area
-        spawning_area_offset_x = current_unit["weapon_offset"][0].get_value()
-        spawning_area_offset_y = current_unit["weapon_offset"][1].get_value()
-        spawning_area_offset_z = current_unit["weapon_offset"][2].get_value()
+        spawning_area_offset_x = current_unit["weapon_offset"][0].value
+        spawning_area_offset_y = current_unit["weapon_offset"][1].value
+        spawning_area_offset_z = current_unit["weapon_offset"][2].value
 
         ability_raw_api_object.add_raw_member("spawning_area_offset_x",
                                               spawning_area_offset_x,

--- a/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
@@ -117,8 +117,8 @@ class RoRAuxiliarySubprocessor:
 
         cost_amounts = []
         cost_repair_amounts = []
-        for resource_amount in current_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in current_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             resource = None
             resource_name = ""
@@ -148,10 +148,10 @@ class RoRAuxiliarySubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
-            amount = resource_amount["amount"].get_value()
+            amount = resource_amount["amount"].value
 
             cost_amount_name = f"{cost_name}.{resource_name}Amount"
             cost_amount = RawAPIObject(cost_amount_name,
@@ -209,7 +209,7 @@ class RoRAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
         # Creation time
         if isinstance(line, GenieUnitLineGroup):
-            creation_time = current_unit["creation_time"].get_value()
+            creation_time = current_unit["creation_time"].value
 
         else:
             # Buildings are created immediately
@@ -220,7 +220,7 @@ class RoRAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
 
         # Creation sound
-        creation_sound_id = current_unit["train_sound_id"].get_value()
+        creation_sound_id = current_unit["train_sound_id"].value
 
         # Create sound object
         obj_name = f"{game_entity_name}.CreatableGameEntity.Sound"
@@ -296,8 +296,8 @@ class RoRAuxiliarySubprocessor:
                                                 1.0,
                                                 "engine.util.placement_mode.type.Place")
             # Clearance size
-            clearance_size_x = current_unit["clearance_size_x"].get_value()
-            clearance_size_y = current_unit["clearance_size_y"].get_value()
+            clearance_size_x = current_unit["clearance_size_x"].value
+            clearance_size_y = current_unit["clearance_size_y"].value
             place_raw_api_object.add_raw_member("clearance_size_x",
                                                 clearance_size_x,
                                                 "engine.util.placement_mode.type.Place")
@@ -311,7 +311,7 @@ class RoRAuxiliarySubprocessor:
                                                 "engine.util.placement_mode.type.Place")
 
             # Max elevation difference
-            elevation_mode = current_unit["elevation_mode"].get_value()
+            elevation_mode = current_unit["elevation_mode"].value
             if elevation_mode == 2:
                 max_elevation_difference = 0
 

--- a/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/auxiliary_subprocessor.py
@@ -100,8 +100,8 @@ class RoRAuxiliarySubprocessor:
 
         if isinstance(line, GenieBuildingLineGroup) or line.get_class_id() in (2, 13, 20, 21, 22):
             # Cost (repair) for buildings
-            cost_repair_name = "%s.CreatableGameEntity.%sRepairCost" % (game_entity_name,
-                                                                        game_entity_name)
+            cost_repair_name = (f"{game_entity_name}.CreatableGameEntity."
+                                f"{game_entity_name}RepairCost")
             cost_repair_raw_api_object = RawAPIObject(cost_repair_name,
                                                       f"{game_entity_name}RepairCost",
                                                       dataset.nyan_api_objects)

--- a/openage/convert/processor/conversion/ror/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/civ_subprocessor.py
@@ -36,10 +36,10 @@ class RoRCivSubprocessor:
         civ_name = civ_lookup_dict[civ_id][0]
 
         # Find starting resource amounts
-        food_amount = civ_group.civ["resources"][0].get_value()
-        wood_amount = civ_group.civ["resources"][1].get_value()
-        gold_amount = civ_group.civ["resources"][2].get_value()
-        stone_amount = civ_group.civ["resources"][3].get_value()
+        food_amount = civ_group.civ["resources"][0].value
+        wood_amount = civ_group.civ["resources"][1].value
+        gold_amount = civ_group.civ["resources"][2].value
+        stone_amount = civ_group.civ["resources"][3].value
 
         # Find civ unique starting resources
         tech_tree = civ_group.get_tech_tree_effects()
@@ -49,8 +49,8 @@ class RoRCivSubprocessor:
             if type_id != 1:
                 continue
 
-            resource_id = effect["attr_a"].get_value()
-            amount = effect["attr_d"].get_value()
+            resource_id = effect["attr_a"].value
+            amount = effect["attr_d"].value
             if resource_id == 0:
                 food_amount += amount
 

--- a/openage/convert/processor/conversion/ror/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/nyan_subprocessor.py
@@ -189,13 +189,14 @@ class RoRNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_unit["unit_type"].get_value()
+        unit_type = current_unit["unit_type"].value
 
         if unit_type >= 70:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
-        unit_class = current_unit["unit_class"].get_value()
+        unit_class = current_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -374,20 +375,22 @@ class RoRNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_building["unit_type"].get_value()
+        unit_type = current_building["unit_type"].value
 
         if unit_type >= 80:
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
-        unit_class = current_building["unit_class"].get_value()
+        unit_class = current_building["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
         types_set.append(type_obj)
 
         if building_line.is_dropsite():
-            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object()
+            type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.DropSite"].get_nyan_object(
+            )
             types_set.append(type_obj)
 
         raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
@@ -502,10 +505,11 @@ class RoRNyanSubprocessor:
         # Create or use existing auxiliary types
         types_set = []
 
-        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object()
+        type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Ambient"].get_nyan_object(
+        )
         types_set.append(type_obj)
 
-        unit_class = ambient_unit["unit_class"].get_value()
+        unit_class = ambient_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -518,7 +522,7 @@ class RoRNyanSubprocessor:
         # =======================================================================
         abilities_set = []
 
-        interaction_mode = ambient_unit["interaction_mode"].get_value()
+        interaction_mode = ambient_unit["interaction_mode"].value
 
         if interaction_mode >= 0:
             abilities_set.append(AoCAbilitySubprocessor.death_ability(ambient_group))
@@ -629,7 +633,8 @@ class RoRNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(tech_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -650,7 +655,8 @@ class RoRNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(tech_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -691,7 +697,8 @@ class RoRNyanSubprocessor:
 
         name_lookup_dict = internal_name_lookups.get_entity_lookups(dataset.game_version)
         terrain_lookup_dict = internal_name_lookups.get_terrain_lookups(dataset.game_version)
-        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(dataset.game_version)
+        terrain_type_lookup_dict = internal_name_lookups.get_terrain_type_lookups(
+            dataset.game_version)
 
         # Start with the Terrain object
         terrain_name = terrain_lookup_dict[terrain_index][1]
@@ -766,11 +773,11 @@ class RoRNyanSubprocessor:
         # Ambience
         # =======================================================================
         terrain = terrain_group.get_terrain()
-        ambients_count = terrain["terrain_units_used_count"].get_value()
+        ambients_count = terrain["terrain_units_used_count"].value
 
         ambience = []
         for ambient_index in range(ambients_count):
-            ambient_id = terrain["terrain_unit_id"][ambient_index].get_value()
+            ambient_id = terrain["terrain_unit_id"][ambient_index].value
 
             if ambient_id not in dataset.unit_ref.keys():
                 # Unit does not exist
@@ -794,7 +801,7 @@ class RoRNyanSubprocessor:
                                                   "engine.util.terrain.TerrainAmbient")
 
             # Max density
-            max_density = terrain["terrain_unit_density"][ambient_index].get_value()
+            max_density = terrain["terrain_unit_density"][ambient_index].value
             ambient_raw_api_object.add_raw_member("max_density",
                                                   max_density,
                                                   "engine.util.terrain.TerrainAmbient")
@@ -894,7 +901,8 @@ class RoRNyanSubprocessor:
         description_raw_api_object = RawAPIObject(description_ref,
                                                   f"{tech_name}Description",
                                                   dataset.nyan_api_objects)
-        description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         description_location = ForwardRef(civ_group, tech_name)
         description_raw_api_object.set_location(description_location)
 
@@ -915,7 +923,8 @@ class RoRNyanSubprocessor:
         long_description_raw_api_object = RawAPIObject(long_description_ref,
                                                        f"{tech_name}LongDescription",
                                                        dataset.nyan_api_objects)
-        long_description_raw_api_object.add_raw_parent("engine.util.language.translated.type.TranslatedMarkupFile")
+        long_description_raw_api_object.add_raw_parent(
+            "engine.util.language.translated.type.TranslatedMarkupFile")
         long_description_location = ForwardRef(civ_group, tech_name)
         long_description_raw_api_object.set_location(long_description_location)
 
@@ -981,7 +990,7 @@ class RoRNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 
@@ -997,30 +1006,38 @@ class RoRNyanSubprocessor:
             # =======================================================================
             # Types
             # =======================================================================
-            types_set = [dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
-            proj_raw_api_object.add_raw_member("types", types_set, "engine.util.game_entity.GameEntity")
+            types_set = [
+                dataset.pregen_nyan_objects["util.game_entity_type.types.Projectile"].get_nyan_object()]
+            proj_raw_api_object.add_raw_member(
+                "types", types_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Abilities
             # =======================================================================
             abilities_set = []
-            abilities_set.append(RoRAbilitySubprocessor.projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(line, position=projectile_num))
-            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(line, 7, False, projectile_num))
+            abilities_set.append(RoRAbilitySubprocessor.projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.move_projectile_ability(
+                line, position=projectile_num))
+            abilities_set.append(AoCAbilitySubprocessor.apply_discrete_effect_ability(
+                line, 7, False, projectile_num))
             # TODO: Death, Despawn
-            proj_raw_api_object.add_raw_member("abilities", abilities_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "abilities", abilities_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Modifiers
             # =======================================================================
             modifiers_set = []
 
-            proj_raw_api_object.add_raw_member("modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "modifiers", modifiers_set, "engine.util.game_entity.GameEntity")
 
             # =======================================================================
             # Variants
             # =======================================================================
             variants_set = []
-            proj_raw_api_object.add_raw_member("variants", variants_set, "engine.util.game_entity.GameEntity")
+            proj_raw_api_object.add_raw_member(
+                "variants", variants_set, "engine.util.game_entity.GameEntity")
 
             line.add_raw_api_object(proj_raw_api_object)

--- a/openage/convert/processor/conversion/ror/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/nyan_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements,too-many-branches
 #
@@ -995,9 +995,8 @@ class RoRNyanSubprocessor:
             projectile_indices.append(0)
 
         for projectile_num in projectile_indices:
-            obj_ref = "%s.ShootProjectile.Projectile%s" % (game_entity_name,
-                                                           str(projectile_num))
-            obj_name = f"Projectile{str(projectile_num)}"
+            obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{projectile_num}"
+            obj_name = f"Projectile{projectile_num}"
             proj_raw_api_object = RawAPIObject(obj_ref, obj_name, dataset.nyan_api_objects)
             proj_raw_api_object.add_raw_parent("engine.util.game_entity.GameEntity")
             proj_raw_api_object.set_location(projectiles_location)

--- a/openage/convert/processor/conversion/ror/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/nyan_subprocessor.py
@@ -990,7 +990,7 @@ class RoRNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
+        projectile_primary = current_unit["projectile_id0"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 

--- a/openage/convert/processor/conversion/ror/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/pregen_subprocessor.py
@@ -54,8 +54,8 @@ class RoRPregenSubprocessor:
             pregen_object.create_nyan_members()
 
             if not pregen_object.is_ready():
-                raise Exception("%s: Pregenerated object is not ready for export: "
-                                "Member or object not initialized." % (pregen_object))
+                raise Exception(f"{repr(pregen_object)}: Pregenerated object is not ready "
+                                "for export. Member or object not initialized.")
 
     @staticmethod
     def generate_death_condition(

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -192,20 +192,19 @@ class RoRProcessor:
 
         # Gaia units
         # call hierarchy: wrapper[0]->civs[0]->units
-        raw_units.extend(gamespec[0]["civs"][0]["units"].get_value())
+        raw_units.extend(gamespec[0]["civs"][0]["units"].value)
 
         # Egyptians
         # call hierarchy: wrapper[0]->civs[1]->units
-        raw_units.extend(gamespec[0]["civs"][1]["units"].get_value())
+        raw_units.extend(gamespec[0]["civs"][1]["units"].value)
 
         for raw_unit in raw_units:
-            unit_id = raw_unit["id0"].get_value()
+            unit_id = raw_unit["id0"].value
 
             if unit_id in full_data_set.genie_units.keys():
                 continue
 
-            unit_members = raw_unit.get_value()
-
+            unit_members = raw_unit.value
             # Turn attack and armor into containers to make diffing work
             if "attacks" in unit_members.keys():
                 attacks_member = unit_members.pop("attacks")
@@ -231,11 +230,10 @@ class RoRProcessor:
         :type gamespec: class: ...dataformat.value_members.ArrayMember
         """
         # call hierarchy: wrapper[0]->sounds
-        raw_sounds = gamespec[0]["sounds"].get_value()
-
+        raw_sounds = gamespec[0]["sounds"].value
         for raw_sound in raw_sounds:
-            sound_id = raw_sound["sound_id"].get_value()
-            sound_members = raw_sound.get_value()
+            sound_id = raw_sound["sound_id"].value
+            sound_members = raw_sound.value
 
             sound = RoRSound(sound_id, full_data_set, members=sound_members)
             full_data_set.genie_sounds.update({sound.get_id(): sound})
@@ -251,25 +249,25 @@ class RoRProcessor:
         :type full_data_set: class: ...dataformat.aoc.genie_object_container.GenieObjectContainer
         """
         # Search a player civ (egyptians) for the starting units
-        player_civ_units = gamespec[0]["civs"][1]["units"].get_value()
+        player_civ_units = gamespec[0]["civs"][1]["units"].value
         task_group_ids = set()
         villager_unit_ids = set()
 
         for raw_unit in player_civ_units.values():
-            unit_id = raw_unit["id0"].get_value()
-            enabled = raw_unit["enabled"].get_value()
+            unit_id = raw_unit["id0"].value
+            enabled = raw_unit["enabled"].value
             entity = full_data_set.genie_units[unit_id]
 
             if not enabled:
                 # Unlocked by tech
                 continue
 
-            unit_type = entity["unit_type"].get_value()
+            unit_type = entity["unit_type"].value
 
             if unit_type == 70:
                 if entity.has_member("task_group") and\
-                        entity["task_group"].get_value() > 0:
-                    task_group_id = entity["task_group"].get_value()
+                        entity["task_group"].value > 0:
+                    task_group_id = entity["task_group"].value
                     villager_unit_ids.add(unit_id)
 
                     if task_group_id in task_group_ids:
@@ -319,7 +317,7 @@ class RoRProcessor:
             # TODO: Make this cleaner
             unlock_effects = unit_unlock.get_effects(effect_type=2)
             for unlock_effect in unlock_effects:
-                line_id = unlock_effect["attr_a"].get_value()
+                line_id = unlock_effect["attr_a"].value
                 unit = full_data_set.genie_units[line_id]
 
                 if line_id not in full_data_set.unit_lines.keys():
@@ -336,9 +334,9 @@ class RoRProcessor:
             unit = full_data_set.genie_units[target_id]
 
             # Find the previous unit in the line
-            required_techs = unit_upgrade.tech["required_techs"].get_value()
+            required_techs = unit_upgrade.tech["required_techs"].value
             for required_tech in required_techs:
-                required_tech_id = required_tech.get_value()
+                required_tech_id = required_tech.value
                 if required_tech_id in full_data_set.unit_unlocks.keys():
                     source_id = full_data_set.unit_unlocks[required_tech_id].get_line_id()
                     break
@@ -371,9 +369,9 @@ class RoRProcessor:
             unit = full_data_set.genie_units[target_id]
 
             # Find the previous unit in the line
-            required_techs = building_upgrade.tech["required_techs"].get_value()
+            required_techs = building_upgrade.tech["required_techs"].value
             for required_tech in required_techs:
-                required_tech_id = required_tech.get_value()
+                required_tech_id = required_tech.value
                 if required_tech_id in full_data_set.building_unlocks.keys():
                     source_id = full_data_set.building_unlocks[required_tech_id].get_line_id()
                     break
@@ -392,8 +390,8 @@ class RoRProcessor:
         for age_up in age_ups.values():
             effects = age_up.get_effects(effect_type=3)
             for effect in effects:
-                source_id = effect["attr_a"].get_value()
-                target_id = effect["attr_b"].get_value()
+                source_id = effect["attr_a"].value
+                target_id = effect["attr_b"].value
                 unit = full_data_set.genie_units[target_id]
 
                 if source_id in full_data_set.building_lines.keys():
@@ -459,15 +457,15 @@ class RoRProcessor:
         genie_techs = full_data_set.genie_techs
 
         for tech_id, tech in genie_techs.items():
-            tech_type = tech["tech_type"].get_value()
+            tech_type = tech["tech_type"].value
 
             # Test if a tech exist and skip it if it doesn't
-            required_techs = tech["required_techs"].get_value()
-            if all(required_tech.get_value() == 0 for required_tech in required_techs):
+            required_techs = tech["required_techs"].value
+            if all(required_tech.value == 0 for required_tech in required_techs):
                 # If all required techs are tech ID 0, the tech doesnt exist
                 continue
 
-            effect_bundle_id = tech["tech_effect_id"].get_value()
+            effect_bundle_id = tech["tech_effect_id"].value
 
             if effect_bundle_id == -1:
                 continue
@@ -483,10 +481,10 @@ class RoRProcessor:
                 # Age ID is set as resource value
                 setr_effects = effect_bundle.get_effects(effect_type=1)
                 for effect in setr_effects:
-                    resource_id = effect["attr_a"].get_value()
+                    resource_id = effect["attr_a"].value
 
                     if resource_id == 6:
-                        age_id = int(effect["attr_d"].get_value())
+                        age_id = int(effect["attr_d"].value)
                         break
 
                 age_up = RoRAgeUpgrade(tech_id, age_id, full_data_set)
@@ -498,9 +496,9 @@ class RoRProcessor:
                 for effect in effects:
                     # Enabling techs
                     if effect.get_type() == 2:
-                        unit_id = effect["attr_a"].get_value()
+                        unit_id = effect["attr_a"].value
                         unit = full_data_set.genie_units[unit_id]
-                        unit_type = unit["unit_type"].get_value()
+                        unit_type = unit["unit_type"].value
 
                         if unit_type == 70:
                             unit_unlock = RoRUnitUnlock(tech_id, unit_id, full_data_set)
@@ -524,10 +522,10 @@ class RoRProcessor:
 
                     # Upgrades
                     elif effect.get_type() == 3:
-                        source_unit_id = effect["attr_a"].get_value()
-                        target_unit_id = effect["attr_b"].get_value()
+                        source_unit_id = effect["attr_a"].value
+                        target_unit_id = effect["attr_b"].value
                         unit = full_data_set.genie_units[source_unit_id]
-                        unit_type = unit["unit_type"].get_value()
+                        unit_type = unit["unit_type"].value
 
                         if unit_type == 70:
                             unit_upgrade = RoRUnitLineUpgrade(tech_id,
@@ -568,8 +566,8 @@ class RoRProcessor:
             if not genie_unit.has_member("research_id"):
                 continue
 
-            building_id = genie_unit["id0"].get_value()
-            initiated_tech_id = genie_unit["research_id"].get_value()
+            building_id = genie_unit["id0"].value
+            initiated_tech_id = genie_unit["research_id"].value
 
             if initiated_tech_id == -1:
                 continue
@@ -600,14 +598,14 @@ class RoRProcessor:
         for unit_line in unit_lines.values():
             head_unit = unit_line.get_head_unit()
 
-            unit_commands = head_unit["unit_commands"].get_value()
+            unit_commands = head_unit["unit_commands"].value
             for command in unit_commands:
-                command_type = command["type"].get_value()
+                command_type = command["type"].value
 
                 if not command_type == 3:
                     continue
 
-                class_id = command["class_id"].get_value()
+                class_id = command["class_id"].value
 
                 if class_id in garrison_class_assignments.keys():
                     garrison_class_assignments[class_id].append(unit_line)
@@ -644,14 +642,14 @@ class RoRProcessor:
         repair_classes = []
         for villager in villager_groups.values():
             repair_unit = villager.get_units_with_command(106)[0]
-            unit_commands = repair_unit["unit_commands"].get_value()
+            unit_commands = repair_unit["unit_commands"].value
             for command in unit_commands:
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id != 106:
                     continue
 
-                class_id = command["class_id"].get_value()
+                class_id = command["class_id"].value
                 if class_id == -1:
                     # Buildings/Siege
                     repair_classes.append(3)

--- a/openage/convert/processor/conversion/ror/processor.py
+++ b/openage/convert/processor/conversion/ror/processor.py
@@ -607,7 +607,7 @@ class RoRProcessor:
 
                 class_id = command["class_id"].value
 
-                if class_id in garrison_class_assignments.keys():
+                if class_id in garrison_class_assignments:
                     garrison_class_assignments[class_id].append(unit_line)
 
                 else:
@@ -618,7 +618,7 @@ class RoRProcessor:
         for garrison in unit_lines.values():
             class_id = garrison.get_class_id()
 
-            if class_id in garrison_class_assignments.keys():
+            if class_id in garrison_class_assignments:
                 for line in garrison_class_assignments[class_id]:
                     garrison.garrison_entities.append(line)
                     line.garrison_locations.append(garrison)

--- a/openage/convert/processor/conversion/ror/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/tech_subprocessor.py
@@ -123,10 +123,10 @@ class RoRTechSubprocessor:
             raise Exception("Effect type %s is not a valid attribute effect"
                             % str(effect_type))
 
-        unit_id = effect["attr_a"].get_value()
-        class_id = effect["attr_b"].get_value()
-        attribute_type = effect["attr_c"].get_value()
-        value = effect["attr_d"].get_value()
+        unit_id = effect["attr_a"].value
+        class_id = effect["attr_b"].value
+        attribute_type = effect["attr_c"].value
+        value = effect["attr_d"].value
 
         if attribute_type == -1:
             return patches
@@ -179,7 +179,7 @@ class RoRTechSubprocessor:
         effect_type = effect.get_type()
         operator = None
         if effect_type == 1:
-            mode = effect["attr_b"].get_value()
+            mode = effect["attr_b"].value
 
             if mode == 0:
                 operator = MemberOperator.ASSIGN
@@ -194,8 +194,8 @@ class RoRTechSubprocessor:
             raise Exception("Effect type %s is not a valid resource effect"
                             % str(effect_type))
 
-        resource_id = effect["attr_a"].get_value()
-        value = effect["attr_d"].get_value()
+        resource_id = effect["attr_a"].value
+        value = effect["attr_d"].value
 
         if resource_id in (-1, 6, 21, 30):
             # -1 = invalid ID
@@ -223,8 +223,8 @@ class RoRTechSubprocessor:
 
         tech_lookup_dict = internal_name_lookups.get_tech_lookups(dataset.game_version)
 
-        head_unit_id = effect["attr_a"].get_value()
-        upgrade_target_id = effect["attr_b"].get_value()
+        head_unit_id = effect["attr_a"].value
+        upgrade_target_id = effect["attr_b"].value
 
         if head_unit_id not in dataset.unit_ref.keys() or\
                 upgrade_target_id not in dataset.unit_ref.keys():

--- a/openage/convert/processor/conversion/ror/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/tech_subprocessor.py
@@ -120,8 +120,7 @@ class RoRTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid attribute effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid attribute effect")
 
         unit_id = effect["attr_a"].value
         class_id = effect["attr_b"].value
@@ -191,8 +190,7 @@ class RoRTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid resource effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid resource effect")
 
         resource_id = effect["attr_a"].value
         value = effect["attr_d"].value

--- a/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
@@ -185,7 +185,7 @@ class RoRUpgradeAbilitySubprocessor:
                     attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.value
+                    attack_graphic_id = diff_animation.ref.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()

--- a/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
@@ -121,7 +121,7 @@ class RoRUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_animation, NoDiffMember):
                 animations_set = []
-                diff_animation_id = diff_animation.get_value()
+                diff_animation_id = diff_animation.value
                 if diff_animation_id > -1:
                     # Patch the new animation in
                     animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
@@ -140,7 +140,7 @@ class RoRUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_comm_sound, NoDiffMember):
                 sounds_set = []
-                diff_comm_sound_id = diff_comm_sound.get_value()
+                diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
                     sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
@@ -157,7 +157,7 @@ class RoRUpgradeAbilitySubprocessor:
                                                                MemberOperator.ASSIGN)
 
             if not isinstance(diff_min_range, NoDiffMember):
-                min_range = diff_min_range.get_value()
+                min_range = diff_min_range.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("min_range",
                                                                min_range,
@@ -165,7 +165,7 @@ class RoRUpgradeAbilitySubprocessor:
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_max_range, NoDiffMember):
-                max_range = diff_max_range.get_value()
+                max_range = diff_max_range.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("max_range",
                                                                max_range,
@@ -173,7 +173,7 @@ class RoRUpgradeAbilitySubprocessor:
                                                                MemberOperator.ADD)
 
             if not isinstance(diff_reload_time, NoDiffMember):
-                reload_time = diff_reload_time.get_value()
+                reload_time = diff_reload_time.value
 
                 nyan_patch_raw_api_object.add_raw_patch_member("reload_time",
                                                                reload_time,
@@ -182,14 +182,14 @@ class RoRUpgradeAbilitySubprocessor:
 
             if not isinstance(diff_spawn_delay, NoDiffMember):
                 if not isinstance(diff_animation, NoDiffMember):
-                    attack_graphic_id = diff_animation.get_value()
+                    attack_graphic_id = diff_animation.value
 
                 else:
-                    attack_graphic_id = diff_animation.value.get_value()
+                    attack_graphic_id = diff_animation.value.value
 
                 attack_graphic = dataset.genie_graphics[attack_graphic_id]
                 frame_rate = attack_graphic.get_frame_rate()
-                frame_delay = diff_spawn_delay.get_value()
+                frame_delay = diff_spawn_delay.value
                 spawn_delay = frame_rate * frame_delay
 
                 nyan_patch_raw_api_object.add_raw_patch_member("spawn_delay",
@@ -203,7 +203,7 @@ class RoRUpgradeAbilitySubprocessor:
                 diff_spawn_area_z = diff_spawn_area_offsets[2]
 
                 if not isinstance(diff_spawn_area_x, NoDiffMember):
-                    spawn_area_x = diff_spawn_area_x.get_value()
+                    spawn_area_x = diff_spawn_area_x.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_x",
                                                                    spawn_area_x,
@@ -211,7 +211,7 @@ class RoRUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_spawn_area_y, NoDiffMember):
-                    spawn_area_y = diff_spawn_area_y.get_value()
+                    spawn_area_y = diff_spawn_area_y.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_y",
                                                                    spawn_area_y,
@@ -219,7 +219,7 @@ class RoRUpgradeAbilitySubprocessor:
                                                                    MemberOperator.ADD)
 
                 if not isinstance(diff_spawn_area_z, NoDiffMember):
-                    spawn_area_z = diff_spawn_area_z.get_value()
+                    spawn_area_z = diff_spawn_area_z.value
 
                     nyan_patch_raw_api_object.add_raw_patch_member("spawning_area_offset_z",
                                                                    spawn_area_z,

--- a/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_ability_subprocessor.py
@@ -101,8 +101,8 @@ class RoRUpgradeAbilitySubprocessor:
             if isinstance(line, GenieBuildingLineGroup):
                 # Store building upgrades next to their game entity definition,
                 # not in the Age up techs.
-                wrapper_raw_api_object.set_location("data/game_entity/generic/%s/"
-                                                    % (name_lookup_dict[head_unit_id][1]))
+                wrapper_raw_api_object.set_location(("data/game_entity/generic/"
+                                                     f"{name_lookup_dict[head_unit_id][1]}/"))
                 wrapper_raw_api_object.set_filename(f"{tech_lookup_dict[tech_id][1]}_upgrade")
 
             else:
@@ -124,13 +124,14 @@ class RoRUpgradeAbilitySubprocessor:
                 diff_animation_id = diff_animation.value
                 if diff_animation_id > -1:
                     # Patch the new animation in
-                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(converter_group,
-                                                                                           line,
-                                                                                           diff_animation_id,
-                                                                                           nyan_patch_ref,
-                                                                                           ability_name,
-                                                                                           "%s_"
-                                                                                           % command_lookup_dict[command_id][1])
+                    animation_forward_ref = AoCUpgradeAbilitySubprocessor.create_animation(
+                        converter_group,
+                        line,
+                        diff_animation_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     animations_set.append(animation_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("animations",
@@ -143,12 +144,13 @@ class RoRUpgradeAbilitySubprocessor:
                 diff_comm_sound_id = diff_comm_sound.value
                 if diff_comm_sound_id > -1:
                     # Patch the new sound in
-                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(converter_group,
-                                                                                   diff_comm_sound_id,
-                                                                                   nyan_patch_ref,
-                                                                                   ability_name,
-                                                                                   "%s_"
-                                                                                   % command_lookup_dict[command_id][1])
+                    sound_forward_ref = AoCUpgradeAbilitySubprocessor.create_sound(
+                        converter_group,
+                        diff_comm_sound_id,
+                        nyan_patch_ref,
+                        ability_name,
+                        f"{command_lookup_dict[command_id][1]}_"
+                    )
                     sounds_set.append(sound_forward_ref)
 
                 nyan_patch_raw_api_object.add_raw_patch_member("sounds",

--- a/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
@@ -74,7 +74,7 @@ class RoRUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].value
         if projectile_id0 > -1:
             patch_target_ref = f"{game_entity_name}.ShootProjectile.Projectile0.Projectile"
             patch_target_forward_ref = ForwardRef(line, patch_target_ref)

--- a/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/upgrade_attribute_subprocessor.py
@@ -74,7 +74,7 @@ class RoRUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        projectile_id0 = head_unit["attack_projectile_primary_unit_id"].value
+        projectile_id0 = head_unit["projectile_id0"].value
         if projectile_id0 > -1:
             patch_target_ref = f"{game_entity_name}.ShootProjectile.Projectile0.Projectile"
             patch_target_forward_ref = ForwardRef(line, patch_target_ref)

--- a/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
@@ -91,7 +91,7 @@ class SWGBCCAbilitySubprocessor:
         """
         if isinstance(line, GenieVillagerGroup):
             current_unit = line.get_units_with_command(command_id)[0]
-            current_unit_id = current_unit["id0"].get_value()
+            current_unit_id = current_unit["id0"].value
 
         else:
             current_unit = line.get_head_unit()
@@ -123,7 +123,7 @@ class SWGBCCAbilitySubprocessor:
             ability_location = ForwardRef(line, game_entity_name)
             ability_raw_api_object.set_location(ability_location)
 
-            ability_animation_id = current_unit["attack_sprite_id"].get_value()
+            ability_animation_id = current_unit["attack_sprite_id"].value
 
         else:
             ability_ref = f"{game_entity_name}.ShootProjectile.Projectile{str(projectile)}.{ability_name}"
@@ -175,10 +175,10 @@ class SWGBCCAbilitySubprocessor:
                 civ_id = civ_group.get_id()
 
                 # Only proceed if the civ stores the unit in the line
-                if current_unit_id not in civ["units"].get_value().keys():
+                if current_unit_id not in civ["units"].value.keys():
                     continue
 
-                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].get_value()
+                civ_animation_id = civ["units"][current_unit_id]["attack_sprite_id"].value
 
                 if civ_animation_id != ability_animation_id:
                     # Find the corresponding graphics set
@@ -206,7 +206,7 @@ class SWGBCCAbilitySubprocessor:
 
         # Command Sound
         if projectile == -1:
-            ability_comm_sound_id = current_unit["command_sound_id"].get_value()
+            ability_comm_sound_id = current_unit["command_sound_id"].value
 
         else:
             ability_comm_sound_id = -1
@@ -269,13 +269,13 @@ class SWGBCCAbilitySubprocessor:
 
         if ranged:
             # Min range
-            min_range = current_unit["weapon_range_min"].get_value()
+            min_range = current_unit["weapon_range_min"].value
             ability_raw_api_object.add_raw_member("min_range",
                                                   min_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
 
             # Max range
-            max_range = current_unit["weapon_range_max"].get_value()
+            max_range = current_unit["weapon_range_max"].value
             ability_raw_api_object.add_raw_member("max_range",
                                                   max_range,
                                                   "engine.ability.type.RangedDiscreteEffect")
@@ -313,7 +313,7 @@ class SWGBCCAbilitySubprocessor:
 
         # Reload time
         if projectile == -1:
-            reload_time = current_unit["attack_speed"].get_value()
+            reload_time = current_unit["attack_speed"].value
 
         else:
             reload_time = 0
@@ -324,10 +324,10 @@ class SWGBCCAbilitySubprocessor:
 
         # Application delay
         if projectile == -1:
-            attack_graphic_id = current_unit["attack_sprite_id"].get_value()
+            attack_graphic_id = current_unit["attack_sprite_id"].value
             attack_graphic = dataset.genie_graphics[attack_graphic_id]
             frame_rate = attack_graphic.get_frame_rate()
-            frame_delay = current_unit["frame_delay"].get_value()
+            frame_delay = current_unit["frame_delay"].value
             application_delay = frame_rate * frame_delay
 
         else:
@@ -421,13 +421,13 @@ class SWGBCCAbilitySubprocessor:
                                               "engine.ability.type.AttributeChangeTracker")
 
         # Change progress
-        damage_graphics = current_unit["damage_graphics"].get_value()
+        damage_graphics = current_unit["damage_graphics"].value
         progress_forward_refs = []
 
         # Damage graphics are ordered ascending, so we start from 0
         interval_left_bound = 0
         for damage_graphic_member in damage_graphics:
-            interval_right_bound = damage_graphic_member["damage_percent"].get_value()
+            interval_right_bound = damage_graphic_member["damage_percent"].value
             progress_ref = f"{game_entity_name}.AttributeChangeTracker.ChangeProgress{interval_right_bound}"
             progress_raw_api_object = RawAPIObject(progress_ref,
                                                    f"ChangeProgress{interval_right_bound}",
@@ -456,7 +456,7 @@ class SWGBCCAbilitySubprocessor:
             # =====================================================================================
             # AnimationOverlay property
             # =====================================================================================
-            progress_animation_id = damage_graphic_member["graphic_id"].get_value()
+            progress_animation_id = damage_graphic_member["graphic_id"].value
             if progress_animation_id > -1:
                 property_ref = f"{progress_ref}.AnimationOverlay"
                 property_raw_api_object = RawAPIObject(property_ref,
@@ -628,7 +628,7 @@ class SWGBCCAbilitySubprocessor:
 
         abilities = []
         for gatherer in gatherers:
-            unit_commands = gatherer["unit_commands"].get_value()
+            unit_commands = gatherer["unit_commands"].value
             resource = None
             ability_animation_id = -1
             harvestable_class_ids = OrderedSet()
@@ -637,24 +637,24 @@ class SWGBCCAbilitySubprocessor:
             for command in unit_commands:
                 # Find a gather ability. It doesn't matter which one because
                 # they should all produce the same resource for one genie unit.
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id not in (5, 110):
                     continue
 
-                target_class_id = command["class_id"].get_value()
+                target_class_id = command["class_id"].value
                 if target_class_id > -1:
                     harvestable_class_ids.add(target_class_id)
 
-                target_unit_id = command["unit_id"].get_value()
+                target_unit_id = command["unit_id"].value
                 if target_unit_id > -1:
                     harvestable_unit_ids.add(target_unit_id)
 
-                resource_id = command["resource_out"].get_value()
+                resource_id = command["resource_out"].value
 
                 # If resource_out is not specified, the gatherer harvests resource_in
                 if resource_id == -1:
-                    resource_id = command["resource_in"].get_value()
+                    resource_id = command["resource_in"].value
 
                 if resource_id == 0:
                     resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
@@ -676,10 +676,10 @@ class SWGBCCAbilitySubprocessor:
                     continue
 
                 if type_id == 110:
-                    ability_animation_id = command["work_sprite_id"].get_value()
+                    ability_animation_id = command["work_sprite_id"].value
 
                 else:
-                    ability_animation_id = command["proceed_sprite_id"].get_value()
+                    ability_animation_id = command["proceed_sprite_id"].value
 
             # Look for the harvestable groups that match the class IDs and unit IDs
             check_groups = []
@@ -797,7 +797,7 @@ class SWGBCCAbilitySubprocessor:
             rate_raw_api_object.add_raw_member(
                 "type", resource, "engine.util.resource.ResourceRate")
 
-            gather_rate = gatherer["work_rate"].get_value()
+            gather_rate = gatherer["work_rate"].value
             rate_raw_api_object.add_raw_member(
                 "rate", gather_rate, "engine.util.resource.ResourceRate")
 
@@ -863,10 +863,10 @@ class SWGBCCAbilitySubprocessor:
         ability_raw_api_object.set_location(ability_location)
 
         # Resource spot
-        resource_storage = current_unit["resource_storage"].get_value()
+        resource_storage = current_unit["resource_storage"].value
 
         for storage in resource_storage:
-            resource_id = storage["type"].get_value()
+            resource_id = storage["type"].value
 
             # IDs 15, 16, 17 are other types of food (meat, berries, fish)
             if resource_id in (0, 15, 16, 17):
@@ -901,15 +901,15 @@ class SWGBCCAbilitySubprocessor:
             # Start amount (equals max amount)
             if line.get_id() == 50:
                 # Farm food amount (hardcoded in civ)
-                starting_amount = dataset.genie_civs[1]["resources"][36].get_value()
+                starting_amount = dataset.genie_civs[1]["resources"][36].value
 
             elif line.get_id() == 199:
                 # Aqua harvester food amount (hardcoded in civ)
-                starting_amount = storage["amount"].get_value()
-                starting_amount += dataset.genie_civs[1]["resources"][88].get_value()
+                starting_amount = storage["amount"].value
+                starting_amount += dataset.genie_civs[1]["resources"][88].value
 
             else:
-                starting_amount = storage["amount"].get_value()
+                starting_amount = storage["amount"].value
 
             spot_raw_api_object.add_raw_member("starting_amount",
                                                starting_amount,
@@ -921,7 +921,7 @@ class SWGBCCAbilitySubprocessor:
                                                "engine.util.resource_spot.ResourceSpot")
 
             # Decay rate
-            decay_rate = current_unit["resource_decay"].get_value()
+            decay_rate = current_unit["resource_decay"].value
             spot_raw_api_object.add_raw_member("decay_rate",
                                                decay_rate,
                                                "engine.util.resource_spot.ResourceSpot")
@@ -1204,7 +1204,7 @@ class SWGBCCAbilitySubprocessor:
                                               "engine.ability.type.Harvestable")
 
         # Unit have to die before they are harvestable (except for farms)
-        harvestable_by_default = current_unit["hit_points"].get_value() == 0
+        harvestable_by_default = current_unit["hit_points"].value == 0
         if line.get_class_id() == 7:
             harvestable_by_default = True
 
@@ -1389,11 +1389,11 @@ class SWGBCCAbilitySubprocessor:
         attribute_rate = 0
         if current_unit_id in (115, 180):
             # stored in civ resources
-            attribute_rate = dataset.genie_civs[0]["resources"][35].get_value()
+            attribute_rate = dataset.genie_civs[0]["resources"][35].value
 
         elif current_unit_id == 8:
             # stored in civ resources
-            heal_timer = dataset.genie_civs[0]["resources"][96].get_value()
+            heal_timer = dataset.genie_civs[0]["resources"][96].value
             attribute_rate = heal_timer
 
         rate_raw_api_object.add_raw_member("rate",
@@ -1448,23 +1448,23 @@ class SWGBCCAbilitySubprocessor:
         # Create containers
         containers = []
         for gatherer in gatherers:
-            unit_commands = gatherer["unit_commands"].get_value()
+            unit_commands = gatherer["unit_commands"].value
             resource = None
 
             used_command = None
             for command in unit_commands:
                 # Find a gather ability. It doesn't matter which one because
                 # they should all produce the same resource for one genie unit.
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id not in (5, 110, 111):
                     continue
 
-                resource_id = command["resource_out"].get_value()
+                resource_id = command["resource_out"].value
 
                 # If resource_out is not specified, the gatherer harvests resource_in
                 if resource_id == -1:
-                    resource_id = command["resource_in"].get_value()
+                    resource_id = command["resource_in"].value
 
                 if resource_id == 0:
                     resource = dataset.pregen_nyan_objects["util.resource.types.Food"].get_nyan_object(
@@ -1483,7 +1483,7 @@ class SWGBCCAbilitySubprocessor:
                     )
 
                 elif type_id == 111:
-                    target_id = command["unit_id"].get_value()
+                    target_id = command["unit_id"].value
                     if target_id not in dataset.building_lines.keys():
                         # Skips the trade workshop trading which is never used
                         continue
@@ -1509,7 +1509,7 @@ class SWGBCCAbilitySubprocessor:
 
                 container_name = f"{gather_lookup_dict[gatherer_unit_id][0]}Container"
 
-            elif used_command["type"].get_value() == 111:
+            elif used_command["type"].value == 111:
                 # Trading
                 container_name = "TradeContainer"
 
@@ -1528,14 +1528,14 @@ class SWGBCCAbilitySubprocessor:
                                                     "engine.util.storage.ResourceContainer")
 
             # Carry capacity
-            carry_capacity = gatherer["resource_capacity"].get_value()
+            carry_capacity = gatherer["resource_capacity"].value
             container_raw_api_object.add_raw_member("max_amount",
                                                     carry_capacity,
                                                     "engine.util.storage.ResourceContainer")
 
             # Carry progress
             carry_progress = []
-            carry_move_animation_id = used_command["carry_sprite_id"].get_value()
+            carry_move_animation_id = used_command["carry_sprite_id"].value
             if carry_move_animation_id > -1:
                 # ===========================================================================================
                 progress_ref = f"{ability_ref}.{container_name}CarryProgress"
@@ -1767,15 +1767,15 @@ class SWGBCCAbilitySubprocessor:
         # Trade route (use the trade route o the market)
         trade_routes = []
 
-        unit_commands = current_unit["unit_commands"].get_value()
+        unit_commands = current_unit["unit_commands"].value
         for command in unit_commands:
             # Find the trade command and the trade post id
-            type_id = command["type"].get_value()
+            type_id = command["type"].value
 
             if type_id != 111:
                 continue
 
-            trade_post_id = command["unit_id"].get_value()
+            trade_post_id = command["unit_id"].value
             if trade_post_id == 530:
                 # Ignore Tattoine Spaceport
                 continue

--- a/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
@@ -708,7 +708,7 @@ class SWGBCCAbilitySubprocessor:
                 continue
 
             gatherer_unit_id = gatherer.get_id()
-            if gatherer_unit_id not in gather_lookup_dict.keys():
+            if gatherer_unit_id not in gather_lookup_dict:
                 # Skips hunting wolves
                 continue
 
@@ -1507,7 +1507,7 @@ class SWGBCCAbilitySubprocessor:
 
             if line.is_gatherer():
                 gatherer_unit_id = gatherer.get_id()
-                if gatherer_unit_id not in gather_lookup_dict.keys():
+                if gatherer_unit_id not in gather_lookup_dict:
                     # Skips hunting wolves
                     continue
 

--- a/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/ability_subprocessor.py
@@ -131,8 +131,8 @@ class SWGBCCAbilitySubprocessor:
                 ability_ref, ability_name, dataset.nyan_api_objects)
             ability_raw_api_object.add_raw_parent(ability_parent)
             ability_location = ForwardRef(line,
-                                          "%s.ShootProjectile.Projectile%s"
-                                          % (game_entity_name, str(projectile)))
+                                          (f"{game_entity_name}.ShootProjectile."
+                                           f"Projectile{projectile}"))
             ability_raw_api_object.set_location(ability_location)
 
             ability_animation_id = -1
@@ -153,12 +153,13 @@ class SWGBCCAbilitySubprocessor:
             line.add_raw_api_object(property_raw_api_object)
 
             animations_set = []
-            animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                            ability_animation_id,
-                                                                            property_ref,
-                                                                            ability_name,
-                                                                            "%s_"
-                                                                            % command_lookup_dict[command_id][1])
+            animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                line,
+                ability_animation_id,
+                property_ref,
+                ability_name,
+                f"{command_lookup_dict[command_id][1]}_"
+            )
             animations_set.append(animation_forward_ref)
             property_raw_api_object.add_raw_member("animations", animations_set,
                                                    "engine.ability.property.type.Animated")
@@ -194,8 +195,8 @@ class SWGBCCAbilitySubprocessor:
                         handled_graphics_set_ids.add(graphics_set_id)
 
                     obj_prefix = f"{gset_lookup_dict[graphics_set_id][1]}{ability_name}"
-                    filename_prefix = "%s_%s_" % (command_lookup_dict[command_id][1],
-                                                  gset_lookup_dict[graphics_set_id][2],)
+                    filename_prefix = (f"{command_lookup_dict[command_id][1]}_"
+                                       f"{gset_lookup_dict[graphics_set_id][2]}_")
                     AoCAbilitySubprocessor.create_civ_animation(line,
                                                                 civ_group,
                                                                 civ_animation_id,
@@ -471,12 +472,13 @@ class SWGBCCAbilitySubprocessor:
 
                 # Animation
                 animations_set = []
-                animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                                progress_animation_id,
-                                                                                property_ref,
-                                                                                "Idle",
-                                                                                "idle_damage_override_%s_"
-                                                                                % (interval_right_bound))
+                animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                    line,
+                    progress_animation_id,
+                    property_ref,
+                    "Idle",
+                    f"idle_damage_override_{interval_right_bound}_"
+                )
                 animations_set.append(animation_forward_ref)
                 property_raw_api_object.add_raw_member("overlays",
                                                        animations_set,
@@ -577,18 +579,18 @@ class SWGBCCAbilitySubprocessor:
                                                   "engine.ability.type.ExchangeResources")
 
             # Exchange rate
-            exchange_rate = dataset.pregen_nyan_objects[("util.resource.market_trading.Market%sExchangeRate"
-                                                         % (resource_name))].get_nyan_object()
+            exchange_rate_ref = f"util.resource.market_trading.Market{resource_name}ExchangeRate"
+            exchange_rate = dataset.pregen_nyan_objects[exchange_rate_ref].get_nyan_object()
             ability_raw_api_object.add_raw_member("exchange_rate",
                                                   exchange_rate,
                                                   "engine.ability.type.ExchangeResources")
 
             # Exchange modes
+            buy_exchange_ref = "util.resource.market_trading.MarketBuyExchangeMode"
+            sell_exchange_ref = "util.resource.market_trading.MarketSellExchangeMode"
             exchange_modes = [
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketBuyExchangeMode"].get_nyan_object(
-                ),
-                dataset.pregen_nyan_objects["util.resource.market_trading.MarketSellExchangeMode"].get_nyan_object(
-                ),
+                dataset.pregen_nyan_objects[buy_exchange_ref].get_nyan_object(),
+                dataset.pregen_nyan_objects[sell_exchange_ref].get_nyan_object(),
             ]
             ability_raw_api_object.add_raw_member("exchange_modes",
                                                   exchange_modes,
@@ -737,12 +739,13 @@ class SWGBCCAbilitySubprocessor:
                 line.add_raw_api_object(property_raw_api_object)
 
                 animations_set = []
-                animation_forward_ref = AoCAbilitySubprocessor.create_animation(line,
-                                                                                ability_animation_id,
-                                                                                property_ref,
-                                                                                ability_name,
-                                                                                "%s_"
-                                                                                % gather_lookup_dict[gatherer_unit_id][1])
+                animation_forward_ref = AoCAbilitySubprocessor.create_animation(
+                    line,
+                    ability_animation_id,
+                    property_ref,
+                    ability_name,
+                    f"{gather_lookup_dict[gatherer_unit_id][1]}_"
+                )
                 animations_set.append(animation_forward_ref)
                 property_raw_api_object.add_raw_member("animations", animations_set,
                                                        "engine.ability.property.type.Animated")
@@ -809,8 +812,8 @@ class SWGBCCAbilitySubprocessor:
                                                   "engine.ability.type.Gather")
 
             # Resource container
-            container_ref = "%s.ResourceStorage.%sContainer" % (game_entity_name,
-                                                                gather_lookup_dict[gatherer_unit_id][0])
+            container_ref = (f"{game_entity_name}.ResourceStorage."
+                             f"{gather_lookup_dict[gatherer_unit_id][0]}Container")
             container_forward_ref = ForwardRef(line, container_ref)
             ability_raw_api_object.add_raw_member("container",
                                                   container_forward_ref,
@@ -823,9 +826,10 @@ class SWGBCCAbilitySubprocessor:
                 group_id = group.get_head_unit_id()
                 group_name = entity_lookups[group_id][0]
 
-                spot_forward_ref = ForwardRef(group,
-                                              "%s.Harvestable.%sResourceSpot"
-                                              % (group_name, group_name))
+                spot_forward_ref = ForwardRef(
+                    group,
+                    f"{group_name}.Harvestable.{group_name}ResourceSpot"
+                )
                 spot_forward_refs.append(spot_forward_ref)
 
             ability_raw_api_object.add_raw_member("targets",

--- a/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
@@ -115,8 +115,8 @@ class SWGBCCAuxiliarySubprocessor:
 
         if line.is_repairable():
             # Cost (repair) for buildings
-            cost_repair_name = "%s.CreatableGameEntity.%sRepairCost" % (game_entity_name,
-                                                                        game_entity_name)
+            cost_repair_name = (f"{game_entity_name}.CreatableGameEntity."
+                                f"{game_entity_name}RepairCost")
             cost_repair_raw_api_object = RawAPIObject(cost_repair_name,
                                                       f"{game_entity_name}RepairCost",
                                                       dataset.nyan_api_objects)
@@ -386,8 +386,8 @@ class SWGBCCAuxiliarySubprocessor:
 
             # Container
             container_forward_ref = ForwardRef(train_location,
-                                               "%s.Storage.%sContainer"
-                                               % (train_location_name, train_location_name))
+                                               (f"{train_location_name}.Storage."
+                                                f"{train_location_name}Container"))
             own_storage_raw_api_object.add_raw_member("container",
                                                       container_forward_ref,
                                                       "engine.util.placement_mode.type.OwnStorage")

--- a/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/auxiliary_subprocessor.py
@@ -73,7 +73,7 @@ class SWGBCCAuxiliarySubprocessor:
             # Add object to the Civ object
             enabling_research_id = line.get_enabling_research_id()
             enabling_research = dataset.genie_techs[enabling_research_id]
-            enabling_civ_id = enabling_research["civilization_id"].get_value()
+            enabling_civ_id = enabling_research["civilization_id"].value
 
             civ = dataset.civ_groups[enabling_civ_id]
             civ_name = civ_lookup_dict[enabling_civ_id][0]
@@ -132,8 +132,8 @@ class SWGBCCAuxiliarySubprocessor:
 
         cost_amounts = []
         cost_repair_amounts = []
-        for resource_amount in current_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in current_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
 
             resource = None
             resource_name = ""
@@ -163,10 +163,10 @@ class SWGBCCAuxiliarySubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
-            amount = resource_amount["amount"].get_value()
+            amount = resource_amount["amount"].value
 
             cost_amount_name = f"{cost_name}.{resource_name}Amount"
             cost_amount = RawAPIObject(cost_amount_name,
@@ -223,7 +223,7 @@ class SWGBCCAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
         # Creation time
         if isinstance(line, GenieUnitLineGroup):
-            creation_time = current_unit["creation_time"].get_value()
+            creation_time = current_unit["creation_time"].value
 
         else:
             # Buildings are created immediately
@@ -234,7 +234,7 @@ class SWGBCCAuxiliarySubprocessor:
                                                 "engine.util.create.CreatableGameEntity")
 
         # Creation sound
-        creation_sound_id = current_unit["train_sound_id"].get_value()
+        creation_sound_id = current_unit["train_sound_id"].value
 
         # Create sound object
         obj_name = f"{game_entity_name}.CreatableGameEntity.Sound"
@@ -312,8 +312,8 @@ class SWGBCCAuxiliarySubprocessor:
                                                 1.0,
                                                 "engine.util.placement_mode.type.Place")
             # Clearance size
-            clearance_size_x = current_unit["clearance_size_x"].get_value()
-            clearance_size_y = current_unit["clearance_size_y"].get_value()
+            clearance_size_x = current_unit["clearance_size_x"].value
+            clearance_size_y = current_unit["clearance_size_y"].value
             place_raw_api_object.add_raw_member("clearance_size_x",
                                                 clearance_size_x,
                                                 "engine.util.placement_mode.type.Place")
@@ -327,7 +327,7 @@ class SWGBCCAuxiliarySubprocessor:
                                                 "engine.util.placement_mode.type.Place")
 
             # Max elevation difference
-            elevation_mode = current_unit["elevation_mode"].get_value()
+            elevation_mode = current_unit["elevation_mode"].value
             if elevation_mode == 2:
                 max_elevation_difference = 0
 
@@ -465,8 +465,8 @@ class SWGBCCAuxiliarySubprocessor:
                                            "engine.util.cost.Cost")
 
         cost_amounts = []
-        for resource_amount in tech_group.tech["research_resource_costs"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
+        for resource_amount in tech_group.tech["research_resource_costs"].value:
+            resource_id = resource_amount["type_id"].value
 
             resource = None
             resource_name = ""
@@ -496,10 +496,10 @@ class SWGBCCAuxiliarySubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
-            amount = resource_amount["amount"].get_value()
+            amount = resource_amount["amount"].value
 
             cost_amount_ref = f"{cost_ref}.{resource_name}Amount"
             cost_amount = RawAPIObject(cost_amount_ref,
@@ -529,7 +529,7 @@ class SWGBCCAuxiliarySubprocessor:
                                                    cost_forward_ref,
                                                    "engine.util.research.ResearchableTech")
 
-        research_time = tech_group.tech["research_time"].get_value()
+        research_time = tech_group.tech["research_time"].value
 
         researchable_raw_api_object.add_raw_member("research_time",
                                                    research_time,

--- a/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/civ_subprocessor.py
@@ -71,10 +71,10 @@ class SWGBCCCivSubprocessor:
         civ_name = civ_lookup_dict[civ_id][0]
 
         # Find starting resource amounts
-        food_amount = civ_group.civ["resources"][91].get_value()
-        carbon_amount = civ_group.civ["resources"][92].get_value()
-        nova_amount = civ_group.civ["resources"][93].get_value()
-        ore_amount = civ_group.civ["resources"][94].get_value()
+        food_amount = civ_group.civ["resources"][91].value
+        carbon_amount = civ_group.civ["resources"][92].value
+        nova_amount = civ_group.civ["resources"][93].value
+        ore_amount = civ_group.civ["resources"][94].value
 
         # Find civ unique starting resources
         tech_tree = civ_group.get_tech_tree_effects()
@@ -84,8 +84,8 @@ class SWGBCCCivSubprocessor:
             if type_id != 1:
                 continue
 
-            resource_id = effect["attr_a"].get_value()
-            amount = effect["attr_d"].get_value()
+            resource_id = effect["attr_a"].value
+            amount = effect["attr_d"].value
             if resource_id == 91:
                 food_amount += amount
 

--- a/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
@@ -890,8 +890,7 @@ class SWGBCCNyanSubprocessor:
             projectile_indices.append(1)
 
         for projectile_num in projectile_indices:
-            obj_ref = "%s.ShootProjectile.Projectile%s" % (game_entity_name,
-                                                           str(projectile_num))
+            obj_ref = f"{game_entity_name}.ShootProjectile.Projectile{projectile_num}"
             obj_name = f"Projectile{str(projectile_num)}"
             proj_raw_api_object = RawAPIObject(obj_ref, obj_name, dataset.nyan_api_objects)
             proj_raw_api_object.add_raw_parent("engine.util.game_entity.GameEntity")

--- a/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
@@ -881,11 +881,11 @@ class SWGBCCNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
+        projectile_primary = current_unit["projectile_id0"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
+        projectile_secondary = current_unit["projectile_id1"].value
         if projectile_secondary > -1:
             projectile_indices.append(1)
 

--- a/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/nyan_subprocessor.py
@@ -197,14 +197,14 @@ class SWGBCCNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_unit["unit_type"].get_value()
+        unit_type = current_unit["unit_type"].value
 
         if unit_type >= 70:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Unit"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_unit["unit_class"].get_value()
+        unit_class = current_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -400,14 +400,14 @@ class SWGBCCNyanSubprocessor:
         # =======================================================================
         # Create or use existing auxiliary types
         types_set = []
-        unit_type = current_building["unit_type"].get_value()
+        unit_type = current_building["unit_type"].value
 
         if unit_type >= 80:
             type_obj = dataset.pregen_nyan_objects["util.game_entity_type.types.Building"].get_nyan_object(
             )
             types_set.append(type_obj)
 
-        unit_class = current_building["unit_class"].get_value()
+        unit_class = current_building["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -565,7 +565,7 @@ class SWGBCCNyanSubprocessor:
         )
         types_set.append(type_obj)
 
-        unit_class = ambient_unit["unit_class"].get_value()
+        unit_class = ambient_unit["unit_class"].value
         class_name = class_lookup_dict[unit_class]
         class_obj_name = f"util.game_entity_type.types.{class_name}"
         type_obj = dataset.pregen_nyan_objects[class_obj_name].get_nyan_object()
@@ -578,7 +578,7 @@ class SWGBCCNyanSubprocessor:
         # =======================================================================
         abilities_set = []
 
-        interaction_mode = ambient_unit["interaction_mode"].get_value()
+        interaction_mode = ambient_unit["interaction_mode"].value
 
         if interaction_mode >= 0:
             abilities_set.append(AoCAbilitySubprocessor.death_ability(ambient_group))
@@ -881,11 +881,11 @@ class SWGBCCNyanSubprocessor:
         projectiles_location = f"data/game_entity/generic/{game_entity_filename}/projectiles/"
 
         projectile_indices = []
-        projectile_primary = current_unit["attack_projectile_primary_unit_id"].get_value()
+        projectile_primary = current_unit["attack_projectile_primary_unit_id"].value
         if projectile_primary > -1:
             projectile_indices.append(0)
 
-        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].get_value()
+        projectile_secondary = current_unit["attack_projectile_secondary_unit_id"].value
         if projectile_secondary > -1:
             projectile_indices.append(1)
 

--- a/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/pregen_subprocessor.py
@@ -61,8 +61,8 @@ class SWGBCCPregenSubprocessor:
             pregen_object.create_nyan_members()
 
             if not pregen_object.is_ready():
-                raise Exception("%s: Pregenerated object is not ready for export."
-                                "Member or object not initialized." % (pregen_object))
+                raise Exception(f"{repr(pregen_object)}: Pregenerated object is not ready "
+                                "for export. Member or object not initialized.")
 
     @staticmethod
     def generate_effect_types(

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -265,8 +265,8 @@ class SWGBCCProcessor:
                     break
 
             else:
-                raise Exception("Unit %s is not first in line, but no previous unit can"
-                                " be found in other_connections" % (unit_id))
+                raise Exception(f"Unit {unit_id} is not first in line, but no previous "
+                                "unit can be found in other_connections")
 
             connected_ids = connection["other_connected_ids"].value
             previous_unit_id = connected_ids[connected_index].value
@@ -469,8 +469,8 @@ class SWGBCCProcessor:
                     break
 
             else:
-                raise Exception("Building %s is not first in line, but no previous building can"
-                                " be found in other_connections" % (building_id))
+                raise Exception("Building {building_id} is not first in line, but no previous "
+                                "building can be found in other_connections")
 
             connected_ids = connection["other_connected_ids"].value
             previous_unit_id = connected_ids[connected_index].value

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -207,9 +207,9 @@ class SWGBCCProcessor:
 
         # First only handle the line heads (first units in a line)
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
+            unit_id = connection["id"].value
             unit = full_data_set.genie_units[unit_id]
-            line_mode = connection["line_mode"].get_value()
+            line_mode = connection["line_mode"].value
 
             if line_mode != 2:
                 # It's an upgrade. Skip and handle later
@@ -217,11 +217,11 @@ class SWGBCCProcessor:
 
             # Check for special cases first
             if unit.has_member("transform_unit_id")\
-                    and unit["transform_unit_id"].get_value() > -1:
+                    and unit["transform_unit_id"].value > -1:
                 # Cannon
                 # SWGB stores the deployed cannon in the connections, but we
                 # want the undeployed cannon
-                transform_id = unit["transform_unit_id"].get_value()
+                transform_id = unit["transform_unit_id"].value
                 unit_line = SWGBUnitTransformGroup(transform_id, transform_id, full_data_set)
 
             elif unit_id in MONK_GROUP_ASSOCS.keys():
@@ -232,7 +232,7 @@ class SWGBCCProcessor:
                 unit_line = SWGBMonkGroup(unit_id, unit_id, switch_unit_id, full_data_set)
 
             elif unit.has_member("task_group")\
-                    and unit["task_group"].get_value() > 0:
+                    and unit["task_group"].value > 0:
                 # Villager
                 # done somewhere else because they are special^TM
                 continue
@@ -247,18 +247,18 @@ class SWGBCCProcessor:
 
         # Second, handle all upgraded units
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
+            unit_id = connection["id"].value
             unit = full_data_set.genie_units[unit_id]
-            line_mode = connection["line_mode"].get_value()
+            line_mode = connection["line_mode"].value
 
             if line_mode != 3:
                 # This unit is not an upgrade and was handled in the last for-loop
                 continue
 
             # Search other_connections for the previous unit in line
-            connected_types = connection["other_connections"].get_value()
+            connected_types = connection["other_connections"].value
             for index, _ in enumerate(connected_types):
-                connected_type = connected_types[index]["other_connection"].get_value()
+                connected_type = connected_types[index]["other_connection"].value
                 if connected_type == 2:
                     # 2 == Unit
                     connected_index = index
@@ -268,8 +268,8 @@ class SWGBCCProcessor:
                 raise Exception("Unit %s is not first in line, but no previous unit can"
                                 " be found in other_connections" % (unit_id))
 
-            connected_ids = connection["other_connected_ids"].get_value()
-            previous_unit_id = connected_ids[connected_index].get_value()
+            connected_ids = connection["other_connected_ids"].value
+            previous_unit_id = connected_ids[connected_index].value
 
             # Search for the first unit ID in the line recursively
             previous_id = previous_unit_id
@@ -279,17 +279,17 @@ class SWGBCCProcessor:
                     # Short-circuit here, if we the previous unit was already handled
                     break
 
-                connected_types = previous_connection["other_connections"].get_value()
+                connected_types = previous_connection["other_connections"].value
                 connected_index = -1
                 for index, _ in enumerate(connected_types):
-                    connected_type = connected_types[index]["other_connection"].get_value()
+                    connected_type = connected_types[index]["other_connection"].value
                     if connected_type == 2:
                         # 2 == Unit
                         connected_index = index
                         break
 
-                connected_ids = previous_connection["other_connected_ids"].get_value()
-                previous_id = connected_ids[connected_index].get_value()
+                connected_ids = previous_connection["other_connected_ids"].value
+                previous_id = connected_ids[connected_index].value
                 previous_connection = unit_connections[previous_id]
 
             unit_line = unit_ref[previous_id]
@@ -375,7 +375,7 @@ class SWGBCCProcessor:
         # Search all techs for building upgrades. This is necessary because they are
         # not stored in tech connections in SWGB
         for tech_id, tech in genie_techs.items():
-            tech_effect_id = tech["tech_effect_id"].get_value()
+            tech_effect_id = tech["tech_effect_id"].value
             if tech_effect_id < 0:
                 continue
 
@@ -384,11 +384,11 @@ class SWGBCCProcessor:
             # Search for upgrade or unlock effects
             age_up = False
             for effect in tech_effects:
-                effect_type = effect["type_id"].get_value()
-                unit_id_a = effect["attr_a"].get_value()
-                unit_id_b = effect["attr_b"].get_value()
+                effect_type = effect["type_id"].value
+                unit_id_a = effect["attr_a"].value
+                unit_id_b = effect["attr_b"].value
 
-                if effect_type == 1 and effect["attr_a"].get_value() == 6:
+                if effect_type == 1 and effect["attr_a"].value == 6:
                     # if this is an age up tech, we do not need to create any additional
                     # unlock techs
                     age_up = True
@@ -409,8 +409,8 @@ class SWGBCCProcessor:
                     building = full_data_set.genie_units[unit_id_a]
 
                     if building.has_member("stack_unit_id") and \
-                            building["stack_unit_id"].get_value() > -1:
-                        unit_id_a = building["stack_unit_id"].get_value()
+                            building["stack_unit_id"].value > -1:
+                        unit_id_a = building["stack_unit_id"].value
                         unlocked_by_tech.add(unit_id_a)
 
                         if not age_up:
@@ -424,7 +424,7 @@ class SWGBCCProcessor:
 
         # First only handle the line heads (first buildings in a line)
         for connection in building_connections.values():
-            building_id = connection["id"].get_value()
+            building_id = connection["id"].value
 
             if building_id not in unlocked_by_tech:
                 continue
@@ -433,14 +433,14 @@ class SWGBCCProcessor:
 
             # Check if we have to create a GenieStackBuildingGroup
             if building.has_member("stack_unit_id") and \
-                    building["stack_unit_id"].get_value() > -1:
+                    building["stack_unit_id"].value > -1:
                 # we don't care about head units because we process
                 # them with their stack unit
                 continue
 
             if building.has_member("head_unit_id") and \
-                    building["head_unit_id"].get_value() > -1:
-                head_unit_id = building["head_unit_id"].get_value()
+                    building["head_unit_id"].value > -1:
+                head_unit_id = building["head_unit_id"].value
                 building_line = SWGBStackBuildingGroup(building_id, head_unit_id, full_data_set)
 
             else:
@@ -452,7 +452,7 @@ class SWGBCCProcessor:
 
         # Second, handle all upgraded buildings
         for connection in building_connections.values():
-            building_id = connection["id"].get_value()
+            building_id = connection["id"].value
 
             if building_id not in upgraded_by_tech.keys():
                 continue
@@ -460,9 +460,9 @@ class SWGBCCProcessor:
             building = full_data_set.genie_units[building_id]
 
             # Search other_connections for the previous unit in line
-            connected_types = connection["other_connections"].get_value()
+            connected_types = connection["other_connections"].value
             for index, _ in enumerate(connected_types):
-                connected_type = connected_types[index]["other_connection"].get_value()
+                connected_type = connected_types[index]["other_connection"].value
                 if connected_type == 1:
                     # 1 == Building
                     connected_index = index
@@ -472,8 +472,8 @@ class SWGBCCProcessor:
                 raise Exception("Building %s is not first in line, but no previous building can"
                                 " be found in other_connections" % (building_id))
 
-            connected_ids = connection["other_connected_ids"].get_value()
-            previous_unit_id = connected_ids[connected_index].get_value()
+            connected_ids = connection["other_connected_ids"].value
+            previous_unit_id = connected_ids[connected_index].value
 
             # Search for the first unit ID in the line recursively
             previous_id = previous_unit_id
@@ -483,17 +483,17 @@ class SWGBCCProcessor:
                     # Short-circuit here, if we the previous unit was already handled
                     break
 
-                connected_types = previous_connection["other_connections"].get_value()
+                connected_types = previous_connection["other_connections"].value
                 connected_index = -1
                 for index, _ in enumerate(connected_types):
-                    connected_type = connected_types[index]["other_connection"].get_value()
+                    connected_type = connected_types[index]["other_connection"].value
                     if connected_type == 1:
                         # 1 == Building
                         connected_index = index
                         break
 
-                connected_ids = previous_connection["other_connected_ids"].get_value()
-                previous_id = connected_ids[connected_index].get_value()
+                connected_ids = previous_connection["other_connected_ids"].value
+                previous_id = connected_ids[connected_index].value
                 previous_connection = building_connections[previous_id]
 
             building_line = full_data_set.unit_ref[previous_id]
@@ -528,7 +528,7 @@ class SWGBCCProcessor:
         # Find task groups in the dataset
         for unit in units.values():
             if unit.has_member("task_group"):
-                task_group_id = unit["task_group"].get_value()
+                task_group_id = unit["task_group"].value
 
             else:
                 task_group_id = 0
@@ -555,7 +555,7 @@ class SWGBCCProcessor:
                 full_data_set.task_groups.update({task_group_id: task_group})
 
             task_group_ids.add(task_group_id)
-            unit_ids.add(unit["id0"].get_value())
+            unit_ids.add(unit["id0"].value)
 
         # Create the villager task group
         villager = GenieVillagerGroup(118, task_group_ids, full_data_set)
@@ -619,10 +619,10 @@ class SWGBCCProcessor:
         tech_connections = full_data_set.tech_connections
 
         for connection in tech_connections.values():
-            tech_id = connection["id"].get_value()
+            tech_id = connection["id"].value
             tech = full_data_set.genie_techs[tech_id]
 
-            effect_id = tech["tech_effect_id"].get_value()
+            effect_id = tech["tech_effect_id"].value
             if effect_id < 0:
                 continue
 
@@ -633,10 +633,10 @@ class SWGBCCProcessor:
             resource_effects = tech_effects.get_effects(effect_type=1)
             for effect in resource_effects:
                 # Resource ID 6: Current Age
-                if effect["attr_a"].get_value() != 6:
+                if effect["attr_a"].value != 6:
                     continue
 
-                age_id = effect["attr_b"].get_value()
+                age_id = effect["attr_b"].value
                 age_up = AgeUpgrade(tech_id, age_id, full_data_set)
                 full_data_set.tech_groups.update({age_up.get_id(): age_up})
                 full_data_set.age_upgrades.update({age_up.get_id(): age_up})
@@ -658,10 +658,10 @@ class SWGBCCProcessor:
         unit_unlocks = {}
         unit_upgrades = {}
         for connection in unit_connections.values():
-            unit_id = connection["id"].get_value()
-            required_research_id = connection["required_research"].get_value()
-            enabling_research_id = connection["enabling_research"].get_value()
-            line_mode = connection["line_mode"].get_value()
+            unit_id = connection["id"].value
+            required_research_id = connection["required_research"].value
+            enabling_research_id = connection["enabling_research"].value
+            line_mode = connection["line_mode"].value
             line_id = full_data_set.unit_ref[unit_id].get_id()
 
             if required_research_id == -1 and enabling_research_id == -1:
@@ -736,8 +736,8 @@ class SWGBCCProcessor:
             if not genie_unit.has_member("research_id"):
                 continue
 
-            building_id = genie_unit["id0"].get_value()
-            initiated_tech_id = genie_unit["research_id"].get_value()
+            building_id = genie_unit["id0"].value
+            initiated_tech_id = genie_unit["research_id"].value
 
             if initiated_tech_id == -1:
                 continue
@@ -757,17 +757,17 @@ class SWGBCCProcessor:
             tech_id = index
 
             # Civ ID must be positive and non-zero
-            civ_id = genie_techs[index]["civilization_id"].get_value()
+            civ_id = genie_techs[index]["civilization_id"].value
             if civ_id <= 0:
                 continue
 
             # Passive boni are not researched anywhere
-            research_location_id = genie_techs[index]["research_location_id"].get_value()
+            research_location_id = genie_techs[index]["research_location_id"].value
             if research_location_id > 0:
                 continue
 
             # Passive boni are not available in full tech mode
-            full_tech_mode = genie_techs[index]["full_tech_mode"].get_value()
+            full_tech_mode = genie_techs[index]["full_tech_mode"].value
             if full_tech_mode:
                 continue
 
@@ -800,14 +800,14 @@ class SWGBCCProcessor:
             garrison_units = []
 
             if unit_line.has_command(3):
-                unit_commands = unit_line.get_head_unit()["unit_commands"].get_value()
+                unit_commands = unit_line.get_head_unit()["unit_commands"].value
                 for command in unit_commands:
-                    type_id = command["type"].get_value()
+                    type_id = command["type"].value
 
                     if type_id != 3:
                         continue
 
-                    class_id = command["class_id"].get_value()
+                    class_id = command["class_id"].value
                     if class_id > -1:
                         garrison_classes.append(class_id)
 
@@ -815,7 +815,7 @@ class SWGBCCProcessor:
                             # Towers because LucasArts ALSO didn't like consistent rules
                             garrison_classes.append(10)
 
-                    unit_id = command["unit_id"].get_value()
+                    unit_id = command["unit_id"].value
                     if unit_id > -1:
                         garrison_units.append(unit_id)
 
@@ -827,13 +827,13 @@ class SWGBCCProcessor:
                 garrison_mode = garrison_line.get_garrison_mode()
                 if garrison_mode == GenieGarrisonMode.NATURAL:
                     if unit_line.get_head_unit().has_member("creatable_type"):
-                        creatable_type = unit_line.get_head_unit()["creatable_type"].get_value()
+                        creatable_type = unit_line.get_head_unit()["creatable_type"].value
 
                     else:
                         creatable_type = 0
 
                     if garrison_line.get_head_unit().has_member("garrison_type"):
-                        garrison_type = garrison_line.get_head_unit()["garrison_type"].get_value()
+                        garrison_type = garrison_line.get_head_unit()["garrison_type"].value
 
                     else:
                         garrison_type = 0
@@ -881,14 +881,14 @@ class SWGBCCProcessor:
                 # Jedi/Sith inventories
                 elif garrison_mode == GenieGarrisonMode.MONK:
                     # Search for a pickup command
-                    unit_commands = garrison_line.get_head_unit()["unit_commands"].get_value()
+                    unit_commands = garrison_line.get_head_unit()["unit_commands"].value
                     for command in unit_commands:
-                        type_id = command["type"].get_value()
+                        type_id = command["type"].value
 
                         if type_id != 132:
                             continue
 
-                        unit_id = command["unit_id"].get_value()
+                        unit_id = command["unit_id"].value
                         if unit_id == unit_line.get_head_unit_id():
                             unit_line.garrison_locations.append(garrison_line)
                             garrison_line.garrison_entities.append(unit_line)
@@ -912,14 +912,14 @@ class SWGBCCProcessor:
         repair_classes = []
         for villager in villager_groups.values():
             repair_unit = villager.get_units_with_command(106)[0]
-            unit_commands = repair_unit["unit_commands"].get_value()
+            unit_commands = repair_unit["unit_commands"].value
             for command in unit_commands:
-                type_id = command["type"].get_value()
+                type_id = command["type"].value
 
                 if type_id != 106:
                     continue
 
-                class_id = command["class_id"].get_value()
+                class_id = command["class_id"].value
                 if class_id == -1:
                     # Buildings/Siege
                     repair_classes.append(10)

--- a/openage/convert/processor/conversion/swgbcc/processor.py
+++ b/openage/convert/processor/conversion/swgbcc/processor.py
@@ -224,7 +224,7 @@ class SWGBCCProcessor:
                 transform_id = unit["transform_unit_id"].value
                 unit_line = SWGBUnitTransformGroup(transform_id, transform_id, full_data_set)
 
-            elif unit_id in MONK_GROUP_ASSOCS.keys():
+            elif unit_id in MONK_GROUP_ASSOCS:
                 # Jedi/Sith
                 # Switch to monk with relic is hardcoded :(
                 # for every civ (WTF LucasArts)
@@ -275,7 +275,7 @@ class SWGBCCProcessor:
             previous_id = previous_unit_id
             previous_connection = unit_connections[previous_unit_id]
             while previous_connection["line_mode"] != 2:
-                if previous_id in unit_ref.keys():
+                if previous_id in unit_ref:
                     # Short-circuit here, if we the previous unit was already handled
                     break
 
@@ -299,7 +299,7 @@ class SWGBCCProcessor:
         final_unit_lines = {}
         final_unit_lines.update(unit_lines)
         for line in unit_lines.values():
-            if line.get_head_unit_id() not in CIV_LINE_ASSOCS.keys():
+            if line.get_head_unit_id() not in CIV_LINE_ASSOCS:
                 for main_head_unit_id, civ_head_unit_ids in CIV_LINE_ASSOCS.items():
                     if line.get_head_unit_id() in civ_head_unit_ids:
                         # The line is an alternative civ line and should be stored
@@ -454,7 +454,7 @@ class SWGBCCProcessor:
         for connection in building_connections.values():
             building_id = connection["id"].value
 
-            if building_id not in upgraded_by_tech.keys():
+            if building_id not in upgraded_by_tech:
                 continue
 
             building = full_data_set.genie_units[building_id]
@@ -683,7 +683,7 @@ class SWGBCCProcessor:
         final_unit_unlocks = {}
         for unit_unlock in unit_unlocks.values():
             line = unit_unlock.get_unlocked_line()
-            if line.get_head_unit_id() not in CIV_LINE_ASSOCS.keys():
+            if line.get_head_unit_id() not in CIV_LINE_ASSOCS:
                 for main_head_unit_id, civ_head_unit_ids in CIV_LINE_ASSOCS.items():
                     if line.get_head_unit_id() in civ_head_unit_ids:
                         if isinstance(line, SWGBUnitTransformGroup):
@@ -710,7 +710,7 @@ class SWGBCCProcessor:
         final_unit_upgrades = {}
         for unit_upgrade in unit_upgrades.values():
             tech_id = unit_upgrade.tech.get_id()
-            if tech_id not in CIV_TECH_ASSOCS.keys():
+            if tech_id not in CIV_TECH_ASSOCS:
                 for main_tech_id, civ_tech_ids in CIV_TECH_ASSOCS.items():
                     if tech_id in civ_tech_ids:
                         # The tech is upgrade for an alternative civ so the upgrade

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -210,10 +210,10 @@ class SWGBCCTechSubprocessor:
             raise Exception("Effect type %s is not a valid attribute effect"
                             % str(effect_type))
 
-        unit_id = effect["attr_a"].get_value()
-        class_id = effect["attr_b"].get_value()
-        attribute_type = effect["attr_c"].get_value()
-        value = effect["attr_d"].get_value()
+        unit_id = effect["attr_a"].value
+        class_id = effect["attr_b"].value
+        attribute_type = effect["attr_c"].value
+        value = effect["attr_d"].value
 
         if attribute_type == -1:
             return patches
@@ -266,7 +266,7 @@ class SWGBCCTechSubprocessor:
         effect_type = effect.get_type()
         operator = None
         if effect_type == 1:
-            mode = effect["attr_b"].get_value()
+            mode = effect["attr_b"].value
 
             if mode == 0:
                 operator = MemberOperator.ASSIGN
@@ -281,8 +281,8 @@ class SWGBCCTechSubprocessor:
             raise Exception("Effect type %s is not a valid resource effect"
                             % str(effect_type))
 
-        resource_id = effect["attr_a"].get_value()
-        value = effect["attr_d"].get_value()
+        resource_id = effect["attr_a"].value
+        value = effect["attr_d"].value
 
         if resource_id in (-1, 6, 21):
             # -1 = invalid ID

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -207,8 +207,7 @@ class SWGBCCTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid attribute effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid resource effect")
 
         unit_id = effect["attr_a"].value
         class_id = effect["attr_b"].value
@@ -278,8 +277,7 @@ class SWGBCCTechSubprocessor:
             operator = MemberOperator.MULTIPLY
 
         else:
-            raise Exception("Effect type %s is not a valid resource effect"
-                            % str(effect_type))
+            raise Exception(f"Effect type {effect_type} is not a valid resource effect")
 
         resource_id = effect["attr_a"].value
         value = effect["attr_d"].value

--- a/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
@@ -67,8 +67,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.CarbonAmount" % (game_entity_name,
-                                                                           game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.CarbonAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -160,8 +160,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.NovaAmount" % (game_entity_name,
-                                                                         game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.NovaAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -253,8 +253,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        patch_target_ref = "%s.CreatableGameEntity.%sCost.OreAmount" % (game_entity_name,
-                                                                        game_entity_name)
+        patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                            f"{game_entity_name}Cost.OreAmount")
         patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
         # Wrapper
@@ -374,9 +374,9 @@ class SWGBCCUpgradeAttributeSubprocessor:
             if not resource_amount["enabled"].value:
                 continue
 
-            patch_target_ref = "%s.CreatableGameEntity.%sCost.%sAmount" % (game_entity_name,
-                                                                           game_entity_name,
-                                                                           resource_name)
+            patch_target_ref = (f"{game_entity_name}.CreatableGameEntity."
+                                f"{game_entity_name}Cost."
+                                f"{resource_name}Amount")
             patch_target_forward_ref = ForwardRef(line, patch_target_ref)
 
             # Wrapper

--- a/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/upgrade_attribute_subprocessor.py
@@ -347,9 +347,8 @@ class SWGBCCUpgradeAttributeSubprocessor:
 
         game_entity_name = name_lookup_dict[head_unit_id][0]
 
-        for resource_amount in head_unit["resource_cost"].get_value():
-            resource_id = resource_amount["type_id"].get_value()
-
+        for resource_amount in head_unit["resource_cost"].value:
+            resource_id = resource_amount["type_id"].value
             resource_name = ""
             if resource_id == -1:
                 # Not a valid resource
@@ -372,7 +371,7 @@ class SWGBCCUpgradeAttributeSubprocessor:
                 continue
 
             # Skip resources that are only expected to be there
-            if not resource_amount["enabled"].get_value():
+            if not resource_amount["enabled"].value:
                 continue
 
             patch_target_ref = "%s.CreatableGameEntity.%sCost.%sAmount" % (game_entity_name,

--- a/openage/convert/processor/export/media_exporter.py
+++ b/openage/convert/processor/export/media_exporter.py
@@ -504,7 +504,7 @@ class MediaExporter:
             # only allow png
             if ext != ".png":
                 raise ValueError("Filename invalid, a texture must be saved"
-                                 "as 'filename.png', not '%s'" % (filename))
+                                 f"as '*.png', not '*.{ext}'")
 
         compression_method = compression_levels.get(
             compression_level,

--- a/openage/convert/service/conversion/internal_name_lookups.py
+++ b/openage/convert/service/conversion/internal_name_lookups.py
@@ -64,8 +64,7 @@ def get_armor_class_lookups(game_version: GameVersion) -> dict[int, str]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.ARMOR_CLASS_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_civ_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -108,8 +107,7 @@ def get_civ_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.CIV_GROUP_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_class_lookups(game_version: GameVersion) -> dict[int, str]:
@@ -131,8 +129,7 @@ def get_class_lookups(game_version: GameVersion) -> dict[int, str]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.CLASS_ID_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_command_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -154,8 +151,7 @@ def get_command_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]
     if game_edition.game_id == "SWGB":
         return swgb_internal.COMMAND_TYPE_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_entity_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -240,8 +236,7 @@ def get_entity_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
 
         return entity_lookup_dict
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_gather_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -263,8 +258,7 @@ def get_gather_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.GATHER_TASK_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_graphic_set_lookups(
@@ -309,8 +303,7 @@ def get_graphic_set_lookups(
     if game_edition.game_id == "SWGB":
         return swgb_internal.GRAPHICS_SET_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_restock_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -336,8 +329,7 @@ def get_restock_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]
     if game_edition.game_id == "SWGB":
         return swgb_internal.RESTOCK_TARGET_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_tech_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
@@ -380,8 +372,7 @@ def get_tech_lookups(game_version: GameVersion) -> dict[int, tuple[str, str]]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.TECH_GROUP_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_terrain_lookups(
@@ -426,8 +417,7 @@ def get_terrain_lookups(
     if game_edition.game_id == "SWGB":
         return swgb_internal.TERRAIN_GROUP_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")
 
 
 def get_terrain_type_lookups(game_version: GameVersion) -> dict[int, tuple]:
@@ -470,5 +460,4 @@ def get_terrain_type_lookups(game_version: GameVersion) -> dict[int, tuple]:
     if game_edition.game_id == "SWGB":
         return swgb_internal.TERRAIN_TYPE_LOOKUPS
 
-    raise Exception("No lookup dict found for game version %s"
-                    % game_edition.edition_name)
+    raise Exception(f"No lookup dict found for game version {game_edition.edition_name}")

--- a/openage/convert/service/export/interface/cutter.py
+++ b/openage/convert/service/export/interface/cutter.py
@@ -77,7 +77,7 @@ class InterfaceCutter:
         matches = visgrep(search_area, pattern, 100000)
 
         if len(matches) < 2:
-            raise Exception("visgrep failed to find repeating pattern in id=%d)\n" % self.idx)
+            raise Exception(f"visgrep failed to find repeating pattern in id={self.idx})\n")
 
         # create the found pattern texture
         return TextureImage(

--- a/openage/convert/service/export/interface/rename.py
+++ b/openage/convert/service/export/interface/rename.py
@@ -20,10 +20,9 @@ def hud_rename(filepath: Path) -> Path:
     and hardcoded metadata.
     """
     try:
-        return filepath.parent["hud{}{}".format(
-            str(ingame_hud_background_index(int(filepath.stem))).zfill(4),
-            filepath.suffix
-        )]
+        return filepath.parent[
+            f"hud{str(ingame_hud_background_index(int(filepath.stem))).zfill(4)}{filepath.suffix}"
+        ]
 
     except ValueError:
         return asset_rename(filepath)

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -11,9 +11,6 @@ import pickle
 from tempfile import gettempdir
 from zlib import decompress
 
-from openage.convert.value_object.read.dynamic_loader import DynamicLoader
-
-
 from ....log import spam, dbg, info, warn
 from ...value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
 from ...value_object.read.media_types import MediaType
@@ -102,7 +99,7 @@ def load_gamespec(
     spam("length of decompressed data: %d", len(file_data))
 
     wrapper = EmpiresDatWrapper()
-    _, gamespec = wrapper.read(file_data, 0, game_version)
+    _, gamespec = wrapper.read(file_data, 0, game_version, dynamic_load=dynamic_load)
 
     # Remove the list sorrounding the converted data
     gamespec = gamespec[0]

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -11,6 +11,8 @@ import pickle
 from tempfile import gettempdir
 from zlib import decompress
 
+from openage.convert.entity_object.conversion.dynamic_loader import DynamicLoader
+
 
 from ....log import spam, dbg, info, warn
 from ...value_object.read.media.datfile.empiresdat import EmpiresDatWrapper
@@ -57,7 +59,8 @@ def load_gamespec(
     fileobj: GuardedFile,
     game_version: GameVersion,
     cachefile_name: str = None,
-    pickle_cache: bool = False
+    pickle_cache: bool = False,
+    dynamic_load = False
 ) -> ArrayMember:
     """
     Helper method that loads the contents of a 'empires.dat' gzipped wrapper
@@ -103,6 +106,7 @@ def load_gamespec(
 
     # Remove the list sorrounding the converted data
     gamespec = gamespec[0]
+    del wrapper
 
     if cachefile_name and pickle_cache:
         dbg("dumping dat file contents to cache file: %s", cachefile_name)

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -38,8 +38,8 @@ def get_gamespec(srcdir: Directory, game_version: GameVersion, pickle_cache: boo
             filepath = srcdir.joinpath(game_version.edition.media_paths[MediaType.DATFILE][0])
 
     else:
-        raise Exception("No service found for reading data file of version %s"
-                        % game_version.edition.game_id)
+        raise Exception("No service found for reading data file of "
+                        f"version {game_version.edition.game_id}")
 
     cache_file = os.path.join(
         gettempdir(), f"{game_version.edition.game_id}_{filepath.name}.pickle")

--- a/openage/convert/service/read/gamedata.py
+++ b/openage/convert/service/read/gamedata.py
@@ -11,7 +11,7 @@ import pickle
 from tempfile import gettempdir
 from zlib import decompress
 
-from openage.convert.entity_object.conversion.dynamic_loader import DynamicLoader
+from openage.convert.value_object.read.dynamic_loader import DynamicLoader
 
 
 from ....log import spam, dbg, info, warn

--- a/openage/convert/service/read/string_resource.py
+++ b/openage/convert/service/read/string_resource.py
@@ -53,8 +53,8 @@ def get_string_resources(args: Namespace) -> StringResource:
             stringres.fill_from(strings)
 
         else:
-            raise Exception("No service found for parsing language files of version %s"
-                            % game_edition.game_id)
+            raise Exception("No service found for parsing language files "
+                            f"of version {game_edition.game_id}")
 
         # TODO: Other game versions
 

--- a/openage/convert/tool/driver.py
+++ b/openage/convert/tool/driver.py
@@ -76,7 +76,7 @@ def convert_metadata(args: Namespace) -> typing.Generator[str, None, None]:
 
     # Blending mode count
     if args.game_version.edition.game_id == "SWGB":
-        args.blend_mode_count = gamespec[0]["blend_mode_count_swgb"].get_value()
+        args.blend_mode_count = gamespec[0]["blend_mode_count_swgb"].value
 
     else:
         args.blend_mode_count = None

--- a/openage/convert/value_object/conversion/de2/internal_nyan_names.py
+++ b/openage/convert/value_object/conversion/de2/internal_nyan_names.py
@@ -154,6 +154,7 @@ CIV_GROUP_LOOKUPS = {
 GRAPHICS_SET_LOOKUPS = {
     0: ((0, 1, 2, 13, 14, 36), "WesternEuropean", "western_european"),
     4: ((7, 37), "Byzantine", "byzantine"),
+    7: ((20, 40, 41, 42), "Indian", "indian"),
     8: ((22, 23, 32, 35, 38, 39), "EasternEuropean", "eastern_european"),
     11: ((33, 34), "CentralAsian", "central_asian"),
 }

--- a/openage/convert/value_object/conversion/de2/internal_nyan_names.py
+++ b/openage/convert/value_object/conversion/de2/internal_nyan_names.py
@@ -34,7 +34,18 @@ UNIT_LINE_LOOKUPS = {
     # DOTD
     1701: ("Obuch", "obuch"),
     1704: ("HussiteWagon", "hussite_wagon"),
-    1709: ("Obuch", "obuch"),
+    1709: ("Houfnice", "houfnice"),
+
+    # DOI
+    1735: ("UrumiSwordsman", "urumi_swordsman"),
+    1738: ("MRatha", "mratha"),                 # Melee Rhata
+    1741: ("ChakramThrower", "chakram_thrower"),
+    1744: ("ArmoredElephant", "armored_elephant"),
+    1747: ("Ghulam", "ghulam"),
+    1750: ("Thirisadai", "thirisadai"),
+    1751: ("ShrivamshaRider", "shrivamsha_rider"),
+    1755: ("CamelScout", "camel_scout"),        # technically in line with Camel rider
+    1759: ("RRatha", "rratha"),                 # Ranged Rhata
 }
 
 # key: head unit id; value: (nyan object name, filename prefix)
@@ -47,6 +58,9 @@ BUILDING_LINE_LOOKUPS = {
 
     # DOTD
     1734: ("Folwark", "folwark"),
+
+    # DOI
+    1754: ("Caravanserai", "caravanserai"),
 }
 
 # key: (head) unit id; value: (nyan object name, filename prefix)
@@ -97,6 +111,19 @@ TECH_GROUP_LOOKUPS = {
     786: ("WingedHussar", "winged_hussar"),
     787: ("Houfnice", "houfnice"),
     793: ("Folwark", "folwark"),
+
+    # DOI
+    828: ("EliteRatha", "elite_ratha"),
+    830: ("EliteChakramThrower", "elite_chakram_thrower"),
+    831: ("MedicalCorps", "medical_corps"),
+    832: ("WootzSteel", "wootz_steel"),
+    833: ("Paiks", "paiks"),
+    834: ("Mahayana", "mahayana"),
+    835: ("Kshatriyas", "kshatriyas"),
+    836: ("FrontierGuards", "frontier_guards"),
+    838: ("SiegeElephant", "siege_elephant"),
+    840: ("EliteGhulam", "elite_ghulam"),
+    843: ("EliteSHrivamshaRider", "elite_shrivamsha_rider"),
 }
 
 # key: civ index; value: (nyan object name, filename prefix)
@@ -114,6 +141,12 @@ CIV_GROUP_LOOKUPS = {
     # DOTD
     38: ("Poles", "poles"),
     39: ("Bohemians", "bohemians"),
+
+    # DOI
+    20: ("Hindustanis", "hindustanis"),     # Indians in HD
+    40: ("Dravidians", "dravidians"),
+    41: ("Bengalis", "bengalis"),
+    42: ("Gurjaras", "gurjaras"),
 }
 
 # key: civ index; value: (civ ids, nyan object name, filename prefix)

--- a/openage/convert/value_object/conversion/de2/internal_nyan_names.py
+++ b/openage/convert/value_object/conversion/de2/internal_nyan_names.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 the openage authors. See copying.md for legal info.
+# Copyright 2020-2022 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=line-too-long
 

--- a/openage/convert/value_object/init/game_version.py
+++ b/openage/convert/value_object/init/game_version.py
@@ -61,7 +61,7 @@ class GameBase:
         self.media_paths = {}
 
         self.media_cache = None
-        if "media_cache" in flags.keys():
+        if "media_cache" in flags:
             self.media_cache = flags["media_cache"]
 
         for path, hash_map in game_version_info:

--- a/openage/convert/value_object/read/CMakeLists.txt
+++ b/openage/convert/value_object/read/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_py_modules(
 	__init__.py
+	dynamic_loader.py
+	genie_structure.py
 	media_types.py
 	member_access.py
 	read_members.py

--- a/openage/convert/value_object/read/dynamic_loader.py
+++ b/openage/convert/value_object/read/dynamic_loader.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.genie_structure import GenieStructure
+    from openage.convert.value_object.read.genie_structure import GenieStructure
     from openage.convert.value_object.init.game_version import GameVersion
     from openage.convert.value_object.read.value_members import ValueMember
 

--- a/openage/convert/value_object/read/genie_structure.py
+++ b/openage/convert/value_object/read/genie_structure.py
@@ -9,17 +9,17 @@ import math
 import re
 import struct
 
-from openage.convert.entity_object.conversion.dynamic_loader import DynamicLoader
+from openage.convert.value_object.read.dynamic_loader import DynamicLoader
 
 from ....util.strings import decode_until_null
-from ...value_object.read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP, MemberAccess
-from ...value_object.read.read_members import (IncludeMembers, ContinueReadMember,
+from .member_access import READ, READ_GEN, READ_UNKNOWN, SKIP, MemberAccess
+from .read_members import (IncludeMembers, ContinueReadMember,
                                                MultisubtypeMember, GroupMember, SubdataMember,
                                                ReadMember,
                                                EnumLookupMember)
-from ...value_object.read.value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
+from .value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
     StringMember, BooleanMember, IDMember, BitfieldMember, ValueMember
-from ...value_object.read.value_members import StorageType
+from .value_members import StorageType
 
 if typing.TYPE_CHECKING:
     from openage.convert.value_object.init.game_version import GameVersion

--- a/openage/convert/value_object/read/genie_structure.py
+++ b/openage/convert/value_object/read/genie_structure.py
@@ -662,4 +662,4 @@ class GenieStructure:
         raise NotImplementedError("Subclass has not implemented this function")
 
     def __repr__(self) -> str:
-        return self.__class__.name
+        return self.__class__.__name__

--- a/openage/convert/value_object/read/genie_structure.py
+++ b/openage/convert/value_object/read/genie_structure.py
@@ -14,9 +14,9 @@ from openage.convert.value_object.read.dynamic_loader import DynamicLoader
 from ....util.strings import decode_until_null
 from .member_access import READ, READ_GEN, READ_UNKNOWN, SKIP, MemberAccess
 from .read_members import (IncludeMembers, ContinueReadMember,
-                                               MultisubtypeMember, GroupMember, SubdataMember,
-                                               ReadMember,
-                                               EnumLookupMember)
+                           MultisubtypeMember, GroupMember, SubdataMember,
+                           ReadMember,
+                           EnumLookupMember)
 from .value_members import ContainerMember, ArrayMember, IntMember, FloatMember,\
     StringMember, BooleanMember, IDMember, BitfieldMember, ValueMember
 from .value_members import StorageType
@@ -76,7 +76,7 @@ class GenieStructure:
         game_version: GameVersion,
         cls: GenieStructure = None,
         members: tuple = None,
-        dynamic_load = True
+        dynamic_load = False
     ) -> tuple[int, list[ValueMember]]:
         """
         recursively read defined binary data from raw at given offset.

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -18,7 +18,7 @@ import numpy
 
 
 from .....log import dbg
-from ....entity_object.conversion.genie_structure import GenieStructure
+from ..genie_structure import GenieStructure
 
 
 if typing.TYPE_CHECKING:

--- a/openage/convert/value_object/read/media/blendomatic.py
+++ b/openage/convert/value_object/read/media/blendomatic.py
@@ -122,7 +122,7 @@ class BlendingMode:
         # each of these images gets 2353 bit as data.
         # TODO: why 32 images? isn't that depending on tile_count?
 
-        alpha_masks_raw = unpack_from("%dB" % (self.pxcount * 4),
+        alpha_masks_raw = unpack_from(f"{self.pxcount * 4:d}B",
                                       data_file.read(self.pxcount * 4))
 
         # list of alpha-mask tiles
@@ -130,7 +130,7 @@ class BlendingMode:
 
         # draw mask tiles for this blending mode
         for _ in range(tile_count):
-            pixels = unpack_from("%dB" % self.pxcount,
+            pixels = unpack_from(f"{self.pxcount:d}B",
                                  data_file.read(self.pxcount))
             self.alphamasks.append(self.get_tile_from_data(pixels))
 
@@ -185,7 +185,7 @@ class BlendingMode:
             if read_values > (tile_size - read_so_far):
                 raise Exception("reading more bytes than tile has left")
             if read_values < 0:
-                raise Exception("reading negative count: %d" % read_values)
+                raise Exception(f"reading negative count: {read_values:d}")
 
             # grab the pixels out of the big list
             pixels = list(data[read_so_far:(read_so_far + read_values)])
@@ -204,7 +204,7 @@ class BlendingMode:
             tilerows.append(pixels)
 
         if read_so_far != tile_size:
-            raise Exception("got leftover bytes: %d" % (tile_size - read_so_far))
+            raise Exception(f"got leftover bytes: {tile_size - read_so_far:d}")
 
         return BlendingTile(tilerows, max_width, self.row_count)
 
@@ -249,7 +249,7 @@ class Blendomatic(GenieStructure):
             dbg("reading only the first %d blending modes",
                 custom_mode_count)
 
-        blending_mode = Struct("< I %dB" % (tile_count))
+        blending_mode = Struct(f"< I {tile_count:d}B")
 
         self.blending_modes = []
 

--- a/openage/convert/value_object/read/media/colortable.py
+++ b/openage/convert/value_object/read/media/colortable.py
@@ -10,7 +10,7 @@ import numpy
 
 
 from .....log import dbg
-from ....entity_object.conversion.genie_structure import GenieStructure
+from ..genie_structure import GenieStructure
 
 if typing.TYPE_CHECKING:
     from PIL import Image

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 from . import unit
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import MultisubtypeMember, EnumLookupMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/civ.py
+++ b/openage/convert/value_object/read/media/datfile/civ.py
@@ -35,11 +35,11 @@ class Civ(GenieStructure):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ])
         else:
             data_format.extend([
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[20]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[20]"),
             ])
 
         data_format.extend([

--- a/openage/convert/value_object/read/media/datfile/empiresdat.py
+++ b/openage/convert/value_object/read/media/datfile/empiresdat.py
@@ -14,7 +14,7 @@ from . import sound
 from . import tech
 from . import terrain
 from . import unit
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, READ_UNKNOWN, SKIP
 from ....read.read_members import SubdataMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -114,6 +114,8 @@ class GraphicAttackSound(GenieStructure):
 
 class Graphic(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,

--- a/openage/convert/value_object/read/media/datfile/graphic.py
+++ b/openage/convert/value_object/read/media/datfile/graphic.py
@@ -51,15 +51,15 @@ class DE2SoundProp(GenieStructure):
         Return the members in this struct.
         """
         data_format = [
-            (READ_GEN, "sound_delay0", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "sound_id0", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "wwise_sound0", StorageType.ID_MEMBER, "uint32_t"),
-            (READ_GEN, "sound_delay1", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "wwise_sound1", StorageType.ID_MEMBER, "uint32_t"),
-            (READ_GEN, "sound_id1", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "sound_delay2", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "wwise_sound2", StorageType.ID_MEMBER, "uint32_t"),
-            (READ_GEN, "sound_id2", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "sound_delay0", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "sound_id0", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "wwise_sound0", StorageType.ID_MEMBER, "uint32_t"),
+            (SKIP, "sound_delay1", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "wwise_sound1", StorageType.ID_MEMBER, "uint32_t"),
+            (SKIP, "sound_id1", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "sound_delay2", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "wwise_sound2", StorageType.ID_MEMBER, "uint32_t"),
+            (SKIP, "sound_id2", StorageType.ID_MEMBER, "int16_t"),
         ]
 
         return data_format
@@ -76,8 +76,8 @@ class SoundProp(GenieStructure):
         Return the members in this struct.
         """
         data_format = [
-            (READ_GEN, "sound_delay", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "sound_delay", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "sound_id", StorageType.ID_MEMBER, "int16_t"),
         ]
 
         return data_format
@@ -95,7 +95,7 @@ class GraphicAttackSound(GenieStructure):
         """
         if game_version.edition.game_id == "AOE2DE":
             data_format = [
-                (READ_GEN, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
+                (SKIP, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=DE2SoundProp,
                     length=1,
                 )),
@@ -103,7 +103,7 @@ class GraphicAttackSound(GenieStructure):
 
         else:
             data_format = [
-                (READ_GEN, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
+                (SKIP, "sound_props", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=SoundProp,
                     length=3,
                 )),
@@ -131,7 +131,7 @@ class Graphic(GenieStructure):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_len]"),
                 (SKIP, "filename_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "filename_len", StorageType.INT_MEMBER, "uint16_t"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[filename_len]"),
@@ -150,12 +150,12 @@ class Graphic(GenieStructure):
 
         elif game_version.edition.game_id == "SWGB":
             data_format.extend([
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[25]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[25]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[25]"),
             ])
         else:
             data_format.extend([
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[21]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[21]"),
                 (READ_GEN, "filename", StorageType.STRING_MEMBER, "char[13]"),
             ])
 
@@ -169,14 +169,14 @@ class Graphic(GenieStructure):
                 type_name   = "graphics_layer",
                 lookup_dict = GRAPHICS_LAYER
             )),
-            (READ_GEN, "player_color_force_id", StorageType.ID_MEMBER,
+            (SKIP, "player_color_force_id", StorageType.ID_MEMBER,
              "int8_t"),    # force given player color
             # playercolor can be changed on sight (like sheep)
-            (READ_GEN, "adapt_color", StorageType.INT_MEMBER, "int8_t"),
-            (READ_GEN, "transparent_selection", StorageType.INT_MEMBER, "uint8_t"),  # loop animation
+            (SKIP, "adapt_color", StorageType.INT_MEMBER, "int8_t"),
+            (SKIP, "transparent_selection", StorageType.INT_MEMBER, "uint8_t"),  # loop animation
             (READ, "coordinates", StorageType.ARRAY_INT, "int16_t[4]"),
             (READ, "delta_count", StorageType.INT_MEMBER, "uint16_t"),
-            (READ_GEN, "sound_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
         if game_version.edition.game_id == "AOE2DE":
@@ -191,7 +191,7 @@ class Graphic(GenieStructure):
             # number of heading angles stored, some of the frames must be mirrored
             (READ_GEN, "angle_count", StorageType.INT_MEMBER, "uint16_t"),
             # multiplies the speed of the unit this graphic is applied to
-            (READ_GEN, "speed_adjust", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "speed_adjust", StorageType.FLOAT_MEMBER, "float"),
             (READ_GEN, "frame_rate", StorageType.FLOAT_MEMBER,
              "float"),             # how long a frame is displayed
             # seconds to wait before current_frame=0 again
@@ -212,7 +212,7 @@ class Graphic(GenieStructure):
             )),
 
             # if attack_sound_used:
-            (READ_GEN, "graphic_attack_sounds", StorageType.ARRAY_CONTAINER, SubdataMember(
+            (SKIP, "graphic_attack_sounds", StorageType.ARRAY_CONTAINER, SubdataMember(
                 ref_type=GraphicAttackSound,
                 length=lambda o: "angle_count" if o.attack_sound_used != 0 else 0,
             )),

--- a/openage/convert/value_object/read/media/datfile/lookup_dicts.py
+++ b/openage/convert/value_object/read/media/datfile/lookup_dicts.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2021 the openage authors. See copying.md for legal info.
+# Copyright 2021-2022 the openage authors. See copying.md for legal info.
 
 """
 Lookup dicts for the EnumLookupMember instances.

--- a/openage/convert/value_object/read/media/datfile/lookup_dicts.py
+++ b/openage/convert/value_object/read/media/datfile/lookup_dicts.py
@@ -13,6 +13,7 @@ GRAPHICS_LAYER = {
     5: "SHADOW",       # farm fields as well
     6: "RUBBLE",
     7: "PLANT",
+    8: "DE2_BRIDGE",
     9: "SWGB_EFFECT",
     10: "UNIT_LOW",    # constructions, dead units, tree stumps, flowers, paths
     11: "FISH",
@@ -305,6 +306,9 @@ EFFECT_APPLY_TYPE = {
 
     # a == unit_id, b == building_id, c == amount
     7: "SPAWN_UNIT",
+
+    # a == tech_id, b == action_id (5 = set?), c == amount
+    8: "RESEARCH_TIME_MODIFY",
 
     # same as 0-6 but applied to team members
     10: "TEAM_ATTRIBUTE_ABSSET",
@@ -719,6 +723,7 @@ BLAST_OFFENSE_TYPES = {
     18: "UNKNOWN_18",
     34: "UNKNOWN_34",
     66: "UNKNOWN_66",
+    138: "PIERCE",      # attack units behind target (Ghulam)
 }
 
 CREATABLE_TYPES = {

--- a/openage/convert/value_object/read/media/datfile/maps.py
+++ b/openage/convert/value_object/read/media/datfile/maps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, SKIP
 from ....read.read_members import SubdataMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -17,6 +17,8 @@ if typing.TYPE_CHECKING:
 
 class PlayerColor(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ_GEN, SKIP
 from ....read.value_members import StorageType
 

--- a/openage/convert/value_object/read/media/datfile/playercolor.py
+++ b/openage/convert/value_object/read/media/datfile/playercolor.py
@@ -6,7 +6,7 @@ import typing
 
 
 from .....entity_object.conversion.genie_structure import GenieStructure
-from ....read.member_access import READ_GEN
+from ....read.member_access import READ_GEN, SKIP
 from ....read.value_members import StorageType
 
 if typing.TYPE_CHECKING:
@@ -45,7 +45,7 @@ class PlayerColor(GenieStructure):
             ]
         else:
             data_format = [
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[30]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[30]"),
                 (READ_GEN, "id", StorageType.ID_MEMBER, "int16_t"),
                 (READ_GEN, "resource_id", StorageType.ID_MEMBER, "int16_t"),
                 (READ_GEN, "minimap_color", StorageType.ID_MEMBER, "uint8_t"),

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -92,11 +92,11 @@ class Tech(GenieStructure):
             # 0: normal tech, 2: show in Age progress bar
             (READ_GEN, "tech_type", StorageType.ID_MEMBER, "int16_t"),
             # frame id - 1 in icon slp (57029)
-            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "icon_id", StorageType.ID_MEMBER, "int16_t"),
             # button id as defined in the unit.py button matrix
             (READ_GEN, "button_id", StorageType.ID_MEMBER, "int8_t"),
             # 100000 + the language file id for the name/description
-            (READ_GEN, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),
+            (SKIP, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),
             (READ_GEN, "language_dll_techtree", StorageType.ID_MEMBER,
              "int32_t"),     # 149000 + lang_dll_description
             (READ_GEN, "hotkey", StorageType.ID_MEMBER, "int32_t"),                    # -1 for every tech
@@ -106,7 +106,7 @@ class Tech(GenieStructure):
             data_format.extend([
                 (SKIP, "name_length_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
             if game_version.edition.game_id == "AOE2DE":
@@ -117,13 +117,13 @@ class Tech(GenieStructure):
         else:
             data_format.extend([
                 (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
             if game_version.edition.game_id == "SWGB":
                 data_format.extend([
                     (READ, "name2_length", StorageType.INT_MEMBER, "uint16_t"),
-                    (READ_GEN, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),
+                    (SKIP, "name2", StorageType.STRING_MEMBER, "char[name2_length]"),
                 ])
 
         return data_format

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -83,8 +83,20 @@ class Tech(GenieStructure):
         data_format.extend([
             # unit id, where the tech will appear to be researched
             (READ_GEN, "research_location_id", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint16_t"),
-            (READ_GEN, "language_dll_description", StorageType.ID_MEMBER, "uint16_t"),
+        ])
+
+        if game_version.edition.game_id == "AOE2DE":
+            data_format.extend([
+                (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint32_t"),
+                (READ_GEN, "language_dll_description", StorageType.ID_MEMBER, "uint32_t"),
+            ])
+        else:
+            data_format.extend([
+                (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint16_t"),
+                (READ_GEN, "language_dll_description", StorageType.ID_MEMBER, "uint16_t"),
+            ])
+
+        data_format.extend([
             # time in seconds that are needed to finish this research
             (READ_GEN, "research_time", StorageType.INT_MEMBER, "int16_t"),
             # techage id that actually contains the research effect information

--- a/openage/convert/value_object/read/media/datfile/research.py
+++ b/openage/convert/value_object/read/media/datfile/research.py
@@ -42,6 +42,8 @@ class TechResourceCost(GenieStructure):
 
 class Tech(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -32,7 +32,7 @@ class SoundItem(GenieStructure):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ])
         elif game_version.edition.game_id == "SWGB":
             data_format.extend([

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ_GEN, READ, SKIP
 from ....read.read_members import SubdataMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/sound.py
+++ b/openage/convert/value_object/read/media/datfile/sound.py
@@ -59,6 +59,8 @@ class SoundItem(GenieStructure):
 
 class Sound(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import SubdataMember, EnumLookupMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -56,12 +56,12 @@ class EffectBundle(GenieStructure):  # also called techage in some other tools
             data_format = [
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ]
         else:
             data_format = [
                 # always CHUN4 (change unit 4-arg) in AoE1-AoC, later versions name them
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[31]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[31]"),
             ]
 
         data_format.extend([

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -98,6 +98,8 @@ class OtherConnection(GenieStructure):
 
 class AgeTechTree(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,
@@ -196,6 +198,8 @@ class AgeTechTree(GenieStructure):
 
 class BuildingConnection(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,
@@ -286,6 +290,8 @@ class BuildingConnection(GenieStructure):
 
 class UnitConnection(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,
@@ -364,6 +370,8 @@ class UnitConnection(GenieStructure):
 
 
 class ResearchConnection(GenieStructure):
+
+    dynamic_load = True
 
     @classmethod
     def get_data_format_members(

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -131,6 +131,8 @@ class TerrainAnimation(GenieStructure):
 
 class Terrain(GenieStructure):
 
+    dynamic_load = True
+
     @classmethod
     def get_data_format_members(
         cls,
@@ -292,6 +294,8 @@ class Terrain(GenieStructure):
 
 
 class TerrainBorder(GenieStructure):
+
+    dynamic_load = True
 
     @classmethod
     def get_data_format_members(

--- a/openage/convert/value_object/read/media/datfile/terrain.py
+++ b/openage/convert/value_object/read/media/datfile/terrain.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import ArrayMember, SubdataMember, IncludeMembers
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -48,7 +48,7 @@ class UnitCommand(GenieStructure):
             )),
             (READ_GEN, "class_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "unit_id", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "terrain_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "terrain_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "resource_in", StorageType.INT_MEMBER, "int16_t"),        # carry resource
             # resource that multiplies the amount you can gather
             (READ_GEN, "resource_multiplier", StorageType.INT_MEMBER, "int16_t"),
@@ -56,22 +56,22 @@ class UnitCommand(GenieStructure):
             (SKIP, "unused_resource", StorageType.INT_MEMBER, "int16_t"),
             (READ_GEN, "work_value1", StorageType.FLOAT_MEMBER, "float"),        # quantity
             (READ_GEN, "work_value2", StorageType.FLOAT_MEMBER, "float"),        # execution radius?
-            (READ_GEN, "work_range", StorageType.FLOAT_MEMBER, "float"),
-            (READ_GEN, "search_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "search_time", StorageType.FLOAT_MEMBER, "float"),
-            (READ_GEN, "enable_targeting", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "combat_level_flag", StorageType.ID_MEMBER, "int8_t"),
-            (READ_GEN, "gather_type", StorageType.INT_MEMBER, "int16_t"),
-            (READ, "work_mode2", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "owner_type", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "work_range", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "search_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "search_time", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "enable_targeting", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "combat_level_flag", StorageType.ID_MEMBER, "int8_t"),
+            (SKIP, "gather_type", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "work_mode2", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "owner_type", StorageType.ID_MEMBER, EnumLookupMember(
                 # what can be selected as a target for the unit command?
                 raw_type="int8_t",
                 type_name="selection_type",
                 lookup_dict=OWNER_TYPE
             )),
             # checks if the targeted unit has > 0 resources
-            (READ_GEN, "carry_check", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "state_build", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "carry_check", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "state_build", StorageType.BOOLEAN_MEMBER, "int8_t"),
             # walking with tool but no resource
             (READ_GEN, "move_sprite_id", StorageType.ID_MEMBER, "int16_t"),
             # proceeding resource gathering or attack
@@ -132,7 +132,7 @@ class UnitLine(GenieStructure):
         data_format = [
             (READ_GEN, "id", StorageType.ID_MEMBER, "int16_t"),
             (READ, "name_length", StorageType.INT_MEMBER, "uint16_t"),
-            (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
+            (SKIP, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             (READ, "unit_ids_count", StorageType.INT_MEMBER, "uint16_t"),
             (READ_GEN, "unit_ids", StorageType.ARRAY_ID, "int16_t[unit_ids_count]"),
         ]
@@ -153,7 +153,7 @@ class ResourceStorage(GenieStructure):
         data_format = [
             (READ_GEN, "type", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "amount", StorageType.FLOAT_MEMBER, "float"),
-            (READ_GEN, "used_mode", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "used_mode", StorageType.ID_MEMBER, EnumLookupMember(
                 raw_type="int8_t",
                 type_name="resource_handling",
                 lookup_dict=RESOURCE_HANDLING
@@ -178,7 +178,7 @@ class DamageGraphic(GenieStructure):
             (READ_GEN, "damage_percent", StorageType.INT_MEMBER, "int8_t"),
             # gets overwritten in aoe memory by the real apply_mode:
             (SKIP, "old_apply_mode", StorageType.ID_MEMBER, "int8_t"),
-            (READ_GEN, "apply_mode", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "apply_mode", StorageType.ID_MEMBER, EnumLookupMember(
                 raw_type="int8_t",
                 type_name="damage_draw_type",
                 lookup_dict=DAMAGE_DRAW_TYPE
@@ -244,9 +244,9 @@ class BuildingAnnex(GenieStructure):
         Return the members in this struct.
         """
         data_format = [
-            (READ_GEN, "unit_id", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "misplaced0", StorageType.FLOAT_MEMBER, "float"),
-            (READ_GEN, "misplaced1", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "unit_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "misplaced0", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "misplaced1", StorageType.FLOAT_MEMBER, "float"),
         ]
 
         return data_format
@@ -279,12 +279,12 @@ class UnitObject(GenieStructure):
         if game_version.edition.game_id == "AOE2DE":
             data_format.extend([
                 (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint32_t"),
-                (READ_GEN, "language_dll_creation", StorageType.ID_MEMBER, "uint32_t"),
+                (SKIP, "language_dll_creation", StorageType.ID_MEMBER, "uint32_t"),
             ])
         else:
             data_format.extend([
                 (READ_GEN, "language_dll_name", StorageType.ID_MEMBER, "uint16_t"),
-                (READ_GEN, "language_dll_creation", StorageType.ID_MEMBER, "uint16_t"),
+                (SKIP, "language_dll_creation", StorageType.ID_MEMBER, "uint16_t"),
             ])
 
         data_format.extend([
@@ -298,14 +298,14 @@ class UnitObject(GenieStructure):
 
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
-                (READ_GEN, "idle_graphic1", StorageType.ID_MEMBER, "int16_t"),
+                (SKIP, "idle_graphic1", StorageType.ID_MEMBER, "int16_t"),
             ])
 
         data_format.extend([
             (READ_GEN, "dying_graphic", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "undead_graphic", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "undead_graphic", StorageType.ID_MEMBER, "int16_t"),
             # 1 = become `dead_unit_id` (reviving does not make it usable again)
-            (READ_GEN, "death_mode", StorageType.ID_MEMBER, "int8_t"),
+            (SKIP, "death_mode", StorageType.ID_MEMBER, "int8_t"),
             # unit health. -1=insta-die
             (READ_GEN, "hit_points", StorageType.INT_MEMBER, "int16_t"),
             (READ_GEN, "line_of_sight", StorageType.FLOAT_MEMBER, "float"),
@@ -333,10 +333,10 @@ class UnitObject(GenieStructure):
 
         data_format.extend([
             # 0=placable on top of others in scenario editor, 5=can't
-            (READ_GEN, "placement_mode", StorageType.ID_MEMBER, "int8_t"),
-            (READ_GEN, "can_be_built_on", StorageType.BOOLEAN_MEMBER, "int8_t"),  # 1=no footprints
+            (SKIP, "placement_mode", StorageType.ID_MEMBER, "int8_t"),
+            (SKIP, "can_be_built_on", StorageType.BOOLEAN_MEMBER, "int8_t"),  # 1=no footprints
             # frame id of the icon slp (57029) to place on the creation button
-            (READ_GEN, "icon_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "icon_id", StorageType.ID_MEMBER, "int16_t"),
             (SKIP, "hidden_in_editor", StorageType.BOOLEAN_MEMBER, "int8_t"),
             (SKIP, "old_portrait_icon_id", StorageType.ID_MEMBER, "int16_t"),
             # 0=unlocked by research, 1=insta-available
@@ -349,12 +349,12 @@ class UnitObject(GenieStructure):
         data_format.extend([
             # terrain id that's needed somewhere on the foundation (e.g. dock
             # water)
-            (READ_GEN, "placement_side_terrain0", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "placement_side_terrain1", StorageType.ID_MEMBER, "int16_t"),    # second slot for ^
+            (SKIP, "placement_side_terrain0", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "placement_side_terrain1", StorageType.ID_MEMBER, "int16_t"),    # second slot for ^
             # terrain needed for placement (e.g. dock: water)
-            (READ_GEN, "placement_terrain0", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "placement_terrain0", StorageType.ID_MEMBER, "int16_t"),
             # alternative terrain needed for placement (e.g. dock: shallows)
-            (READ_GEN, "placement_terrain1", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "placement_terrain1", StorageType.ID_MEMBER, "int16_t"),
             # minimum space required to allow placement in editor
             (READ_GEN, "clearance_size_x", StorageType.FLOAT_MEMBER, "float"),
             (READ_GEN, "clearance_size_y", StorageType.FLOAT_MEMBER, "float"),
@@ -386,7 +386,7 @@ class UnitObject(GenieStructure):
                 type_name="blast_types",
                 lookup_dict=BLAST_DEFENSE_TYPES
             )),
-            (READ_GEN, "combat_level", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "combat_level", StorageType.ID_MEMBER, EnumLookupMember(
                 raw_type="int8_t",
                 type_name="combat_levels",
                 lookup_dict=COMBAT_LEVELS
@@ -397,30 +397,30 @@ class UnitObject(GenieStructure):
                 type_name="interaction_modes",
                 lookup_dict=INTERACTION_MODES
             )),
-            (READ_GEN, "map_draw_level", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "map_draw_level", StorageType.ID_MEMBER, EnumLookupMember(
                 # how does the unit show up on the minimap?
                 raw_type="int8_t",
                 type_name="minimap_modes",
                 lookup_dict=MINIMAP_MODES
             )),
-            (READ_GEN, "unit_level", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "unit_level", StorageType.ID_MEMBER, EnumLookupMember(
                 # selects the available ui command buttons for the unit
                 raw_type="int8_t",
                 type_name="command_attributes",
                 lookup_dict=UNIT_LEVELS
             )),
-            (READ_GEN, "attack_reaction", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "attack_reaction", StorageType.FLOAT_MEMBER, "float"),
             # palette color id for the minimap
-            (READ_GEN, "minimap_color", StorageType.ID_MEMBER, "int8_t"),
+            (SKIP, "minimap_color", StorageType.ID_MEMBER, "int8_t"),
             # help text for this unit, stored in the translation dll.
-            (READ_GEN, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),
-            (READ_GEN, "language_dll_hotkey_text", StorageType.ID_MEMBER, "int32_t"),
+            (SKIP, "language_dll_help", StorageType.ID_MEMBER, "int32_t"),
+            (SKIP, "language_dll_hotkey_text", StorageType.ID_MEMBER, "int32_t"),
             # language dll dependent (kezb lazouts!)
-            (READ_GEN, "hot_keys", StorageType.ID_MEMBER, "int32_t"),
+            (SKIP, "hot_keys", StorageType.ID_MEMBER, "int32_t"),
             (SKIP, "recyclable", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "enable_auto_gather", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "doppelgaenger_on_death", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "resource_gather_drop", StorageType.INT_MEMBER, "int8_t"),
+            (SKIP, "enable_auto_gather", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "doppelgaenger_on_death", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "resource_gather_drop", StorageType.INT_MEMBER, "int8_t"),
         ])
 
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
@@ -429,7 +429,7 @@ class UnitObject(GenieStructure):
             # val == {-1, 7}: in open area mask is partially displayed
             # val == {6, 10}: building, causes mask to appear on units behind it
             data_format.extend([
-                (READ_GEN, "occlusion_mode", StorageType.ID_MEMBER, "uint8_t"),
+                (SKIP, "occlusion_mode", StorageType.ID_MEMBER, "uint8_t"),
                 (READ_GEN, "obstruction_type", StorageType.ID_MEMBER, EnumLookupMember(
                     raw_type="int8_t",
                     type_name="obstruction_types",
@@ -462,7 +462,7 @@ class UnitObject(GenieStructure):
             ])
 
         data_format.extend([
-            (READ_GEN, "selection_effect", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "selection_effect", StorageType.ID_MEMBER, EnumLookupMember(
                 # things that happen when the unit was selected
                 raw_type="int8_t",
                 type_name="selection_effects",
@@ -518,12 +518,12 @@ class UnitObject(GenieStructure):
             data_format.extend([
                 (SKIP, "name_len_debug", StorageType.INT_MEMBER, "uint16_t"),
                 (READ, "name_len", StorageType.INT_MEMBER, "uint16_t"),
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_len]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_len]"),
             ])
 
         else:
             data_format.extend([
-                (READ_GEN, "name", StorageType.STRING_MEMBER, "char[name_length]"),
+                (SKIP, "name", StorageType.STRING_MEMBER, "char[name_length]"),
             ])
 
             if game_version.edition.game_id == "SWGB":
@@ -534,10 +534,10 @@ class UnitObject(GenieStructure):
                     (READ_GEN, "min_tech_level", StorageType.ID_MEMBER, "int8_t"),
                 ])
 
-        data_format.append((READ_GEN, "id1", StorageType.ID_MEMBER, "int16_t"))
+        data_format.append((SKIP, "id1", StorageType.ID_MEMBER, "int16_t"))
 
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
-            data_format.append((READ_GEN, "id2", StorageType.ID_MEMBER, "int16_t"))
+            data_format.append((SKIP, "id2", StorageType.ID_MEMBER, "int16_t"))
         elif game_version.edition.game_id == "AOE1DE":
             data_format.append((READ_GEN, "telemetry_id", StorageType.ID_MEMBER, "int16_t"))
 
@@ -623,26 +623,26 @@ class MovingUnit(DoppelgangerUnit):
         data_format = [
             (READ_GEN, None, None, IncludeMembers(cls=DoppelgangerUnit)),
             (READ_GEN, "move_graphics", StorageType.ID_MEMBER, "int16_t"),
-            (READ_GEN, "run_graphics", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "run_graphics", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "turn_speed", StorageType.FLOAT_MEMBER, "float"),
             (SKIP, "old_size_class", StorageType.ID_MEMBER, "int8_t"),
             # unit id for the ground traces
-            (READ_GEN, "trail_unit_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "trail_unit_id", StorageType.ID_MEMBER, "int16_t"),
             # ground traces: -1: no tracking present, 2: projectiles with tracking unit
-            (READ_GEN, "trail_opsions", StorageType.ID_MEMBER, "uint8_t"),
+            (SKIP, "trail_opsions", StorageType.ID_MEMBER, "uint8_t"),
             # ground trace spacing: 0: no tracking, 0.5: trade cart, 0.12: some
             # projectiles, 0.4: other projectiles
-            (READ_GEN, "trail_spacing", StorageType.FLOAT_MEMBER, "float"),
+            (SKIP, "trail_spacing", StorageType.FLOAT_MEMBER, "float"),
             (SKIP, "old_move_algorithm", StorageType.ID_MEMBER, "int8_t"),
         ]
 
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
-                (READ_GEN, "turn_radius", StorageType.FLOAT_MEMBER, "float"),
-                (READ_GEN, "turn_radius_speed", StorageType.FLOAT_MEMBER, "float"),
+                (SKIP, "turn_radius", StorageType.FLOAT_MEMBER, "float"),
+                (SKIP, "turn_radius_speed", StorageType.FLOAT_MEMBER, "float"),
                 (READ_GEN, "max_yaw_per_sec_moving", StorageType.FLOAT_MEMBER, "float"),
-                (READ_GEN, "stationary_yaw_revolution_time", StorageType.FLOAT_MEMBER, "float"),
-                (READ_GEN, "max_yaw_per_sec_stationary", StorageType.FLOAT_MEMBER, "float"),
+                (SKIP, "stationary_yaw_revolution_time", StorageType.FLOAT_MEMBER, "float"),
+                (SKIP, "max_yaw_per_sec_stationary", StorageType.FLOAT_MEMBER, "float"),
             ])
 
             if game_version.edition.game_id == "AOE2DE":
@@ -673,7 +673,7 @@ class ActionUnit(MovingUnit):
             # monument and sheep: 107 = enemy convert.
             # all auto-convertible units: 0, most other units: -1
             # e.g. when sheep are discovered
-            (READ_GEN, "default_task_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "default_task_id", StorageType.ID_MEMBER, "int16_t"),
             (READ_GEN, "search_radius", StorageType.FLOAT_MEMBER, "float"),
             (READ_GEN, "work_rate", StorageType.FLOAT_MEMBER, "float"),
         ]
@@ -699,7 +699,7 @@ class ActionUnit(MovingUnit):
             # sound played when a command is instanciated
             (READ_GEN, "command_sound_id", StorageType.ID_MEMBER, "int16_t"),
             # sound when the command is done (e.g. unit stops at target position)
-            (READ_GEN, "stop_sound_id", StorageType.ID_MEMBER, "int16_t"),
+            (SKIP, "stop_sound_id", StorageType.ID_MEMBER, "int16_t"),
         ])
 
         if game_version.edition.game_id == "AOE2DE":
@@ -744,9 +744,9 @@ class ProjectileUnit(ActionUnit):
         ]
 
         if game_version.edition.game_id == "ROR":
-            data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "uint8_t"))
+            data_format.append((SKIP, "default_armor", StorageType.INT_MEMBER, "uint8_t"))
         else:
-            data_format.append((READ_GEN, "default_armor", StorageType.INT_MEMBER, "int16_t"))
+            data_format.append((SKIP, "default_armor", StorageType.INT_MEMBER, "int16_t"))
 
         data_format.extend([
             (READ, "attack_count", StorageType.INT_MEMBER, "uint16_t"),
@@ -759,7 +759,7 @@ class ProjectileUnit(ActionUnit):
                 ref_type=HitType,
                 length="armor_count",
             )),
-            (READ_GEN, "boundary_id", StorageType.ID_MEMBER, EnumLookupMember(
+            (SKIP, "boundary_id", StorageType.ID_MEMBER, EnumLookupMember(
                 # the damage received by this unit is multiplied by
                 # the accessible values on the specified terrain restriction
                 raw_type="int16_t",
@@ -777,7 +777,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, "blast_range", StorageType.FLOAT_MEMBER, "float"),
             (READ_GEN, "attack_speed", StorageType.FLOAT_MEMBER, "float"),  # = "reload time"
             # which projectile to use?
-            (READ_GEN, "attack_projectile_primary_unit_id", StorageType.ID_MEMBER, "int16_t"),
+            (READ_GEN, "projectile_id0", StorageType.ID_MEMBER, "int16_t"),
             # probablity of attack hit in percent
             (READ_GEN, "accuracy", StorageType.INT_MEMBER, "int16_t"),
             # = tower mode?; not used anywhere
@@ -905,7 +905,7 @@ class LivingUnit(ProjectileUnit):
                 )),
                 # if building: "others" tab in editor, if living unit: "heroes" tab,
                 # regenerate health + monk immunity
-                (READ_GEN, "hero_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
+                (SKIP, "hero_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
                 # graphic to display when units are garrisoned
                 (READ_GEN, "garrison_graphic", StorageType.ID_MEMBER, "int32_t"),
                 # projectile count when nothing garrisoned, including both normal and
@@ -924,20 +924,20 @@ class LivingUnit(ProjectileUnit):
                 ])
 
             data_format.extend([
-                (READ_GEN, "attack_projectile_count", StorageType.INT_MEMBER, "float"),
+                (READ_GEN, "projectile_min_count", StorageType.INT_MEMBER, "float"),
                 # total projectiles when fully garrisoned
-                (READ_GEN, "attack_projectile_max_count", StorageType.INT_MEMBER, "int8_t"),
-                (READ_GEN, "attack_projectile_spawning_area_width", StorageType.FLOAT_MEMBER, "float"),
-                (READ_GEN, "attack_projectile_spawning_area_length", StorageType.FLOAT_MEMBER, "float"),
+                (READ_GEN, "projectile_max_count", StorageType.INT_MEMBER, "int8_t"),
+                (READ_GEN, "projectile_spawning_area_width", StorageType.FLOAT_MEMBER, "float"),
+                (READ_GEN, "projectile_spawning_area_length", StorageType.FLOAT_MEMBER, "float"),
                 # placement randomness, 0=from single spot, 1=random, 1<less random
-                (READ_GEN, "attack_projectile_spawning_area_randomness", StorageType.FLOAT_MEMBER, "float"),
+                (READ_GEN, "projectile_spawning_area_randomness", StorageType.FLOAT_MEMBER, "float"),
                 # uses its own attack values
-                (READ_GEN, "attack_projectile_secondary_unit_id", StorageType.ID_MEMBER, "int32_t"),
+                (READ_GEN, "projectile_id1", StorageType.ID_MEMBER, "int32_t"),
                 # used just before unit reaches its target enemy, configuration:
-                (READ_GEN, "special_graphic_id", StorageType.ID_MEMBER, "int32_t"),
+                (SKIP, "special_graphic_id", StorageType.ID_MEMBER, "int32_t"),
                 # determines adjacent unit graphics, if 1: building can adapt graphics
                 # by adjacent buildings
-                (READ_GEN, "special_activation", StorageType.ID_MEMBER, "int8_t"),
+                (SKIP, "special_activation", StorageType.ID_MEMBER, "int8_t"),
                 # 0: default: only works when facing the hit angle.
                 # 1: block: activates special graphic when receiving damage and not pursuing the attacker.
                 # while idle, blocking decreases damage taken by 1/3.
@@ -975,7 +975,7 @@ class BuildingUnit(LivingUnit):
         ]
 
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
-            data_format.append((READ_GEN, "snow_graphic_id", StorageType.ID_MEMBER, "int16_t"))
+            data_format.append((SKIP, "snow_graphic_id", StorageType.ID_MEMBER, "int16_t"))
 
             if game_version.edition.game_id == "AOE2DE":
                 data_format.extend([
@@ -987,9 +987,9 @@ class BuildingUnit(LivingUnit):
 
         data_format.extend([
             # 1=adjacent units may change the graphics
-            (READ_GEN, "adjacent_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
-            (READ_GEN, "graphics_angle", StorageType.INT_MEMBER, "int16_t"),
-            (READ_GEN, "disappears_when_built", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "adjacent_mode", StorageType.BOOLEAN_MEMBER, "int8_t"),
+            (SKIP, "graphics_angle", StorageType.INT_MEMBER, "int16_t"),
+            (SKIP, "disappears_when_built", StorageType.BOOLEAN_MEMBER, "int8_t"),
             # second building to place directly on top
             (READ_GEN, "stack_unit_id", StorageType.ID_MEMBER, "int16_t"),
             # change underlying terrain to this id when building completed
@@ -1004,7 +1004,7 @@ class BuildingUnit(LivingUnit):
         if game_version.edition.game_id not in ("ROR", "AOE1DE"):
             data_format.extend([
                 (SKIP, "can_burn", StorageType.BOOLEAN_MEMBER, "int8_t"),
-                (READ_GEN, "building_annex", StorageType.ARRAY_CONTAINER, SubdataMember(
+                (SKIP, "building_annex", StorageType.ARRAY_CONTAINER, SubdataMember(
                     ref_type=BuildingAnnex,
                     length=4
                 )),

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing
 
 
-from .....entity_object.conversion.genie_structure import GenieStructure
+from ...genie_structure import GenieStructure
 from ....read.member_access import READ, READ_GEN, SKIP
 from ....read.read_members import EnumLookupMember, ContinueReadMember, IncludeMembers, SubdataMember
 from ....read.value_members import StorageType

--- a/openage/convert/value_object/read/media/datfile/unit.py
+++ b/openage/convert/value_object/read/media/datfile/unit.py
@@ -788,7 +788,7 @@ class ProjectileUnit(ActionUnit):
             (READ_GEN, "weapon_offset", StorageType.ARRAY_FLOAT, "float[3]"),
             (READ_GEN, "blast_level_offence", StorageType.ID_MEMBER, EnumLookupMember(
                 # blasts damage units that have higher or same blast_defense_level
-                raw_type="int8_t",
+                raw_type="uint8_t",
                 type_name="range_damage_type",
                 lookup_dict=BLAST_OFFENSE_TYPES
             )),

--- a/openage/convert/value_object/read/read_members.py
+++ b/openage/convert/value_object/read/read_members.py
@@ -9,7 +9,7 @@ from enum import Enum
 
 
 if typing.TYPE_CHECKING:
-    from openage.convert.entity_object.conversion.genie_structure import GenieStructure
+    from openage.convert.value_object.read.genie_structure import GenieStructure
     from openage.convert.value_object.read.member_access import MemberAccess
     from openage.convert.value_object.read.value_members import StorageType
 

--- a/openage/convert/value_object/read/value_members.py
+++ b/openage/convert/value_object/read/value_members.py
@@ -537,18 +537,20 @@ class NoDiffMember(ValueMember):
 
         self._value = value
 
-    def get_reference(self) -> ValueMember:
+    @property
+    def ref(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
-        return self.value
+        return self._value
 
-    def get_value(self) -> typing.NoReturn:
+    @property
+    def value(self) -> typing.Any:
         """
         Returns the value of a member.
         """
         raise NotImplementedError(
-            f"{type(self)} cannot have values; use get_reference() instead")
+            f"{type(self)} cannot have values; use 'ref' instead")
 
     def get_type(self) -> typing.NoReturn:
         """
@@ -584,18 +586,20 @@ class LeftMissingMember(ValueMember):
 
         self._value = value
 
-    def get_reference(self) -> ValueMember:
+    @property
+    def ref(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
         return self._value
 
-    def get_value(self) -> typing.NoReturn:
+    @property
+    def value(self) -> typing.Any:
         """
         Returns the value of a member.
         """
         raise NotImplementedError(
-            f"{type(self)} cannot have values; use get_reference() instead")
+            f"{type(self)} cannot have values; use 'ref' instead")
 
     def get_type(self) -> typing.NoReturn:
         """
@@ -631,18 +635,20 @@ class RightMissingMember(ValueMember):
 
         self._value = value
 
-    def get_reference(self) -> ValueMember:
+    @property
+    def ref(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
         return self._value
 
-    def get_value(self) -> typing.NoReturn:
+    @property
+    def value(self) -> typing.Any:
         """
         Returns the value of a member.
         """
         raise NotImplementedError(
-            f"{type(self)} cannot have values; use get_reference() instead")
+            f"{type(self)} cannot have values; use 'ref' instead")
 
     def get_type(self) -> typing.NoReturn:
         """

--- a/openage/convert/value_object/read/value_members.py
+++ b/openage/convert/value_object/read/value_members.py
@@ -29,6 +29,8 @@ from enum import Enum
 from math import isclose
 from abc import ABC, abstractmethod
 
+from .dynamic_loader import DynamicLoader
+
 
 class ValueMember(ABC):
     """
@@ -302,12 +304,13 @@ class ContainerMember(ValueMember):
 
         self._value = {}
 
-        # submembers is a list of members
-        if not isinstance(submembers, dict):
-            self._create_dict(submembers)
+        if isinstance(submembers, (dict, DynamicLoader)):
+            # submembers is a list or loads dynamically
+            self._value = submembers
 
         else:
-            self._value = submembers
+            # submembers is a list of members
+            self._create_dict(submembers)
 
     def get_type(self) -> StorageType:
         return StorageType.CONTAINER_MEMBER

--- a/openage/convert/value_object/read/value_members.py
+++ b/openage/convert/value_object/read/value_members.py
@@ -27,39 +27,41 @@ import typing
 
 from enum import Enum
 from math import isclose
+from abc import ABC, abstractmethod
 
 
-class ValueMember:
+class ValueMember(ABC):
     """
     Stores a value member from a data file.
     """
 
-    __slots__ = ('name', 'value')
+    __slots__ = ('_name', '_value')
 
     def __init__(self, name: str):
-        self.name = name
-        self.value = None
+        self._name = name
+        self._value = None
 
-    def get_name(self) -> str:
+    @property
+    def name(self) -> str:
         """
         Returns the name of the member.
         """
-        return self.name
+        return self._name
 
-    def get_value(self) -> typing.Any:
+    @property
+    def value(self) -> typing.Any:
         """
         Returns the value of a member.
         """
-        raise NotImplementedError(
-            f"{type(self)} cannot have values")
+        return self._value
 
+    @abstractmethod
     def get_type(self) -> StorageType:
         """
         Returns the type of a member.
         """
-        raise NotImplementedError(
-            f"{type(self)} cannot have a type")
 
+    @abstractmethod
     def diff(self, other: ValueMember) -> ValueMember:
         """
         Returns a new member object that contains the diff between
@@ -67,12 +69,9 @@ class ValueMember:
 
         If they are equal, return a NoDiffMember.
         """
-        raise NotImplementedError(
-            f"{type(self)} has no diff implemented")
 
     def __repr__(self):
-        raise NotImplementedError(
-            f"return short description of the member type {type(self)}")
+        return f"{self.__class__.__name__}<{self.name}>"
 
 
 class IntMember(ValueMember):
@@ -83,10 +82,7 @@ class IntMember(ValueMember):
     def __init__(self, name: str, value: typing.Union[int, float]):
         super().__init__(name)
 
-        self.value = int(value)
-
-    def get_value(self) -> int:
-        return self.value
+        self._value = int(value)
 
     def get_type(self) -> StorageType:
         return StorageType.INT_MEMBER
@@ -97,20 +93,17 @@ class IntMember(ValueMember):
     ) -> typing.Union[NoDiffMember, IntMember]:
         if self.get_type() is other.get_type():
 
-            if self.get_value() == other.get_value():
+            if self.value == other.value:
                 return NoDiffMember(self.name, self)
 
             else:
-                diff_value = other.get_value() - self.get_value()
+                diff_value = other.value - self.value
 
                 return IntMember(self.name, diff_value)
 
         else:
             raise Exception(
                 f"type {type(self)} member cannot be diffed with type {type(other)}")
-
-    def __repr__(self):
-        return f"IntMember<{self.name}>"
 
 
 class FloatMember(ValueMember):
@@ -121,10 +114,7 @@ class FloatMember(ValueMember):
     def __init__(self, name: str, value: typing.Union[int, float]):
         super().__init__(name)
 
-        self.value = float(value)
-
-    def get_value(self) -> float:
-        return self.value
+        self._value = float(value)
 
     def get_type(self) -> StorageType:
         return StorageType.FLOAT_MEMBER
@@ -135,20 +125,17 @@ class FloatMember(ValueMember):
     ) -> typing.Union[NoDiffMember, FloatMember]:
         if self.get_type() is other.get_type():
             # Float must have the last 6 digits in common
-            if isclose(self.get_value(), other.get_value(), rel_tol=1e-7):
+            if isclose(self.value, other.value, rel_tol=1e-7):
                 return NoDiffMember(self.name, self)
 
             else:
-                diff_value = other.get_value() - self.get_value()
+                diff_value = other.value - self.value
 
                 return FloatMember(self.name, diff_value)
 
         else:
             raise Exception(
                 f"type {type(self)} member cannot be diffed with type {type(other)}")
-
-    def __repr__(self):
-        return f"FloatMember<{self.name}>"
 
 
 class BooleanMember(ValueMember):
@@ -159,10 +146,7 @@ class BooleanMember(ValueMember):
     def __init__(self, name: str, value: bool):
         super().__init__(name)
 
-        self.value = bool(value)
-
-    def get_value(self) -> bool:
-        return self.value
+        self._value = bool(value)
 
     def get_type(self) -> StorageType:
         return StorageType.BOOLEAN_MEMBER
@@ -172,18 +156,15 @@ class BooleanMember(ValueMember):
         other: BooleanMember
     ) -> typing.Union[NoDiffMember, BooleanMember]:
         if self.get_type() is other.get_type():
-            if self.get_value() == other.get_value():
+            if self.value == other.value:
                 return NoDiffMember(self.name, self)
 
             else:
-                return BooleanMember(self.name, other.get_value())
+                return BooleanMember(self.name, other.value)
 
         else:
             raise Exception(
                 f"type {type(self)} member cannot be diffed with type {type(other)}")
-
-    def __repr__(self):
-        return f"BooleanMember<{self.name}>"
 
 
 class IDMember(ValueMember):
@@ -194,10 +175,7 @@ class IDMember(ValueMember):
     def __init__(self, name: str, value: int):
         super().__init__(name)
 
-        self.value = int(value)
-
-    def get_value(self) -> int:
-        return self.value
+        self._value = int(value)
 
     def get_type(self) -> StorageType:
         return StorageType.ID_MEMBER
@@ -207,18 +185,15 @@ class IDMember(ValueMember):
         other: IDMember
     ) -> typing.Union[NoDiffMember, IDMember]:
         if self.get_type() is other.get_type():
-            if self.get_value() == other.get_value():
+            if self.value == other.value:
                 return NoDiffMember(self.name, self)
 
             else:
-                return IDMember(self.name, other.get_value())
+                return IDMember(self.name, other.value)
 
         else:
             raise Exception(
                 f"type {type(self)} member cannot be diffed with type {type(other)}")
-
-    def __repr__(self):
-        return f"IDMember<{self.name}>"
 
 
 class BitfieldMember(ValueMember):
@@ -229,10 +204,7 @@ class BitfieldMember(ValueMember):
     def __init__(self, name: str, value: int):
         super().__init__(name)
 
-        self.value = value
-
-    def get_value(self) -> int:
-        return self.value
+        self._value = value
 
     def get_value_at_pos(self, pos: int) -> bool:
         """
@@ -255,11 +227,11 @@ class BitfieldMember(ValueMember):
         Uses XOR to determine which bits are different in 'other'.
         """
         if self.get_type() is other.get_type():
-            if self.get_value() == other.get_value():
+            if self.value == other.value:
                 return NoDiffMember(self.name, self)
 
             else:
-                difference = self.value ^ other.get_value()
+                difference = self.value ^ other.value
                 return BitfieldMember(self.name, difference)
 
         else:
@@ -268,9 +240,6 @@ class BitfieldMember(ValueMember):
 
     def __len__(self):
         return len(self.value)
-
-    def __repr__(self):
-        return f"BitfieldMember<{self.name}>"
 
 
 class StringMember(ValueMember):
@@ -281,10 +250,7 @@ class StringMember(ValueMember):
     def __init__(self, name: str, value: StringMember):
         super().__init__(name)
 
-        self.value = str(value)
-
-    def get_value(self) -> str:
-        return self.value
+        self._value = str(value)
 
     def get_type(self) -> StorageType:
         return StorageType.STRING_MEMBER
@@ -294,11 +260,11 @@ class StringMember(ValueMember):
         other: StringMember
     ) -> typing.Union[NoDiffMember, StringMember]:
         if self.get_type() is other.get_type():
-            if self.get_value() == other.get_value():
+            if self.value == other.value:
                 return NoDiffMember(self.name, self)
 
             else:
-                return StringMember(self.name, other.get_value())
+                return StringMember(self.name, other.value)
 
         else:
             raise Exception(
@@ -306,9 +272,6 @@ class StringMember(ValueMember):
 
     def __len__(self):
         return len(self.value)
-
-    def __repr__(self):
-        return f"StringMember<{self.name}>"
 
 
 class ContainerMember(ValueMember):
@@ -337,24 +300,14 @@ class ContainerMember(ValueMember):
         """
         super().__init__(name)
 
-        self.value = {}
+        self._value = {}
 
         # submembers is a list of members
         if not isinstance(submembers, dict):
             self._create_dict(submembers)
 
         else:
-            self.value = submembers
-
-    def get_value(self) -> dict[str, typing.Union[IntMember,
-                                                  FloatMember,
-                                                  BooleanMember,
-                                                  IDMember,
-                                                  BitfieldMember,
-                                                  StringMember,
-                                                  ArrayMember,
-                                                  ContainerMember]]:
-        return self.value
+            self._value = submembers
 
     def get_type(self) -> StorageType:
         return StorageType.CONTAINER_MEMBER
@@ -366,7 +319,7 @@ class ContainerMember(ValueMember):
         if self.get_type() is other.get_type():
             diff_dict = {}
 
-            other_dict = other.get_value()
+            other_dict = other.value
 
             for key in self.value.keys():
                 if key in other.value.keys():
@@ -405,21 +358,16 @@ class ContainerMember(ValueMember):
         Creates the dict from the member list passed to __init__.
         """
         for member in member_list:
-            key = member.get_name()
-
-            self.value.update({key: member})
+            self._value.update({member.name: member})
 
     def __getitem__(self, key):
         """
         Short command for getting a member in the container.
         """
-        return self.get_value()[key]
+        return self.value[key]
 
     def __len__(self):
         return len(self.value)
-
-    def __repr__(self):
-        return f"ContainerMember<{self.name}>"
 
 
 class ArrayMember(ValueMember):
@@ -444,7 +392,7 @@ class ArrayMember(ValueMember):
     ):
         super().__init__(name)
 
-        self.value = members
+        self._value = members
 
         self._allowed_member_type = allowed_member_type
 
@@ -454,16 +402,6 @@ class ArrayMember(ValueMember):
                 if member.get_type() is not self._allowed_member_type:
                     raise Exception("%s has type %s, but this ArrayMember only allows %s"
                                     % (member, member.get_type(), allowed_member_type))
-
-    def get_value(self) -> list[typing.Union[IntMember,
-                                             FloatMember,
-                                             BooleanMember,
-                                             IDMember,
-                                             BitfieldMember,
-                                             StringMember,
-                                             ArrayMember,
-                                             ContainerMember]]:
-        return self.value
 
     def get_type(self) -> StorageType:
         if self._allowed_member_type is StorageType.INT_MEMBER:
@@ -515,14 +453,14 @@ class ArrayMember(ValueMember):
 
         member_dict = {}
         for container in self.value:
-            if key_member_name not in container.get_value().keys():
+            if key_member_name not in container.value.keys():
                 if force_not_found:
                     continue
 
                 raise Exception("%s: Container %s has no member called %s"
                                 % (self, container, key_member_name))
 
-            key_member_value = container[key_member_name].get_value()
+            key_member_value = container[key_member_name].value
 
             if key_member_value in member_dict.keys():
                 if force_duplicate:
@@ -541,7 +479,7 @@ class ArrayMember(ValueMember):
     ) -> typing.Union[NoDiffMember, ArrayMember]:
         if self.get_type() == other.get_type():
             diff_list = []
-            other_list = other.get_value()
+            other_list = other.value
 
             index = 0
             if len(self) <= len(other):
@@ -579,13 +517,10 @@ class ArrayMember(ValueMember):
         """
         Short command for getting a member in the array.
         """
-        return self.get_value()[key]
+        return self.value[key]
 
     def __len__(self):
         return len(self.value)
-
-    def __repr__(self):
-        return f"ArrayMember<{self.name}>"
 
 
 class NoDiffMember(ValueMember):
@@ -600,7 +535,7 @@ class NoDiffMember(ValueMember):
         """
         super().__init__(name)
 
-        self.value = value
+        self._value = value
 
     def get_reference(self) -> ValueMember:
         """
@@ -608,8 +543,29 @@ class NoDiffMember(ValueMember):
         """
         return self.value
 
-    def __repr__(self):
-        return f"NoDiffMember<{self.name}>"
+    def get_value(self) -> typing.NoReturn:
+        """
+        Returns the value of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have values; use get_reference() instead")
+
+    def get_type(self) -> typing.NoReturn:
+        """
+        Returns the type of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have a type")
+
+    def diff(self, other: typing.Any) -> typing.NoReturn:
+        """
+        Returns a new member object that contains the diff between
+        self's and other's values.
+
+        If they are equal, return a NoDiffMember.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot be diffed")
 
 
 class LeftMissingMember(ValueMember):
@@ -626,16 +582,37 @@ class LeftMissingMember(ValueMember):
         """
         super().__init__(name)
 
-        self.value = value
+        self._value = value
 
     def get_reference(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
-        return self.value
+        return self._value
 
-    def __repr__(self):
-        return f"LeftMissingMember<{self.name}>"
+    def get_value(self) -> typing.NoReturn:
+        """
+        Returns the value of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have values; use get_reference() instead")
+
+    def get_type(self) -> typing.NoReturn:
+        """
+        Returns the type of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have a type")
+
+    def diff(self, other: typing.Any) -> typing.NoReturn:
+        """
+        Returns a new member object that contains the diff between
+        self's and other's values.
+
+        If they are equal, return a NoDiffMember.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot be diffed")
 
 
 class RightMissingMember(ValueMember):
@@ -652,16 +629,37 @@ class RightMissingMember(ValueMember):
         """
         super().__init__(name)
 
-        self.value = value
+        self._value = value
 
     def get_reference(self) -> ValueMember:
         """
         Returns the reference to the diffed object.
         """
-        return self.value
+        return self._value
 
-    def __repr__(self):
-        return f"RightMissingMember<{self.name}>"
+    def get_value(self) -> typing.NoReturn:
+        """
+        Returns the value of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have values; use get_reference() instead")
+
+    def get_type(self) -> typing.NoReturn:
+        """
+        Returns the type of a member.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot have a type")
+
+    def diff(self, other: typing.Any) -> typing.NoReturn:
+        """
+        Returns a new member object that contains the diff between
+        self's and other's values.
+
+        If they are equal, return a NoDiffMember.
+        """
+        raise NotImplementedError(
+            f"{type(self)} cannot be diffed")
 
 
 class StorageType(Enum):

--- a/openage/default_dirs.py
+++ b/openage/default_dirs.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 the openage authors. See copying.md for legal info.
+# Copyright 2017-2022 the openage authors. See copying.md for legal info.
 
 """
 
@@ -78,12 +78,10 @@ def get_dir(which):
     elif default_template:
         env_vars = {var: os.environ.get(var) for var in required_envs}
         if not all(env_vars.values()):
-            raise Exception("could not reconstruct {}, "
-                            "missing env variables: '{}'".format(
-                                which,
-                                [var for (var, val) in env_vars.items()
-                                 if val is None].join(", ")
-                            ))
+            env_var_str = ', '.join([var for (var, val) in env_vars.items()
+                                     if val is None])
+            raise Exception(f"could not reconstruct {which}, "
+                            f"missing env variables: '{env_var_str}'")
 
         path = default_template.format(**env_vars)
 

--- a/openage/nyan/CMakeLists.txt
+++ b/openage/nyan/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_py_modules(
+	__init__.py
 	import_tree.py
 	nyan_structs.py
 )

--- a/openage/nyan/__init__.py
+++ b/openage/nyan/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2022-2022 the openage authors. See copying.md for legal info.
+
+"""
+Nyan-compatible object creation and export for use with
+https://github.com/SFTtech/nyan
+"""

--- a/openage/nyan/import_tree.py
+++ b/openage/nyan/import_tree.py
@@ -94,7 +94,7 @@ class Node:
         :param name: Name of the child node.
         :type name: str
         """
-        return name in self.children.keys()
+        return name in self.children
 
     def get_child(self, name: str):
         """
@@ -153,7 +153,7 @@ class ImportTree:
             try:
                 current_node = current_node.get_child(node_str)
 
-            except KeyError as err:
+            except KeyError:  # as err:
                 # TODO: Do not silently fail
                 return
                 # raise KeyError(f"fqon '{'.'.join(fqon)}' "
@@ -246,7 +246,12 @@ class ImportTree:
 
                 index += 1
 
-        # Recursively search the nyan objects for nested objects
+        self._expand_nested_objects(nyan_object)
+
+    def _expand_nested_objects(self, nyan_object: NyanObject):
+        """
+        Recursively search the nyan objects for nested objects
+        """
         unsearched_objects = []
         unsearched_objects.extend(nyan_object.get_nested_objects())
         found_nested_objects = []
@@ -286,7 +291,7 @@ class ImportTree:
         """
         aliases = {}
         for current_node in self.alias_nodes:
-            if current_node.alias in aliases.keys():
+            if current_node.alias in aliases:
                 raise Exception(f"duplicate alias: {current_node.alias}")
 
             aliases.update({current_node.alias: current_node.get_fqon()})
@@ -313,10 +318,10 @@ class ImportTree:
 
             if len(namespace) <= len(fqon):
                 # Check if the fqon is in the namespace by comparing their identifiers
-                for index in range(len(namespace)):
-                    current_node = current_node.get_child(namespace[index])
+                for index, namespace_part in enumerate(namespace):
+                    current_node = current_node.get_child(namespace_part)
 
-                    if namespace[index] != fqon[index]:
+                    if namespace_part != fqon[index]:
                         break
 
                 else:

--- a/openage/nyan/import_tree.py
+++ b/openage/nyan/import_tree.py
@@ -79,7 +79,7 @@ class Node:
             if current_node.parent is ancestor_node:
                 return True
 
-            elif not current_node.parent:
+            if not current_node.parent:
                 return False
 
             current_node = current_node.parent

--- a/openage/nyan/nyan_structs.py
+++ b/openage/nyan/nyan_structs.py
@@ -200,8 +200,7 @@ class NyanObject:
                     if inherited_member.get_name() == member_name:
                         return inherited_member
 
-            raise Exception("%s has no member '%s' with origin '%s'"
-                            % (self, member_name, origin))
+            raise Exception(f"{repr(self)} has no member '{member_name}' with origin '{origin}'")
 
         # Else: Member should be a direct member of this nyan object
         for member in self._members:
@@ -291,10 +290,10 @@ class NyanObject:
         parent objects.
         """
         if not self.has_ancestor(new_inherited_member.get_origin()):
-            raise Exception("%s: cannot add inherited member %s because"
-                            " %s is not an ancestor of %s"
-                            % (self.__repr__(), new_inherited_member,
-                               new_inherited_member.get_origin(), self))
+            raise Exception(f"{repr(self)}: cannot add inherited member "
+                            f"{new_inherited_member} because "
+                            f"{new_inherited_member.get_origin()} is not "
+                            f"an ancestor of {repr(self)}")
 
         if not isinstance(new_inherited_member, InheritedNyanMember):
             raise Exception("added member must have <InheritedNyanMember> type")
@@ -346,14 +345,12 @@ class NyanObject:
             for inherited_member in self._inherited_members:
                 if inherited_member.has_value():
                     empty = False
-                    output_str += "%s%s\n" % (
-                        (indent_depth + 1) * INDENT,
-                        inherited_member.dump(
-                            indent_depth + 1,
-                            import_tree=import_tree,
-                            namespace=self.get_fqon()
-                        )
+                    member_str = inherited_member.dump(
+                        indent_depth + 1,
+                        import_tree=import_tree,
+                        namespace=self.get_fqon()
                     )
+                    output_str += f"{(indent_depth + 1) * INDENT}{member_str}\n"
             if not empty:
                 output_str += "\n"
 
@@ -362,23 +359,20 @@ class NyanObject:
             for member in self._members:
                 if self.is_patch():
                     # Patches do not need the type definition
-                    output_str += "%s%s\n" % (
-                        (indent_depth + 1) * INDENT,
-                        member.dump_short(
-                            indent_depth + 1,
-                            import_tree=import_tree,
-                            namespace=self.get_fqon()
-                        )
+                    member_str = member.dump_short(
+                        indent_depth + 1,
+                        import_tree=import_tree,
+                        namespace=self.get_fqon()
                     )
+
                 else:
-                    output_str += "%s%s\n" % (
-                        (indent_depth + 1) * INDENT,
-                        member.dump(
-                            indent_depth + 1,
-                            import_tree=import_tree,
-                            namespace=self.get_fqon()
-                        )
+                    member_str = member.dump(
+                        indent_depth + 1,
+                        import_tree=import_tree,
+                        namespace=self.get_fqon()
                     )
+
+                output_str += f"{(indent_depth + 1) * INDENT}{member_str}\n"
 
             output_str += "\n"
 
@@ -386,15 +380,13 @@ class NyanObject:
         if len(self._nested_objects) > 0:
             empty = False
             for nested_object in self._nested_objects:
-                output_str += "%s%s" % (
-                    (indent_depth + 1) * INDENT,
-                    nested_object.dump(
-                        indent_depth + 1,
-                        import_tree=import_tree
-                    )
+                nested_str = nested_object.dump(
+                    indent_depth + 1,
+                    import_tree=import_tree
                 )
+                output_str += f"{(indent_depth + 1) * INDENT}{nested_str}\n"
 
-            output_str += ""
+            output_str += "\n"
 
         # Empty objects need a 'pass' line
         if empty:
@@ -444,39 +436,34 @@ class NyanObject:
         """
         # self.name must be a string
         if not isinstance(self.name, str):
-            raise Exception(f"{self.__repr__()}: 'name' must be a string")
+            raise Exception(f"{repr(self)}: 'name' must be a string")
 
         # self.name must conform to nyan grammar rules
         if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", self.name):
-            raise Exception(f"{self.__repr__()}: 'name' is not well-formed")
+            raise Exception(f"{repr(self)}: 'name' is not well-formed")
 
         # self._parents must be NyanObjects
         for parent in self._parents:
             if not isinstance(parent, NyanObject):
-                raise Exception("%s: %s must have NyanObject type"
-                                % (self.__repr__(), parent.__repr__()))
+                raise Exception(f"{repr(self)}: {repr(parent)} must have NyanObject type")
 
         # self._members must be NyanMembers
         for member in self._members:
             if not isinstance(member, NyanMember):
-                raise Exception("%s: %s must have NyanMember type"
-                                % (self.__repr__(), member.__repr__()))
+                raise Exception(f"{repr(self)}: {repr(member)} must have NyanMember type")
 
             # a member in self._members must also not be inherited
             if isinstance(member, InheritedNyanMember):
-                raise Exception("%s: %s must not have InheritedNyanMember type"
-                                % (self.__repr__(), member.__repr__()))
+                raise Exception(f"{repr(self)}: regular member {repr(member)} must not "
+                                "have InheritedNyanMember type")
 
         # self._nested_objects must be NyanObjects
         for nested_object in self._nested_objects:
             if not isinstance(nested_object, NyanObject):
-                raise Exception("%s: %s must have NyanObject type"
-                                % (self.__repr__(),
-                                   nested_object.__repr__()))
+                raise Exception(f"{repr(self)}: {repr(nested_object)} must have NyanObject type")
 
             if nested_object is self:
-                raise Exception("%s: must not contain itself as nested object"
-                                % (self.__repr__()))
+                raise Exception(f"{repr(self)}: must not contain itself as nested object")
 
     def __repr__(self):
         return f"NyanObject<{self.name}>"
@@ -566,11 +553,11 @@ class NyanPatch(NyanObject):
 
             output_str = output_str[:-2] + "]"
 
-        output_str += super()._prepare_inheritance_content(import_tree=import_tree)
+        output_str += super()._prepare_inheritance_content(import_tree = import_tree)
 
         # Members
-        output_str += super()._prepare_object_content(indent_depth=indent_depth,
-                                                      import_tree=import_tree)
+        output_str += super()._prepare_object_content(indent_depth = indent_depth,
+                                                      import_tree = import_tree)
 
         return output_str
 
@@ -584,28 +571,23 @@ class NyanPatch(NyanObject):
         # Target must be a nyan object
         if self._target:
             if not isinstance(self._target, NyanObject):
-                raise Exception("%s: '_target' must have NyanObject type"
-                                % (self.__repr__()))
+                raise Exception(f"{repr(self)}: '_target' must have NyanObject type")
 
         # Added inheritance must be tuples of "FRONT"/"BACK"
         # and a nyan object
         if len(self._add_inheritance) > 0:
             for inherit in self._add_inheritance:
                 if not isinstance(inherit, tuple):
-                    raise Exception("%s: '_add_inheritance' must be a tuple"
-                                    % (self.__repr__()))
+                    raise Exception(f"{repr(self)}: '_add_inheritance' must be a tuple")
 
                 if len(inherit) != 2:
-                    raise Exception("%s: '_add_inheritance' tuples must have length 2"
-                                    % (self.__repr__()))
+                    raise Exception(f"{repr(self)}: '_add_inheritance' tuples must have length 2")
 
                 if inherit[0] not in ("FRONT", "BACK"):
-                    raise Exception("%s: added inheritance must be FRONT or BACK mode"
-                                    % (self.__repr__()))
+                    raise Exception(f"{repr(self)}: added inheritance must be FRONT or BACK mode")
 
                 if not isinstance(inherit[1], NyanObject):
-                    raise Exception("%s: added inheritance must contain NyanObject"
-                                    % (self.__repr__()))
+                    raise Exception(f"{repr(self)}: added inheritance must contain NyanObject")
 
     def __repr__(self):
         return f"NyanPatch<{self.name}<{self._target.name}>>"
@@ -620,7 +602,7 @@ class NyanMemberType:
 
     def __init__(
         self,
-        member_type: typing.Union[MemberType, NyanObject],
+        member_type: typing.Union[str, MemberType, NyanObject],
         element_types: typing.Collection[NyanMemberType] = None
     ):
         """
@@ -1008,13 +990,12 @@ class NyanMember:
         output_str = f"{self.name} : {self._member_type.dump()}"
 
         if self.is_initialized():
-            output_str += " %s%s %s" % ("@" * self._override_depth,
-                                        self._operator.value,
-                                        self._get_value_str(
-                                            indent_depth,
-                                            import_tree=import_tree,
-                                            namespace=namespace
-                                        ))
+            value_str = self._get_value_str(
+                indent_depth,
+                import_tree=import_tree,
+                namespace=namespace
+            )
+            output_str += (f" {'@' * self._override_depth}{self._operator.value} {value_str}")
 
         return output_str
 
@@ -1028,16 +1009,12 @@ class NyanMember:
         Returns the nyan string representation of the member, but
         without the type definition.
         """
-        return "%s %s%s %s" % (
-            self.get_name(),
-            "@" * self._override_depth,
-            self._operator.value,
-            self._get_value_str(
-                indent_depth,
-                import_tree=import_tree,
-                namespace=namespace
-            )
+        value_str = self._get_value_str(
+            indent_depth,
+            import_tree=import_tree,
+            namespace=namespace
         )
+        return f"{self.get_name()} {'@' * self._override_depth}{self._operator.value} {value_str}"
 
     def _sanity_check(self) -> None:
         """
@@ -1338,16 +1315,13 @@ class NyanPatchMember(NyanMember):
         Returns the nyan string representation of the member, but
         without the type definition.
         """
-        return "%s %s%s %s" % (
-            self.get_name_with_origin(),
-            "@" * self._override_depth,
-            self._operator.value,
-            self._get_value_str(
-                indent_depth,
-                import_tree=import_tree,
-                namespace=namespace
-            )
+        value_str = self._get_value_str(
+            indent_depth,
+            import_tree=import_tree,
+            namespace=namespace
         )
+        return (f"{self.get_name_with_origin()} {'@' * self._override_depth}"
+                f"{self._operator.value} {value_str}")
 
     def _sanity_check(self) -> None:
         """
@@ -1454,16 +1428,13 @@ class InheritedNyanMember(NyanMember):
         Returns the nyan string representation of the member, but
         without the type definition.
         """
-        return "%s %s%s %s" % (
-            self.get_name_with_origin(),
-            "@" * self._override_depth,
-            self._operator.value,
-            self._get_value_str(
-                indent_depth,
-                import_tree=import_tree,
-                namespace=namespace
-            )
+        value_str = self._get_value_str(
+            indent_depth,
+            import_tree=import_tree,
+            namespace=namespace
         )
+        return (f"{self.get_name_with_origin()} {'@' * self._override_depth}"
+                f"{self._operator.value} {value_str}")
 
     def _sanity_check(self) -> None:
         """

--- a/openage/testing/main.py
+++ b/openage/testing/main.py
@@ -2,9 +2,11 @@
 
 """ CLI module for running all tests. """
 
+from __future__ import annotations
+import typing
+
 import argparse
 import sys
-import typing
 
 from ..util.strings import format_progress
 
@@ -25,7 +27,7 @@ def print_test_list(test_list: typing.OrderedDict) -> None:
     for current_type in ['test', 'demo', 'benchmark']:
         for (name, type_), (_, lang, desc, _) in test_list.items():
             if type_ == current_type:
-                print("[%s %3s] %-*s  %s" % (type_, lang, namelen, name, desc))
+                print(f"[{type_} {lang:3}] {name:{namelen}}  {desc}")
 
     print("")
     print("To see how to run them, add --help to your invocation!")
@@ -53,7 +55,7 @@ def init_subparser(cli):
     cli.add_argument("test", nargs='*', help="run this test")
 
 
-def process_args(args: argparse.Namespace, error):
+def process_args(args: Namespace, error):
     """ Processes the given args, detecting errors. """
     if not (args.run_all_tests or args.demo or args.test or args.benchmark):
         args.list = True
@@ -125,10 +127,7 @@ def main(args, error):
         for idx, name in enumerate(args.test):
             _, lang, _, testfun = test_list[name, 'test']
 
-            print("\x1b[32m[%s]\x1b[m %3s %s" % (
-                format_progress(idx, len(args.test)),
-                lang,
-                name))
+            print(f"\x1b[32m[{format_progress(idx, len(args.test))}]\x1b[m {lang:3} {name}")
 
             try:
                 testfun()
@@ -141,9 +140,7 @@ def main(args, error):
                 traceback.print_exc()
 
         if failed:
-            print("\x1b[31;1m%d out of %d tests have failed\x1b[m" % (
-                failed,
-                len(args.test)))
+            print(f"\x1b[31;1m{failed:d} out of {len(args.test):d} tests have failed\x1b[m")
 
             sys.exit(1)
 

--- a/openage/util/fslike/path.py
+++ b/openage/util/fslike/path.py
@@ -44,7 +44,7 @@ class Path:
 
         if not isinstance(parts, (list, tuple)):
             raise ValueError("path parts must be str, bytes, list or tuple, "
-                             "but not: %s" % type(parts))
+                             f"but not: {type(parts)}")
 
         result = []
         for part in parts:

--- a/openage/util/fslike/union.py
+++ b/openage/util/fslike/union.py
@@ -35,13 +35,11 @@ class Union(FSLikeObject):
         self.dirstructure = {}
 
     def __str__(self):
-        return "Union({})".format(
-            ", ".join(["%s @ %s" % (repr(pnt[1]),
-                                    repr(pnt[0]))
-                       for pnt in self.mounts])
-        )
+        content = ", ".join([f"{repr(pnt[1])} @ {repr(pnt[0])}"
+                             for pnt in self.mounts])
+        return f"Union({content})"
 
-    @property
+    @ property
     def root(self):
         return UnionPath(self, [])
 

--- a/openage/util/fsprinting.py
+++ b/openage/util/fsprinting.py
@@ -97,7 +97,7 @@ def print_tree(
 
     if len(entries) > max_entries:
         omit = len(entries) - max_entries + 1
-        entries = entries[:-omit] + [("[%d omitted]" % omit, False, True)]
+        entries = entries[:-omit] + [(f"[{omit} omitted]", False, True)]
 
     from .iterators import denote_last
     for (name, isdir, is_meta), is_last in denote_last(entries):

--- a/openage/util/observer.py
+++ b/openage/util/observer.py
@@ -54,8 +54,7 @@ class Observable:
         :type observer: Observer
         """
         if not isinstance(observer, Observer):
-            raise Exception("%s does not inherit from Observer sperclass"
-                            % (type(observer)))
+            raise Exception(f"{type(observer)} does not inherit from Observer sperclass")
 
         self.observers.add(weakref.ref(observer))
 

--- a/openage/util/ordered_set.py
+++ b/openage/util/ordered_set.py
@@ -7,10 +7,12 @@ be ordered since Python 3.6.
 """
 
 
-from typing import Hashable
+from typing import Generic, Hashable, TypeVar
+
+OrderedSetItem = TypeVar("OrderedSetItem")
 
 
-class OrderedSet:
+class OrderedSet(Generic[OrderedSetItem]):
     """
     Set that saves the input order of elements.
     """

--- a/openage/util/profiler.py
+++ b/openage/util/profiler.py
@@ -89,6 +89,7 @@ class Tracemalloc:
 
     snapshot0 = None
     snapshot1 = None
+    peak = None
 
     def __init__(self, o_stream=None):
         # o_stream can be a file if the profile results want to be saved.
@@ -125,7 +126,7 @@ class Tracemalloc:
     def report(
         self,
         sortby: str = 'lineno',
-        cumulative: bool = True,
+        cumulative: bool = False,
         limit: int = 100
     ) -> None:
         """
@@ -140,6 +141,15 @@ class Tracemalloc:
         for stat in stats:
             print(stat)
 
+    def get_peak(self) -> int:
+        """
+        Return the peak memory consumption.
+        """
+        if not self.peak:
+            return tracemalloc.get_traced_memory()[1]
+
+        return self.peak
+
     @staticmethod
     def enable() -> None:
         """
@@ -153,5 +163,7 @@ class Tracemalloc:
         """
         if self.snapshot0 is None:
             self.snapshot()
+
+        self.peak = tracemalloc.get_traced_memory()[1]
 
         tracemalloc.stop()

--- a/openage/util/profiler.py
+++ b/openage/util/profiler.py
@@ -27,10 +27,10 @@ class Profiler:
     profile_stats: pstats.Stats = None
     profile_stream = None
 
-    def __init__(self, oStream=None):
-        # oStream can be a file if the profile results want to be saved.
+    def __init__(self, o_stream=None):
+        # o_stream can be a file if the profile results want to be saved.
         self.profile = cProfile.Profile()
-        self.profile_stream = oStream
+        self.profile_stream = o_stream
 
     def __enter__(self):
         """
@@ -89,9 +89,9 @@ class Tracemalloc:
 
     snapshot = None
 
-    def __init__(self, oStream=None):
-        # oStream can be a file if the profile results want to be saved.
-        self.tracemalloc_stream = oStream
+    def __init__(self, o_stream=None):
+        # o_stream can be a file if the profile results want to be saved.
+        self.tracemalloc_stream = o_stream
 
     def __enter__(self):
         """

--- a/openage/util/strings.py
+++ b/openage/util/strings.py
@@ -4,6 +4,8 @@ Misc string helper functions; this includes encoding, decoding,
 manipulation, ...
 """
 
+from sys import stdout
+
 
 def decode_until_null(data: bytes, encoding: str = 'utf-8') -> str:
     """
@@ -107,3 +109,11 @@ def format_progress(progress: int, total: int) -> str:
     ' 5/20'
     """
     return f"{progress:>{len(str(total))}}/{total}"
+
+
+def print_progress(progress: int, total: int) -> str:
+    """
+    Print an "x out of y" string with fixed width to stdout.
+    The output overwrites itself.
+    """
+    stdout.write(format_progress(progress, total) + "\r")

--- a/openage/util/strings.py
+++ b/openage/util/strings.py
@@ -62,8 +62,7 @@ def colorize(string: str, colorcode: str) -> str:
     '\\x1b[31;1mfoo\\x1b[m'
     """
     if colorcode:
-        colorized = '\x1b[{colorcode}m{string}\x1b[m'.format(
-            colorcode=colorcode, string=string)
+        colorized = f'\x1b[{colorcode}m{string}\x1b[m'
     else:
         colorized = string
 
@@ -107,6 +106,4 @@ def format_progress(progress: int, total: int) -> str:
     >>> format_progress(5, 20)
     ' 5/20'
     """
-    return "{progress:>{width}}/{total}".format(progress=progress,
-                                                width=len(str(total)),
-                                                total=total)
+    return f"{progress:>{len(str(total))}}/{total}"

--- a/openage/util/struct.py
+++ b/openage/util/struct.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 """
 Provides some classes designed to expand the functionality of struct.struct
@@ -63,8 +63,8 @@ class NamedStructMeta(type):
                 pass
             else:
                 raise TypeError(
-                    "NamedStruct member %s: expected str, but got %s"
-                    % (membername, repr(value)))
+                    f"NamedStruct member {membername}: expected str, but got {repr(value)}"
+                )
 
             specstr += value
 


### PR DESCRIPTION
This PR adds changes to support the conversion of the new Dynasties of India expansion for DE2.

It also brings some othert changes to speed up conversion including:
* Removing `.keys()` call for checking if an element is a key in a dict
* Replace %-strings with f-strings whereever possible
* Don't generate value members for Genie members that are (currently) unused. This also cuts down memory usage by ~30%
* Introduce a `DynamicLoader` class that can be used for loading a Genie structure at runtime (instead of loading everything at the start). This behaviour is turned off by default.