### PR TITLE
complete if-else branch to fix pylint error

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -151,6 +151,7 @@ _the openage authors_ are:
 | Md Ashhar                   | ashhar                      | mdashhar01 à gmail dawt com                       |
 | Fábio Barkoski              | fabiobarkoski               | fabiobarkoskii à gmail dawt com                   |
 | Astitva Kamble              | askastitva                  | astitvakamble5 à gmail dawt com                   |
+| Haoyang Bi                  | AyiStar                     | ayistar à outlook dawt com                        |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/entity_object/conversion/aoc/genie_unit.py
+++ b/openage/convert/entity_object/conversion/aoc/genie_unit.py
@@ -479,6 +479,8 @@ class GenieGameEntityGroup(ConverterObjectGroup):
             else:
                 # AoE1
                 return False
+        else:
+            raise ValueError(f"Unknown group type for {repr(self)}")
 
         enabling_research_id = head_unit_connection["enabling_research"].value
 


### PR DESCRIPTION
`make checkall` gets pylint error as follows:
openage/convert/entity_object/conversion/aoc/genie_unit.py:483:31: E0601: Using variable 'head_unit_connection' before assignment (used-before-assignment)
It is caused by an incomplete if-else block, and can be fixed by adding an else-branch raising ValueError.