### PR TITLE
Fix version tag regex failure when HEAD is tagged

### DIFF
--- a/buildsystem/DetectProjectVersion.cmake
+++ b/buildsystem/DetectProjectVersion.cmake
@@ -12,7 +12,7 @@ endif()
 if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
 	message(STATUS "Set PROJECT_VERSION from git.")
 	execute_process(
-		COMMAND git describe --tags
+		COMMAND git describe --tags --long
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 		RESULT_VARIABLE _RES
 		OUTPUT_VARIABLE PROJECT_VERSION


### PR DESCRIPTION
Our buildsystem expects version tags in the format `v1.2.3-4-g00abcdef` (tag + commit distance to tag + commit hash). However, since https://github.com/SFTtech/openage/pull/1576 we call `git describe --tags`. When `HEAD` is tagged, this command only outputs the tag and omits commit distance and commit hash (only `v1.2.3` is returned). This results in a configure failure since our regex cannot match the version format in this case.

This PR switches the version fetch command to `git describe --tags --long`, so that the long format is always used.