### PR TITLE
Add setuptools as conditionl dependency

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Brew install DeJaVu fonts
         run: brew tap homebrew/cask-fonts && brew install font-dejavu
       - name: Remove python's 2to3 link so that 'brew link' does not fail
-        run: rm '/usr/local/bin/2to3' && rm '/usr/local/bin/2to3-3.11'
+        run: rm /usr/local/bin/2to3* && rm /usr/local/bin/idle3*
       - name: Install environment helpers with homebrew
         run: brew install ccache
       - name: Install dependencies with homebrew
@@ -66,7 +66,7 @@ jobs:
         # cython, numpy and pygments are in homebrew,
         # but "cython is keg-only, which means it was not symlinked into /usr/local"
         # numpy pulls gcc as dep? and pygments doesn't work.
-        run: pip3 install --upgrade cython numpy mako lz4 pillow pygments toml
+        run: pip3 install --upgrade cython numpy mako lz4 pillow pygments setuptools toml
       - name: Configure
         run: |
           CLANG_PATH="$HOME/clang-15.0.0/bin/clang++"

--- a/doc/building.md
+++ b/doc/building.md
@@ -32,9 +32,10 @@ Dependency list:
     C     cython >=0.29.31
     C     cmake >=3.16
       A   numpy
+      A   lz4
       A   python imaging library (PIL) -> pillow
-     RA   toml
-     RA   lz4
+     RA   setuptools (for python>=3.12 and cython<3.1)
+      A   toml
     CR    opengl >=3.3
     CR    libepoxy
     CR    libpng


### PR DESCRIPTION
Python 3.12 removed `distutils` but Cython still requires it for building. Until this is solved, we have to pull `setuptools` (which contains `distutils`) as a dependency on platforms that don't automatically support it.