### PR TITLE
Clean up graphics documention

### DIFF
--- a/doc/media/patterns/slp.hexpat
+++ b/doc/media/patterns/slp.hexpat
@@ -1,5 +1,10 @@
 // Copyright 2023-2023 the openage authors. See copying.md for legal info.
 
+#pragma endian little
+
+// only show a specific frame (at the specified index)
+// if this value is -1 all frames are shown
+#define SHOW_FRAME -1
 
 struct slp_header {
     char version[4];
@@ -63,11 +68,11 @@ struct slp_frame_row_edge {
 
 struct slp_cmd {
     u8 cmd;
-    
+
     low_crumb = cmd & 0x03;
     low_nibble = cmd & 0x0f;
     high_nibble = cmd & 0xf0;
-    
+
     if (low_crumb == 0b00) {
         cmd_len = cmd >> 2;
         payload_len = cmd_len;
@@ -144,15 +149,15 @@ struct slp_cmd {
         cmd_len = 0;
         payload_len = 0;
     }
-    
+
     u8 payload[payload_len];
-    
+
     cur_cmd = cmd;
 };
 
 struct slp_cmd_row {
     slp_cmd commands[while(cur_cmd != 0x0F)];
-    
+
     cur_cmd = 0x00;
 };
 
@@ -164,12 +169,14 @@ struct slp_frame {
     slp_frame_row_edge outline_offsets[cur_height];
     u32 cmd_offsets[cur_height];
     slp_cmd_table table;
-    
+
     if (cur_frame < header.num_frames - 1)
         next_frame();
+
+    if (SHOW_FRAME >= 0 && cur_frame - 1 != SHOW_FRAME)
+        continue;
 };
 
 offset += sizeof(infos);
 
 slp_frame frames[header.num_frames] @ offset;
-

--- a/doc/media/patterns/slp_v4.hexpat
+++ b/doc/media/patterns/slp_v4.hexpat
@@ -1,0 +1,254 @@
+// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+
+#pragma endian little
+#pragma pattern_limit 3000000
+
+// Decode the secondary offsets if set to 1
+// switch off if you have performance problems
+#define DECODE_SECONDARY 0
+
+// only show a specific frame (at the specified index)
+// if this value is -1 all frames are shown
+#define SHOW_FRAME -1
+
+struct slp_header {
+    char version[4];
+    s16 num_frames;
+    s16 type;
+    s16 num_directions;
+    s16 frames_per_direction;
+    s32 palette_id;
+    s32 offset_main;
+    s32 offset_secondary;
+    padding[8];
+};
+
+struct slp_frame_info {
+    u32 cmd_table_offset;
+    u32 outline_table_offset;
+    u32 palette_offset;
+    u32 properties;
+    s32 width;
+    s32 height;
+    s32 hotspot_x;
+    s32 hotspot_y;
+};
+
+enum pixel_type : u8 {
+    index,
+    index_modifier,
+    bgra,
+};
+
+u32 offset = 0x00;
+
+char version[4] @ offset;
+slp_header header @ offset;
+
+offset += sizeof(header);
+
+slp_frame_info infos[header.num_frames] @ offset;
+
+s32 cur_frame = 0;
+s32 cur_height = infos[cur_frame].height;
+s32 cur_width = infos[cur_frame].width;
+s32 cur_outline_table_offset = infos[cur_frame].outline_table_offset;
+s32 cur_cmd_table_offset = infos[cur_frame].cmd_table_offset;
+pixel_type cur_pixel_type = pixel_type::index;
+if (infos[cur_frame].properties & 0x07)
+    cur_pixel_type = pixel_type::bgra;
+else if (version == "4.1X")
+    cur_pixel_type = pixel_type::index_modifier;
+
+char cur_cmd = 0x00;
+char low_crumb = 0;
+char low_nibble = 0;
+char high_nibble = 0;
+u16 cmd_len = 0;
+u16 payload_len = 0;
+
+fn next_frame() {
+    cur_frame += 1;
+    cur_height = infos[cur_frame].height;
+    cur_width = infos[cur_frame].width;
+    cur_outline_table_offset = infos[cur_frame].outline_table_offset;
+    cur_cmd_table_offset = infos[cur_frame].cmd_table_offset;
+
+    if (infos[cur_frame].properties & 0x07)
+        cur_pixel_type = pixel_type::bgra;
+    else if (version == "4.1X")
+        cur_pixel_type = pixel_type::index_modifier;
+    else
+        cur_pixel_type = pixel_type::index;
+};
+
+struct slp_frame_row_edge {
+    u16 left_space;
+    u16 right_space;
+};
+
+struct slp_cmd {
+    u8 cmd;
+
+    low_crumb = cmd & 0x03;
+    low_nibble = cmd & 0x0f;
+    high_nibble = cmd & 0xf0;
+
+    if (low_crumb == 0b00) {
+        cmd_len = cmd >> 2;
+        payload_len = cmd_len;
+    }
+    else if (low_crumb == 0b01) {
+        cmd_len = cmd >> 2;
+        payload_len = 0;
+        if (cmd_len == 0) {
+            u8 next;
+            cmd_len = next;
+        }
+    }
+    else if (low_nibble == 0b0010) {
+        cmd_len = cmd << 4;
+        u8 next;
+        cmd_len += next;
+        payload_len = cmd_len;
+    }
+    else if (low_nibble == 0b0011) {
+        cmd_len = cmd << 4;
+        u8 next;
+        cmd_len += next;
+        payload_len = 0;
+    }
+    else if (low_nibble == 0b0110) {
+        cmd_len = cmd >> 4;
+        payload_len = cmd_len;
+        if (cmd_len == 0) {
+            u8 next;
+            cmd_len = next;
+            payload_len = cmd_len;
+        }
+    }
+    else if (low_nibble == 0b0111) {
+        cmd_len = cmd >> 4;
+        payload_len = 1;
+        if (cmd_len == 0) {
+            u8 next;
+            cmd_len = next;
+        }
+    }
+    else if (low_nibble == 0b1010) {
+        cmd_len = cmd >> 4;
+        payload_len = 1;
+        if (cmd_len == 0) {
+            u8 next;
+            cmd_len = next;
+        }
+    }
+    else if (low_nibble == 0b1011) {
+        cmd_len = cmd >> 4;
+        payload_len = 0;
+        if (cmd_len == 0) {
+            u8 next;
+            cmd_len = next;
+        }
+    }
+    else if (cmd == 0x5E) {
+        u8 next;
+        cmd_len = next;
+        payload_len = 0;
+    }
+    else if (cmd == 0x7E) {
+        u8 next;
+        cmd_len = next;
+        payload_len = 0;
+    }
+    else if (cmd == 0x9E) {
+        u8 next;
+        cmd_len = next;
+        payload_len = 0;
+    }
+    else {
+        cmd_len = 0;
+        payload_len = 0;
+    }
+
+    if (cur_pixel_type == pixel_type::index_modifier)
+        u16 payload[payload_len];
+    else if (cur_pixel_type == pixel_type::bgra)
+        u32 payload[payload_len];
+    else
+        u8 payload[payload_len];
+
+    cur_cmd = cmd;
+};
+
+struct slp_cmd_row {
+    slp_cmd commands[while(cur_cmd != 0x0F)];
+
+    cur_cmd = 0x00;
+};
+
+struct slp_cmd_table {
+    slp_cmd_row rows[cur_height];
+};
+
+struct slp_frame {
+    $ = cur_outline_table_offset;
+    slp_frame_row_edge outline_offsets[cur_height];
+
+    $ = cur_cmd_table_offset;
+    u32 cmd_offsets[cur_height];
+
+    $ = cmd_offsets[0];
+    slp_cmd_table table;
+
+    if (cur_frame < header.num_frames - 1)
+        next_frame();
+
+    if (SHOW_FRAME >= 0 && cur_frame - 1 != SHOW_FRAME)
+        continue;
+};
+
+offset += sizeof(infos);
+
+slp_frame frames[header.num_frames] @ offset;
+
+offset = header.offset_secondary;
+
+if (offset == 0x00 || !DECODE_SECONDARY)
+    return;
+
+slp_frame_info infos_secondary[header.num_frames] @ offset;
+
+cur_frame = 0;
+cur_height = infos_secondary[cur_frame].height;
+cur_width = infos_secondary[cur_frame].width;
+cur_outline_table_offset = infos_secondary[cur_frame].outline_table_offset;
+cur_cmd_table_offset = infos_secondary[cur_frame].cmd_table_offset;
+cur_pixel_type = pixel_type::index;
+
+fn next_frame_secondary() {
+    cur_frame += 1;
+    cur_height = infos_secondary[cur_frame].height;
+    cur_width = infos_secondary[cur_frame].width;
+    cur_outline_table_offset = infos_secondary[cur_frame].outline_table_offset;
+    cur_cmd_table_offset = infos_secondary[cur_frame].cmd_table_offset;
+};
+
+struct slp_frame_secondary {
+    $ = cur_outline_table_offset;
+    slp_frame_row_edge outline_offsets[cur_height];
+
+    $ = cur_cmd_table_offset;
+    u32 cmd_offsets[cur_height];
+    slp_cmd_table table;
+
+    if (cur_frame < header.num_frames - 1)
+        next_frame_secondary();
+
+    if (SHOW_FRAME >= 0 && cur_frame - 1 != SHOW_FRAME)
+        continue;
+};
+
+offset += sizeof(infos_secondary);
+
+slp_frame_secondary frames_secondary[header.num_frames] @ offset;

--- a/doc/media/sld-files.md
+++ b/doc/media/sld-files.md
@@ -1,9 +1,22 @@
 # SLD files
 
 SLD is the sprite storage format introduced in Build 66692 of Age of Empires 2: Definitive Edition.
+
 Unlike the [SMX](smx-files.md) and [SLP](slp-files.md) formats, the SLD format does not use
 indexed palettes for pixel data. Instead, SLD image data utilizes lossy texture compression
 algorithms [DXT1](https://en.wikipedia.org/wiki/S3_Texture_Compression#DXT1) and [DXT4](https://en.wikipedia.org/wiki/S3_Texture_Compression#DXT1) (also known as BC1 and BC4, respectively).
+
+1. [SLD File Format](#sld-file-format)
+    1. [Header](#header)
+    1. [Frame Header](#sld-frame-header)
+    1. [Layers](#sld-layers)
+        1. [Main Graphics](#sld-main-graphics-layer)
+        1. [Shadow](#sld-shadow-graphics-layer)
+        1. [Damage Mask](#sld-damage-mask-layer)
+        1. [Playercolor Mask](#sld-playercolor-mask-layer)
+1. [Excursion: DXT1/BC1 Block Compression](#excursion-dxt1bc1-block-compression)
+1. [Excursion: DXT4/BC4 Block Compression](#excursion-dxt4bc4-block-compression)
+1. [Processing the Command Array (Example)](#processing-the-command-array-example)
 
 ## SLD file format
 

--- a/doc/media/slp-files.md
+++ b/doc/media/slp-files.md
@@ -4,7 +4,7 @@ SLP files are stored in the DRS files. They contain all the (animation)
 textures. Like the DRS format, it can also be read sequentially.
 
 In addition to the format description found in this document, we also
-provide a [pattern file](doc/media/patterns/slp.hexpat) for the [imHex](https://imhex.werwolv.net/)
+provide a [pattern file](/doc/media/patterns/slp.hexpat) for the [imHex](https://imhex.werwolv.net/)
 editor which can be used to explore the SLP data visually.
 
 ## SLP file format

--- a/doc/media/smp-files.md
+++ b/doc/media/smp-files.md
@@ -1,12 +1,26 @@
 # SMP Files
 
-SMP files are the successor format to SLP files. Like SLP files,
+SMP files are a successor format to SLP files. Like SLP files,
 they contain animations, shadows and outlines for units. SMPs
-were introduced with Age of Empires 2: Definitive Edition.
-
-The Age of Empires 2: Definitive Edition almost exclusively stores
-sprites in a compressed version of the format that is called SMX.
+were introduced in the beta release of Age of Empires 2: Definitive Edition.
+It was mostly phased out before the final release in favor of a
+compressed version of the format that is called SMX.
 You can read more about SMX files [here](smx-files.md).
+
+1. [SMP File Format](#smp-file-format)
+    1. [Header](#header)
+    1. [Frame Header](#smp-frame-header)
+    1. [Layer Header](#smp-layer-header)
+    1. Layer Data
+        1. [Outline Table](#outline-table)
+        1. [Command Offset Table](#command-offset-table)
+        1. [Draw Commands](#draw-commands)
+        1. [SMP Pixel Data](#smp-pixel)
+            1. [Palette Info](#palette-info)
+            1. [Damage Info](#damage-info)
+1. [Examples](#examples)
+    1. [Retrieving a color value](#retrieving-a-color-value-from-a-smp-pixel)
+    1. [Calculating an RGB damage modifier value](#calculating-an-rgb-damage-modifier-value-for-an-smp-pixel)
 
 ## SMP File Format
 
@@ -130,7 +144,7 @@ Remarks:
 * Outline and command table offsets **are always relative to the frame offset**.
 
 
-### SMP Layer Row Edge
+### Outline Table
 
 At `outline_table_offset` (after the `smp_layer_header` structs), an array of
 `smp_layer_row_edge` (of length `height`) structs begins.
@@ -161,7 +175,7 @@ Note that there are no command bytes for these rows, so it has to be skipped
 `width - left_space - right_space` = number of pixels in this line.
 
 
-### SMP Command Table
+### Command Offset Table
 
 At `smp_layer_header.cmd_table_offset`, an array of
 uint32 (of length `height`) begins:
@@ -182,7 +196,7 @@ since the commands can be read sequentially, although they can be used for
 validation purposes.
 
 
-### SMP Drawing Commands
+### Draw Commands
 
 The image is drawn line by line, a line is finished with the *End of Row*
 command (0x03). A command is a one-byte number (`cmd_byte`), followed

--- a/doc/media/smx-files.md
+++ b/doc/media/smx-files.md
@@ -1,12 +1,25 @@
 # SMX files
 
-SMX is the sprite storage format of Age of Empires 2: Definitive Edition.
-The SMX format is a compressed version of the SMP format that was
-used during the Beta of the game. In the release version almost all
-sprite media files are compressed SMX files.
+SMX is a sprite storage format of Age of Empires 2: Definitive Edition.
+The SMX format is a compressed version of the [SMP format](smp-files.md) that was
+used during the Beta release of the game.
 
-It is recommended to read the [SMP documentation](smp-files.md) first
-to get a better understanding of the concepts of the format.
+The current release of Age of Empires 2: Definitive Edition uses a different
+graphics format called [SLD](sld-files.md).
+
+1. [SMX File Format](#smx-file-format)
+    1. [Header](#header)
+    1. [Frame Header](#smx-frame-header)
+    1. [Layer Header](#smx-layer-header)
+    1. Layer Data
+        1. [Outline Table](#outline-table)
+        1. [SMX Pixel Data](#smx-pixel-data)
+            1. [Main Graphics](#main-graphics-type)
+            1. [Shadow](#shadow-type)
+            1. [Outline](#outline-type)
+1. [Compression Methods](#compression-algorithms)
+    1. [4plus1 method](#4plus1-method)
+    1. [8to5 method](#8to5-method)
 
 ## SMX file format
 
@@ -122,11 +135,11 @@ struct smx_layer_header {
 ```
 Python format: `Struct("< 4H 2I")`
 
-#### SMX Layer row edge
+#### Outline Table
 
 Directly after the layer header, an array of `smp_layer_row_edge`
 (of length `height`) structs begins. These work exactly like the row edges
-in the [SMP files](smp-files.md#smp-layer-row-edge).
+in the [SMP files](smp-files.md#outline-table).
 
 
 #### SMX Pixel data


### PR DESCRIPTION
Fixes the link to the imHex pattern files and adds table of contents to the format specs for better readability.

Also adds a new pattern file for SLP>=v4.0