### PR TITLE
Let `make run` call `main` sumodule instead of `game`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install: $(BUILDDIR)
 
 .PHONY: run
 run: build
-	cd $(BUILDDIR) && ./run game
+	cd $(BUILDDIR) && ./run main
 
 .PHONY: test
 test: tests checkfast


### PR DESCRIPTION
Fixes https://github.com/SFTtech/openage/issues/1571

`main` and `game` were switched in the latest feature release and `game` requires arguments now. `main` has a more "main menu" CLI flow, so using it as the default entry point makes sense.