### PR TITLE
Add math constants corresbonding to `util/math_constants.h` for FixedPoint

### DIFF
--- a/libopenage/util/fixed_point.h
+++ b/libopenage/util/fixed_point.h
@@ -170,14 +170,71 @@ public:
 	}
 
 	/**
-	 * Constants
+	 * Math constants represented in FixedPoint
 	 */
+	// naming, definition and value are kept compatible with `math_constants.h`
 	static constexpr FixedPoint e() {
 		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(6267931151224907085ll));
 	}
 
+	static constexpr FixedPoint log2e() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(3326628274461080622ll));
+	}
+
+	static constexpr FixedPoint log10e() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(1001414895036696345ll));
+	}
+
+	static constexpr FixedPoint ln2() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(1598288580650331957ll));
+	}
+
+	static constexpr FixedPoint ln10() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(5309399739799983627ll));
+	}
+
 	static constexpr FixedPoint pi() {
 		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(7244019458077122842ll));
+	}
+
+	static constexpr FixedPoint pi_2() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(3622009729038561421ll));
+	}
+
+	static constexpr FixedPoint pi_4() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(1811004864519280710ll));
+	}
+
+	static constexpr FixedPoint inv_pi() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(733972625820500306ll));
+	}
+
+	static constexpr FixedPoint inv2_pi() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(1467945251641000613ll));
+	}
+
+	static constexpr FixedPoint inv2_sqrt_pi() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(2601865214189558307ll));
+	}
+
+	static constexpr FixedPoint tau() {
+		return from_fixedpoint(FixedPoint<int64_t, 60>::from_raw_value(7244019458077122842ll));
+	}
+
+	static constexpr FixedPoint degs_per_rad() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(40244552544872904ll));
+	}
+
+	static constexpr FixedPoint rads_per_deg() {
+		return from_fixedpoint(FixedPoint<int64_t, 57>::from_raw_value(8257192040480628449ll));
+	}
+
+	static constexpr FixedPoint sqrt_2() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(3260954456333195553ll));
+	}
+
+	static constexpr FixedPoint inv_sqrt_2() {
+		return from_fixedpoint(FixedPoint<int64_t, 61>::from_raw_value(1630477228166597776ll));
 	}
 
 	/**

--- a/libopenage/util/fixed_point_test.cpp
+++ b/libopenage/util/fixed_point_test.cpp
@@ -6,6 +6,7 @@
 
 #include "../testing/testing.h"
 #include "stringformatter.h"
+#include "math_constants.h"
 
 namespace openage {
 namespace util {
@@ -98,6 +99,14 @@ void fixed_point() {
 	std::stringstream sstr("1234.5678");
 	sstr >> e;
 	TESTEQUALS_FLOAT(e.to_double(), 1234.5678, 1e-7);
+
+	TESTEQUALS_FLOAT(TestType::e().to_double(), math::E, 1e-7);
+	TESTEQUALS_FLOAT(TestType::pi().to_double(), math::PI, 1e-7);
+
+	using TestTypeShort = FixedPoint<int32_t, 16>;
+	TESTEQUALS_FLOAT(TestTypeShort::e().to_double(), math::E, 1e-3);
+	TESTEQUALS_FLOAT(TestTypeShort::pi().to_double(), math::PI, 1e-3);
+
 }
 
 }}} // openage::util::tests

--- a/libopenage/util/fixed_point_test.cpp
+++ b/libopenage/util/fixed_point_test.cpp
@@ -101,7 +101,22 @@ void fixed_point() {
 	TESTEQUALS_FLOAT(e.to_double(), 1234.5678, 1e-7);
 
 	TESTEQUALS_FLOAT(TestType::e().to_double(), math::E, 1e-7);
+	TESTEQUALS_FLOAT(TestType::log2e().to_double(), math::LOG2E, 1e-7);
+	TESTEQUALS_FLOAT(TestType::log10e().to_double(), math::LOG10E, 1e-7);
+	TESTEQUALS_FLOAT(TestType::ln2().to_double(), math::LN2, 1e-7);
+	TESTEQUALS_FLOAT(TestType::ln10().to_double(), math::LN10, 1e-7);
 	TESTEQUALS_FLOAT(TestType::pi().to_double(), math::PI, 1e-7);
+	TESTEQUALS_FLOAT(TestType::pi_2().to_double(), math::PI_2, 1e-7);
+	TESTEQUALS_FLOAT(TestType::pi_4().to_double(), math::PI_4, 1e-7);
+	TESTEQUALS_FLOAT(TestType::inv_pi().to_double(), math::INV_PI, 1e-7);
+	TESTEQUALS_FLOAT(TestType::inv2_pi().to_double(), math::INV2_PI, 1e-7);
+	TESTEQUALS_FLOAT(TestType::inv2_sqrt_pi().to_double(), math::INV2_SQRT_PI, 1e-7);
+	TESTEQUALS_FLOAT(TestType::tau().to_double(), math::TAU, 1e-7);
+	TESTEQUALS_FLOAT(TestType::degs_per_rad().to_double(), math::DEGSPERRAD, 1e-7);
+	TESTEQUALS_FLOAT(TestType::rads_per_deg().to_double(), math::RADSPERDEG, 1e-7);
+	TESTEQUALS_FLOAT(TestType::sqrt_2().to_double(), math::SQRT_2, 1e-7);
+	TESTEQUALS_FLOAT(TestType::inv_sqrt_2().to_double(), math::INV_SQRT_2, 1e-7);
+
 
 	using TestTypeShort = FixedPoint<int32_t, 16>;
 	TESTEQUALS_FLOAT(TestTypeShort::e().to_double(), math::E, 1e-3);


### PR DESCRIPTION
To add pure fixed-point math functions (issue #1543), I found it would be better add some math constants (issue #1544). So here is a WIP PR which adds first two important constants, E and PI. The solution is as follows.

(1) In "fixed_point.h", I add two staic functions which return E and PI, respectively, referrng to the implementation of the fpm library.

(2) The from_fixedpoint() function is fixed to avoid the situation of narrowing warning/error furing compilation when the fractional_bits  of created FixedPoint constant object is smaller than the predefined one, i.e., 61.

(3) By the way, I also amend the comment doc of safeshift function.

(4) In "fixed_point_test.cpp", I add some tests which utilizes the constants defined in "math_constant.h" for comparison. I also test constant under different precisions (see TestTypeShort in the tests).