### PR TITLE
Fix append mode not available

### DIFF
--- a/openage/util/fslike/path.py
+++ b/openage/util/fslike/path.py
@@ -149,6 +149,10 @@ class Path:
         """ open with mode='wb' """
         return self.fsobj.open_w(self.parts)
 
+    def open_a(self):
+        """ open with mode='ab' """
+        return self.fsobj.open_a(self.parts)
+
     def _get_native_path(self):
         """
         return the native path (usable by your kernel) of this path,

--- a/openage/util/fslike/union.py
+++ b/openage/util/fslike/union.py
@@ -116,6 +116,14 @@ class Union(FSLikeObject):
         raise UnsupportedOperation(
             "not writable: " + b'/'.join(parts).decode(errors='replace'))
 
+    def open_a(self, parts):
+        for path in self.candidate_paths(parts):
+            if path.writable():
+                return path.open_a()
+
+        raise UnsupportedOperation(
+            "not appendable: " + b'/'.join(parts).decode(errors='replace'))
+
     def resolve_r(self, parts):
         for path in self.candidate_paths(parts):
             if path.is_file() or path.is_dir():


### PR DESCRIPTION
Turns out append modes were not properly checked for unions which made it unusable for writing to files.