### PR TITLE
Fix an inappropriate test expression to remove a logical short circuit

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -147,6 +147,7 @@ _the openage authors_ are:
 | Martin                      | Starman                     | mstarman à seznam dawt cz                         |
 | Zoltán Ács                  | zoli111                     | acszoltan111 à gmail dawt com                     |
 | Trevor Slocum               | tslocum                     | trevor à rocket9labs dawt com                     |
+| Munawar Hafiz               | munahaf                     | munawar dawt hafiz à gmail dawt com               |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -663,7 +663,7 @@ class AoCProcessor:
 
                 upgrade_effects = effect_bundle.get_effects(effect_type=3)
 
-                if len(upgrade_effects) < 0:
+                if not upgrade_effects:
                     continue
 
                 # Search upgrade effects for the line_id

--- a/openage/convert/processor/conversion/aoc/processor.py
+++ b/openage/convert/processor/conversion/aoc/processor.py
@@ -663,7 +663,7 @@ class AoCProcessor:
 
                 upgrade_effects = effect_bundle.get_effects(effect_type=3)
 
-                if not upgrade_effects:
+                if len(upgrade_effects) == 0:
                     continue
 
                 # Search upgrade effects for the line_id


### PR DESCRIPTION
In file: processor.py, the comparison of Collection length creates a logical short circuit. The length of a collection is always greater than or equal to zero. So testing that a length is less than zero is always false.

I suggested that the Collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.