### PR TITLE
Queue curve rework

### DIFF
--- a/libopenage/curve/iterator.h
+++ b/libopenage/curve/iterator.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -98,7 +98,7 @@ public:
 	}
 
 	/**
-	 * Access the underlying
+	 * Access the underlying iterator.
 	 */
 	const iterator_t &get_base() const {
 		return base;

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 
+#include "error/error.h"
+
 #include "curve/iterator.h"
 #include "curve/queue_filter_iterator.h"
 #include "event/evententity.h"
@@ -276,12 +278,8 @@ typename Queue<T>::const_iterator Queue<T>::first_alive(const time::time_t &time
 
 template <typename T>
 const T &Queue<T>::front(const time::time_t &time) const {
-	if (this->empty(time)) [[unlikely]] {
-		throw Error{MSG(err) << "Tried accessing front at "
-		                     << time << " but queue is empty."};
-	}
-
 	auto it = this->first_alive(time);
+	ENSURE(it != this->container.end(), "Tried accessing front at " << time << " but queue is empty.");
 
 	return it->value;
 }
@@ -289,12 +287,8 @@ const T &Queue<T>::front(const time::time_t &time) const {
 
 template <class T>
 const T &Queue<T>::pop_front(const time::time_t &time) {
-	if (this->empty(time)) [[unlikely]] {
-		throw Error{MSG(err) << "Tried accessing front at "
-		                     << time << " but queue is empty."};
-	}
-
 	Queue<T>::const_iterator it = this->first_alive(time);
+	ENSURE(it != this->container.end(), "Tried accessing front at " << time << " but queue is empty.");
 
 	// cache the search start position for the next front() call
 	this->front_start = it;

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -128,24 +128,30 @@ public:
      *
      * Does not ignore dead elements.
 	 *
-	 * @param t The time to get the element at.
+	 * @param t The time to get the element at (default: \p time::TIME_MAX ).
+     *
 	 * @return Iterator to the last element.
 	 */
 	QueueFilterIterator<T, Queue<T>> end(const time::time_t &time = time::TIME_MAX) const;
 
 	/**
 	 * Get an iterator to elements that are in the queue between two time frames.
+     *
+     * Does not ignore dead elements.
 	 *
-	 * @param begin Start time.
-	 * @param end End time.
+	 * @param begin Start time (default: \p time::TIME_MIN ).
+	 * @param end End time (default: \p time::TIME_MAX ).
+     *
 	 * @return Iterator to the first element in the time frame.
 	 */
 	QueueFilterIterator<T, Queue<T>> between(
-		const time::time_t &begin = time::TIME_MAX,
+		const time::time_t &begin = time::TIME_MIN,
 		const time::time_t &end = time::TIME_MAX) const;
 
 	/**
 	 * Erase an element from the queue.
+     *
+     * Does not ignore dead elements.
 	 *
 	 * @param it The iterator to the element to erase.
 	 */
@@ -256,8 +262,6 @@ Queue<T>::const_iterator Queue<T>::first_alive(const time::time_t &time) const {
 	}
 
 	// Iterate until we find an alive element
-	bool al = hint->alive() <= time;
-	bool en = hint != this->container.end();
 	while (hint->alive() <= time
 	       and hint != this->container.end()) {
 		if (hint->dead() > time) {

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -80,22 +80,22 @@ public:
 
 	/**
 	 * Get the first element inserted at t <= time.
-     *
-     * Ignores dead elements.
+	 *
+	 * Ignores dead elements.
 	 *
 	 * @param time The time to get the element at.
-     *
+	 *
 	 * @return Queue element.
 	 */
 	const T &front(const time::time_t &time) const;
 
 	/**
 	 * Check if the queue is empty at the given time (no elements alive
-     * before t <= time).
-     *
-     * Ignores dead elements.
-     *
-     * @param time The time to check at.
+	 * before t <= time).
+	 *
+	 * Ignores dead elements.
+	 *
+	 * @param time The time to check at.
 	 *
 	 * @return true if the queue is empty, false otherwise.
 	 */
@@ -105,9 +105,9 @@ public:
 
 	/**
 	 * Get the first element inserted at t <= time and erase it from the
-     * queue.
-     *
-     * Ignores dead elements.
+	 * queue.
+	 *
+	 * Ignores dead elements.
 	 *
 	 * @param time The time to get the element at.
 	 * @param value Queue element.
@@ -116,34 +116,34 @@ public:
 
 	/**
 	 * Get an iterator to the first element inserted at t >= time.
-     *
-     * Does not ignore dead elements.
+	 *
+	 * Does not ignore dead elements.
 	 *
 	 * @param time The time to get the element at (default: \p time::TIME_MIN ).
-     *
+	 *
 	 * @return Iterator to the first element.
 	 */
 	QueueFilterIterator<T, Queue<T>> begin(const time::time_t &time = time::TIME_MIN) const;
 
 	/**
 	 * Get an iterator to the last element in the queue at the given time.
-     *
-     * Does not ignore dead elements.
+	 *
+	 * Does not ignore dead elements.
 	 *
 	 * @param t The time to get the element at (default: \p time::TIME_MAX ).
-     *
+	 *
 	 * @return Iterator to the last element.
 	 */
 	QueueFilterIterator<T, Queue<T>> end(const time::time_t &time = time::TIME_MAX) const;
 
 	/**
 	 * Get an iterator to elements that are in the queue between two time frames.
-     *
-     * Does not ignore dead elements.
+	 *
+	 * Does not ignore dead elements.
 	 *
 	 * @param begin Start time (default: \p time::TIME_MIN ).
 	 * @param end End time (default: \p time::TIME_MAX ).
-     *
+	 *
 	 * @return Iterator to the first element in the time frame.
 	 */
 	QueueFilterIterator<T, Queue<T>> between(
@@ -152,8 +152,8 @@ public:
 
 	/**
 	 * Erase an element from the queue.
-     *
-     * Does not ignore dead elements.
+	 *
+	 * Does not ignore dead elements.
 	 *
 	 * @param it The iterator to the element to erase.
 	 */
@@ -164,7 +164,7 @@ public:
 	 *
 	 * @param time The time to insert at.
 	 * @param e The element to insert.
-     *
+	 *
 	 * @return Iterator to the inserted element.
 	 */
 	QueueFilterIterator<T, Queue<T>> insert(const time::time_t &time, const T &e);
@@ -210,18 +210,18 @@ private:
 	/**
 	 * Erase an element from the queue at the given time.
 	 *
-     * @param time The time to erase at.
+	 * @param time The time to erase at.
 	 * @param it The iterator to the element to erase.
 	 */
 	void erase(const time::time_t &time, const_iterator &it);
 
 	/**
-     * Get the first alive element inserted at t <= time.
-     *
-     * @param time The time to get the element at.
-     *
-     * @return Iterator to the first alive element or end() if no such element exists.
-     */
+	 * Get the first alive element inserted at t <= time.
+	 *
+	 * @param time The time to get the element at.
+	 *
+	 * @return Iterator to the first alive element or end() if no such element exists.
+	 */
 	const_iterator first_alive(const time::time_t &time) const;
 
 	/**
@@ -240,15 +240,15 @@ private:
 	container_t container;
 
 	/**
-     * Simulation time of the last modifying change to the queue.
-     */
+	 * Simulation time of the last modifying change to the queue.
+	 */
 	time::time_t last_change;
 
 	/**
-     * Caches the search start position for the next front() call.
-     *
-     * All iterators before are guaranteed to be dead at t >= last_change.
-     */
+	 * Caches the search start position for the next front() call.
+	 *
+	 * All iterators before are guaranteed to be dead at t >= last_change.
+	 */
 	mutable typename Queue<T>::const_iterator front_start;
 };
 

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -252,7 +252,7 @@ private:
 
 
 template <class T>
-Queue<T>::const_iterator Queue<T>::first_alive(const time::time_t &time) const {
+typename Queue<T>::const_iterator Queue<T>::first_alive(const time::time_t &time) const {
 	auto hint = this->container.begin();
 
 	// check if the access is later than the last change
@@ -377,17 +377,17 @@ template <typename T>
 QueueFilterIterator<T, Queue<T>> Queue<T>::insert(const time::time_t &time,
                                                   const T &e) {
 	const_iterator insertion_point = this->container.end();
-	for (auto it = this->container.begin(); it != this->container.end(); ++it) {
-		if (time < it->alive()) {
-			insertion_point = this->container.insert(it, queue_wrapper(time, e));
+	while (insertion_point != this->container.begin()) {
+		--insertion_point;
+		if (insertion_point->alive() <= time) {
+			++insertion_point;
 			break;
 		}
 	}
+	insertion_point = this->container.insert(insertion_point, queue_wrapper{time, e});
 
-	if (insertion_point == this->container.end()) {
-		insertion_point = this->container.insert(this->container.end(),
-		                                         queue_wrapper(time, e));
-	}
+	// TODO: Inserting before any dead elements shoud reset their death time
+	//       since by definition, they cannot be popped before the new element
 
 	// cache the insertion time
 	this->last_change = time;

--- a/libopenage/curve/queue_filter_iterator.h
+++ b/libopenage/curve/queue_filter_iterator.h
@@ -33,7 +33,7 @@ public:
 
 	virtual bool valid() const override {
 		if (this->container->end().get_base() != this->get_base()) {
-			return (this->get_base()->time() >= this->from and this->get_base()->time() < this->to);
+			return (this->get_base()->alive() >= this->from and this->get_base()->alive() < this->to);
 		}
 		return false;
 	}

--- a/libopenage/curve/queue_filter_iterator.h
+++ b/libopenage/curve/queue_filter_iterator.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/curve/tests/container.cpp
+++ b/libopenage/curve/tests/container.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include <algorithm>
 #include <deque>
@@ -178,17 +178,6 @@ void test_queue() {
 	TESTEQUALS(*q.begin(12), 5);
 	TESTEQUALS(*q.begin(100000), 5);
 
-	TESTEQUALS(q.front(0), 1);
-	TESTEQUALS(q.front(1), 1);
-	TESTEQUALS(q.front(2), 2);
-	TESTEQUALS(q.front(3), 2);
-	TESTEQUALS(q.front(4), 3);
-	TESTEQUALS(q.front(5), 3);
-	TESTEQUALS(q.front(10), 4);
-	TESTEQUALS(q.front(12), 4);
-	TESTEQUALS(q.front(100000), 4);
-	TESTEQUALS(q.front(100001), 6);
-
 	{
 		std::unordered_set<int> reference = {1, 2, 3};
 		for (auto it = q.between(0, 6); it != q.end(); ++it) {
@@ -230,18 +219,27 @@ void test_queue() {
 		TESTEQUALS(reference.empty(), true);
 	}
 
+	TESTEQUALS(q.front(0), 1);
+	TESTEQUALS(q.front(2), 1);
+	TESTEQUALS(q.front(5), 1);
+	TESTEQUALS(q.front(10), 1);
+	TESTEQUALS(q.front(100001), 1);
 
 	TESTEQUALS(q.pop_front(0), 1);
 	TESTEQUALS(q.empty(0), true);
 
-	TESTEQUALS(q.pop_front(12), 4);
+	TESTEQUALS(q.pop_front(12), 2);
 	TESTEQUALS(q.empty(12), false);
 
 	TESTEQUALS(q.pop_front(12), 3);
 	TESTEQUALS(q.empty(12), false);
 
-	TESTEQUALS(q.pop_front(12), 2);
+	TESTEQUALS(q.pop_front(12), 4);
 	TESTEQUALS(q.empty(12), true);
+
+	q.clear(0);
+	TESTEQUALS(q.empty(0), true);
+	TESTEQUALS(q.empty(100001), false);
 }
 
 


### PR DESCRIPTION
Reworks the curve queue to make it more intuitive to use and more efficient in certain situations.

In the original design by @Tomatower , elements in a curved queue are mostly accessed by requesting all elements in a timespan (e.g. all elements between `t1 == 0` and `t2 == 5`). You could then iterate through these elements to process them. `front(t)` or `pop(t)` access (like in "normal" queues) to retrieve/remove the front element at a time `t` was not possible.

However, there are a few problems with this in practice which made the queue unintuitive to use. If the elements are processed one at a time, the requirement for a timespan puts a burden on the calling code to track which time/elements have already been processed. If the queue is shared by multiple callers, this adds a lot of additional complexity. Furthermore, since popping is not possible, there is no real way to "empty" the queue for a specific timespan, except by tracking this status outside of the queue. Filtering a timespan was also an expensive operation with a complexity of O(n) vs. O(1) for most operations in `std::queue`.

https://github.com/SFTtech/openage/pull/1609 already introduced a few changes like the addition of `front(t)`, `pop_front(t)` and `empty(t)` to address some of these problems, but these only work under the assumption that time is always progressing forward, so they didn't fulfill the basic curve properties. This PR addresses this and also changes the operations logic to make more sense for people familiar with `std::queue`.

**Track lifespan of elements with `dead` time**

Like `curve::UnorderedMap`, `curve::Queue` now tracks the lifespan of elements with insertion time (`alive`) and erasure time (`dead`). `dead` is now set when an element is removed by `pop_front(t)` which makes the element invisible for pops at later times. Elements are also no longer erased from the queue if they are popped.

**Change timespan observed by `front`/`pop_front`**

Previously, the operations `front(t)` and `pop_front(t)` only considered elements that were inserted *after* or at `t`. However, this meant that e.g. `front(2)` had no result even if the queue contained elements `A` and `B` with insertion times `0` and `1` respectively. Since this was counter-intuitive, these operations will now consider elements inserted until `t`, i.e. *before* or at `t`. In other words, the front element is now the element with the lowest insertion time that is also still alive at `t`.

**Optimizations for common operations**

`front(t)`/`pop_front(t)`/`empty(t)`/`insert(t)` have been optimized for the case that simulation time always progresses forwards, i.e. that the time `t` always increases for each access, by caching the iterator to the last accessed element. This optimization should cover the normal use case of running a game. Complexity for these operations is then O(1) (vs. O(n) previously).