### PR TITLE
Fix Python search during build

### DIFF
--- a/buildsystem/CheckRuntimeDependencies.cmake
+++ b/buildsystem/CheckRuntimeDependencies.cmake
@@ -1,11 +1,11 @@
-# Copyright 2015-2018 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 # python modules
 # a list of imported modules may be obtained via
 #
 # grep -RE '^ *(import |from [^.])' | cut -d: -f2- | \
 #     sed 's/^ *//g' | sort -u | grep -v openage
-set(REQUIRED_PYTHON_MODULES "PIL.Image" "PIL.ImageDraw" "numpy" "pygments" "jinja2")
+set(REQUIRED_PYTHON_MODULES "PIL.Image" "PIL.ImageDraw" "numpy" "pygments" "jinja2" "toml" "lz4")
 
 # command-line tools
 # example: set(REQUIRED_UTILITIES "foobar")

--- a/buildsystem/HandlePythonOptions.cmake
+++ b/buildsystem/HandlePythonOptions.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 the openage authors. See copying.md for legal info.
+# Copyright 2015-2022 the openage authors. See copying.md for legal info.
 
 # finds the python interpreter, install destination and extension flags.
 
@@ -45,7 +45,7 @@ if(NOT CMAKE_PY_INSTALL_PREFIX)
 	if(MSVC)
 		set(CMAKE_PY_INSTALL_PREFIX "python")
 	else()
-		py_exec("from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))" PREFIX)
+		py_exec("import sysconfig, os; print(os.path.join('${CMAKE_INSTALL_PREFIX}', os.path.relpath(sysconfig.get_path('purelib'), sysconfig.get_path('data'))))" PREFIX)
 		set(CMAKE_PY_INSTALL_PREFIX "${PREFIX}")
 	endif()
 endif()

--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -25,28 +25,39 @@
 # to CMake. It's used as a hint where to look at
 if(PYTHON_DIR)
 	set(Python3_ROOT_DIR "${PYTHON_DIR}")
+	set(PYTHON_USED_VERSION "${PYTHON_MIN_VERSION}")
+
+else()
+	# when there are multiple pythons, preferrably use the version of
+	# the default `python3` executable.
+	execute_process(
+		COMMAND "python3" -c "import platform; print(platform.python_version())"
+		OUTPUT_VARIABLE PYVER_OUTPUT
+		RESULT_VARIABLE PYVER_RETVAL
+	)
+
+	# if a system version exists, check if it's compatible with our min requirements
+	if(PYVER_RETVAL EQUAL 0)
+		string(REGEX MATCH "^[0-9]+\\.[0-9]+" PYTHON_USED_VERSION "${PYVER_OUTPUT}")
+
+		if(PYTHON_USED_VERSION VERSION_GREATER_EQUAL PYTHON_MIN_VERSION)
+			# set EXACT so we get the system version from find_package
+			set(need_exact_version "EXACT")
+
+		else()
+			# search for alternatives if version doesn't fulfill min requirements
+			set(PYTHON_USED_VERSION "${PYTHON_MIN_VERSION}")
+
+		endif()
+	endif()
 endif()
 ###############################################################
-
 
 # Never use the Windows Registry to find python
 set(Python3_FIND_REGISTRY "NEVER")
 
-# when there are multiple pythons, preferrably use the version of
-# the default `python3` executable.
-execute_process(
-	COMMAND "python3" -c "import platform; print(platform.python_version())"
-	OUTPUT_VARIABLE PYVER_OUTPUT
-	RESULT_VARIABLE PYVER_RETVAL
-)
-
-if(PYVER_RETVAL EQUAL 0)
-	string(REGEX MATCH "^[0-9]+\\.[0-9]+" PYTHON_MIN_VERSION "${PYVER_OUTPUT}")
-	set(need_exact_version "EXACT")
-endif()
-
 # use cmake's FindPython3 to locate library and interpreter
-find_package(Python3 ${PYTHON_MIN_VERSION} ${need_exact_version} COMPONENTS Interpreter Development NumPy)
+find_package(Python3 ${PYTHON_USED_VERSION} ${need_exact_version} COMPONENTS Interpreter Development NumPy)
 
 # python version string to cpython api test in modules/FindPython_test.cpp
 # we use the solution from CPython's header (see https://github.com/SFTtech/openage/issues/1438#issuecomment-1036311012):

--- a/buildsystem/modules/FindPython.cmake
+++ b/buildsystem/modules/FindPython.cmake
@@ -133,7 +133,7 @@ endfunction()
 function(py_get_config_var VAR RESULTVAR)
 	# uses py_exec to determine a config var as in distutils.sysconfig.get_config_var().
 	py_exec(
-		"from distutils.sysconfig import get_config_var; print(get_config_var('${VAR}'))"
+		"from sysconfig import get_config_var; print(get_config_var('${VAR}'))"
 		RESULT
 	)
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -60,9 +60,13 @@ Dependency list:
       A   An installed version of any of the following (wine is your friend).
           Other versions _might_ work:
 
+     - Age of Empires I: Rise of Rome Patch 1.0a
+     - Age of Empires I: Definitive Edition
      - Age of Empires II: The Conquerors Patch 1.0c
      - Age of Empires II: Forgotten Empires
-     - Age of Empires II HD
+     - Age of Empires II: HD (now also called: Age of Empires II (2013))
+     - Age of Empires II: Definitive Edition
+     - Star Wars: Galactic Battlegrounds: Clone Campaigns
 
 
 ### Dependency installation


### PR DESCRIPTION
Fixes #1481 and improves the code base a bit.

* Check system version for compatibility and don't try to use it if it is too low
* do not search for the system version if `PYTHON_DIR` is set
* Remove a `distutils` deprecation warning
* Let the build script search for `toml` and `lz4` which are required modules