### PR TITLE
Modpack load fixes

### DIFF
--- a/doc/media/openage/modpack_definition_file.md
+++ b/doc/media/openage/modpack_definition_file.md
@@ -31,19 +31,22 @@ The following parameters have to be specified.
 
 `[info]` contains general information about the modpack.
 
-| Parameter          | Data Type     | Optional | Description                                                              |
-| ------------------ | ------------- | -------- | ------------------------------------------------------------------------ |
-| `packagename`      | String        | No       | Name of the modpack.                                                     |
-| `version`          | String        | No       | Internal version number. Must have [semver](https://semver.org/) format. |
-| `versionstr`       | String        | Yes      | Human-readable version string.                                           |
-| `repo`             | String        | Yes      | Name of the repo where the package is hosted.                            |
-| `alias`            | String        | Yes      | Alias of the modpack. Aliases can be used for replacing other modpacks.  |
-| `title`            | String        | Yes      | Title used in UI.                                                        |
-| `description`      | String        | Yes      | Path to a file with a short description (max 500 chars).                 |
-| `long_description` | String        | Yes      | Path to a file with a detailed description.                              |
-| `url`              | String        | Yes      | Link to the modpack's website.                                           |
-| `license`          | Array[String] | Yes      | License(s) of the modpack.                                               |
+| Parameter          | Data Type     | Optional | Description                                                             |
+| ------------------ | ------------- | -------- | ----------------------------------------------------------------------- |
+| `packagename`      | String        | No       | Name of the modpack.                                                    |
+| `version`\*        | String        | No       | The modpack's internal version number. Must use [semver] format.        |
+| `versionstr`\*     | String        | Yes      | Human-readable version string.                                          |
+| `repo`             | String        | Yes      | Name of the repo where the package is hosted.                           |
+| `alias`            | String        | Yes      | Alias of the modpack. Aliases can be used for replacing other modpacks. |
+| `title`            | String        | Yes      | Title used in UI.                                                       |
+| `description`      | String        | Yes      | Path to a file with a short description (max 500 chars).                |
+| `long_description` | String        | Yes      | Path to a file with a detailed description.                             |
+| `url`              | String        | Yes      | Link to the modpack's website.                                          |
+| `license`          | Array[String] | Yes      | License(s) of the modpack.                                              |
 
+[semver]: https://semver.org/
+
+\* `version` is used by the engine to determine the most recent version of a modpack. Therefore, it should be bumped when something in the modpack changes (e.g. whenever a new version gets published). `versionstr` is what is displayed to the user and can contain any string, so it can be used to represent any sensible version format.
 
 ## [assets] Section
 

--- a/libopenage/gamestate/game.cpp
+++ b/libopenage/gamestate/game.cpp
@@ -67,11 +67,12 @@ void Game::load_data(const std::shared_ptr<assets::ModManager> &mod_manager) {
 				recursive = true;
 				if (parts.size() == 1) {
 					// include = "**"
-					search = include.substr(0, include.size() - 2);
+					// start in root directory
+					search = "";
 				}
 				else {
 					// include = "path/to/somewhere/**"
-					// remove the slash '/' too
+					// remove the wildcard '**' and the slash '/'
 					search = include.substr(0, include.size() - 3);
 				}
 			}

--- a/openage/convert/tool/api_export.py
+++ b/openage/convert/tool/api_export.py
@@ -33,7 +33,7 @@ def main(args, error):
     del error  # unused
 
     path = Union().root
-    path.mount(Directory(args.dir))
+    path.mount(Directory(args.dir).root)
 
     export_api(path)
 


### PR DESCRIPTION
Improves modpack loading a bit

- Clarify difference between `version` and `versionstr` in modpack info file
- Fix engine modpack export via CLI
- Replace a usage of `std::string::substr()` with a constant string

This is a cherry-picked version of https://github.com/SFTtech/openage/pull/1574 without the changes to the `engine` modpack version.