### PR TITLE
Use block indent for aligning after open brackets

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 # see documentation in doc/code_style/ for details and explainations.
 Language:        Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: BlockIndent
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false


### PR DESCRIPTION
Finnaly let's us auto-format the enclosing bracket on a new line.

Before:

```cpp
this->display_shader->new_mom(
    "mass",
    1337,
    "hide",
    false);
```

After:

```cpp
this->display_shader->new_mom(
    "mass",
    1337,
    "hide",
    false
);
```