### PR TITLE
Add AUR instructions for installing `toml11`

### DIFF
--- a/doc/build_instructions/arch_linux.md
+++ b/doc/build_instructions/arch_linux.md
@@ -2,9 +2,14 @@
 
 > NOTE: `openage` is packaged in the [AUR](https://aur.archlinux.org/packages/openage-git/)!
 
-This command should provide required packages for Arch Linux installation:
+This command should provide required packages from the Arch Linux repositories:
 
 `sudo pacman -S --needed eigen python python-mako python-pillow python-numpy python-lz4 python-pygments cython libepoxy libogg libpng ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus python-pylint python-toml qt6-declarative`
+
+Additionally, you have to install [`toml11`](https://aur.archlinux.org/packages/toml11) from the AUR.
+If you have `yay`, you can run this command:
+
+`yay -S toml11`
 
 If you don't have a compiler installed, you can select between these commands to install it:
  - `sudo pacman -S --needed gcc`


### PR DESCRIPTION
Add instructions on how to add `toml11` from the AUR on Arch Linux.