### PR TITLE
Add missing asset directories to CMakeLists

### DIFF
--- a/assets/test/CMakeLists.txt
+++ b/assets/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Copyright 2023-2023 the openage authors. See copying.md for legal info.
 
+add_subdirectory(nyan/)
+add_subdirectory(qml/)
 add_subdirectory(shaders/)
 add_subdirectory(textures/)

--- a/assets/test/nyan/CMakeLists.txt
+++ b/assets/test/nyan/CMakeLists.txt
@@ -1,0 +1,4 @@
+install(DIRECTORY "."
+	DESTINATION "${ASSET_DIR}/test/nyan"
+	FILES_MATCHING PATTERN "*.nyan"
+)

--- a/assets/test/qml/CMakeLists.txt
+++ b/assets/test/qml/CMakeLists.txt
@@ -1,0 +1,4 @@
+install(DIRECTORY "."
+	DESTINATION "${ASSET_DIR}/test/qml"
+	FILES_MATCHING PATTERN "*.qml"
+)

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -158,16 +158,19 @@ void Presenter::init_gui() {
 	//// -- gui initialization
 	// TODO: Do not use test GUI
 	util::Path qml_root = this->root_dir / "assets" / "test" / "qml";
+	log::log(INFO << "Presenter: Setting QML root to " << qml_root.resolve_native_path());
 	if (not qml_root.is_dir()) {
 		throw Error{ERR << "could not find qml root folder " << qml_root};
 	}
 
 	util::Path qml_assets = this->root_dir / "assets";
+	log::log(INFO << "Presenter: Setting QML asset path to " << qml_assets.resolve_native_path());
 	if (not qml_assets.is_dir()) {
 		throw Error{ERR << "could not find asset root folder " << qml_assets};
 	}
 
 	util::Path qml_root_file = qml_root / "main.qml";
+	log::log(INFO << "Presenter: Setting QML root file to " << qml_root_file.resolve_native_path());
 	if (not qml_root_file.is_file()) {
 		throw Error{ERR << "could not find main.qml file " << qml_root_file};
 	}


### PR DESCRIPTION
Fixes https://github.com/SFTtech/openage/issues/1564

The test asset folders should now be correctly picked up by cmake.