### PR TITLE
Revert "Merge pull request #1602 from heinezen/clang-format-align"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 # see documentation in doc/code_style/ for details and explainations.
 Language:        Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: BlockIndent
+AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false


### PR DESCRIPTION
Currently, using `BlockIndent` can reformat other parts of the code to something less readable, e.g.

```cpp
void WorldRenderEntity::update(const uint32_t ref_id,
                               const curve::Continuous<coord::phys3> &position,
                               const curve::Segmented<coord::phys_angle_t> &angle,
                               const std::string animation_path,
                               const time::time_t time)
```

to

```cpp
void WorldRenderEntity::update(const uint32_t ref_id, const curve::Continuous<coord::phys3> &position, const curve::Segmented<coord::phys_angle_t> &angle, const std::string animation_path, const time::time_t time)
```

This is not really great for readability, so I would switch back to the old style until we or clang-format has a solution for this.