### PR TITLE
Fix clang build

### DIFF
--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -25,8 +25,6 @@ public:
 	}
 };
 } // namespace std
-#else
-#error "jthread is supported now, remove custom definition"
 #endif
 #else
 #include <stop_token>

--- a/libopenage/renderer/opengl/shader_program.cpp
+++ b/libopenage/renderer/opengl/shader_program.cpp
@@ -204,7 +204,7 @@ GlShaderProgram::GlShaderProgram(const std::shared_ptr<GlContext> &context,
 
 		GLuint loc = glGetUniformLocation(handle, name.data());
 
-		this->uniforms.emplace_back(type, loc);
+		this->uniforms.push_back({type, loc});
 
 		this->uniforms_by_name.insert(std::make_pair(
 			name.data(),


### PR DESCRIPTION
Fixes https://github.com/SFTtech/openage/issues/1556

* Removes pre-processor error when `std::jthread` is not found
* Fixes another weird substitution error in renderer