### PR TITLE
Fix tabs in multi-line comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignEscapedNewlines: DontAlign
 AlignOperands:   Align
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never

--- a/.clang-format
+++ b/.clang-format
@@ -100,7 +100,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-ReflowComments: false
+ReflowComments: true
 SortIncludes:    CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/libopenage/assets/mod_manager.h
+++ b/libopenage/assets/mod_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -22,67 +22,67 @@ public:
 	~ModManager() = default;
 
 	/**
-     * Adds a modpack to the list of available modpacks.
-     *
-     * @param info_file Path to the modpack definition file.
-     */
+	 * Adds a modpack to the list of available modpacks.
+	 *
+	 * @param info_file Path to the modpack definition file.
+	 */
 	void register_modpack(const util::Path &info_file);
 
 	/**
-     * Adds a modpack to the list of available modpacks.
-     *
-     * @param info Modpack definition.
-     */
+	 * Adds a modpack to the list of available modpacks.
+	 *
+	 * @param info Modpack definition.
+	 */
 	void register_modpack(const ModpackInfo &info);
 
 	/**
-     * Ready a set of modpacks with the given IDs.
-     *
-     * This prepares the modpacks for loading by valiating the integrity of
-     * the contained data, checking if the load order and mounting the
-     * assets into the virtual filesystem.
-     *
-     * TODO:
-     *     - Mount modpacks into virtual filesystem.
-     *     - Validate manifest.toml
-     *     - Verify signature of manifest.toml (if signed)
-     *
-     * Note that data inside the modpack is not loaded yet. Data
-     * loading is done inside the simulation before the game starts or
-     * in case of media files, when they are requested during the game.
-     *
-     * Modpacks must have been registered with \p register_modpack() before
-     * activating.
-     *
-     * @param load_order Load order of modpacks.
-     */
+	 * Ready a set of modpacks with the given IDs.
+	 *
+	 * This prepares the modpacks for loading by valiating the integrity of
+	 * the contained data, checking if the load order and mounting the
+	 * assets into the virtual filesystem.
+	 *
+	 * TODO:
+	 *     - Mount modpacks into virtual filesystem.
+	 *     - Validate manifest.toml
+	 *     - Verify signature of manifest.toml (if signed)
+	 *
+	 * Note that data inside the modpack is not loaded yet. Data
+	 * loading is done inside the simulation before the game starts or
+	 * in case of media files, when they are requested during the game.
+	 *
+	 * Modpacks must have been registered with \p register_modpack() before
+	 * activating.
+	 *
+	 * @param load_order Load order of modpacks.
+	 */
 	void activate_modpacks(const std::vector<std::string> &load_order);
 
 	/**
-     * Get a loaded modpack by its ID.
-     *
-     * @param modpack_id ID of the modpack to get.
-     *
-     * @return Modpack with the given ID.
-     */
+	 * Get a loaded modpack by its ID.
+	 *
+	 * @param modpack_id ID of the modpack to get.
+	 *
+	 * @return Modpack with the given ID.
+	 */
 	std::shared_ptr<Modpack> get_modpack(const std::string &modpack_id) const;
 
 	/**
-     * Get the load order of modpacks.
-     *
-     * @return Modpack IDs in the order that they should be loaded.
-     */
+	 * Get the load order of modpacks.
+	 *
+	 * @return Modpack IDs in the order that they should be loaded.
+	 */
 	const std::vector<std::string> &get_load_order() const;
 
 	/**
-     * Enumerates all modpack ids in a given directory.
-     *
-     * This also loads available modpack definition files.
-     *
-     * @param directory Path to the directory to enumerate.
-     *
-     * @return Infos of the identified modpacks.
-     */
+	 * Enumerates all modpack ids in a given directory.
+	 *
+	 * This also loads available modpack definition files.
+	 *
+	 * @param directory Path to the directory to enumerate.
+	 *
+	 * @return Infos of the identified modpacks.
+	 */
 	static std::vector<ModpackInfo> enumerate_modpacks(const util::Path &directory) {
 		std::vector<ModpackInfo> result;
 
@@ -106,37 +106,37 @@ public:
 
 private:
 	/**
-     * Set the order in which modpack data should be loaded.
-     *
-     * This also checks whether the given load order is valid, i.e.
-     * by checking if all dependencies/conflicts are resolved.
-     *
-     * TODO: Dynamically resolve load order?
-     *
-     * @param load_order Load order of modpacks.
-     */
+	 * Set the order in which modpack data should be loaded.
+	 *
+	 * This also checks whether the given load order is valid, i.e.
+	 * by checking if all dependencies/conflicts are resolved.
+	 *
+	 * TODO: Dynamically resolve load order?
+	 *
+	 * @param load_order Load order of modpacks.
+	 */
 	void set_load_order(const std::vector<std::string> &load_order);
 
 	/**
-     * TODO: Mount point for modpacks.
-     */
+	 * TODO: Mount point for modpacks.
+	 */
 	util::Path asset_base_dir;
 
 	/**
-     * Active modpacks. Maps their ID ('name' in the modpack definition file)
-     * to the modpack.
-     */
+	 * Active modpacks. Maps their ID ('name' in the modpack definition file)
+	 * to the modpack.
+	 */
 	std::unordered_map<std::string, std::shared_ptr<Modpack>> active;
 
 	/**
-     * Available modpacks that can be activated. Maps their ID ('name' in the modpack
-     * definition file) to the modpack info.
-     */
+	 * Available modpacks that can be activated. Maps their ID ('name' in the modpack
+	 * definition file) to the modpack info.
+	 */
 	std::unordered_map<std::string, ModpackInfo> available;
 
 	/**
-     * Load order of modpacks.
-     */
+	 * Load order of modpacks.
+	 */
 	std::vector<std::string> load_order;
 };
 

--- a/libopenage/assets/modpack.h
+++ b/libopenage/assets/modpack.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -79,26 +79,26 @@ ModpackInfo parse_modepack_def(const util::Path &info_file);
 class Modpack {
 public:
 	/**
-     * Create a new modpack.
-     *
-     * Loads the modpack using the information in the definition file.
-     *
-     * @param info_file Path to the modpack definition file.
-     */
+	 * Create a new modpack.
+	 *
+	 * Loads the modpack using the information in the definition file.
+	 *
+	 * @param info_file Path to the modpack definition file.
+	 */
 	Modpack(const util::Path &info_file);
 
 	/**
-     * Create a new modpack from an existing modpack info.
-     *
-     * @param info Modpack metadata information.
-     */
+	 * Create a new modpack from an existing modpack info.
+	 *
+	 * @param info Modpack metadata information.
+	 */
 	Modpack(const ModpackInfo &info);
 
 	/**
-     * Create a new modpack from an existing modpack info.
-     *
-     * @param info Modpack metadata information.
-     */
+	 * Create a new modpack from an existing modpack info.
+	 *
+	 * @param info Modpack metadata information.
+	 */
 	Modpack(const ModpackInfo &&info);
 
 	Modpack(const Modpack &) = delete;
@@ -106,23 +106,23 @@ public:
 	~Modpack() = default;
 
 	/**
-     * Get the metadata information of the modpack.
-     *
-     * @return Modpack metadata information.
-     */
+	 * Get the metadata information of the modpack.
+	 *
+	 * @return Modpack metadata information.
+	 */
 	const ModpackInfo &get_info() const;
 
 	/**
-     * Check if the modpack is valid.
-     *
-     * @return true if the modpack is valid, false otherwise.
-     */
+	 * Check if the modpack is valid.
+	 *
+	 * @return true if the modpack is valid, false otherwise.
+	 */
 	bool check_integrity() const;
 
 private:
 	/**
-     * Modpack metadata information.
-     */
+	 * Modpack metadata information.
+	 */
 	ModpackInfo info;
 };
 

--- a/libopenage/audio/category.h
+++ b/libopenage/audio/category.h
@@ -1,12 +1,10 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <iostream>
 
-namespace openage {
-namespace audio {
-
+namespace openage::audio {
 
 enum class category_t {
 	GAME,
@@ -17,7 +15,7 @@ enum class category_t {
 
 
 const char *category_t_to_str(category_t val);
-std::ostream &operator <<(std::ostream &os, category_t val);
+std::ostream &operator<<(std::ostream &os, category_t val);
 
 
-}} // openage::audio
+} // namespace openage::audio

--- a/libopenage/audio/dynamic_loader.h
+++ b/libopenage/audio/dynamic_loader.h
@@ -1,13 +1,13 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <memory>
 #include <string>
 
+#include "../util/path.h"
 #include "format.h"
 #include "types.h"
-#include "../util/path.h"
 
 
 namespace openage {
@@ -43,7 +43,8 @@ public:
 	 * @param offset the offset from the resource's beginning
 	 * @param chunk_size the number of int16_t values that fit in one chunk
 	 */
-	virtual size_t load_chunk(int16_t *chunk_buffer, size_t offset,
+	virtual size_t load_chunk(int16_t *chunk_buffer,
+	                          size_t offset,
 	                          size_t chunk_size) = 0;
 
 	/**
@@ -55,4 +56,5 @@ public:
 	                                             format_t format);
 };
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/dynamic_resource.h
+++ b/libopenage/audio/dynamic_resource.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,15 +8,15 @@
 #include <unordered_map>
 #include <vector>
 
+#include "../datastructure/concurrent_queue.h"
+#include "../job/job.h"
+#include "../job/job_group.h"
+#include "../util/path.h"
 #include "category.h"
 #include "dynamic_loader.h"
 #include "format.h"
 #include "resource.h"
 #include "types.h"
-#include "../datastructure/concurrent_queue.h"
-#include "../job/job.h"
-#include "../job/job_group.h"
-#include "../util/path.h"
 
 namespace openage {
 namespace audio {
@@ -59,10 +59,10 @@ public:
 	                category_t category,
 	                int id,
 	                const util::Path &path,
-	                format_t format=format_t::OPUS,
-	                int preload_amount=DEFAULT_PRELOAD_AMOUNT,
-	                size_t chunk_size=DEFAULT_CHUNK_SIZE,
-	                size_t max_chunks=DEFAULT_MAX_CHUNKS);
+	                format_t format = format_t::OPUS,
+	                int preload_amount = DEFAULT_PRELOAD_AMOUNT,
+	                size_t chunk_size = DEFAULT_CHUNK_SIZE,
+	                size_t max_chunks = DEFAULT_MAX_CHUNKS);
 
 	virtual ~DynamicResource() = default;
 
@@ -95,7 +95,7 @@ public:
 	static constexpr int DEFAULT_PRELOAD_AMOUNT = 10;
 
 	/** The default used chunk size in bytes (100ms for 48kHz stereo audio). */
-	static constexpr size_t DEFAULT_CHUNK_SIZE = 9600*2;
+	static constexpr size_t DEFAULT_CHUNK_SIZE = 9600 * 2;
 
 	/** The default number of chunks, that can be loaded at the same time. */
 	static constexpr size_t DEFAULT_MAX_CHUNKS = 100;
@@ -138,11 +138,11 @@ private:
 	 * Resource chunk index to chunk mapping.
 	 * Loading and usage state is reached through this.
 	 */
-	std::unordered_map<size_t,std::shared_ptr<chunk_info_t>> chunks;
+	std::unordered_map<size_t, std::shared_ptr<chunk_info_t>> chunks;
 
 	/** The background loading job group. */
 	job::JobGroup loading_job_group;
 };
 
-}
-}
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/error.h
+++ b/libopenage/audio/error.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,4 +12,5 @@ public:
 	Error(const log::message &msg);
 };
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/format.h
+++ b/libopenage/audio/format.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,6 +17,7 @@ enum class format_t {
 
 const char *format_t_to_str(format_t val);
 
-std::ostream &operator <<(std::ostream &os, format_t val);
+std::ostream &operator<<(std::ostream &os, format_t val);
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/hash_functions.h
+++ b/libopenage/audio/hash_functions.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,18 +8,18 @@
 
 namespace std {
 
-template<>
+template <>
 struct hash<::openage::audio::category_t> {
 	size_t operator()(const ::openage::audio::category_t &c) const {
 		return static_cast<int>(c);
 	}
 };
 
-template<>
-struct hash<std::tuple<::openage::audio::category_t,int>> {
-	size_t operator()(const std::tuple<::openage::audio::category_t,int> &t) const {
+template <>
+struct hash<std::tuple<::openage::audio::category_t, int>> {
+	size_t operator()(const std::tuple<::openage::audio::category_t, int> &t) const {
 		return static_cast<size_t>(std::get<0>(t)) << (sizeof(size_t) * 8 - 2) | std::get<1>(t);
 	}
 };
 
-}
+} // namespace std

--- a/libopenage/audio/in_memory_loader.h
+++ b/libopenage/audio/in_memory_loader.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,9 +6,9 @@
 #include <string>
 #include <tuple>
 
+#include "../util/path.h"
 #include "format.h"
 #include "types.h"
-#include "../util/path.h"
 
 
 namespace openage {
@@ -47,4 +47,5 @@ public:
 	                                              format_t format);
 };
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/in_memory_resource.h
+++ b/libopenage/audio/in_memory_resource.h
@@ -1,13 +1,13 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <string>
 
+#include "../util/path.h"
 #include "format.h"
 #include "resource.h"
 #include "types.h"
-#include "../util/path.h"
 
 
 namespace openage {
@@ -26,7 +26,7 @@ public:
 	                 category_t category,
 	                 int id,
 	                 const util::Path &path,
-	                 format_t format=format_t::OPUS);
+	                 format_t format = format_t::OPUS);
 	virtual ~InMemoryResource() = default;
 
 	void use() override;
@@ -35,5 +35,5 @@ public:
 	audio_chunk_t get_data(size_t position, size_t data_length) override;
 };
 
-}
-}
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/loader_policy.h
+++ b/libopenage/audio/loader_policy.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,6 +17,7 @@ enum class loader_policy_t {
 
 const char *loader_policy_t_to_str(loader_policy_t val);
 
-std::ostream &operator <<(std::ostream &os, loader_policy_t val);
+std::ostream &operator<<(std::ostream &os, loader_policy_t val);
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/opus_dynamic_loader.h
+++ b/libopenage/audio/opus_dynamic_loader.h
@@ -1,14 +1,14 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#include <string>
 #include <memory>
+#include <string>
 
-#include "opus_loading.h"
-#include "dynamic_loader.h"
-#include "types.h"
 #include "../util/path.h"
+#include "dynamic_loader.h"
+#include "opus_loading.h"
+#include "types.h"
 
 
 namespace openage {
@@ -40,4 +40,5 @@ public:
 	                  size_t chunk_size) override;
 };
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/opus_in_memory_loader.h
+++ b/libopenage/audio/opus_in_memory_loader.h
@@ -1,12 +1,12 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <string>
 
+#include "../util/path.h"
 #include "in_memory_loader.h"
 #include "types.h"
-#include "../util/path.h"
 
 
 namespace openage {
@@ -28,4 +28,5 @@ public:
 	pcm_data_t get_resource() override;
 };
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/opus_loading.h
+++ b/libopenage/audio/opus_loading.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,7 +21,7 @@ struct opus_file_t {
 	 * The opusfile handle, with a custom deleter that frees
 	 * the opusfile memory.
 	 */
-	std::unique_ptr<OggOpusFile, std::function<void(OggOpusFile*)>> handle;
+	std::unique_ptr<OggOpusFile, std::function<void(OggOpusFile *)>> handle;
 
 	/**
 	 * File used to supply the data.
@@ -37,4 +37,5 @@ struct opus_file_t {
  */
 opus_file_t open_opus_file(const util::Path &path);
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/resource.h
+++ b/libopenage/audio/resource.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,11 +27,11 @@ public:
 	Resource(AudioManager *manager, category_t category, int id);
 	virtual ~Resource() = default;
 
-	Resource(const Resource&) = delete;
-	Resource &operator=(const Resource&) = delete;
+	Resource(const Resource &) = delete;
+	Resource &operator=(const Resource &) = delete;
 
-	Resource(Resource&&) = delete;
-	Resource &operator=(Resource&&) = delete;
+	Resource(Resource &&) = delete;
+	Resource &operator=(Resource &&) = delete;
 
 	virtual category_t get_category() const;
 	virtual int get_id() const;
@@ -83,5 +83,5 @@ private:
 	int id;
 };
 
-}
-}
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/resource_def.h
+++ b/libopenage/audio/resource_def.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,4 +27,5 @@ struct resource_def {
 };
 
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/sound.h
+++ b/libopenage/audio/sound.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,7 +23,7 @@ class Resource;
  */
 class SoundImpl {
 public:
-	SoundImpl(std::shared_ptr<Resource> resource, int32_t volume=128);
+	SoundImpl(std::shared_ptr<Resource> resource, int32_t volume = 128);
 	~SoundImpl();
 
 	/**
@@ -167,4 +167,5 @@ private:
 };
 
 
-}} // namespace openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/audio/types.h
+++ b/libopenage/audio/types.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -34,4 +34,5 @@ using pcm_data_t = std::vector<int16_t>;
  */
 using pcm_chunk_t = std::vector<int16_t>;
 
-}} // openage::audio
+} // namespace audio
+} // namespace openage

--- a/libopenage/console/buf.h
+++ b/libopenage/console/buf.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -51,12 +51,11 @@ struct buf_char {
 	/**
 	 * Default copy constructor
 	 */
-	buf_char(int cp, chrcol_t fgcol, chrcol_t bgcol, chrflags_t flags)
-	:
-	cp{cp},
-	fgcol{fgcol},
-	bgcol{bgcol},
-	flags{flags} {
+	buf_char(int cp, chrcol_t fgcol, chrcol_t bgcol, chrflags_t flags) :
+		cp{cp},
+		fgcol{fgcol},
+		bgcol{bgcol},
+		flags{flags} {
 	}
 
 	buf_char() = default;
@@ -78,16 +77,12 @@ struct buf_char {
 	 */
 	chrflags_t flags;
 
-	bool operator ==(const buf_char &other) const {
-		return
-		 (this->cp == other.cp) &&
-		 (this->fgcol == other.fgcol) &&
-		 (this->bgcol == other.bgcol) &&
-		 (this->flags == other.flags);
+	bool operator==(const buf_char &other) const {
+		return (this->cp == other.cp) && (this->fgcol == other.fgcol) && (this->bgcol == other.bgcol) && (this->flags == other.flags);
 	}
 
-	bool operator !=(const buf_char &other) const {
-		return not (*this == other);
+	bool operator!=(const buf_char &other) const {
+		return not(*this == other);
 	}
 };
 
@@ -116,20 +111,19 @@ struct buf_line {
 	linetype_t type;
 };
 
-constexpr buf_line BUF_LINE_DEFAULT {LINE_EMPTY};
+constexpr buf_line BUF_LINE_DEFAULT{LINE_EMPTY};
 
 class Buf {
 	friend class NewBuf;
 
 public:
-	Buf(coord::term dims, coord::term_t scrollback_lines, coord::term_t min_width,
-	    buf_char default_char_fmt = {0x20, 254, 0, 0});
+	Buf(coord::term dims, coord::term_t scrollback_lines, coord::term_t min_width, buf_char default_char_fmt = {0x20, 254, 0, 0});
 	~Buf();
 
 	/*
 	 * we don't want this object to be copyable
 	 */
-	Buf& operator=(const Buf &) = delete;
+	Buf &operator=(const Buf &) = delete;
 	Buf(const Buf &) = delete;
 
 
@@ -407,7 +401,7 @@ public:
 	 */
 	buf_line *screen_linedata;
 
-	//following this line are all terminal size related variables
+	// following this line are all terminal size related variables
 
 	/**
 	 * minimum screen buffer width
@@ -425,7 +419,7 @@ public:
 	 */
 	coord::term_t scrollback_lines;
 
-	//following this line are all cursor state related variables
+	// following this line are all cursor state related variables
 
 	/**
 	 * cursor position
@@ -450,7 +444,7 @@ public:
 	 */
 	bool cursor_special_lastcol;
 
-	//following this line are misc variables
+	// following this line are misc variables
 
 	/**
 	 * true if we are currently reading an escape sequence
@@ -518,4 +512,5 @@ public:
 	coord::term_t scrollback_pos;
 };
 
-}} // openage::console
+} // namespace console
+} // namespace openage

--- a/libopenage/coord/chunk.h
+++ b/libopenage/coord/chunk.h
@@ -1,10 +1,10 @@
-// Copyright 2016-2018 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#include "declarations.h"
 #include "coord_nese.gen.h"
 #include "coord_neseup.gen.h"
+#include "declarations.h"
 
 namespace openage {
 namespace coord {

--- a/libopenage/curve/base_curve.h
+++ b/libopenage/curve/base_curve.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -104,52 +104,52 @@ public:
 	void check_integrity() const;
 
 	/**
-     * Copy keyframes from another curve to this curve. After syncing, the two curves
-     * are guaranteed to return the same values for t >= start.
-     *
-     * The operation may insert new keyframes at \p start on the curve.
-     *
-     * @param other Curve that keyframes are copied from.
-     * @param start Start time at which keyframes are replaced (default = -INF).
-     *              Using the default value replaces ALL keyframes of \p this with
-     *              the keyframes of \p other.
-     */
+	 * Copy keyframes from another curve to this curve. After syncing, the two curves
+	 * are guaranteed to return the same values for t >= start.
+	 *
+	 * The operation may insert new keyframes at \p start on the curve.
+	 *
+	 * @param other Curve that keyframes are copied from.
+	 * @param start Start time at which keyframes are replaced (default = -INF).
+	 *              Using the default value replaces ALL keyframes of \p this with
+	 *              the keyframes of \p other.
+	 */
 	void sync(const BaseCurve<T> &other,
 	          const time::time_t &start = time::TIME_MIN);
 
 	/**
-     * Copy keyframes from another curve (with a different element type) to this curve.
-     * After syncing, the two curves are guaranteed to return the same values
-     * for t >= start.
-     *
-     * The operation may insert new keyframes at \p start on the curve.
-     *
-     * @param other Curve that keyframes are copied from.
-     * @param converter Function that converts the value type of \p other to the
-     *                  value type of \p this.
-     * @param start Start time at which keyframes are replaced (default = -INF).
-     *              Using the default value replaces ALL keyframes of \p this with
-     *              the keyframes of \p other.
-     */
+	 * Copy keyframes from another curve (with a different element type) to this curve.
+	 * After syncing, the two curves are guaranteed to return the same values
+	 * for t >= start.
+	 *
+	 * The operation may insert new keyframes at \p start on the curve.
+	 *
+	 * @param other Curve that keyframes are copied from.
+	 * @param converter Function that converts the value type of \p other to the
+	 *                  value type of \p this.
+	 * @param start Start time at which keyframes are replaced (default = -INF).
+	 *              Using the default value replaces ALL keyframes of \p this with
+	 *              the keyframes of \p other.
+	 */
 	template <typename O>
 	void sync(const BaseCurve<O> &other,
 	          const std::function<T(const O &)> &converter,
 	          const time::time_t &start = time::TIME_MIN);
 
 	/**
-     * Get the identifier of this curve.
-     *
-     * @return Identifier.
-     */
+	 * Get the identifier of this curve.
+	 *
+	 * @return Identifier.
+	 */
 	size_t id() const override {
 		return this->_id;
 	}
 
 	/**
-     * Get the human-readable identifier of this curve.
-     *
-     * @return Human-readable identifier.
-     */
+	 * Get the human-readable identifier of this curve.
+	 *
+	 * @return Human-readable identifier.
+	 */
 	std::string idstr() const override {
 		if (this->_idstr.size() == 0) {
 			return std::to_string(this->id());
@@ -163,10 +163,10 @@ public:
 	std::string str() const;
 
 	/**
-     * Get the container containing all keyframes of this curve.
-     *
-     * @return Keyframe container.
-     */
+	 * Get the container containing all keyframes of this curve.
+	 *
+	 * @return Keyframe container.
+	 */
 	const KeyframeContainer<T> &get_container() const {
 		return this->container;
 	}

--- a/libopenage/curve/discrete_mod.h
+++ b/libopenage/curve/discrete_mod.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -65,8 +65,8 @@ public:
 
 private:
 	/**
-     * Length of the time interval of this curve (time between first and last keyframe).
-     */
+	 * Length of the time interval of this curve (time between first and last keyframe).
+	 */
 	time::time_t time_length;
 };
 

--- a/libopenage/curve/interpolated.h
+++ b/libopenage/curve/interpolated.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -59,8 +59,8 @@ T Interpolated<T>::get(const time::time_t &time) const {
 
 	// If the next element is at the same time, just return the value of this one.
 	if (nxt == this->container.end() // use the last curve value
-	    || offset == 0 // values equal -> don't need to interpolate
-	    || interval == 0) { // values at the same time -> division-by-zero-error
+	    || offset == 0               // values equal -> don't need to interpolate
+	    || interval == 0) {          // values at the same time -> division-by-zero-error
 
 		return e->value;
 	}

--- a/libopenage/curve/keyframe_container.h
+++ b/libopenage/curve/keyframe_container.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -47,25 +47,25 @@ public:
 	using const_iterator = typename container_t::const_iterator;
 
 	/**
-     * Create a new container.
-     *
-     * Inserts a default element with value \p T() at \p time = -INF to ensure
-     * that accessing the container always returns an element.
-     *
-     * TODO: need the datamanger for change management
-     */
+	 * Create a new container.
+	 *
+	 * Inserts a default element with value \p T() at \p time = -INF to ensure
+	 * that accessing the container always returns an element.
+	 *
+	 * TODO: need the datamanger for change management
+	 */
 	KeyframeContainer();
 
 	/**
-     * Create a new container.
-     *
-     * Inserts a default element at \p time = -INF to ensure
-     * that accessing the container always returns an element.
-     *
-     * @param defaultval Value of default element at -INF.
-     *
-     * TODO: need the datamanger for change management
-     */
+	 * Create a new container.
+	 *
+	 * Inserts a default element at \p time = -INF to ensure
+	 * that accessing the container always returns an element.
+	 *
+	 * @param defaultval Value of default element at -INF.
+	 *
+	 * TODO: need the datamanger for change management
+	 */
 	KeyframeContainer(const T &defaultval);
 
 	/**
@@ -259,42 +259,42 @@ public:
 	}
 
 	/**
-     * Remove all keyframes from the container, EXCEPT for the default value
-     * at -INF.
-     *
-     * Essentially, the container is reset to the state immediately after construction.
-     */
+	 * Remove all keyframes from the container, EXCEPT for the default value
+	 * at -INF.
+	 *
+	 * Essentially, the container is reset to the state immediately after construction.
+	 */
 	void clear() {
 		this->container.erase(++this->begin(), this->end());
 	}
 
 	/**
-     * Copy keyframes from another container to this container.
-     *
-     * Replaces all keyframes beginning at t >= start with keyframes from \p other.
-     *
-     * @param other Curve that keyframes are copied from.
-     * @param converter Function that converts the value type of \p other to the
-     *                  value type of \p this.
-     * @param start Start time at which keyframes are replaced (default = -INF).
-     *              Using the default value replaces ALL keyframes of \p this with
-     *              the keyframes of \p other.
-     */
+	 * Copy keyframes from another container to this container.
+	 *
+	 * Replaces all keyframes beginning at t >= start with keyframes from \p other.
+	 *
+	 * @param other Curve that keyframes are copied from.
+	 * @param converter Function that converts the value type of \p other to the
+	 *                  value type of \p this.
+	 * @param start Start time at which keyframes are replaced (default = -INF).
+	 *              Using the default value replaces ALL keyframes of \p this with
+	 *              the keyframes of \p other.
+	 */
 	iterator sync(const KeyframeContainer<T> &other,
 	              const time::time_t &start = time::TIME_MIN);
 
 	/**
-     * Copy keyframes from another container (with a different element type) to this container.
-     *
-     * Replaces all keyframes beginning at t >= start with keyframes from \p other.
-     *
-     * @param other Curve that keyframes are copied from.
-     * @param converter Function that converts the value type of \p other to the
-     *                  value type of \p this.
-     * @param start Start time at which keyframes are replaced (default = -INF).
-     *              Using the default value replaces ALL keyframes of \p this with
-     *              the keyframes of \p other.
-     */
+	 * Copy keyframes from another container (with a different element type) to this container.
+	 *
+	 * Replaces all keyframes beginning at t >= start with keyframes from \p other.
+	 *
+	 * @param other Curve that keyframes are copied from.
+	 * @param converter Function that converts the value type of \p other to the
+	 *                  value type of \p this.
+	 * @param start Start time at which keyframes are replaced (default = -INF).
+	 *              Using the default value replaces ALL keyframes of \p this with
+	 *              the keyframes of \p other.
+	 */
 	template <typename O>
 	iterator sync(const KeyframeContainer<O> &other,
 	              const std::function<T(const O &)> &converter,

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -70,7 +70,7 @@ public:
 
 	/**
 	 * Get the first element in the queue at the given time and remove it from
-     * the queue.
+	 * the queue.
 	 *
 	 * @param time The time to get the element at.
 	 * @param value Queue element.
@@ -148,19 +148,19 @@ public:
 	}
 
 	/**
-     * Get the identifier of this curve.
-     *
-     * @return Identifier.
-     */
+	 * Get the identifier of this curve.
+	 *
+	 * @return Identifier.
+	 */
 	size_t id() const override {
 		return this->_id;
 	}
 
 	/**
-     * Get the human-readable identifier of this curve.
-     *
-     * @return Human-readable identifier.
-     */
+	 * Get the human-readable identifier of this curve.
+	 *
+	 * @return Human-readable identifier.
+	 */
 	std::string idstr() const override {
 		if (this->_idstr.size() == 0) {
 			return std::to_string(this->id());
@@ -185,8 +185,8 @@ private:
 	container_t container;
 
 	/**
-     * The time of the last access to the queue.
-     */
+	 * The time of the last access to the queue.
+	 */
 	time::time_t last_pop;
 };
 

--- a/libopenage/cvar/cvar.h
+++ b/libopenage/cvar/cvar.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2017 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -40,7 +40,6 @@ using set_func = std::function<void(std::string)>;
  *     void load_config(Path path) except +
  */
 class OAAPI CVarManager {
-
 public:
 	CVarManager(const util::Path &path);
 
@@ -102,4 +101,5 @@ private:
  */
 extern OAAPI pyinterface::PyIfFunc<void, CVarManager *, const util::Path &> pyx_load_config_file;
 
-}} // openage::cvar
+} // namespace cvar
+} // namespace openage

--- a/libopenage/datastructure/concurrent_queue.h
+++ b/libopenage/datastructure/concurrent_queue.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -47,8 +47,8 @@ public:
 	}
 
 	/** Copies the front item in the queue and removes it from the queue. */
-	template<typename... None, typename U = T>
-	T pop([[maybe_unused]] typename std::enable_if_t<!std::is_move_constructible_v<U> and std::is_copy_constructible_v<U>>* t = nullptr) {
+	template <typename... None, typename U = T>
+	T pop([[maybe_unused]] typename std::enable_if_t<!std::is_move_constructible_v<U> and std::is_copy_constructible_v<U>> *t = nullptr) {
 		static_assert(sizeof...(None) == 0, "User-specified template arguments are prohibited.");
 		std::scoped_lock lock{this->mutex};
 		T ret = this->front();
@@ -60,8 +60,8 @@ public:
 	}
 
 	/** Moves the front item in the queue and removes it from the queue. */
-	template<typename... None, typename U = T>
-	T pop([[maybe_unused]] typename std::enable_if_t<std::is_move_constructible_v<U>>* t = nullptr) {
+	template <typename... None, typename U = T>
+	T pop([[maybe_unused]] typename std::enable_if_t<std::is_move_constructible_v<U>> *t = nullptr) {
 		static_assert(sizeof...(None) == 0, "User-specified template arguments are prohibited.");
 		std::scoped_lock lock{this->mutex};
 		T ret = std::move(this->front());
@@ -70,8 +70,8 @@ public:
 	}
 
 	/** Appends the given item to the queue by copying it. */
-	template<typename... None, typename U = T>
-	void push(typename std::enable_if_t<std::is_copy_constructible_v<U>, const T&> item) {
+	template <typename... None, typename U = T>
+	void push(typename std::enable_if_t<std::is_copy_constructible_v<U>, const T &> item) {
 		static_assert(sizeof...(None) == 0, "User-specified template arguments are prohibited.");
 		std::unique_lock<mutex_t> lock{this->mutex};
 		this->queue.push(item);
@@ -80,8 +80,8 @@ public:
 	}
 
 	/** Appends the given item to the queue by moving it. */
-	template<typename... None, typename U = T>
-	void push(typename std::enable_if_t<std::is_move_constructible_v<U>, T&&> item) {
+	template <typename... None, typename U = T>
+	void push(typename std::enable_if_t<std::is_move_constructible_v<U>, T &&> item) {
 		static_assert(sizeof...(None) == 0, "User-specified template arguments are prohibited.");
 		std::unique_lock<mutex_t> lock{this->mutex};
 		this->queue.push(std::move(item));
@@ -111,4 +111,4 @@ private:
 	std::condition_variable_any elements_available;
 };
 
-}	// openage::datastructure
+} // namespace openage::datastructure

--- a/libopenage/datastructure/pairing_heap.h
+++ b/libopenage/datastructure/pairing_heap.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,13 +16,13 @@
  * Algorithmica 1, no. 1-4 (1986): 111-129.
  */
 
-#include <memory>
 #include <functional>
+#include <memory>
 #include <type_traits>
 #include <unordered_set>
 
-#include "../util/compiler.h"
 #include "../error/error.h"
+#include "../util/compiler.h"
 
 
 #define OPENAGE_PAIRINGHEAP_DEBUG false
@@ -31,14 +31,13 @@
 namespace openage::datastructure {
 
 
-template<typename T,
-         typename compare,
-         typename heapnode_t>
+template <typename T,
+          typename compare,
+          typename heapnode_t>
 class PairingHeap;
 
 
-
-template<typename T, typename compare=std::less<T>>
+template <typename T, typename compare = std::less<T>>
 class PairingHeapNode : public std::enable_shared_from_this<PairingHeapNode<T, compare>> {
 public:
 	using this_type = PairingHeapNode<T, compare>;
@@ -49,12 +48,10 @@ public:
 	compare cmp;
 
 public:
-	PairingHeapNode(const T &data)
-		:
+	PairingHeapNode(const T &data) :
 		data{data} {}
 
-	PairingHeapNode(T &&data)
-		:
+	PairingHeapNode(T &&data) :
 		data{std::move(data)} {}
 
 	~PairingHeapNode() = default;
@@ -101,11 +98,11 @@ public:
 		std::shared_ptr<this_type> new_child;
 
 		if (this->cmp(this->data, node->data)) {
-			new_root  = this->shared_from_this();
+			new_root = this->shared_from_this();
 			new_child = node;
 		}
 		else {
-			new_root  = node;
+			new_root = node;
 			new_child = this->shared_from_this();
 		}
 
@@ -182,16 +179,16 @@ private:
 	std::shared_ptr<this_type> first_child;
 	std::shared_ptr<this_type> prev_sibling;
 	std::shared_ptr<this_type> next_sibling;
-	std::shared_ptr<this_type> parent;       // for decrease-key and delete
+	std::shared_ptr<this_type> parent; // for decrease-key and delete
 };
 
 
 /**
  * (Quite) efficient heap implementation.
  */
-template<typename T,
-         typename compare=std::less<T>,
-         typename heapnode_t=PairingHeapNode<T, compare>>
+template <typename T,
+          typename compare = std::less<T>,
+          typename heapnode_t = PairingHeapNode<T, compare>>
 class PairingHeap final {
 public:
 	using node_t = heapnode_t;
@@ -202,8 +199,7 @@ public:
 	/**
 	 * create a empty heap.
 	 */
-	PairingHeap()
-		:
+	PairingHeap() :
 		node_count(0),
 		root_node(nullptr) {
 	}
@@ -291,7 +287,8 @@ public:
 					// link0 was the only node
 					first_pair = link0;
 					link0->prev_sibling = nullptr;
-				} else {
+				}
+				else {
 					previous_pair->next_sibling = link0;
 					link0->prev_sibling = previous_pair;
 				}
@@ -589,7 +586,6 @@ public:
 protected:
 	void walk_tree(const element_t &root,
 	               const std::function<void(const element_t &)> &func) const {
-
 		func(root);
 
 		if (root) {
@@ -629,7 +625,8 @@ protected:
 	void root_insert(const element_t &node) {
 		if (this->root_node == nullptr) [[unlikely]] {
 			this->root_node = node;
-		} else {
+		}
+		else {
 			this->root_node = this->root_node->link_with(node);
 		}
 	}
@@ -644,4 +641,4 @@ protected:
 #endif
 };
 
-} // openage::datastructure
+} // namespace openage::datastructure

--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -67,10 +67,10 @@ public:
 
 	/**
 	 * Create the engine instance for this run.
-     *
-     * @param mode The run mode to use.
-     * @param root_dir openage root directory.
-     * @param mods The mods to load.
+	 *
+	 * @param mode The run mode to use.
+	 * @param root_dir openage root directory.
+	 * @param mods The mods to load.
 	 * @param debug_graphics If true, enable OpenGL debug logging.
 	 */
 	Engine(mode mode,
@@ -87,8 +87,8 @@ public:
 
 
 	/**
-     * Run the main loop.
-     */
+	 * Run the main loop.
+	 */
 	void loop();
 
 	/**
@@ -99,38 +99,38 @@ public:
 
 private:
 	/**
-     * The run mode to use.
-     */
+	 * The run mode to use.
+	 */
 	mode run_mode;
 
 	/**
-     * openage root directory.
-     */
+	 * openage root directory.
+	 */
 	util::Path root_dir;
 
 	/**
-     * The threads used by the engine.
-     */
+	 * The threads used by the engine.
+	 */
 	std::vector<std::jthread> threads;
 
 	/**
-     * Environment variables.
-     */
+	 * Environment variables.
+	 */
 	std::shared_ptr<cvar::CVarManager> cvar_manager;
 
 	/**
-     * Controls and update the clock for time-based measurements.
-     */
+	 * Controls and update the clock for time-based measurements.
+	 */
 	std::shared_ptr<time::TimeLoop> time_loop;
 
 	/**
-     * Gameplay simulation.
-     */
+	 * Gameplay simulation.
+	 */
 	std::shared_ptr<gamestate::GameSimulation> simulation;
 
 	/**
-     * Video/audio/input management. Can be nullptr in headless mode.
-     */
+	 * Video/audio/input management. Can be nullptr in headless mode.
+	 */
 	std::shared_ptr<presenter::Presenter> presenter;
 };
 

--- a/libopenage/error/backtrace.h
+++ b/libopenage/error/backtrace.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,8 +6,8 @@
 
 #include <vector>
 // pxd: from libcpp.string cimport string
-#include <string>
 #include <iostream>
+#include <string>
 // pxd: from libopenage.pyinterface.functional cimport Func1
 #include <functional>
 
@@ -32,14 +32,14 @@ namespace error {
  * ctypedef const backtrace_symbol *backtrace_symbol_constptr
  */
 struct backtrace_symbol {
-	std::string filename;      // empty if unknown
-	unsigned int lineno;       // 0 if unknown
-	std::string functionname;  // empty if unknown
-	void *pc;                  // nullptr if unknown
+	std::string filename;     // empty if unknown
+	unsigned int lineno;      // 0 if unknown
+	std::string functionname; // empty if unknown
+	void *pc;                 // nullptr if unknown
 };
 
 
-std::ostream &operator <<(std::ostream &os, const backtrace_symbol &bt_sym);
+std::ostream &operator<<(std::ostream &os, const backtrace_symbol &bt_sym);
 
 
 /**
@@ -66,8 +66,8 @@ public:
 	 * @param reversed
 	 *    if true, the most recent call is given last.
 	 */
-	virtual void get_symbols(std::function<void (const backtrace_symbol *)> cb,
-	                         bool reversed=true) const = 0;
+	virtual void get_symbols(std::function<void(const backtrace_symbol *)> cb,
+	                         bool reversed = true) const = 0;
 
 	/**
 	 * Removes all the lower frames that are also present in the current stack.
@@ -77,13 +77,16 @@ public:
 	 *
 	 * Defaults to no-op.
 	 */
-	virtual void trim_to_current_stack_frame() {};
+	virtual void trim_to_current_stack_frame() {
+		return;
+	};
 
 	virtual ~Backtrace() = default;
 };
 
 
-std::ostream &operator <<(std::ostream &os, const Backtrace &bt);
+std::ostream &operator<<(std::ostream &os, const Backtrace &bt);
 
 
-}} // openage::error
+} // namespace error
+} // namespace openage

--- a/libopenage/error/handlers.h
+++ b/libopenage/error/handlers.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,4 +21,5 @@ namespace error {
 OAAPI void set_exit_ok(bool value);
 
 
-}} // openage::error
+} // namespace error
+} // namespace openage

--- a/libopenage/event/demo/aicontroller.h
+++ b/libopenage/event/demo/aicontroller.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,4 +12,4 @@ std::vector<PongEvent> get_ai_inputs(const std::shared_ptr<PongPlayer> &player,
                                      const std::shared_ptr<PongBall> &ball,
                                      const time::time_t &now);
 
-}  // openage::event::demo
+} // namespace openage::event::demo

--- a/libopenage/event/demo/main.h
+++ b/libopenage/event/demo/main.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,4 +12,4 @@ namespace openage::event::demo {
 OAAPI void curvepong(bool disable_gui, bool no_human);
 
 
-} // openage::event::demo
+} // namespace openage::event::demo

--- a/libopenage/event/event.h
+++ b/libopenage/event/event.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -63,8 +63,8 @@ public:
 	void depend_on(const std::shared_ptr<EventEntity> &dependency);
 
 	/**
-     * Cancel the event.
-     */
+	 * Cancel the event.
+	 */
 	void cancel(const time::time_t reference_time);
 
 	/**

--- a/libopenage/event/event_loop.h
+++ b/libopenage/event/event_loop.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -33,31 +33,31 @@ class EventLoop {
 
 public:
 	/**
-     * Create a new event loop.
-     */
+	 * Create a new event loop.
+	 */
 	EventLoop() = default;
 	~EventLoop() = default;
 
 	/**
-     * Register a new event handler.
-     *
-     * Created event can reference the event handler ID to invoke it on
-     * execution.
-     *
-     * @param eventhandler Event handler.
-     */
+	 * Register a new event handler.
+	 *
+	 * Created event can reference the event handler ID to invoke it on
+	 * execution.
+	 *
+	 * @param eventhandler Event handler.
+	 */
 	void add_event_handler(const std::shared_ptr<EventHandler> eventhandler);
 
 	/**
 	 * Add a new event to the queue using a registered event handler.
-     *
-     * @param eventhandler Event handler ID. The handler must already be registered on the loop.
-     * @param target Target entity. Can be \p nullptr.
-     * @param state Global state.
-     * @param reference_time Reference time to calculate the event execution time. The actual
-     *                       depends execution time on the type of event and may be changed
-     *                       by other events.
-     * @param params Event parameters map (default = {}). Passed to the event handler on event execution.
+	 *
+	 * @param eventhandler Event handler ID. The handler must already be registered on the loop.
+	 * @param target Target entity. Can be \p nullptr.
+	 * @param state Global state.
+	 * @param reference_time Reference time to calculate the event execution time. The actual
+	 *                       depends execution time on the type of event and may be changed
+	 *                       by other events.
+	 * @param params Event parameters map (default = {}). Passed to the event handler on event execution.
 	 */
 	std::shared_ptr<Event> create_event(const std::string eventhandler,
 	                                    const std::shared_ptr<EventEntity> target,
@@ -67,19 +67,19 @@ public:
 
 	/**
 	 * Add a new event to the queue using an arbritary event handler. If an event handler
-     * with the same ID is already registered, the registered event handler will be used
-     * instead.
-     *
-     * TODO: Why use this function when one can simply add the event handler and use the other
-     *      create_event function?
-     *
-     * @param eventhandler Event handler.
-     * @param target Target entity. Can be \p nullptr.
-     * @param state Global state.
-     * @param reference_time Reference time to calculate the event execution time. The actual
-     *                       depends execution time on the type of event and may be changed
-     *                       by other events.
-     * @param params Event parameters map (default = {}). Passed to the event handler on event execution.
+	 * with the same ID is already registered, the registered event handler will be used
+	 * instead.
+	 *
+	 * TODO: Why use this function when one can simply add the event handler and use the other
+	 *      create_event function?
+	 *
+	 * @param eventhandler Event handler.
+	 * @param target Target entity. Can be \p nullptr.
+	 * @param state Global state.
+	 * @param reference_time Reference time to calculate the event execution time. The actual
+	 *                       depends execution time on the type of event and may be changed
+	 *                       by other events.
+	 * @param params Event parameters map (default = {}). Passed to the event handler on event execution.
 	 */
 	std::shared_ptr<Event> create_event(const std::shared_ptr<EventHandler> eventhandler,
 	                                    const std::shared_ptr<EventEntity> target,
@@ -89,33 +89,33 @@ public:
 
 	/**
 	 * Execute events in the queue with execution time <= a given point in time.
-     *
-     * @param time_until Maximum time until which events are executed.
-     * @param state Global state.
+	 *
+	 * @param time_until Maximum time until which events are executed.
+	 * @param state Global state.
 	 */
 	void reach_time(const time::time_t &time_until,
 	                const std::shared_ptr<State> &state);
 
 	/**
 	 * Initiate a reevaluation of a given event at a given time.
-     *
+	 *
 	 * This usually happens because this event depended on an event entity
 	 * that got changed at this time.
-     *
+	 *
 	 * This inserts the event into the changes queue
 	 * so it will be evaluated in the next loop iteration.
-     *
-     * @param event Event to reevaluate.
-     * @param changes_at Time at which the event should be reevaluated.
+	 *
+	 * @param event Event to reevaluate.
+	 * @param changes_at Time at which the event should be reevaluated.
 	 */
 	void create_change(const std::shared_ptr<Event> event,
 	                   const time::time_t changes_at);
 
 	/**
-     * Get the event queue.
-     *
-     * @return Event queue.
-     */
+	 * Get the event queue.
+	 *
+	 * @return Event queue.
+	 */
 	const EventQueue &get_queue() const {
 		return this->queue;
 	}
@@ -124,9 +124,9 @@ private:
 	/**
 	 *  Execute events in the queue with execution time <= a given point in time.
 	 *
-     * @param time_until Maximum time until which events are executed.
-     * @param state Global state.
-     *
+	 * @param time_until Maximum time until which events are executed.
+	 * @param state Global state.
+	 *
 	 * @returns number of events processed
 	 */
 	int execute_events(const time::time_t &time_until,
@@ -134,8 +134,8 @@ private:
 
 	/**
 	 * Call all the time change functions. This is constant on the state!
-     *
-     * @param state Global state.
+	 *
+	 * @param state Global state.
 	 */
 	void update_changes(const std::shared_ptr<State> &state);
 

--- a/libopenage/event/state.h
+++ b/libopenage/event/state.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,8 +12,8 @@ class EventLoop;
 
 class State {
 public:
-	State(const std::shared_ptr<EventLoop> &/*mgr*/) {}
+	State(const std::shared_ptr<EventLoop> & /*mgr*/) {}
 	virtual ~State() = default;
 };
 
-} // openage::event
+} // namespace openage::event

--- a/libopenage/gamestate/activity/activity.h
+++ b/libopenage/gamestate/activity/activity.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,51 +19,51 @@ using activity_label = std::string;
 class Activity {
 public:
 	/**
-     * Create a new activity.
-     *
-     * @param id Unique ID.
-     * @param start Start node in the graph.
-     * @param label Human-readable label (optional).
-     */
+	 * Create a new activity.
+	 *
+	 * @param id Unique ID.
+	 * @param start Start node in the graph.
+	 * @param label Human-readable label (optional).
+	 */
 	Activity(activity_id id,
 	         const std::shared_ptr<Node> &start,
 	         activity_label label = "");
 
 	/**
-     * Get the unique ID of this activity.
-     *
-     * @return Unique ID.
-     */
+	 * Get the unique ID of this activity.
+	 *
+	 * @return Unique ID.
+	 */
 	activity_id get_id() const;
 
 	/**
-     * Get the human-readable label of this activity.
-     *
-     * @return Human-readable label.
-     */
+	 * Get the human-readable label of this activity.
+	 *
+	 * @return Human-readable label.
+	 */
 	const activity_label get_label() const;
 
 	/**
-     * Get the start node of this activity.
-     *
-     * @return Start node.
-     */
+	 * Get the start node of this activity.
+	 *
+	 * @return Start node.
+	 */
 	const std::shared_ptr<Node> &get_start() const;
 
 private:
 	/**
-     * Unique ID.
-     */
+	 * Unique ID.
+	 */
 	const activity_id id;
 
 	/**
-     * Human-readable label.
-     */
+	 * Human-readable label.
+	 */
 	const activity_label label;
 
 	/**
-     * Start node.
-     */
+	 * Start node.
+	 */
 	std::shared_ptr<Node> start;
 };
 

--- a/libopenage/gamestate/activity/end_node.h
+++ b/libopenage/gamestate/activity/end_node.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,11 +21,11 @@ namespace openage::gamestate::activity {
 class EndNode : public Node {
 public:
 	/**
-     * Create a new end node.
-     *
-     * @param id Unique identifier for this node.
-     * @param label Human-readable label (optional).
-     */
+	 * Create a new end node.
+	 *
+	 * @param id Unique identifier for this node.
+	 * @param label Human-readable label (optional).
+	 */
 	EndNode(node_id_t id,
 	        node_label_t label = "End");
 	virtual ~EndNode() = default;

--- a/libopenage/gamestate/activity/task_node.h
+++ b/libopenage/gamestate/activity/task_node.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -32,13 +32,13 @@ static const task_func_t no_task = [](const time::time_t &,
 class TaskCustom : public Node {
 public:
 	/**
-     * Create a new task node.
-     *
-     * @param id Unique identifier for this node.
-     * @param label Human-readable label (optional).
-     * @param task_func Action to perform when visiting this node (can be set later).
-     * @param output Next node to visit (optional).
-     */
+	 * Create a new task node.
+	 *
+	 * @param id Unique identifier for this node.
+	 * @param label Human-readable label (optional).
+	 * @param task_func Action to perform when visiting this node (can be set later).
+	 * @param output Next node to visit (optional).
+	 */
 	TaskCustom(node_id_t id,
 	           node_label_t label = "TaskCustom",
 	           const std::shared_ptr<Node> &output = nullptr,
@@ -50,24 +50,24 @@ public:
 	}
 
 	/**
-      * Set the current output node.
-      *
-      * @param output Output node.
-      */
+	 * Set the current output node.
+	 *
+	 * @param output Output node.
+	 */
 	void add_output(const std::shared_ptr<Node> &output);
 
 	/**
-      * Set the task function.
-      *
-      * @param task_func Action to perform when visiting this node.
-      */
+	 * Set the task function.
+	 *
+	 * @param task_func Action to perform when visiting this node.
+	 */
 	void set_task_func(task_func_t task_func);
 
 	/**
-      * Get the task function.
-      *
-      * @return Action to perform when visiting this node.
-      */
+	 * Get the task function.
+	 *
+	 * @return Action to perform when visiting this node.
+	 */
 	task_func_t get_task_func() const;
 
 	/**
@@ -80,8 +80,8 @@ public:
 
 private:
 	/**
-     * Action to perform when visiting this node.
-     */
+	 * Action to perform when visiting this node.
+	 */
 	task_func_t task_func;
 };
 

--- a/libopenage/gamestate/activity/task_system_node.h
+++ b/libopenage/gamestate/activity/task_system_node.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,7 +23,7 @@ public:
 	 * @param id Unique identifier for this node.
 	 * @param label Human-readable label (optional).
 	 * @param output Next node to visit (optional).
-     * @param system_id System to run when visiting this node (can be set later).
+	 * @param system_id System to run when visiting this node (can be set later).
 	 */
 	TaskSystemNode(node_id_t id,
 	               node_label_t label = "TaskSystem",
@@ -36,24 +36,24 @@ public:
 	}
 
 	/**
-	  * Set the current output node.
-	  *
-	  * @param output Output node.
-	  */
+	 * Set the current output node.
+	 *
+	 * @param output Output node.
+	 */
 	void add_output(const std::shared_ptr<Node> &output);
 
 	/**
-	  * Set the system id.
-      *
-      * @param system_id System to run when visiting this node.
-	  */
+	 * Set the system id.
+	 *
+	 * @param system_id System to run when visiting this node.
+	 */
 	void set_system_id(system::system_id_t system_id);
 
 	/**
-	  * Get the system id.
-	  *
-	  * @return System to run when visiting this node.
-	  */
+	 * Get the system id.
+	 *
+	 * @return System to run when visiting this node.
+	 */
 	system::system_id_t get_system_id() const;
 
 	/**
@@ -66,8 +66,8 @@ public:
 
 private:
 	/**
-     * System to run when visiting this node.
-     */
+	 * System to run when visiting this node.
+	 */
 	system::system_id_t system_id;
 };
 

--- a/libopenage/gamestate/activity/xor_event_gate.h
+++ b/libopenage/gamestate/activity/xor_event_gate.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -55,22 +55,22 @@ using event_primer_t = std::function<std::shared_ptr<openage::event::Event>(cons
 class XorEventGate : public Node {
 public:
 	/**
-      * Create a new exclusive event gateway.
-      *
-      * @param id Unique identifier for this node.
-      * @param label Human-readable label (optional).
-      */
+	 * Create a new exclusive event gateway.
+	 *
+	 * @param id Unique identifier for this node.
+	 * @param label Human-readable label (optional).
+	 */
 	XorEventGate(node_id_t id,
 	             node_label_t label = "EventGateWay");
 
 	/**
-     * Create a new exclusive event gateway.
-     *
-     * @param id Unique identifier for this node.
-     * @param label Human-readable label.
-     * @param outputs Output nodes.
-     * @param primers Event primers for each output node.
-     */
+	 * Create a new exclusive event gateway.
+	 *
+	 * @param id Unique identifier for this node.
+	 * @param label Human-readable label.
+	 * @param outputs Output nodes.
+	 * @param primers Event primers for each output node.
+	 */
 	XorEventGate(node_id_t id,
 	             node_label_t label,
 	             const std::vector<std::shared_ptr<Node>> &outputs,
@@ -83,27 +83,27 @@ public:
 	}
 
 	/**
-      * Add an output node.
-      *
-      * @param output Output node.
-      * @param primer Creation function for the event associated with the output node.
-      */
+	 * Add an output node.
+	 *
+	 * @param output Output node.
+	 * @param primer Creation function for the event associated with the output node.
+	 */
 	void add_output(const std::shared_ptr<Node> &output,
 	                const event_primer_t &primer);
 
 	/**
-     * Get the output->event primer mappings.
-     *
-     * @return Event primer functions for each output node.
-     */
+	 * Get the output->event primer mappings.
+	 *
+	 * @return Event primer functions for each output node.
+	 */
 	const std::map<node_id_t, event_primer_t> &get_primers() const;
 
 private:
 	/**
-     * Maps output node IDs to event primer functions.
-     *
-     * Events are created and registered on the event loop when the node is visited.
-     */
+	 * Maps output node IDs to event primer functions.
+	 *
+	 * Events are created and registered on the event loop when the node is visited.
+	 */
 	std::map<node_id_t, event_primer_t> primers;
 };
 

--- a/libopenage/gamestate/activity/xor_gate.h
+++ b/libopenage/gamestate/activity/xor_gate.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -39,23 +39,23 @@ using condition_t = std::function<bool(const time::time_t &,
 class XorGate : public Node {
 public:
 	/**
-     * Creates a new condition node.
-     *
-     * @param id Unique identifier of the node.
-     * @param label Label of the node (optional).
-     */
+	 * Creates a new condition node.
+	 *
+	 * @param id Unique identifier of the node.
+	 * @param label Label of the node (optional).
+	 */
 	XorGate(node_id_t id,
 	        node_label_t label = "ExclusiveGateway");
 
 	/**
-     * Creates a new condition node.
-     *
-     * @param id Unique identifier of the node.
-     * @param label Label of the node.
-     * @param outputs Output nodes.
-     * @param conditions Conditions for each output node.
-     * @param default_node Default output node. Chosen if no condition is true.
-     */
+	 * Creates a new condition node.
+	 *
+	 * @param id Unique identifier of the node.
+	 * @param label Label of the node.
+	 * @param outputs Output nodes.
+	 * @param conditions Conditions for each output node.
+	 * @param default_node Default output node. Chosen if no condition is true.
+	 */
 	XorGate(node_id_t id,
 	        node_label_t label,
 	        const std::vector<std::shared_ptr<Node>> &outputs,
@@ -69,49 +69,49 @@ public:
 	}
 
 	/**
-     * Add an output node.
-     *
-     * @param output Output node.
-     * @param condition_func Function that determines whether this output node is chosen.
-     *                       This must be a valid node ID of one of the output nodes.
-     */
+	 * Add an output node.
+	 *
+	 * @param output Output node.
+	 * @param condition_func Function that determines whether this output node is chosen.
+	 *                       This must be a valid node ID of one of the output nodes.
+	 */
 	void add_output(const std::shared_ptr<Node> &output,
 	                const condition_t condition_func);
 
 	/**
-     * Get the output->condition mappings.
-     *
-     * @return Conditions for each output node.
-     */
+	 * Get the output->condition mappings.
+	 *
+	 * @return Conditions for each output node.
+	 */
 	const std::map<node_id_t, condition_t> &get_conditions() const;
 
 	/**
-     * Get the default output node.
-     *
-     * @return Default output node.
-     */
+	 * Get the default output node.
+	 *
+	 * @return Default output node.
+	 */
 	const std::shared_ptr<Node> &get_default() const;
 
 	/**
-     * Set the the default output node.
-     *
-     * This node is chosen if no condition is true.
-     *
-     * @param node Default output node.
-     */
+	 * Set the the default output node.
+	 *
+	 * This node is chosen if no condition is true.
+	 *
+	 * @param node Default output node.
+	 */
 	void set_default(const std::shared_ptr<Node> &node);
 
 private:
 	/**
-     * Maps output node IDs to condition functions.
-     *
-     * Conditions are checked in order they appear in the map.
-     */
+	 * Maps output node IDs to condition functions.
+	 *
+	 * Conditions are checked in order they appear in the map.
+	 */
 	std::map<node_id_t, condition_t> conditions;
 
 	/**
-     * Default output node. Chosen if no condition is true.
-     */
+	 * Default output node. Chosen if no condition is true.
+	 */
 	std::shared_ptr<Node> default_node;
 };
 

--- a/libopenage/gamestate/api/ability.h
+++ b/libopenage/gamestate/api/ability.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -14,33 +14,33 @@ namespace openage::gamestate::api {
 class APIAbility {
 public:
 	/**
-     * Check if a nyan object is an Ability (type == \p engine.ability.Ability).
-     *
-     * @param obj nyan object.
-     *
-     * @return true if the object is an ability, else false.
-     */
+	 * Check if a nyan object is an Ability (type == \p engine.ability.Ability).
+	 *
+	 * @param obj nyan object.
+	 *
+	 * @return true if the object is an ability, else false.
+	 */
 	static bool is_ability(const nyan::Object &obj);
 
 	/**
-     * Check if an ability has a given property.
-     *
-     * @param ability \p Ability nyan object (type == \p engine.ability.Ability).
-     * @param property Property type.
-     *
-     * @return true if the ability has the property, else false.
-     */
+	 * Check if an ability has a given property.
+	 *
+	 * @param ability \p Ability nyan object (type == \p engine.ability.Ability).
+	 * @param property Property type.
+	 *
+	 * @return true if the ability has the property, else false.
+	 */
 	static bool check_property(const nyan::Object &ability,
 	                           const ability_property_t &property);
 
 	/**
-     * Get the nyan object for a property from an ability.
-     *
-     * @param ability \p Ability nyan object (type == \p engine.ability.Ability).
-     * @param property Property type.
-     *
-     * @return \p Property nyan object (type == \p engine.ability.property.Property).
-     */
+	 * Get the nyan object for a property from an ability.
+	 *
+	 * @param ability \p Ability nyan object (type == \p engine.ability.Ability).
+	 * @param property Property type.
+	 *
+	 * @return \p Property nyan object (type == \p engine.ability.property.Property).
+	 */
 	static const nyan::Object get_property(const nyan::Object &ability,
 	                                       const ability_property_t &property);
 };

--- a/libopenage/gamestate/api/activity.h
+++ b/libopenage/gamestate/api/activity.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -22,21 +22,21 @@ namespace api {
 class APIActivity {
 public:
 	/**
-     * Check if a nyan object is an Activity (type == \p engine.util.activity.Activity).
-     *
-     * @param obj nyan object.
-     *
-     * @return true if the object is an activity, else false.
-     */
+	 * Check if a nyan object is an Activity (type == \p engine.util.activity.Activity).
+	 *
+	 * @param obj nyan object.
+	 *
+	 * @return true if the object is an activity, else false.
+	 */
 	static bool is_activity(const nyan::Object &obj);
 
 	/**
-     * Get the start node of an activity.
-     *
-     * @param activity nyan object.
-     *
-     * @return nyan object handle of the start node.
-     */
+	 * Get the start node of an activity.
+	 *
+	 * @param activity nyan object.
+	 *
+	 * @return nyan object handle of the start node.
+	 */
 	static nyan::Object get_start(const nyan::Object &activity);
 };
 
@@ -46,42 +46,42 @@ public:
 class APIActivityNode {
 public:
 	/**
-     * Check if a nyan object is a node (type == \p engine.util.activity.node.Node).
-     *
-     * @param obj nyan object.
-     *
-     * @return true if the object is a node, else false.
-     */
+	 * Check if a nyan object is a node (type == \p engine.util.activity.node.Node).
+	 *
+	 * @param obj nyan object.
+	 *
+	 * @return true if the object is a node, else false.
+	 */
 	static bool is_node(const nyan::Object &obj);
 
 	/**
-     * Get the type of a node.
-     *
-     * @param node nyan object.
-     *
-     * @return Type of the node.
-     */
+	 * Get the type of a node.
+	 *
+	 * @param node nyan object.
+	 *
+	 * @return Type of the node.
+	 */
 	static activity::node_t get_type(const nyan::Object &node);
 
 	/**
-     * Get the next nodes of a node.
-     *
-     * The number of next nodes depends on the type of the node and can range
-     * from 0 (end nodes) to n (gateways).
-     *
-     * @param node nyan object.
-     *
-     * @return nyan object handles of the next nodes.
-     */
+	 * Get the next nodes of a node.
+	 *
+	 * The number of next nodes depends on the type of the node and can range
+	 * from 0 (end nodes) to n (gateways).
+	 *
+	 * @param node nyan object.
+	 *
+	 * @return nyan object handles of the next nodes.
+	 */
 	static std::vector<nyan::Object> get_next(const nyan::Object &node);
 
 	/**
-     * Get the system id of an Ability node.
-     *
-     * @param node nyan object.
-     *
-     * @return System ID of the node.
-     */
+	 * Get the system id of an Ability node.
+	 *
+	 * @param node nyan object.
+	 *
+	 * @return System ID of the node.
+	 */
 	static system::system_id_t get_system_id(const nyan::Object &ability_node);
 };
 
@@ -91,21 +91,21 @@ public:
 class APIActivityCondition {
 public:
 	/**
-     * Check if a nyan object is a condition (type == \p engine.util.activity.condition.Condition).
-     *
-     * @param obj nyan object.
-     *
-     * @return true if the object is a condition, else false.
-     */
+	 * Check if a nyan object is a condition (type == \p engine.util.activity.condition.Condition).
+	 *
+	 * @param obj nyan object.
+	 *
+	 * @return true if the object is a condition, else false.
+	 */
 	static bool is_condition(const nyan::Object &obj);
 
 	/**
-     * Get the condition function for a condition.
-     *
-     * @param condition nyan object.
-     *
-     * @return Condition function.
-     */
+	 * Get the condition function for a condition.
+	 *
+	 * @param condition nyan object.
+	 *
+	 * @return Condition function.
+	 */
 	static activity::condition_t get_condition(const nyan::Object &condition);
 };
 
@@ -115,21 +115,21 @@ public:
 class APIActivityEvent {
 public:
 	/**
-     * Check if a nyan object is an event (type == \p engine.util.activity.event.Event).
-     *
-     * @param obj nyan object.
-     *
-     * @return true if the object is an event, else false.
-     */
+	 * Check if a nyan object is an event (type == \p engine.util.activity.event.Event).
+	 *
+	 * @param obj nyan object.
+	 *
+	 * @return true if the object is an event, else false.
+	 */
 	static bool is_event(const nyan::Object &obj);
 
 	/**
-     * Get the primer function for an event type.
-     *
-     * @param event nyan object.
-     *
-     * @return Event primer function.
-     */
+	 * Get the primer function for an event type.
+	 *
+	 * @param event nyan object.
+	 *
+	 * @return Event primer function.
+	 */
 	static activity::event_primer_t get_primer(const nyan::Object &event);
 };
 

--- a/libopenage/gamestate/api/animation.h
+++ b/libopenage/gamestate/api/animation.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,34 +16,34 @@ namespace openage::gamestate::api {
 class APIAnimation {
 public:
 	/**
-     * Check if a nyan object is an animation (type == \p engine.util.animation.Animation).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is an animation, else false.
-     */
+	 * Check if a nyan object is an animation (type == \p engine.util.animation.Animation).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is an animation, else false.
+	 */
 	static bool is_animation(nyan::Object &obj);
 
 	/**
-     * Get the sprite path of an animation.
-     *
-     * The path is relative to the directory the modpack is mounted in.
-     *
-     * @param animation \p Animation nyan object (type == \p engine.util.animation.Animation).
-     *
-     * @return Relative path to the animation sprite file.
-     */
+	 * Get the sprite path of an animation.
+	 *
+	 * The path is relative to the directory the modpack is mounted in.
+	 *
+	 * @param animation \p Animation nyan object (type == \p engine.util.animation.Animation).
+	 *
+	 * @return Relative path to the animation sprite file.
+	 */
 	static const std::string get_animation_path(const nyan::Object &animation);
 
 	/**
-     * Get the sprite paths for a collection of animations.
-     *
-     * Paths are relative to the directory the modpack is mounted in.
-     *
-     * @param animations \p Animation nyan objects (type == \p engine.util.animation.Animation).
-     *
-     * @return Relative paths to the animation sprite files.
-     */
+	 * Get the sprite paths for a collection of animations.
+	 *
+	 * Paths are relative to the directory the modpack is mounted in.
+	 *
+	 * @param animations \p Animation nyan objects (type == \p engine.util.animation.Animation).
+	 *
+	 * @return Relative paths to the animation sprite files.
+	 */
 	static const std::vector<std::string> get_animation_paths(const std::vector<nyan::Object> &animations);
 };
 

--- a/libopenage/gamestate/api/patch.h
+++ b/libopenage/gamestate/api/patch.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,33 +15,33 @@ namespace openage::gamestate::api {
 class APIPatch {
 public:
 	/**
-     * Check if a nyan object is a patch (type == \p engine.util.patch.Patch).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is a patch, else false.
-     */
+	 * Check if a nyan object is a patch (type == \p engine.util.patch.Patch).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is a patch, else false.
+	 */
 	static bool is_patch(const nyan::Object &obj);
 
 	/**
-     * Check if a patch has a given property.
-     *
-     * @param patch \p Patch nyan object (type == \p engine.util.patch.Patch).
-     * @param property Property type.
-     *
-     * @return true if the patch has the property, else false.
-     */
+	 * Check if a patch has a given property.
+	 *
+	 * @param patch \p Patch nyan object (type == \p engine.util.patch.Patch).
+	 * @param property Property type.
+	 *
+	 * @return true if the patch has the property, else false.
+	 */
 	static bool check_property(const nyan::Object &patch,
 	                           const patch_property_t &property);
 
 	/**
-     * Get the nyan object for a property from a patch.
-     *
-     * @param patch \p Patch nyan object (type == \p engine.util.patch.Patch).
-     * @param property Property type.
-     *
-     * @return \p Property nyan object (type == \p engine.util.patch.property.PatchProperty).
-     */
+	 * Get the nyan object for a property from a patch.
+	 *
+	 * @param patch \p Patch nyan object (type == \p engine.util.patch.Patch).
+	 * @param property Property type.
+	 *
+	 * @return \p Property nyan object (type == \p engine.util.patch.property.PatchProperty).
+	 */
 	static const nyan::Object get_property(const nyan::Object &patch,
 	                                       const patch_property_t &property);
 };

--- a/libopenage/gamestate/api/player_setup.h
+++ b/libopenage/gamestate/api/player_setup.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,39 +15,39 @@ namespace openage::gamestate::api {
 class APIPlayerSetup {
 public:
 	/**
-     * Check if a nyan object is a player setup (type == \p engine.util.setup.PlayerSetup).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is a player setup, else false.
-     */
+	 * Check if a nyan object is a player setup (type == \p engine.util.setup.PlayerSetup).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is a player setup, else false.
+	 */
 	static bool is_player_setup(const nyan::Object &obj);
 
 	/**
-     * Get the modifiers of a player setup.
-     *
-     * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
-     *
-     * @return \p Modifier nyan objects (type == \p engine.modifier.Modifier).
-     */
+	 * Get the modifiers of a player setup.
+	 *
+	 * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
+	 *
+	 * @return \p Modifier nyan objects (type == \p engine.modifier.Modifier).
+	 */
 	static const std::vector<nyan::Object> get_modifiers(const nyan::Object &player_setup);
 
 	/**
-     * Get the starting resources of a player setup.
-     *
-     * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
-     *
-     * @return \p ResourceAmount nyan objects (type == \p engine.util.resource.ResourceAmount).
-     */
+	 * Get the starting resources of a player setup.
+	 *
+	 * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
+	 *
+	 * @return \p ResourceAmount nyan objects (type == \p engine.util.resource.ResourceAmount).
+	 */
 	static const std::vector<nyan::Object> get_start_resources(const nyan::Object &player_setup);
 
 	/**
-     * Get the initial patches of a player setup.
-     *
-     * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
-     *
-     * @return \p Patch nyan objects (type == \p engine.util.patch.Patch).
-     */
+	 * Get the initial patches of a player setup.
+	 *
+	 * @param player_setup nyan object (type == \p engine.util.setup.PlayerSetup).
+	 *
+	 * @return \p Patch nyan objects (type == \p engine.util.patch.Patch).
+	 */
 	static const std::vector<nyan::Object> get_patches(const nyan::Object &player_setup);
 };
 

--- a/libopenage/gamestate/api/property.h
+++ b/libopenage/gamestate/api/property.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,48 +15,48 @@ namespace openage::gamestate::api {
 class APIAbilityProperty {
 public:
 	/**
-     * Check if a nyan object is a property (type == \p engine.ability.property.Property).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is a property, else false.
-     */
+	 * Check if a nyan object is a property (type == \p engine.ability.property.Property).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is a property, else false.
+	 */
 	static bool is_property(const nyan::Object &obj);
 
 	/**
-     * Get the animations of an \p Animated property (type == \p engine.ability.property.type.Animated).
-     *
-     * @param property \p Property nyan object (type == \p engine.ability.property.Property).
-     *
-     * @return \p Animation nyan objects (type == \p engine.util.animation.Animation).
-     */
+	 * Get the animations of an \p Animated property (type == \p engine.ability.property.type.Animated).
+	 *
+	 * @param property \p Property nyan object (type == \p engine.ability.property.Property).
+	 *
+	 * @return \p Animation nyan objects (type == \p engine.util.animation.Animation).
+	 */
 	static const std::vector<nyan::Object> get_animations(const nyan::Object &property);
 
 	/**
-     * Get the sounds of a \p CommandSound property (type == \p engine.ability.property.type.CommandSound).
-     *
-     * @param property \p Property nyan object (type == \p engine.ability.property.Property).
-     *
-     * @return \p Sound nyan objects (type == \p engine.util.sound.Sound).
-     */
+	 * Get the sounds of a \p CommandSound property (type == \p engine.ability.property.type.CommandSound).
+	 *
+	 * @param property \p Property nyan object (type == \p engine.ability.property.Property).
+	 *
+	 * @return \p Sound nyan objects (type == \p engine.util.sound.Sound).
+	 */
 	static const std::vector<nyan::Object> get_command_sounds(const nyan::Object &property);
 
 	/**
-     * Get the sounds of an \p ExecutionSound property (type == \p engine.ability.property.type.ExecutionSound).
-     *
-     * @param property \p Property nyan object (type == \p engine.ability.property.Property).
-     *
-     * @return \p Sound nyan objects (type == \p engine.util.sound.Sound).
-     */
+	 * Get the sounds of an \p ExecutionSound property (type == \p engine.ability.property.type.ExecutionSound).
+	 *
+	 * @param property \p Property nyan object (type == \p engine.ability.property.Property).
+	 *
+	 * @return \p Sound nyan objects (type == \p engine.util.sound.Sound).
+	 */
 	static const std::vector<nyan::Object> get_execution_sounds(const nyan::Object &property);
 
 	/**
-     * Get the sounds of a \p Diplomatic property (type == \p engine.ability.property.type.Diplomatic).
-     *
-     * @param property \p Property nyan object (type == \p engine.ability.property.Property).
-     *
-     * @return \p DiplomaticStance nyan objects (type == \p engine.util.diplomatic_stance.DiplomaticStance).
-     */
+	 * Get the sounds of a \p Diplomatic property (type == \p engine.ability.property.type.Diplomatic).
+	 *
+	 * @param property \p Property nyan object (type == \p engine.ability.property.Property).
+	 *
+	 * @return \p DiplomaticStance nyan objects (type == \p engine.util.diplomatic_stance.DiplomaticStance).
+	 */
 	static const std::vector<nyan::Object> get_diplo_stances(const nyan::Object &property);
 };
 

--- a/libopenage/gamestate/api/sound.h
+++ b/libopenage/gamestate/api/sound.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,34 +16,34 @@ namespace openage::gamestate::api {
 class APISound {
 public:
 	/**
-     * Check if a nyan object is a sound (type == \p engine.util.sound.Sound).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is a sound, else false.
-     */
+	 * Check if a nyan object is a sound (type == \p engine.util.sound.Sound).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is a sound, else false.
+	 */
 	static bool is_sound(const nyan::Object &obj);
 
 	/**
-     * Get the sound path of a sound.
-     *
-     * The path is relative to the directory the modpack is mounted in.
-     *
-     * @param sound \p Sound nyan object (type == \p engine.util.sound.Sound).
-     *
-     * @return Relative path to the sound file.
-     */
+	 * Get the sound path of a sound.
+	 *
+	 * The path is relative to the directory the modpack is mounted in.
+	 *
+	 * @param sound \p Sound nyan object (type == \p engine.util.sound.Sound).
+	 *
+	 * @return Relative path to the sound file.
+	 */
 	static const std::string get_sound_path(const nyan::Object &sound);
 
 	/**
-     * Get the sound paths for a collection of sounds.
-     *
-     * Paths are relative to the directory the modpack is mounted in.
-     *
-     * @param sounds \p Sound nyan objects (type == \p engine.util.sound.Sound).
-     *
-     * @return Relative paths to the sound files.
-     */
+	 * Get the sound paths for a collection of sounds.
+	 *
+	 * Paths are relative to the directory the modpack is mounted in.
+	 *
+	 * @param sounds \p Sound nyan objects (type == \p engine.util.sound.Sound).
+	 *
+	 * @return Relative paths to the sound files.
+	 */
 	static const std::vector<std::string> get_sound_paths(const std::vector<nyan::Object> &sounds);
 };
 } // namespace openage::gamestate::api

--- a/libopenage/gamestate/api/terrain.h
+++ b/libopenage/gamestate/api/terrain.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,23 +12,23 @@ namespace openage::gamestate::api {
 class APITerrain {
 public:
 	/**
-     * Check if a nyan object is a terrain (type == \p engine.util.terrain.Terrain).
-     *
-     * @param obj nyan object handle.
-     *
-     * @return true if the object is a terrain, else false.
-     */
+	 * Check if a nyan object is a terrain (type == \p engine.util.terrain.Terrain).
+	 *
+	 * @param obj nyan object handle.
+	 *
+	 * @return true if the object is a terrain, else false.
+	 */
 	static bool is_terrain(const nyan::Object &obj);
 
 	/**
-     * Get the terrain path of a terrain.
-     *
-     * The path is relative to the directory the modpack is mounted in.
-     *
-     * @param terrain \p Terrain nyan object (type == \p engine.util.terrain.Terrain).
-     *
-     * @return Relative path to the terrain file.
-     */
+	 * Get the terrain path of a terrain.
+	 *
+	 * The path is relative to the directory the modpack is mounted in.
+	 *
+	 * @param terrain \p Terrain nyan object (type == \p engine.util.terrain.Terrain).
+	 *
+	 * @return Relative path to the terrain file.
+	 */
 	static const std::string get_terrain_path(const nyan::Object &terrain);
 };
 

--- a/libopenage/gamestate/component/api/live.h
+++ b/libopenage/gamestate/component/api/live.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,23 +21,23 @@ public:
 	component_t get_type() const override;
 
 	/**
-     * Add a new attribute to the component attributes.
-     *
-     * @param time The time at which the attribute is added.
-     * @param attribute Attribute identifier (fqon of the nyan object).
-     * @param starting_values Attribute values at the time of addition.
-     */
+	 * Add a new attribute to the component attributes.
+	 *
+	 * @param time The time at which the attribute is added.
+	 * @param attribute Attribute identifier (fqon of the nyan object).
+	 * @param starting_values Attribute values at the time of addition.
+	 */
 	void add_attribute(const time::time_t &time,
 	                   const nyan::fqon_t &attribute,
 	                   std::shared_ptr<curve::Discrete<int64_t>> starting_values);
 
 	/**
-     * Set the value of an attribute at a given time.
-     *
-     * @param time The time at which the attribute is set.
-     * @param attribute Attribute identifier (fqon of the nyan object).
-     * @param value New attribute value.
-     */
+	 * Set the value of an attribute at a given time.
+	 *
+	 * @param time The time at which the attribute is set.
+	 * @param attribute Attribute identifier (fqon of the nyan object).
+	 * @param value New attribute value.
+	 */
 	void set_attribute(const time::time_t &time,
 	                   const nyan::fqon_t &attribute,
 	                   int64_t value);

--- a/libopenage/gamestate/component/api_component.h
+++ b/libopenage/gamestate/component/api_component.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -58,13 +58,13 @@ public:
 
 private:
 	/**
-     * nyan object holding the data for the component.
-     */
+	 * nyan object holding the data for the component.
+	 */
 	nyan::Object ability;
 
 	/**
-     * Determines if the component is available to its game entity.
-     */
+	 * Determines if the component is available to its game entity.
+	 */
 	curve::Discrete<bool> enabled;
 };
 

--- a/libopenage/gamestate/component/base_component.h
+++ b/libopenage/gamestate/component/base_component.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -14,10 +14,10 @@ public:
 	virtual ~Component() = default;
 
 	/**
-     * Get the component type of the component.
-     *
-     * @return Component type of the component.
-     */
+	 * Get the component type of the component.
+	 *
+	 * @return Component type of the component.
+	 */
 	virtual component_t get_type() const = 0;
 };
 

--- a/libopenage/gamestate/component/internal/activity.h
+++ b/libopenage/gamestate/component/internal/activity.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -30,80 +30,80 @@ namespace component {
 class Activity : public InternalComponent {
 public:
 	/**
-     * Creates a new activity component.
-     *
-     * @param loop Event loop that all events from the component are registered on.
-     * @param start_activity Initial activity flow graph.
-     */
+	 * Creates a new activity component.
+	 *
+	 * @param loop Event loop that all events from the component are registered on.
+	 * @param start_activity Initial activity flow graph.
+	 */
 	Activity(const std::shared_ptr<openage::event::EventLoop> &loop,
 	         const std::shared_ptr<activity::Activity> &start_activity);
 
 	component_t get_type() const override;
 
 	/**
-     * Get the initial activity.
-     *
-     * @return Initial activity.
-     */
+	 * Get the initial activity.
+	 *
+	 * @return Initial activity.
+	 */
 	const std::shared_ptr<activity::Activity> &get_start_activity() const;
 
 	/**
-     * Get the node in the activity flow graph at a given time.
-     *
-     * @param time Time at which the node is requested.
-     * @return Current node in the flow graph.
-     */
+	 * Get the node in the activity flow graph at a given time.
+	 *
+	 * @param time Time at which the node is requested.
+	 * @return Current node in the flow graph.
+	 */
 	const std::shared_ptr<activity::Node> get_node(const time::time_t &time) const;
 
 	/**
-     * Sets the current node in the activity flow graph at a given time.
-     *
-     * @param time Time at which the node is set.
-     * @param node Current node in the flow graph.
-     */
+	 * Sets the current node in the activity flow graph at a given time.
+	 *
+	 * @param time Time at which the node is set.
+	 * @param node Current node in the flow graph.
+	 */
 	void set_node(const time::time_t &time,
 	              const std::shared_ptr<activity::Node> &node);
 
 	/**
-     * Set the current node to the start node of the start activity.
-     *
-     * @param time Time at which the node is set.
-     */
+	 * Set the current node to the start node of the start activity.
+	 *
+	 * @param time Time at which the node is set.
+	 */
 	void init(const time::time_t &time);
 
 	/**
-     * Add a scheduled event that is waited for to progress in the node graph.
-     *
-     * @param event Event to add.
-     */
+	 * Add a scheduled event that is waited for to progress in the node graph.
+	 *
+	 * @param event Event to add.
+	 */
 	void add_event(const std::shared_ptr<openage::event::Event> &event);
 
 	/**
-     * Cancel all scheduled events.
-     *
-     * @param time Time at which the events are cancelled.
-     */
+	 * Cancel all scheduled events.
+	 *
+	 * @param time Time at which the events are cancelled.
+	 */
 	void cancel_events(const time::time_t &time);
 
 private:
 	/**
-     * Initial activity that encapsulates the entity's control flow graph.
-     *
-     * When a game entity is spawned, the activity system should advance in
-     * this activity flow graph to initialize the entity's action state.
-     *
-     * TODO: Define as curve, so it's changeable?
-     */
+	 * Initial activity that encapsulates the entity's control flow graph.
+	 *
+	 * When a game entity is spawned, the activity system should advance in
+	 * this activity flow graph to initialize the entity's action state.
+	 *
+	 * TODO: Define as curve, so it's changeable?
+	 */
 	std::shared_ptr<activity::Activity> start_activity;
 
 	/**
-     * Current node in the activity flow graph.
-     */
+	 * Current node in the activity flow graph.
+	 */
 	curve::Discrete<std::shared_ptr<activity::Node>> node;
 
 	/**
-     * Scheduled events that are waited for to progress in the node graph.
-     */
+	 * Scheduled events that are waited for to progress in the node graph.
+	 */
 	std::vector<std::shared_ptr<openage::event::Event>> scheduled_events;
 };
 

--- a/libopenage/gamestate/component/internal/commands/base_command.h
+++ b/libopenage/gamestate/component/internal/commands/base_command.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,10 +15,10 @@ public:
 	virtual ~Command() = default;
 
 	/**
-     * Get the type of the command.
-     *
-     * @return Command type.
-     */
+	 * Get the type of the command.
+	 *
+	 * @return Command type.
+	 */
 	virtual command_t get_type() const = 0;
 };
 

--- a/libopenage/gamestate/component/internal/commands/custom.h
+++ b/libopenage/gamestate/component/internal/commands/custom.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,10 +16,10 @@ namespace openage::gamestate::component::command {
 class CustomCommand : public Command {
 public:
 	/**
-     * Create a new custom command.
-     *
-     * @param id Command identifier.
-     */
+	 * Create a new custom command.
+	 *
+	 * @param id Command identifier.
+	 */
 	CustomCommand(const std::string &id);
 	virtual ~CustomCommand() = default;
 
@@ -28,16 +28,16 @@ public:
 	}
 
 	/**
-     * Get the command identifier.
-     *
-     * @return Command identifier.
-     */
+	 * Get the command identifier.
+	 *
+	 * @return Command identifier.
+	 */
 	const std::string &get_id() const;
 
 private:
 	/**
-     * Command identifier.
-     */
+	 * Command identifier.
+	 */
 	const std::string id;
 
 	// TODO: Payload

--- a/libopenage/gamestate/component/internal/commands/move.h
+++ b/libopenage/gamestate/component/internal/commands/move.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,10 +15,10 @@ namespace openage::gamestate::component::command {
 class MoveCommand : public Command {
 public:
 	/**
-     * Creates a new move command.
-     *
-     * @param target Target position coordinates.
-     */
+	 * Creates a new move command.
+	 *
+	 * @param target Target position coordinates.
+	 */
 	MoveCommand(const coord::phys3 &target);
 	virtual ~MoveCommand() = default;
 
@@ -27,16 +27,16 @@ public:
 	}
 
 	/**
-     * Get the target position.
-     *
-     * @return Target position coordinates.
-     */
+	 * Get the target position.
+	 *
+	 * @return Target position coordinates.
+	 */
 	const coord::phys3 &get_target() const;
 
 private:
 	/**
-     * Target position.
-     */
+	 * Target position.
+	 */
 	const coord::phys3 target;
 };
 

--- a/libopenage/gamestate/component/internal/ownership.h
+++ b/libopenage/gamestate/component/internal/ownership.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -50,16 +50,16 @@ public:
 	void set_owner(const time::time_t &time, const player_id_t owner_id);
 
 	/**
-     * Get the owner IDs over time.
-     *
-     * @return Owner ID curve.
-     */
+	 * Get the owner IDs over time.
+	 *
+	 * @return Owner ID curve.
+	 */
 	const curve::Discrete<player_id_t> &get_owners() const;
 
 private:
 	/**
-     * Owner ID storage over time.
-     */
+	 * Owner ID storage over time.
+	 */
 	curve::Discrete<player_id_t> owner;
 };
 

--- a/libopenage/gamestate/component/internal/position.h
+++ b/libopenage/gamestate/component/internal/position.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,73 +23,73 @@ namespace gamestate::component {
 class Position : public InternalComponent {
 public:
 	/**
-     * Create a Position component.
-     *
-     * @param loop Event loop that all events from the component are registered on.
-     * @param initial_pos Initial position at creation time.
-     * @param creation_time Ingame creation time of the component.
-     */
+	 * Create a Position component.
+	 *
+	 * @param loop Event loop that all events from the component are registered on.
+	 * @param initial_pos Initial position at creation time.
+	 * @param creation_time Ingame creation time of the component.
+	 */
 	Position(const std::shared_ptr<openage::event::EventLoop> &loop,
 	         const coord::phys3 &initial_pos,
 	         const time::time_t &creation_time);
 
 	/**
-     * Create a Position component.
-     *
-     * @param loop Event loop that all events from the component are registered on.
-     */
+	 * Create a Position component.
+	 *
+	 * @param loop Event loop that all events from the component are registered on.
+	 */
 	Position(const std::shared_ptr<openage::event::EventLoop> &loop);
 
 	component_t get_type() const override;
 
 	/**
-     * Get the positions in the world coordinate system over time.
-     *
-     * @return Position curve.
-     */
+	 * Get the positions in the world coordinate system over time.
+	 *
+	 * @return Position curve.
+	 */
 	const curve::Continuous<coord::phys3> &get_positions() const;
 
 	/**
-     * Set the position at a given time.
-     *
-     * This adds a new keyframe to the position curve.
-     *
-     * @param time Time at which the position is set.
-     * @param pos New position.
-     */
+	 * Set the position at a given time.
+	 *
+	 * This adds a new keyframe to the position curve.
+	 *
+	 * @param time Time at which the position is set.
+	 * @param pos New position.
+	 */
 	void set_position(const time::time_t &time, const coord::phys3 &pos);
 
 	/**
-     * Get the directions in degrees over time.
-     *
-     * @return Direction curve.
-     */
+	 * Get the directions in degrees over time.
+	 *
+	 * @return Direction curve.
+	 */
 	const curve::Segmented<coord::phys_angle_t> &get_angles() const;
 
 	/**
-     * Set the angle at a given time.
-     *
-     * This adds a new keyframe to the angle curve.
-     *
-     * @param time Time at which the angle is set.
-     * @param angle New angle.
-     */
+	 * Set the angle at a given time.
+	 *
+	 * This adds a new keyframe to the angle curve.
+	 *
+	 * @param time Time at which the angle is set.
+	 * @param angle New angle.
+	 */
 	void set_angle(const time::time_t &time, const coord::phys_angle_t &angle);
 
 private:
 	/**
-     * Position storage over time.
-     */
+	 * Position storage over time.
+	 */
 	curve::Continuous<coord::phys3> position;
 
 	/**
-     * Angle the entity is facing over time.
-     *
-     * Represents degrees in the range [0, 360). At angle 0, the entity is facing
-     * towards the camera (direction vector {x, y} = {-1, 1}).
-     *
-     * Rotation is clockwise, so at 90 degrees the entity is facing left.
-     */
+	 * Angle the entity is facing over time.
+	 *
+	 * Represents degrees in the range [0, 360). At angle 0, the entity is facing
+	 * towards the camera (direction vector {x, y} = {-1, 1}).
+	 *
+	 * Rotation is clockwise, so at 90 degrees the entity is facing left.
+	 */
 	curve::Segmented<coord::phys_angle_t> angle;
 };
 

--- a/libopenage/gamestate/entity_factory.h
+++ b/libopenage/gamestate/entity_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -36,17 +36,17 @@ class Player;
 class EntityFactory {
 public:
 	/**
-     * Create a new entity factory for game entities.
-     */
+	 * Create a new entity factory for game entities.
+	 */
 	EntityFactory();
 	~EntityFactory() = default;
 
 	/**
-     * Create a new game entity.
+	 * Create a new game entity.
 	 *
 	 * This just creates the entity. The caller is responsible for initializing
 	 * its components and placing it into the game.
-     *
+	 *
 	 * @param loop Event loop for the gamestate.
 	 * @param state State of the game.
 	 * @param owner_id ID of the player owning the entity.
@@ -103,10 +103,10 @@ private:
 	                   const nyan::Object &ability);
 
 	/**
-     * Get a unique ID for creating a game entity.
-     *
-     * @return Unique ID for a game entity.
-     */
+	 * Get a unique ID for creating a game entity.
+	 *
+	 * @return Unique ID for a game entity.
+	 */
 	entity_id_t get_next_entity_id();
 
 	/**
@@ -117,8 +117,8 @@ private:
 	player_id_t get_next_player_id();
 
 	/**
-     * ID of the next game entity to be created.
-     */
+	 * ID of the next game entity to be created.
+	 */
 	entity_id_t next_entity_id;
 
 	/**
@@ -134,13 +134,13 @@ private:
 	// TODO: Cache created game entities.
 
 	/**
-     * Cache for activities.
-     */
+	 * Cache for activities.
+	 */
 	std::unordered_map<nyan::fqon_t, std::shared_ptr<activity::Activity>> activity_cache;
 
 	/**
-     * Mutex for thread safety.
-     */
+	 * Mutex for thread safety.
+	 */
 	std::shared_mutex mutex;
 };
 } // namespace gamestate

--- a/libopenage/gamestate/event/spawn_entity.h
+++ b/libopenage/gamestate/event/spawn_entity.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -41,11 +41,11 @@ public:
 class SpawnEntityHandler : public openage::event::OnceEventHandler {
 public:
 	/**
-     * Creates a new SpawnEntityHandler.
-     *
-     * @param loop: Event loop that the components register on.
-     * @param factory: Factory that is used to create the entity.
-     */
+	 * Creates a new SpawnEntityHandler.
+	 *
+	 * @param loop: Event loop that the components register on.
+	 * @param factory: Factory that is used to create the entity.
+	 */
 	SpawnEntityHandler(const std::shared_ptr<openage::event::EventLoop> &loop,
 	                   const std::shared_ptr<gamestate::EntityFactory> &factory);
 	~SpawnEntityHandler() = default;
@@ -92,13 +92,13 @@ public:
 
 private:
 	/**
-     * Event loop that the entity components are registered on.
-     */
+	 * Event loop that the entity components are registered on.
+	 */
 	std::shared_ptr<openage::event::EventLoop> loop;
 
 	/**
-     * The factory that is used to create the entity.
-     */
+	 * The factory that is used to create the entity.
+	 */
 	std::shared_ptr<gamestate::EntityFactory> factory;
 };
 

--- a/libopenage/gamestate/game.h
+++ b/libopenage/gamestate/game.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -48,8 +48,8 @@ public:
 	/**
 	 * Create a new game.
 	 *
-     * @param event_loop Event simulation loop for the gamestate.
-     * @param mod_manager Mod manager.
+	 * @param event_loop Event simulation loop for the gamestate.
+	 * @param mod_manager Mod manager.
 	 * @param entity_factory Factory for creating entities. Used for creating the players.
 	 */
 	Game(const std::shared_ptr<openage::event::EventLoop> &event_loop,
@@ -59,8 +59,8 @@ public:
 	~Game() = default;
 
 	/**
-     * Get the current game state.
-     */
+	 * Get the current game state.
+	 */
 	const std::shared_ptr<GameState> &get_state() const;
 
 	/**
@@ -74,44 +74,44 @@ public:
 
 private:
 	/**
-     * Load game data from the filesystem.
-     *
-     * @param mod_manager Mod manager.
-     */
+	 * Load game data from the filesystem.
+	 *
+	 * @param mod_manager Mod manager.
+	 */
 	void load_data(const std::shared_ptr<assets::ModManager> &mod_manager);
 
 	/**
-     * Load game data from the filesystem recursively.
-     *
-     * TODO: Move this into nyan.
-     *
-     * @param base_dir Base directory where mods are stored.
-     * @param mod_dir Name of the mod directory.
-     * @param search Search path relative to the mod directory.
-     * @param recursive if true, recursively search subfolders if the the search path is a directory.
-     */
+	 * Load game data from the filesystem recursively.
+	 *
+	 * TODO: Move this into nyan.
+	 *
+	 * @param base_dir Base directory where mods are stored.
+	 * @param mod_dir Name of the mod directory.
+	 * @param search Search path relative to the mod directory.
+	 * @param recursive if true, recursively search subfolders if the the search path is a directory.
+	 */
 	void load_path(const util::Path &base_dir,
 	               const std::string &mod_dir,
 	               const std::string &search,
 	               bool recursive = false);
 
 	/**
-     * Generate the terrain for the current game.
-     *
-     * TODO: Use a real map generator.
-     *
-     * @param terrain_factory Factory for creating terrain objects.
-     */
+	 * Generate the terrain for the current game.
+	 *
+	 * TODO: Use a real map generator.
+	 *
+	 * @param terrain_factory Factory for creating terrain objects.
+	 */
 	void generate_terrain(const std::shared_ptr<TerrainFactory> &terrain_factory);
 
 	/**
-     * Nyan game data database.
-     */
+	 * Nyan game data database.
+	 */
 	std::shared_ptr<nyan::Database> db;
 
 	/**
-     * State of the current game.
-     */
+	 * State of the current game.
+	 */
 	std::shared_ptr<GameState> state;
 
 	/**

--- a/libopenage/gamestate/game_entity.h
+++ b/libopenage/gamestate/game_entity.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -30,10 +30,10 @@ class Component;
 class GameEntity {
 public:
 	/**
-     * Create a new game entity.
-     *
-     * @param id Unique identifier.
-     */
+	 * Create a new game entity.
+	 *
+	 * @param id Unique identifier.
+	 */
 	GameEntity(entity_id_t id);
 
 	~GameEntity() = default;
@@ -51,10 +51,10 @@ public:
 	std::shared_ptr<GameEntity> copy(entity_id_t id);
 
 	/**
-     * Get the unique identifier of this entity.
-     *
-     * @return Unique identifier.
-     */
+	 * Get the unique identifier of this entity.
+	 *
+	 * @return Unique identifier.
+	 */
 	entity_id_t get_id() const;
 
 	/**
@@ -79,32 +79,32 @@ public:
 	const std::shared_ptr<GameEntityManager> &get_manager() const;
 
 	/**
-     * Get a component of this entity.
-     *
-     * @param type Component type.
-     */
+	 * Get a component of this entity.
+	 *
+	 * @param type Component type.
+	 */
 	const std::shared_ptr<component::Component> &get_component(component::component_t type);
 
 	/**
-     * Add a component to this entity.
-     *
-     * @param component Component to add.
-     */
+	 * Add a component to this entity.
+	 *
+	 * @param component Component to add.
+	 */
 	void add_component(const std::shared_ptr<component::Component> &component);
 
 	/**
-     * Check if this entity has a component of the given type.
-     *
-     * @param type Component type.
-     */
+	 * Check if this entity has a component of the given type.
+	 *
+	 * @param type Component type.
+	 */
 	bool has_component(component::component_t type);
 
 	/**
-     * Update the render entity.
-     *
-     * @param time Simulation time of the update.
-     * @param animation_path Path to the animation definition used at \p time.
-     */
+	 * Update the render entity.
+	 *
+	 * @param time Simulation time of the update.
+	 * @param animation_path Path to the animation definition used at \p time.
+	 */
 	void render_update(const time::time_t &time,
 	                   const std::string &animation_path);
 
@@ -133,10 +133,10 @@ private:
 	entity_id_t id;
 
 	/**
-     * Data components.
-     *
-     * TODO: Multiple components of the same type.
-     */
+	 * Data components.
+	 *
+	 * TODO: Multiple components of the same type.
+	 */
 	std::unordered_map<component::component_t, std::shared_ptr<component::Component>> components;
 
 	/**

--- a/libopenage/gamestate/game_state.h
+++ b/libopenage/gamestate/game_state.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -38,58 +38,58 @@ class Terrain;
 class GameState : public openage::event::State {
 public:
 	/**
-     * Create a new game state.
-     *
-     * @param db Nyan game data database.
-     * @param event_loop Event loop for the game state.
-     */
+	 * Create a new game state.
+	 *
+	 * @param db Nyan game data database.
+	 * @param event_loop Event loop for the game state.
+	 */
 	explicit GameState(const std::shared_ptr<nyan::Database> &db,
 	                   const std::shared_ptr<openage::event::EventLoop> &event_loop);
 
 	/**
-     * Get the nyan database view for the whole game.
-     *
-     * Players have individual views for their own data.
-     *
-     * @return nyan database view.
-     */
+	 * Get the nyan database view for the whole game.
+	 *
+	 * Players have individual views for their own data.
+	 *
+	 * @return nyan database view.
+	 */
 	const std::shared_ptr<nyan::View> &get_db_view();
 
 	/**
-     * Add a new game entity to the index.
-     *
-     * @param entity New game entity.
-     */
+	 * Add a new game entity to the index.
+	 *
+	 * @param entity New game entity.
+	 */
 	void add_game_entity(const std::shared_ptr<GameEntity> &entity);
 
 	/**
-     * Add a new player to the index.
-     *
-     * @param player New player.
-     */
+	 * Add a new player to the index.
+	 *
+	 * @param player New player.
+	 */
 	void add_player(const std::shared_ptr<Player> &player);
 
 	/**
-     * Set the terrain of the current game.
-     *
-     * @param terrain Terrain object.
-     */
+	 * Set the terrain of the current game.
+	 *
+	 * @param terrain Terrain object.
+	 */
 	void set_terrain(const std::shared_ptr<Terrain> &terrain);
 
 	/**
-     * Get a game entity by its ID.
-     *
-     * @param id ID of the game entity.
+	 * Get a game entity by its ID.
 	 *
-     * @return Game entity with the given ID.
-     */
+	 * @param id ID of the game entity.
+	 *
+	 * @return Game entity with the given ID.
+	 */
 	const std::shared_ptr<GameEntity> &get_game_entity(entity_id_t id) const;
 
 	/**
-     * Get all game entities in the current game.
-     *
-     * @return Map of all game entities in the current game by their ID.
-     */
+	 * Get all game entities in the current game.
+	 *
+	 * @return Map of all game entities in the current game by their ID.
+	 */
 	const std::unordered_map<entity_id_t, std::shared_ptr<GameEntity>> &get_game_entities() const;
 
 	/**
@@ -102,42 +102,42 @@ public:
 	const std::shared_ptr<Player> &get_player(player_id_t id) const;
 
 	/**
-     * Get the terrain of the current game.
-     *
-     * @return Terrain object.
-     */
+	 * Get the terrain of the current game.
+	 *
+	 * @return Terrain object.
+	 */
 	const std::shared_ptr<Terrain> &get_terrain() const;
 
 	/**
-     * TODO: Only for testing.
-     */
+	 * TODO: Only for testing.
+	 */
 	const std::shared_ptr<assets::ModManager> &get_mod_manager() const;
 	void set_mod_manager(const std::shared_ptr<assets::ModManager> &mod_manager);
 
 private:
 	/**
-     * View for the nyan game data database.
-     */
+	 * View for the nyan game data database.
+	 */
 	std::shared_ptr<nyan::View> db_view;
 
 	/**
-     * Map of all game entities in the current game by their ID.
-     */
+	 * Map of all game entities in the current game by their ID.
+	 */
 	std::unordered_map<entity_id_t, std::shared_ptr<GameEntity>> game_entities;
 
 	/**
-     * Map of all players in the current game by their ID.
-     */
+	 * Map of all players in the current game by their ID.
+	 */
 	std::unordered_map<player_id_t, std::shared_ptr<Player>> players;
 
 	/**
-     * Terrain of the current game.
-     */
+	 * Terrain of the current game.
+	 */
 	std::shared_ptr<Terrain> terrain;
 
 	/**
-     * TODO: Only for testing
-     */
+	 * TODO: Only for testing
+	 */
 	std::shared_ptr<assets::ModManager> mod_manager;
 };
 } // namespace gamestate

--- a/libopenage/gamestate/player.h
+++ b/libopenage/gamestate/player.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -80,8 +80,8 @@ private:
 	player_id_t id;
 
 	/**
-     * Player view of the nyan game data database.
-     */
+	 * Player view of the nyan game data database.
+	 */
 	std::shared_ptr<nyan::View> db_view;
 };
 

--- a/libopenage/gamestate/simulation.h
+++ b/libopenage/gamestate/simulation.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -47,10 +47,10 @@ class GameSimulation final {
 public:
 	/**
 	 * Create the game simulation subsystems depending on the requested run mode.
-     *
-     * @param root_dir openage root directory.
-     * @param cvar_manager Environment variable manager.
-     * @param time_loop Time management loop.
+	 *
+	 * @param root_dir openage root directory.
+	 * @param cvar_manager Environment variable manager.
+	 * @param time_loop Time management loop.
 	 */
 	GameSimulation(const util::Path &root_dir,
 	               const std::shared_ptr<cvar::CVarManager> &cvar_manager,
@@ -85,32 +85,32 @@ public:
 
 	/**
 	 * Get this simulation's cvar manager.
-     *
-     * @return CVarManager instance.
+	 *
+	 * @return CVarManager instance.
 	 */
 	const std::shared_ptr<cvar::CVarManager> get_cvar_manager();
 
 	/**
-     * Get the game running in the simulation.
-     *
-     * @return Game instance.
-     */
+	 * Get the game running in the simulation.
+	 *
+	 * @return Game instance.
+	 */
 	const std::shared_ptr<gamestate::Game> get_game();
 
 	/**
-     * Get the event loop for the gamestate.
-     *
-     * @return Event loop.
-     */
+	 * Get the event loop for the gamestate.
+	 *
+	 * @return Event loop.
+	 */
 	const std::shared_ptr<openage::event::EventLoop> get_event_loop();
 
 	/**
-     * Get the event entity for spawing game entities.
-     *
-     * TODO: Move somewhere else or remove.
-     *
-     * @return Spawner for entity creation.
-     */
+	 * Get the event entity for spawing game entities.
+	 *
+	 * TODO: Move somewhere else or remove.
+	 *
+	 * @return Spawner for entity creation.
+	 */
 	const std::shared_ptr<gamestate::event::Spawner> get_spawner();
 
 	/**
@@ -130,10 +130,10 @@ public:
 	void attach_renderer(const std::shared_ptr<renderer::RenderFactory> &render_factory);
 
 	/**
-     * Set the modpacks to load for a game.
-     *
-     * @param modpacks IDs of the modpacks to load.
-     */
+	 * Set the modpacks to load for a game.
+	 *
+	 * @param modpacks IDs of the modpacks to load.
+	 */
 	void set_modpacks(const std::vector<std::string> &modpacks);
 
 	/**
@@ -144,8 +144,8 @@ public:
 
 private:
 	/**
-     * Initialize event handlers.
-     */
+	 * Initialize event handlers.
+	 */
 	void init_event_handlers();
 
 	/**
@@ -170,23 +170,23 @@ private:
 	std::shared_ptr<openage::time::TimeLoop> time_loop;
 
 	/**
-     * Event loop for processing events in the game.
-     */
+	 * Event loop for processing events in the game.
+	 */
 	std::shared_ptr<openage::event::EventLoop> event_loop;
 
 	/**
-     * Factory for creating game entities.
-     */
+	 * Factory for creating game entities.
+	 */
 	std::shared_ptr<gamestate::EntityFactory> entity_factory;
 
 	/**
-     * Factory for creating terrain.
-     */
+	 * Factory for creating terrain.
+	 */
 	std::shared_ptr<gamestate::TerrainFactory> terrain_factory;
 
 	/**
-     * Mod manager.
-     */
+	 * Mod manager.
+	 */
 	std::shared_ptr<assets::ModManager> mod_manager;
 
 	// TODO: move somewhere sensible or remove
@@ -197,8 +197,8 @@ private:
 	std::shared_ptr<gamestate::Game> game;
 
 	/**
-     * Mutex for thread-safe access to the simulation.
-     */
+	 * Mutex for thread-safe access to the simulation.
+	 */
 	std::shared_mutex mutex;
 };
 

--- a/libopenage/gamestate/system/activity.h
+++ b/libopenage/gamestate/system/activity.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -25,11 +25,11 @@ namespace system {
 class Activity {
 public:
 	/**
-     * Advance in the activity flow graph of the game entity.
-     *
-     * @param start_time Start time of change.
-     * @param entity Game entity.
-     */
+	 * Advance in the activity flow graph of the game entity.
+	 *
+	 * @param start_time Start time of change.
+	 * @param entity Game entity.
+	 */
 	static void advance(const time::time_t &start_time,
 	                    const std::shared_ptr<gamestate::GameEntity> &entity,
 	                    const std::shared_ptr<openage::event::EventLoop> &loop,
@@ -44,7 +44,7 @@ private:
 	 * @param start_time Start time of change.
 	 * @param system_id ID of the subsystem to run.
 	 *
-     * @return Runtime of the change in simulation time.
+	 * @return Runtime of the change in simulation time.
 	 */
 	static const time::time_t handle_subsystem(const std::shared_ptr<gamestate::GameEntity> &entity,
 	                                           const time::time_t &start_time,

--- a/libopenage/gamestate/system/idle.h
+++ b/libopenage/gamestate/system/idle.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,18 +15,18 @@ namespace system {
 class Idle {
 public:
 	/**
-     * Let a game entity idle.
-     *
-     * This does not change the state of a unit. It only changes its animation and
-     * sounds.
-     *
-     * @param entity Game entity.
-     * @param start_time Start time of change.
-     *
-     * @return Runtime of the change in simulation time.
-     */
+	 * Let a game entity idle.
+	 *
+	 * This does not change the state of a unit. It only changes its animation and
+	 * sounds.
+	 *
+	 * @param entity Game entity.
+	 * @param start_time Start time of change.
+	 *
+	 * @return Runtime of the change in simulation time.
+	 */
 	static const time::time_t idle(const std::shared_ptr<gamestate::GameEntity> &entity,
-	                                const time::time_t &start_time);
+	                               const time::time_t &start_time);
 };
 
 } // namespace system

--- a/libopenage/gamestate/system/move.h
+++ b/libopenage/gamestate/system/move.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,28 +16,28 @@ namespace system {
 class Move {
 public:
 	/**
-     * Move a game entity to a destination from a move command.
-     *
-     * @param entity Game entity.
-     * @param start_time Start time of change.
-     *
-     * @return Runtime of the change in simulation time.
-     */
+	 * Move a game entity to a destination from a move command.
+	 *
+	 * @param entity Game entity.
+	 * @param start_time Start time of change.
+	 *
+	 * @return Runtime of the change in simulation time.
+	 */
 	static const time::time_t move_command(const std::shared_ptr<gamestate::GameEntity> &entity,
-	                                        const time::time_t &start_time);
+	                                       const time::time_t &start_time);
 
 	/**
-     * Move a game entity to a destination.
-     *
-     * @param entity Game entity.
-     * @param destination Destination coordinates.
-     * @param start_time Start time of change.
-     *
-     * @return Runtime of the change in simulation time.
-     */
+	 * Move a game entity to a destination.
+	 *
+	 * @param entity Game entity.
+	 * @param destination Destination coordinates.
+	 * @param start_time Start time of change.
+	 *
+	 * @return Runtime of the change in simulation time.
+	 */
 	static const time::time_t move_default(const std::shared_ptr<gamestate::GameEntity> &entity,
-	                                        const coord::phys3 &destination,
-	                                        const time::time_t &start_time);
+	                                       const coord::phys3 &destination,
+	                                       const time::time_t &start_time);
 };
 
 } // namespace system

--- a/libopenage/gamestate/terrain.h
+++ b/libopenage/gamestate/terrain.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -22,23 +22,23 @@ class TerrainChunk;
 class Terrain {
 public:
 	/**
-     * Create a new terrain.
-     */
+	 * Create a new terrain.
+	 */
 	Terrain();
 	~Terrain() = default;
 
 	/**
-     * Add a chunk to the terrain.
-     *
-     * @param chunk New chunk.
-     */
+	 * Add a chunk to the terrain.
+	 *
+	 * @param chunk New chunk.
+	 */
 	void add_chunk(const std::shared_ptr<TerrainChunk> &chunk);
 
 	/**
-     * Get the chunks of the terrain.
-     *
-     * @return Terrain chunks.
-     */
+	 * Get the chunks of the terrain.
+	 *
+	 * @return Terrain chunks.
+	 */
 	const std::vector<std::shared_ptr<TerrainChunk>> &get_chunks() const;
 
 	/**
@@ -56,15 +56,15 @@ public:
 
 private:
 	/**
-     * Total size of the map
+	 * Total size of the map
 	 * origin is the left corner
 	 * x = top left edge; y = top right edge
-     */
+	 */
 	util::Vector2s size;
 
 	/**
-     * Subdivision of the main terrain entity.
-     */
+	 * Subdivision of the main terrain entity.
+	 */
 	std::vector<std::shared_ptr<TerrainChunk>> chunks;
 };
 

--- a/libopenage/gamestate/terrain_chunk.h
+++ b/libopenage/gamestate/terrain_chunk.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -35,26 +35,26 @@ public:
 	void set_render_entity(const std::shared_ptr<renderer::terrain::TerrainRenderEntity> &entity);
 
 	/**
-     * Update the render entity.
-     *
-     * @param time Simulation time of the update.
-     * @param terrain_path Path to the terrain definition used at \p time.
-     */
+	 * Update the render entity.
+	 *
+	 * @param time Simulation time of the update.
+	 * @param terrain_path Path to the terrain definition used at \p time.
+	 */
 	void render_update(const time::time_t &time,
 	                   const std::string &terrain_path);
 
 	/**
-     * Get the size of this terrain chunk.
-     *
-     * @return Size of the terrain chunk (in tiles).
-     */
+	 * Get the size of this terrain chunk.
+	 *
+	 * @return Size of the terrain chunk (in tiles).
+	 */
 	const util::Vector2s &get_size() const;
 
 	/**
-     * Get the offset of this terrain chunk to the terrain origin.
-     *
-     * @return Offset of the terrain chunk (in tiles).
-     */
+	 * Get the offset of this terrain chunk to the terrain origin.
+	 *
+	 * @return Offset of the terrain chunk (in tiles).
+	 */
 	const coord::tile_delta &get_offset() const;
 
 	// TODO: Remove test texture references
@@ -69,20 +69,20 @@ public:
 
 private:
 	/**
-     * Size of the terrain chunk.
-     * Origin is the left corner.
-     * x = top left edge; y = top right edge.
-     */
+	 * Size of the terrain chunk.
+	 * Origin is the left corner.
+	 * x = top left edge; y = top right edge.
+	 */
 	util::Vector2s size;
 
 	/**
-     * Offset of the terrain chunk to the origin.
-     */
+	 * Offset of the terrain chunk to the origin.
+	 */
 	coord::tile_delta offset;
 
 	/**
-     * Height map of the terrain chunk.
-     */
+	 * Height map of the terrain chunk.
+	 */
 	std::vector<TerrainTile> tiles;
 
 	/**

--- a/libopenage/gamestate/terrain_factory.h
+++ b/libopenage/gamestate/terrain_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -26,26 +26,26 @@ class TerrainChunk;
 class TerrainFactory {
 public:
 	/**
-     * Create a new terrain factory.
-     */
+	 * Create a new terrain factory.
+	 */
 	TerrainFactory() = default;
 	~TerrainFactory() = default;
 
 	/**
-     * Create a new empty terrain object.
-     *
-     * @return New terrain object.
-     */
+	 * Create a new empty terrain object.
+	 *
+	 * @return New terrain object.
+	 */
 	std::shared_ptr<Terrain> add_terrain();
 
 	/**
-     * Create a new empty terrain chunk.
-     *
-     * @param size Size of the chunk.
-     * @param offset Offset of the chunk.
-     *
-     * @return New terrain chunk.
-     */
+	 * Create a new empty terrain chunk.
+	 *
+	 * @param size Size of the chunk.
+	 * @param offset Offset of the chunk.
+	 *
+	 * @return New terrain chunk.
+	 */
 	std::shared_ptr<TerrainChunk> add_chunk(const std::shared_ptr<GameState> &gstate,
 	                                        const util::Vector2s size,
 	                                        const coord::tile_delta offset);
@@ -57,8 +57,8 @@ public:
 
 	/**
 	 * Attach a render factory for graphical display.
-     *
-     * This enables rendering for all created terrain chunks.
+	 *
+	 * This enables rendering for all created terrain chunks.
 	 *
 	 * @param render_factory Factory for creating connector objects for gamestate->renderer
 	 *                       communication.
@@ -72,8 +72,8 @@ private:
 	std::shared_ptr<renderer::RenderFactory> render_factory;
 
 	/**
-     * Mutex for thread safety.
-     */
+	 * Mutex for thread safety.
+	 */
 	std::shared_mutex mutex;
 };
 

--- a/libopenage/gamestate/terrain_tile.h
+++ b/libopenage/gamestate/terrain_tile.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,22 +19,22 @@ using terrain_elevation_t = util::FixedPoint<uint64_t, 16>;
  */
 struct TerrainTile {
 	/**
-     * Terrain definition used by this tile.
-     *
-     * TODO: Make this non-optional once all modpacks support terrain graphics.
-     */
+	 * Terrain definition used by this tile.
+	 *
+	 * TODO: Make this non-optional once all modpacks support terrain graphics.
+	 */
 	std::optional<nyan::Object> terrain;
 
 	/**
-     * Path to the terrain asset used by this tile.
-     *
-     * TODO: Remove this and fetch the asset path from the terrain definition.
-     */
+	 * Path to the terrain asset used by this tile.
+	 *
+	 * TODO: Remove this and fetch the asset path from the terrain definition.
+	 */
 	std::string terrain_asset_path;
 
 	/**
-     * Height of this tile on the terrain.
-     */
+	 * Height of this tile on the terrain.
+	 */
 	terrain_elevation_t elevation;
 };
 

--- a/libopenage/gamestate/universe.h
+++ b/libopenage/gamestate/universe.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -26,7 +26,7 @@ public:
 	/**
 	 * Create a new universe.
 	 *
-     * @param state State of the game.
+	 * @param state State of the game.
 	 */
 	Universe(const std::shared_ptr<GameState> &state);
 	~Universe() = default;

--- a/libopenage/gamestate/world.h
+++ b/libopenage/gamestate/world.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,7 +23,7 @@ public:
 	/**
 	 * Create a new world.
 	 *
-     * @param state State of the game.
+	 * @param state State of the game.
 	 */
 	World(const std::shared_ptr<GameState> &state);
 	~World() = default;
@@ -38,8 +38,8 @@ public:
 
 private:
 	/**
-     * State of the current game.
-     */
+	 * State of the current game.
+	 */
 	std::shared_ptr<GameState> state;
 
 	/**

--- a/libopenage/input/controller/camera/binding_context.h
+++ b/libopenage/input/controller/camera/binding_context.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -25,9 +25,9 @@ public:
 	 * Bind a specific key combination to a binding.
 	 *
 	 * This is the first matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const Event &ev, const binding_action bind);
 
@@ -35,26 +35,26 @@ public:
 	 * Bind an event class to an action.
 	 *
 	 * This is the second matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const event_class &cl, const binding_action bind);
 
 	/**
-     * Check whether a specific key event is bound in this context.
-     *
-     * @param ev Input event.
-     *
-     * @return true if event is bound, else false.
-     */
+	 * Check whether a specific key event is bound in this context.
+	 *
+	 * @param ev Input event.
+	 *
+	 * @return true if event is bound, else false.
+	 */
 	bool is_bound(const Event &ev) const;
 
 	/**
-     * Get the bindings for a specific event.
-     *
-     * @param ev Input event mapped to the binding.
-     */
+	 * Get the bindings for a specific event.
+	 *
+	 * @param ev Input event mapped to the binding.
+	 */
 	const binding_action &lookup(const Event &ev) const;
 
 private:

--- a/libopenage/input/controller/game/binding_context.h
+++ b/libopenage/input/controller/game/binding_context.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -25,9 +25,9 @@ public:
 	 * Bind a specific key combination to a binding.
 	 *
 	 * This is the first matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const Event &ev, const binding_action bind);
 
@@ -35,26 +35,26 @@ public:
 	 * Bind an event class to an action.
 	 *
 	 * This is the second matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const event_class &cl, const binding_action bind);
 
 	/**
-     * Check whether a specific key event is bound in this context.
-     *
-     * @param ev Input event.
-     *
-     * @return true if event is bound, else false.
-     */
+	 * Check whether a specific key event is bound in this context.
+	 *
+	 * @param ev Input event.
+	 *
+	 * @return true if event is bound, else false.
+	 */
 	bool is_bound(const Event &ev) const;
 
 	/**
-     * Get the bindings for a specific event.
-     *
-     * @param ev Input event mapped to the binding.
-     */
+	 * Get the bindings for a specific event.
+	 *
+	 * @param ev Input event mapped to the binding.
+	 */
 	const binding_action &lookup(const Event &ev) const;
 
 private:

--- a/libopenage/input/controller/hud/binding_context.h
+++ b/libopenage/input/controller/hud/binding_context.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -25,9 +25,9 @@ public:
 	 * Bind a specific key combination to a binding.
 	 *
 	 * This is the first matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const Event &ev, const binding_action bind);
 
@@ -35,26 +35,26 @@ public:
 	 * Bind an event class to an action.
 	 *
 	 * This is the second matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param bind Binding for the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param bind Binding for the event.
 	 */
 	void bind(const event_class &cl, const binding_action bind);
 
 	/**
-     * Check whether a specific key event is bound in this context.
-     *
-     * @param ev Input event.
-     *
-     * @return true if event is bound, else false.
-     */
+	 * Check whether a specific key event is bound in this context.
+	 *
+	 * @param ev Input event.
+	 *
+	 * @return true if event is bound, else false.
+	 */
 	bool is_bound(const Event &ev) const;
 
 	/**
-     * Get the bindings for a specific event.
-     *
-     * @param ev Input event mapped to the binding.
-     */
+	 * Get the bindings for a specific event.
+	 *
+	 * @param ev Input event mapped to the binding.
+	 */
 	const binding_action &lookup(const Event &ev) const;
 
 private:

--- a/libopenage/input/controller/hud/controller.h
+++ b/libopenage/input/controller/hud/controller.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -38,23 +38,23 @@ public:
 	             const std::shared_ptr<BindingContext> &ctx);
 
 	/**
-     * Set the render entity for the selection box.
-     *
-     * @param entity New render entity.
-     */
+	 * Set the render entity for the selection box.
+	 *
+	 * @param entity New render entity.
+	 */
 	void set_drag_entity(const std::shared_ptr<renderer::hud::HudDragRenderEntity> &entity);
 
 	/**
-     * Get the render entity for the selection box.
-     *
-     * @return Render entity for the selection box.
-     */
+	 * Get the render entity for the selection box.
+	 *
+	 * @return Render entity for the selection box.
+	 */
 	const std::shared_ptr<renderer::hud::HudDragRenderEntity> &get_drag_entity() const;
 
 private:
 	/**
-     * Render entity for the selection box.
-     */
+	 * Render entity for the selection box.
+	 */
 	std::shared_ptr<renderer::hud::HudDragRenderEntity> drag_entity;
 };
 

--- a/libopenage/input/event.h
+++ b/libopenage/input/event.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -30,11 +30,11 @@ enum class event_class {
 	GUI,
 
 	// keyboard subclasses
-	ALPHA, // abc
-	DIGIT, // 123
-	PRINT, // remaining printable chars
+	ALPHA,    // abc
+	DIGIT,    // 123
+	PRINT,    // remaining printable chars
 	NONPRINT, // tab, return, backspace, delete
-	OTHER, // arrows, home, end
+	OTHER,    // arrows, home, end
 
 	// mouse subclasses
 	MOUSE_BUTTON,

--- a/libopenage/input/input_context.h
+++ b/libopenage/input/input_context.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -41,61 +41,61 @@ public:
 	virtual ~InputContext() = default;
 
 	/**
-     * Get the unique ID of the context.
-     *
-     * @return Context ID.
-     */
+	 * Get the unique ID of the context.
+	 *
+	 * @return Context ID.
+	 */
 	const std::string &get_id();
 
 	/**
-     * Set the associated context for binding input events to game events.
-     *
-     * @param bindings Binding context for gamestate events.
-     */
+	 * Set the associated context for binding input events to game events.
+	 *
+	 * @param bindings Binding context for gamestate events.
+	 */
 	void set_game_bindings(const std::shared_ptr<game::BindingContext> &bindings);
 
 	/**
-     * Set the associated context for binding input events to camera actions.
-     *
-     * @param bindings Binding context for camera actions.
-     */
+	 * Set the associated context for binding input events to camera actions.
+	 *
+	 * @param bindings Binding context for camera actions.
+	 */
 	void set_camera_bindings(const std::shared_ptr<camera::BindingContext> &bindings);
 
 	/**
-     * Set the associated context for binding input events to HUD actions.
-     *
-     * @param bindings Binding context for HUD actions.
-     */
+	 * Set the associated context for binding input events to HUD actions.
+	 *
+	 * @param bindings Binding context for HUD actions.
+	 */
 	void set_hud_bindings(const std::shared_ptr<hud::BindingContext> &bindings);
 
 	/**
-     * Get the associated context for binding input events to game events.
-     *
-     * @return Binding context of the input context.
-     */
+	 * Get the associated context for binding input events to game events.
+	 *
+	 * @return Binding context of the input context.
+	 */
 	const std::shared_ptr<game::BindingContext> &get_game_bindings();
 
 	/**
-     * Get the associated context for binding input events to camera actions.
-     *
-     * @return Binding context of the input context.
-     */
+	 * Get the associated context for binding input events to camera actions.
+	 *
+	 * @return Binding context of the input context.
+	 */
 	const std::shared_ptr<camera::BindingContext> &get_camera_bindings();
 
 	/**
-     * Get the associated context for binding input events to HUD actions.
-     *
-     * @return Binding context of the input context.
-     */
+	 * Get the associated context for binding input events to HUD actions.
+	 *
+	 * @return Binding context of the input context.
+	 */
 	const std::shared_ptr<hud::BindingContext> &get_hud_bindings();
 
 	/**
 	 * Bind a specific key combination to a single action.
 	 *
 	 * This is the first matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param act Action executed by the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param act Action executed by the event.
 	 */
 	void bind(const Event &ev, const input_action act);
 
@@ -103,9 +103,9 @@ public:
 	 * Bind an event class to a single action.
 	 *
 	 * This is the second matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param act Action executed by the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param act Action executed by the event.
 	 */
 	void bind(const event_class &cl, const input_action act);
 
@@ -113,9 +113,9 @@ public:
 	 * Bind a specific key combination to a list of actions.
 	 *
 	 * This is the first matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param act Actions executed by the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param act Actions executed by the event.
 	 */
 	void bind(const Event &ev, const std::vector<input_action> &&acts);
 
@@ -123,26 +123,26 @@ public:
 	 * Bind an event class to a list of actions.
 	 *
 	 * This is the second matching priority.
-     *
-     * @param ev Input event triggering the action.
-     * @param act Actions executed by the event.
+	 *
+	 * @param ev Input event triggering the action.
+	 * @param act Actions executed by the event.
 	 */
 	void bind(const event_class &cl, const std::vector<input_action> &&acts);
 
 	/**
-     * Check whether a specific key event is bound in this context.
-     *
-     * @param ev Input event.
-     *
-     * @return true if event is bound, else false.
-     */
+	 * Check whether a specific key event is bound in this context.
+	 *
+	 * @param ev Input event.
+	 *
+	 * @return true if event is bound, else false.
+	 */
 	bool is_bound(const Event &ev) const;
 
 	/**
-     * Get the action(s) bound to the given event.
-     *
-     * @param ev Input event triggering the action.
-     */
+	 * Get the action(s) bound to the given event.
+	 *
+	 * @param ev Input event triggering the action.
+	 */
 	const std::vector<input_action> &lookup(const Event &ev) const;
 
 	/**
@@ -162,8 +162,8 @@ public:
 
 private:
 	/**
-     * Unique ID of the context.
-     */
+	 * Unique ID of the context.
+	 */
 	std::string id;
 
 	/**
@@ -177,18 +177,18 @@ private:
 	std::unordered_map<event_class, std::vector<input_action>, event_class_hash> by_class;
 
 	/**
-     * Additional context for game simulation events.
-     */
+	 * Additional context for game simulation events.
+	 */
 	std::shared_ptr<game::BindingContext> game_bindings;
 
 	/**
-     * Additional context for camera actions.
-     */
+	 * Additional context for camera actions.
+	 */
 	std::shared_ptr<camera::BindingContext> camera_bindings;
 
 	/**
-     * Additional context for HUD actions.
-     */
+	 * Additional context for HUD actions.
+	 */
 	std::shared_ptr<hud::BindingContext> hud_bindings;
 };
 

--- a/libopenage/input/input_manager.h
+++ b/libopenage/input/input_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -44,30 +44,30 @@ public:
 
 	/**
 	 * Set the GUI input handler.
-     *
-     * @param gui_input GUI input handler.
+	 *
+	 * @param gui_input GUI input handler.
 	 */
 	void set_gui(const std::shared_ptr<qtgui::GuiInput> &gui_input);
 
 	/**
-     * Set the controller for the camera.
-     *
-     * @param controller Camera controller.
-     */
+	 * Set the controller for the camera.
+	 *
+	 * @param controller Camera controller.
+	 */
 	void set_camera_controller(const std::shared_ptr<camera::Controller> &controller);
 
 	/**
-     * Set the controller for the game simulation.
-     *
-     * @param controller Game controller.
-     */
+	 * Set the controller for the game simulation.
+	 *
+	 * @param controller Game controller.
+	 */
 	void set_game_controller(const std::shared_ptr<game::Controller> &controller);
 
 	/**
-     * Set the controller for the HUD.
-     *
-     * @param controller HUD controller.
-     */
+	 * Set the controller for the HUD.
+	 *
+	 * @param controller HUD controller.
+	 */
 	void set_hud_controller(const std::shared_ptr<hud::Controller> controller);
 
 	/**
@@ -91,7 +91,7 @@ public:
 
 	/**
 	 * Push a context on top of the stack, making it the
-     * current top context.
+	 * current top context.
 	 *
 	 * if other contexts are registered afterwards,
 	 * it wanders down the stack, i.e. loses priority.
@@ -100,7 +100,7 @@ public:
 
 	/**
 	 * Push the context with the specified ID on top of the stack,
-     * making it the current top context.
+	 * making it the current top context.
 	 *
 	 * if other contexts are registered afterwards,
 	 * it wanders down the stack, i.e. loses priority.
@@ -141,23 +141,23 @@ public:
 	void set_motion(int x, int y);
 
 	/**
-     * Process an input event from the Qt window management.
-     *
-     * @param ev Qt input event.
-     *
-     * @return true if the event is accepted, else false.
-     */
+	 * Process an input event from the Qt window management.
+	 *
+	 * @param ev Qt input event.
+	 *
+	 * @return true if the event is accepted, else false.
+	 */
 	bool process(const QEvent &ev);
 
 
 private:
 	/**
-     * Process the (default) action for an input event.
-     *
-     * @param ev Input event.
-     * @param action Action bound to the event.
-     * @param bind_ctx Context the action is bound in.
-     */
+	 * Process the (default) action for an input event.
+	 *
+	 * @param ev Input event.
+	 * @param action Action bound to the event.
+	 * @param bind_ctx Context the action is bound in.
+	 */
 	void process_action(const input::Event &ev,
 	                    const input_action &action,
 	                    const std::shared_ptr<InputContext> &ctx);
@@ -175,29 +175,29 @@ private:
 
 	/**
 	 * Map of all available contexts, referencable by an ID.
-     *
-     * TODO: Move this to cvar manager?
+	 *
+	 * TODO: Move this to cvar manager?
 	 */
 	std::unordered_map<std::string, std::shared_ptr<InputContext>> available_contexts;
 
 	/**
-     * Interface to the game simulation.
-     */
+	 * Interface to the game simulation.
+	 */
 	std::shared_ptr<game::Controller> game_controller;
 
 	/**
-     * Interface to the camera.
-     */
+	 * Interface to the camera.
+	 */
 	std::shared_ptr<camera::Controller> camera_controller;
 
 	/**
-     * Interface to the HUD.
-     */
+	 * Interface to the HUD.
+	 */
 	std::shared_ptr<hud::Controller> hud_controller;
 
 	/**
-     * Interface to the GUI.
-     */
+	 * Interface to the GUI.
+	 */
 	std::shared_ptr<qtgui::GuiInput> gui_input;
 
 	/**

--- a/libopenage/job/abortable_job_state.h
+++ b/libopenage/job/abortable_job_state.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,7 +17,7 @@ namespace job {
  * providing two function objects to the job's function. One is used to check
  * whether the job should be aborted, while the other one aborts the job.
  */
-template<class T>
+template <class T>
 class AbortableJobState : public TypedJobStateBase<T> {
 public:
 	/** The job's function. */
@@ -25,8 +25,7 @@ public:
 
 	/** Creates a new abortable job with the given function and callback. */
 	AbortableJobState(abortable_function_t<T> function,
-                      callback_function_t<T> callback)
-		:
+	                  callback_function_t<T> callback) :
 		TypedJobStateBase<T>{callback},
 		function{function} {
 	}
@@ -48,4 +47,5 @@ protected:
 };
 
 
-}} // namespace openage::job
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job.h
+++ b/libopenage/job/job.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,7 +24,7 @@ class JobManager;
  *
  * @param T the job's result type
  */
-template<class T>
+template <class T>
 class Job {
 private:
 	/** A shared pointer to the job's shared state. */
@@ -58,7 +58,8 @@ public:
 		ENSURE(this->state->finished.load(), "trying to report a result of an unfinished job");
 		if (this->state->exception != nullptr) {
 			std::rethrow_exception(this->state->exception);
-		} else {
+		}
+		else {
 			return std::move(this->state->result);
 		}
 	}
@@ -68,8 +69,7 @@ private:
 	 * Creates a job with the given shared state. This method may only be called
 	 * by the job manager.
 	 */
-	Job(std::shared_ptr<TypedJobStateBase<T>> state)
-		:
+	Job(std::shared_ptr<TypedJobStateBase<T>> state) :
 		state{state} {
 	}
 
@@ -81,5 +81,5 @@ private:
 	friend class JobManager;
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job_aborted_exception.h
+++ b/libopenage/job/job_aborted_exception.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,4 +15,5 @@ public:
 	}
 };
 
-}} // openage::job
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job_group.h
+++ b/libopenage/job/job_group.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -42,9 +42,9 @@ public:
 	 * @param callback the callback function that is executed, when the background
 	 *        job has finished
 	 */
-	template<class T>
+	template <class T>
 	Job<T> enqueue(job_function_t<T> function,
-	               callback_function_t<T> callback={}) {
+	               callback_function_t<T> callback = {}) {
 		ENSURE(this->parent_worker, "job group has no worker thread associated");
 		auto state = std::make_shared<JobState<T>>(function, callback);
 		this->parent_worker->enqueue(state);
@@ -63,9 +63,9 @@ public:
 	 * @param callback the callback function that is executed, when the background
 	 *        job has finished
 	 */
-	template<class T>
+	template <class T>
 	Job<T> enqueue(abortable_function_t<T> function,
-	               callback_function_t<T> callback={}) {
+	               callback_function_t<T> callback = {}) {
 		ENSURE(this->parent_worker, "job group has no worker thread associated");
 		auto state = std::make_shared<AbortableJobState<T>>(function, callback);
 		this->parent_worker->enqueue(state);
@@ -83,5 +83,5 @@ private:
 	friend class JobManager;
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job_manager.h
+++ b/libopenage/job/job_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -65,11 +65,11 @@ public:
 	/** Destructor that stops the job manager if it is still running. */
 	~JobManager();
 
-	JobManager(const JobManager&) = delete;
-	JobManager(JobManager&&) = delete;
+	JobManager(const JobManager &) = delete;
+	JobManager(JobManager &&) = delete;
 
-	JobManager &operator=(const JobManager&) = delete;
-	JobManager &operator=(JobManager&&) = delete;
+	JobManager &operator=(const JobManager &) = delete;
+	JobManager &operator=(JobManager &&) = delete;
 
 	/** Start the job manager's worker threads. */
 	void start();
@@ -89,9 +89,9 @@ public:
 	 * @param callback the callback function that is executed, when the background
 	 *        job has finished
 	 */
-	template<class T>
+	template <class T>
 	Job<T> enqueue(job_function_t<T> function,
-	               callback_function_t<T> callback={}) {
+	               callback_function_t<T> callback = {}) {
 		auto state = std::make_shared<JobState<T>>(function, callback);
 		this->enqueue_state(state);
 		return Job<T>{state};
@@ -109,9 +109,9 @@ public:
 	 * @param callback the callback function that is executed, when the background
 	 *        job has finished
 	 */
-	template<class T>
+	template <class T>
 	Job<T> enqueue(abortable_function_t<T> function,
-	               callback_function_t<T> callback={}) {
+	               callback_function_t<T> callback = {}) {
 		auto state = std::make_shared<AbortableJobState<T>>(function, callback);
 		this->enqueue_state(state);
 		return Job<T>{state};
@@ -152,5 +152,5 @@ private:
 	friend class Worker;
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job_state.h
+++ b/libopenage/job/job_state.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -14,15 +14,14 @@ namespace job {
  * A job state supports simple job's with functions that return a single
  * result. While executing the job, it cannot be aborted safely.
  */
-template<class T>
+template <class T>
 class JobState : public TypedJobStateBase<T> {
 public:
 	/** A function object which is executed by the JobManager. */
 	job_function_t<T> function;
 
 	/** Creates a new JobState with the given function, that is to be executed. */
-	JobState(job_function_t<T> function, callback_function_t<T> callback)
-		:
+	JobState(job_function_t<T> function, callback_function_t<T> callback) :
 		TypedJobStateBase<T>{callback},
 		function{function} {
 	}
@@ -31,10 +30,10 @@ public:
 	virtual ~JobState() = default;
 
 protected:
-	T execute_and_get(should_abort_t /*should_abort*/) override{
+	T execute_and_get(should_abort_t /*should_abort*/) override {
 		return this->function();
 	}
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/job_state_base.h
+++ b/libopenage/job/job_state_base.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -38,5 +38,5 @@ public:
 	virtual size_t get_thread_id() = 0;
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/typed_job_state_base.h
+++ b/libopenage/job/typed_job_state_base.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,8 +6,8 @@
 #include <exception>
 #include <functional>
 
-#include "../util/thread_id.h"
 #include "../error/error.h"
+#include "../util/thread_id.h"
 #include "job_aborted_exception.h"
 #include "job_state_base.h"
 #include "types.h"
@@ -22,7 +22,7 @@ namespace job {
  * @param T the result type of this job state. This type must have a default
  *          constructor and support move semantics.
  */
-template<class T>
+template <class T>
 class TypedJobStateBase : public JobStateBase {
 public:
 	/** Id of the thread, that created this job state. */
@@ -48,8 +48,7 @@ public:
 	std::exception_ptr exception;
 
 	/** Creates a new typed job with the given callback. */
-	TypedJobStateBase(callback_function_t<T> callback)
-		:
+	TypedJobStateBase(callback_function_t<T> callback) :
 		thread_id{openage::util::get_current_thread_id()},
 		callback{callback},
 		finished{false} {
@@ -66,9 +65,11 @@ public:
 	bool execute(should_abort_t should_abort) override {
 		try {
 			this->result = this->execute_and_get(should_abort);
-		} catch (JobAbortedException &e) {
+		}
+		catch (JobAbortedException &e) {
 			return true;
-		} catch (...) {
+		}
+		catch (...) {
 			this->exception = std::current_exception();
 		}
 		this->finished.store(true);
@@ -85,7 +86,8 @@ public:
 			auto get_result = [this]() {
 				if (this->exception != nullptr) {
 					std::rethrow_exception(this->exception);
-				} else {
+				}
+				else {
 					return std::move(this->result);
 				}
 			};
@@ -105,4 +107,5 @@ protected:
 	virtual T execute_and_get(should_abort_t should_abort) = 0;
 };
 
-}} // openage::job
+} // namespace job
+} // namespace openage

--- a/libopenage/job/types.h
+++ b/libopenage/job/types.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,7 +12,7 @@ namespace job {
  *
  * @param T the job's result type
  */
-template<typename T>
+template <typename T>
 using job_function_t = std::function<T()>;
 
 /**
@@ -21,8 +21,8 @@ using job_function_t = std::function<T()>;
  *
  * @param T the job's result type
  */
-template<typename T>
-using abortable_function_t = std::function<T(std::function<bool()>,std::function<void()>)>;
+template <typename T>
+using abortable_function_t = std::function<T(std::function<bool()>, std::function<void()>)>;
 
 /**
  * Type of a function to retrieve the result of a job. If the job threw an
@@ -30,7 +30,7 @@ using abortable_function_t = std::function<T(std::function<bool()>,std::function
  *
  * @param T the job's result type
  */
-template<typename T>
+template <typename T>
 using result_function_t = std::function<T()>;
 
 /**
@@ -39,7 +39,7 @@ using result_function_t = std::function<T()>;
  *
  * @param T the job's result type
  */
-template<typename T>
+template <typename T>
 using callback_function_t = std::function<void(result_function_t<T>)>;
 
 /** Type of a function that returns whether a job should be aborted. */
@@ -48,5 +48,5 @@ using should_abort_t = std::function<bool()>;
 /** Type of a function that aborts a job. */
 using abort_t = std::function<void()>;
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/job/worker.h
+++ b/libopenage/job/worker.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -79,5 +79,5 @@ private:
 	void process();
 };
 
-}
-}
+} // namespace job
+} // namespace openage

--- a/libopenage/log/logsink.h
+++ b/libopenage/log/logsink.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -46,9 +46,9 @@ private:
 
 
 /**
-* Holds a list of all registered log sinks;
-* Maintained from the LogSink constructors/destructors.
-*/
+ * Holds a list of all registered log sinks;
+ * Maintained from the LogSink constructors/destructors.
+ */
 class OAAPI LogSinkList {
 public:
 	static LogSinkList &instance();

--- a/libopenage/main/demo/pong/aicontroller.h
+++ b/libopenage/main/demo/pong/aicontroller.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,7 +12,6 @@ std::vector<PongEvent> get_ai_inputs(
 	const std::shared_ptr<PongBall> &ball,
 	const std::shared_ptr<curve::Discrete<util::Vector2s>> &area_size,
 	const time::time_t &now,
-	bool right_player
-);
+	bool right_player);
 
-} // openage::main::tests::pong
+} // namespace openage::main::tests::pong

--- a/libopenage/presenter/presenter.h
+++ b/libopenage/presenter/presenter.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -195,8 +195,8 @@ protected:
 	std::shared_ptr<renderer::world::WorldRenderStage> world_renderer;
 
 	/**
-     * Graphics output for the HUD.
-     */
+	 * Graphics output for the HUD.
+	 */
 	std::shared_ptr<renderer::hud::HudRenderStage> hud_renderer;
 
 	/**

--- a/libopenage/pyinterface/defs.h
+++ b/libopenage/pyinterface/defs.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -7,6 +7,6 @@
 #ifndef Py_OBJECT_H
 // pxd: from cpython.ref cimport PyObject
 extern "C" {
-	typedef struct _object PyObject;
+typedef struct _object PyObject;
 }
 #endif

--- a/libopenage/pyinterface/exctranslate.h
+++ b/libopenage/pyinterface/exctranslate.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -146,4 +146,5 @@ OAAPI void set_exc_translation_funcs(
 	void (*describe_py_exception)(PyException *));
 
 
-}} // openage::pyinterface
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/pyinterface/exctranslate_tests.h
+++ b/libopenage/pyinterface/exctranslate_tests.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -44,4 +44,6 @@ OAAPI void bounce_call(const Func<void> &func, int times);
 extern OAAPI PyIfFunc<void, Func<void>, int> bounce_call_py;
 
 
-}}} // openage::pyinterface::tests
+} // namespace tests
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/pyinterface/functional.h
+++ b/libopenage/pyinterface/functional.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -54,53 +54,52 @@ namespace pyinterface {
  * initialization time, use PyIfFunc instead of Func; that class has some
  * additional code to verify successful initialization.
  */
-template<typename ReturnType, typename ... ArgTypes>
+template <typename ReturnType, typename... ArgTypes>
 class Func {
 public:
-	Func()
-		:
+	Func() :
 		fptr{nullptr} {}
 
 	// for construction from lambdas and other callables (from C++).
-	template<typename F>
+	template <typename F>
 	Func(F &&f) {
 		this->fptr = f;
 	}
 
-	template<typename F>
+	template <typename F>
 	Func(std::reference_wrapper<F> f) {
 		this->fptr = f;
 	}
 
 	// for construction from std::function objects (from C++).
-	Func(const std::function<ReturnType (ArgTypes ...)> &f) {
+	Func(const std::function<ReturnType(ArgTypes...)> &f) {
 		this->fptr = f;
 	}
 
-	Func(std::function<ReturnType (ArgTypes ...)> &&f) {
+	Func(std::function<ReturnType(ArgTypes...)> &&f) {
 		this->fptr = f;
 	}
 
 	// for assignment of lambdas and other callables (from C++).
-	template<typename F>
-	Func<ReturnType, ArgTypes ...> &operator =(F &&f) {
+	template <typename F>
+	Func<ReturnType, ArgTypes...> &operator=(F &&f) {
 		this->fptr = f;
 		return *this;
 	}
 
-	template<typename F>
-	Func<ReturnType, ArgTypes ...> &operator =(std::reference_wrapper<F> f) {
+	template <typename F>
+	Func<ReturnType, ArgTypes...> &operator=(std::reference_wrapper<F> f) {
 		this->fptr = f;
 		return *this;
 	}
 
 	// for assignment of std::function objects (from C++).
-	Func<ReturnType, ArgTypes ...> &operator =(const std::function<ReturnType (ArgTypes ...)> &f) {
+	Func<ReturnType, ArgTypes...> &operator=(const std::function<ReturnType(ArgTypes...)> &f) {
 		this->fptr = f;
 		return *this;
 	}
 
-	Func<ReturnType, ArgTypes ...> &operator =(std::function<ReturnType (ArgTypes ...)> &&f) {
+	Func<ReturnType, ArgTypes...> &operator=(std::function<ReturnType(ArgTypes...)> &&f) {
 		this->fptr = f;
 		return *this;
 	}
@@ -111,9 +110,10 @@ public:
 	inline void check_fptr() const {
 		if (not this->fptr) [[unlikely]] {
 			throw Error(
-				MSG(err) << "Uninitialized Func object at " <<
-				util::symbol_name(static_cast<const void *>(this)) << ": "
-				"Can not call or convert to std::function.",
+				MSG(err) << "Uninitialized Func object at "
+						 << util::symbol_name(static_cast<const void *>(this))
+						 << ": "
+							"Can not call or convert to std::function.",
 
 				true // collect backtrace info
 			);
@@ -123,7 +123,7 @@ public:
 	/**
 	 * for direct usage (mostly from Cython)
 	 */
-	ReturnType call(ArgTypes ...args) const {
+	ReturnType call(ArgTypes... args) const {
 		this->check_fptr();
 		return this->fptr(args...);
 	}
@@ -132,7 +132,7 @@ public:
 	 * for implicit conversion to std::function,
 	 * for usage in a context where std::function would be expected.
 	 */
-	operator const std::function<ReturnType (ArgTypes ...)> &() const {
+	operator const std::function<ReturnType(ArgTypes...)> &() const {
 		this->check_fptr();
 		return this->fptr;
 	}
@@ -140,7 +140,7 @@ public:
 	/**
 	 * for explicit conversion to std::function.
 	 */
-	const std::function<ReturnType (ArgTypes ...)> &get() const {
+	const std::function<ReturnType(ArgTypes...)> &get() const {
 		this->check_fptr();
 		return this->fptr;
 	}
@@ -154,9 +154,9 @@ public:
 	 * Note that with clang, it's possible to directly pass function pointers, while with
 	 * gcc they need to be explicitly converted. Meh.
 	 */
-	template<typename ... BoundArgTypes>
-	inline void bind(util::FunctionPtr<ReturnType, BoundArgTypes ..., ArgTypes ...> f, BoundArgTypes ...bound_args) {
-		this->bind_catchexcept_impl<std::is_void<ReturnType>::value, BoundArgTypes ...>(f, bound_args...);
+	template <typename... BoundArgTypes>
+	inline void bind(util::FunctionPtr<ReturnType, BoundArgTypes..., ArgTypes...> f, BoundArgTypes... bound_args) {
+		this->bind_catchexcept_impl<std::is_void<ReturnType>::value, BoundArgTypes...>(f, bound_args...);
 	}
 
 
@@ -164,9 +164,9 @@ private:
 	/**
 	 * Specialization for bind() with void return types.
 	 */
-	template<bool return_type_is_void, typename ... BoundArgTypes>
-	inline typename std::enable_if<return_type_is_void>::type bind_catchexcept_impl(util::FunctionPtr<ReturnType, BoundArgTypes ..., ArgTypes ...> f, BoundArgTypes ...bound_args) {
-		this->fptr = [=](ArgTypes ...args) -> ReturnType {
+	template <bool return_type_is_void, typename... BoundArgTypes>
+	inline typename std::enable_if<return_type_is_void>::type bind_catchexcept_impl(util::FunctionPtr<ReturnType, BoundArgTypes..., ArgTypes...> f, BoundArgTypes... bound_args) {
+		this->fptr = [=](ArgTypes... args) -> ReturnType {
 			f.ptr(bound_args..., args...);
 			translate_exc_py_to_cpp();
 		};
@@ -176,9 +176,9 @@ private:
 	/**
 	 * Specialization for bind() with non-void return types.
 	 */
-	template<bool return_type_is_void, typename ... BoundArgTypes>
-	inline typename std::enable_if<not return_type_is_void>::type bind_catchexcept_impl(util::FunctionPtr<ReturnType, BoundArgTypes ..., ArgTypes ...> f, BoundArgTypes ...bound_args) {
-		this->fptr = [=](ArgTypes ...args) -> ReturnType {
+	template <bool return_type_is_void, typename... BoundArgTypes>
+	inline typename std::enable_if<not return_type_is_void>::type bind_catchexcept_impl(util::FunctionPtr<ReturnType, BoundArgTypes..., ArgTypes...> f, BoundArgTypes... bound_args) {
+		this->fptr = [=](ArgTypes... args) -> ReturnType {
 			ReturnType &&result = f.ptr(bound_args..., args...);
 			translate_exc_py_to_cpp();
 			return result;
@@ -190,62 +190,62 @@ public:
 	/**
 	 * Like bind, but does _not_ add an exception checker.
 	 */
-	template<typename ... BoundArgTypes>
-	void bind_noexcept(util::FunctionPtr<ReturnType, BoundArgTypes ..., ArgTypes ...> f, BoundArgTypes ...bound_args) {
-		this->fptr = [=](ArgTypes ...args) -> ReturnType {
+	template <typename... BoundArgTypes>
+	void bind_noexcept(util::FunctionPtr<ReturnType, BoundArgTypes..., ArgTypes...> f, BoundArgTypes... bound_args) {
+		this->fptr = [=](ArgTypes... args) -> ReturnType {
 			return f.ptr(bound_args..., args...);
 		};
 	}
 
 	// non-variadic aliases for bind, for use by Cython
-	inline void bind0(ReturnType (*f)(ArgTypes ...)) {
+	inline void bind0(ReturnType (*f)(ArgTypes...)) {
 		this->bind<>(
-			util::FunctionPtr<ReturnType, ArgTypes ...>(f));
+			util::FunctionPtr<ReturnType, ArgTypes...>(f));
 	}
 
-	inline void bind_noexcept0(ReturnType (*f)(ArgTypes ...)) {
+	inline void bind_noexcept0(ReturnType (*f)(ArgTypes...)) {
 		this->bind_noexcept<>(
-			util::FunctionPtr<ReturnType, ArgTypes ...>(f));
+			util::FunctionPtr<ReturnType, ArgTypes...>(f));
 	}
 
-	template<typename BoundArgType0>
-	inline void bind1(ReturnType (*f)(BoundArgType0, ArgTypes ...), BoundArgType0 bound_arg0) {
+	template <typename BoundArgType0>
+	inline void bind1(ReturnType (*f)(BoundArgType0, ArgTypes...), BoundArgType0 bound_arg0) {
 		this->bind<BoundArgType0>(
-			util::FunctionPtr<ReturnType, BoundArgType0, ArgTypes ...>(f), bound_arg0);
+			util::FunctionPtr<ReturnType, BoundArgType0, ArgTypes...>(f), bound_arg0);
 	}
 
-	template<typename BoundArgType0>
-	inline void bind_noexcept1(ReturnType (*f)(BoundArgType0, ArgTypes ...), BoundArgType0 bound_arg0) {
+	template <typename BoundArgType0>
+	inline void bind_noexcept1(ReturnType (*f)(BoundArgType0, ArgTypes...), BoundArgType0 bound_arg0) {
 		this->bind_noexcept<BoundArgType0>(
-			util::FunctionPtr<ReturnType, BoundArgType0, ArgTypes ...>(f), bound_arg0);
+			util::FunctionPtr<ReturnType, BoundArgType0, ArgTypes...>(f), bound_arg0);
 	}
 
-	template<typename BoundArgType0, typename BoundArgType1>
-	inline void bind2(ReturnType (*f)(BoundArgType0, BoundArgType1, ArgTypes ...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1) {
+	template <typename BoundArgType0, typename BoundArgType1>
+	inline void bind2(ReturnType (*f)(BoundArgType0, BoundArgType1, ArgTypes...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1) {
 		this->bind<BoundArgType0, BoundArgType1>(
-			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, ArgTypes ...>(f), bound_arg0, bound_arg1);
+			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, ArgTypes...>(f), bound_arg0, bound_arg1);
 	}
 
-	template<typename BoundArgType0, typename BoundArgType1>
-	inline void bind_noexcept2(ReturnType (*f)(BoundArgType0, BoundArgType1, ArgTypes ...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1) {
+	template <typename BoundArgType0, typename BoundArgType1>
+	inline void bind_noexcept2(ReturnType (*f)(BoundArgType0, BoundArgType1, ArgTypes...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1) {
 		this->bind_noexcept<BoundArgType0, BoundArgType1>(
-			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, ArgTypes ...>(f), bound_arg0, bound_arg1);
+			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, ArgTypes...>(f), bound_arg0, bound_arg1);
 	}
 
-	template<typename BoundArgType0, typename BoundArgType1, typename BoundArgType2>
-	inline void bind3(ReturnType (*f)(BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes ...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1, BoundArgType2 bound_arg2) {
+	template <typename BoundArgType0, typename BoundArgType1, typename BoundArgType2>
+	inline void bind3(ReturnType (*f)(BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1, BoundArgType2 bound_arg2) {
 		this->bind<BoundArgType0, BoundArgType1, BoundArgType2>(
-			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes ...>(f), bound_arg0, bound_arg1, bound_arg2);
+			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes...>(f), bound_arg0, bound_arg1, bound_arg2);
 	}
 
-	template<typename BoundArgType0, typename BoundArgType1, typename BoundArgType2>
-	inline void bind_noexcept3(ReturnType (*f)(BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes ...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1, BoundArgType2 bound_arg2) {
+	template <typename BoundArgType0, typename BoundArgType1, typename BoundArgType2>
+	inline void bind_noexcept3(ReturnType (*f)(BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes...), BoundArgType0 bound_arg0, BoundArgType1 bound_arg1, BoundArgType2 bound_arg2) {
 		this->bind_noexcept<BoundArgType0, BoundArgType1, BoundArgType2>(
-			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes ...>(f), bound_arg0, bound_arg1, bound_arg2);
+			util::FunctionPtr<ReturnType, BoundArgType0, BoundArgType1, BoundArgType2, ArgTypes...>(f), bound_arg0, bound_arg1, bound_arg2);
 	}
 
 private:
-	std::function<ReturnType (ArgTypes ...)> fptr;
+	std::function<ReturnType(ArgTypes...)> fptr;
 };
 
 
@@ -271,7 +271,7 @@ private:
  *     void bind_noexcept2 [BT0, BT1]      (RT (*f)(BT0, BT1)               with gil, BT0, BT1     ) except +
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2)          with gil, BT0, BT1, BT2) except +
  */
-template<typename RT>
+template <typename RT>
 using Func0 = Func<RT>;
 
 /*
@@ -292,7 +292,7 @@ using Func0 = Func<RT>;
  *     void bind_noexcept2 [BT0, BT1]      (RT (*f)(BT0, BT1, AT0)               with gil, BT0, BT1     ) except +
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2, AT0)          with gil, BT0, BT1, BT2) except +
  */
-template<typename RT, typename AT0>
+template <typename RT, typename AT0>
 using Func1 = Func<RT, AT0>;
 
 /*
@@ -314,7 +314,7 @@ using Func1 = Func<RT, AT0>;
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2, AT0, AT1)          with gil, BT0, BT1, BT2) except +
  */
 
-template<typename RT, typename AT0, typename AT1>
+template <typename RT, typename AT0, typename AT1>
 using Func2 = Func<RT, AT0, AT1>;
 
 /*
@@ -336,7 +336,7 @@ using Func2 = Func<RT, AT0, AT1>;
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2, AT0, AT1, AT2)          with gil, BT0, BT1, BT2) except +
  */
 
-template<typename RT, typename AT0, typename AT1, typename AT2>
+template <typename RT, typename AT0, typename AT1, typename AT2>
 using Func3 = Func<RT, AT0, AT1, AT2>;
 
 /*
@@ -358,7 +358,7 @@ using Func3 = Func<RT, AT0, AT1, AT2>;
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2, AT0, AT1, AT2, AT3)          with gil, BT0, BT1, BT2) except +
  */
 
-template<typename RT, typename AT0, typename AT1, typename AT2, typename AT3>
+template <typename RT, typename AT0, typename AT1, typename AT2, typename AT3>
 using Func4 = Func<RT, AT0, AT1, AT2, AT3>;
 
 
@@ -381,7 +381,7 @@ using Func4 = Func<RT, AT0, AT1, AT2, AT3>;
  *     void bind_noexcept3 [BT0, BT1, BT2] (RT (*f)(BT0, BT1, BT2, AT0, AT1, AT2, AT3, AT4)          with gil, BT0, BT1, BT2) except +
  */
 
-template<typename RT, typename AT0, typename AT1, typename AT2, typename AT3, typename AT4>
+template <typename RT, typename AT0, typename AT1, typename AT2, typename AT3, typename AT4>
 using Func5 = Func<RT, AT0, AT1, AT2, AT3, AT4>;
 
 
@@ -403,15 +403,16 @@ using Func5 = Func<RT, AT0, AT1, AT2, AT3, AT4>;
  * ctypedef Func4 PyIfFunc4
  * ctypedef Func5 PyIfFunc5
  */
-template<typename ReturnType, typename ... ArgTypes>
-class PyIfFunc : public Func<ReturnType, ArgTypes ...> {
+template <typename ReturnType, typename... ArgTypes>
+class PyIfFunc : public Func<ReturnType, ArgTypes...> {
 public:
 	PyIfFunc() {
 		add_py_if_component(this, [=, this]() -> bool {
 			try {
 				this->check_fptr();
 				return true;
-			} catch (Error &) {
+			}
+			catch (Error &) {
 				return false;
 			}
 		});
@@ -422,16 +423,17 @@ public:
 	}
 
 	// no copy construction!
-	PyIfFunc(const PyIfFunc<ReturnType, ArgTypes ...> &other) = delete;
-	PyIfFunc(PyIfFunc<ReturnType, ArgTypes ...> &&other) = delete;
-	PyIfFunc &operator =(const PyIfFunc<ReturnType, ArgTypes ...> &other) = delete;
-	PyIfFunc &operator =(PyIfFunc<ReturnType, ArgTypes ...> &&other) = delete;
+	PyIfFunc(const PyIfFunc<ReturnType, ArgTypes...> &other) = delete;
+	PyIfFunc(PyIfFunc<ReturnType, ArgTypes...> &&other) = delete;
+	PyIfFunc &operator=(const PyIfFunc<ReturnType, ArgTypes...> &other) = delete;
+	PyIfFunc &operator=(PyIfFunc<ReturnType, ArgTypes...> &&other) = delete;
 
 	// but you may convert this to a regular Func object.
-	operator const Func<ReturnType, ArgTypes ...> &() const {
-		return static_cast<Func<ReturnType, ArgTypes ...>>(this->fptr);
+	operator const Func<ReturnType, ArgTypes...> &() const {
+		return static_cast<Func<ReturnType, ArgTypes...>>(this->fptr);
 	}
 };
 
 
-}} // openage::pyinterface
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/pyinterface/pyexception.h
+++ b/libopenage/pyinterface/pyexception.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -33,12 +33,13 @@ public:
 	/**
 	 * ref is a raw reference to the associated PyObject.
 	 */
-	PyExceptionBacktrace(PyObject *ref) : ref{ref} {}
+	PyExceptionBacktrace(PyObject *ref) :
+		ref{ref} {}
 
 	/**
 	 * Accesses the associated Python exception object to translate the traceback as needed.
 	 */
-	void get_symbols(std::function<void (const error::backtrace_symbol *)> cb, bool reversed) const override;
+	void get_symbols(std::function<void(const error::backtrace_symbol *)> cb, bool reversed) const override;
 
 private:
 	PyObject *ref;
@@ -83,4 +84,5 @@ public:
 extern OAAPI PyIfFunc<void, PyObject *, Func<void, const error::backtrace_symbol *>> pyexception_bt_get_symbols;
 
 
-}} // openage::pyinterface
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/pyinterface/pyobject.h
+++ b/libopenage/pyinterface/pyobject.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -72,13 +72,13 @@ public:
 	 * Assigns from an other PyObjectRef
 	 * (calls Py_XDECREF on the old value, and Py_XINCREF on the new one).
 	 */
-	PyObjectRef &operator =(const PyObjectRef &other);
+	PyObjectRef &operator=(const PyObjectRef &other);
 
 	/**
 	 * Move-assigns from an other PyObject
 	 * (calls Py_XDECREF on the old value).
 	 */
-	PyObjectRef &operator =(PyObjectRef &&other);
+	PyObjectRef &operator=(PyObjectRef &&other);
 
 	/**
 	 * Destroys the object, calls Py_XDECREF.
@@ -116,12 +116,11 @@ public:
 	/**
 	 * obj(args...)
 	 */
-	template <typename ...Args>
+	template <typename... Args>
 	PyObjectRef call(Args... args) const {
 		// this vector collects the function call arguments
-		std::vector<PyObjectRef> arg_objs {
-			PyObjectRef(args)...
-		};
+		std::vector<PyObjectRef> arg_objs{
+			PyObjectRef(args)...};
 
 		return this->call_impl(arg_objs);
 	}
@@ -251,7 +250,7 @@ public:
 	 * Implicit conversion to PyObject *.
 	 * Mainly for convenience to avoid all the get_ref() calls.
 	 */
-	PyObject *operator ()() const noexcept {
+	PyObject *operator()() const noexcept {
 		return this->ref;
 	}
 
@@ -285,7 +284,7 @@ using PyObj = PyObjectRef;
 /**
  * Stream operator for printing PyObjects
  */
-std::ostream &operator <<(std::ostream &os, const PyObjectRef &ref);
+std::ostream &operator<<(std::ostream &os, const PyObjectRef &ref);
 
 
 // now follow the various Python callbacks that implement all of the above,
@@ -313,7 +312,7 @@ extern OAAPI PyIfFunc<bool, PyObject *> py_callable;
 // pxd: PyIfFunc2[void, PyObjectRefPtr, PyObjectPtr] py_call0
 extern OAAPI PyIfFunc<void, PyObjectRef *, PyObject *> py_call0;
 // pxd: PyIfFunc3[void, PyObjectRefPtr, PyObjectPtr, vector[PyObjectPtr]] py_calln
-extern OAAPI PyIfFunc<void, PyObjectRef *, PyObject *, std::vector<PyObject *>&> py_calln;
+extern OAAPI PyIfFunc<void, PyObjectRef *, PyObject *, std::vector<PyObject *> &> py_calln;
 // pxd: PyIfFunc2[cppbool, PyObjectPtr, string] py_hasattr
 extern OAAPI PyIfFunc<bool, PyObject *, std::string> py_hasattr;
 // pxd: PyIfFunc3[void, PyObjectRefPtr, PyObjectPtr, string] py_getattr
@@ -346,13 +345,13 @@ extern OAAPI PyIfFunc<std::string, PyObject *> py_modulename;
 extern OAAPI PyIfFunc<std::string, PyObject *> py_classname;
 
 // pxd: PyIfFunc2[void, PyObjectRefPtr, const string] py_builtin
-extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string&> py_builtin;
+extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string &> py_builtin;
 // pxd: PyIfFunc2[void, PyObjectRefPtr, const string] py_import
-extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string&> py_import;
+extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string &> py_import;
 // pxd: PyIfFunc2[void, PyObjectRefPtr, const string] py_createstr
-extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string&> py_createstr;
+extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string &> py_createstr;
 // pxd: PyIfFunc2[void, PyObjectRefPtr, const string] py_createbytes
-extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string&> py_createbytes;
+extern OAAPI PyIfFunc<void, PyObjectRef *, const std::string &> py_createbytes;
 // pxd: PyIfFunc2[void, PyObjectRefPtr, int] py_createint
 extern OAAPI PyIfFunc<void, PyObjectRef *, int> py_createint;
 // pxd: PyIfFunc1[void, PyObjectRefPtr] py_createdict
@@ -367,7 +366,7 @@ extern OAAPI PyObjectRef True;
 // pxd: PyObjectRef False
 extern OAAPI PyObjectRef False;
 
-} // pyinterface
+} // namespace pyinterface
 
 
 /**
@@ -440,5 +439,5 @@ using pyinterface::True;
  */
 using pyinterface::False;
 
-} // py
-} // openage
+} // namespace py
+} // namespace openage

--- a/libopenage/pyinterface/pyobject_tests.h
+++ b/libopenage/pyinterface/pyobject_tests.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -9,4 +9,6 @@ namespace tests {
 void pyobject();
 void pyobject_demo();
 
-}}} // openage::pyinterface
+} // namespace tests
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/pyinterface/setup.h
+++ b/libopenage/pyinterface/setup.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include <functional>
 
@@ -30,7 +30,7 @@ namespace pyinterface {
  * It shall return true if the object has been properly initialized,
  * and shall not throw any exceptions.
  */
-void add_py_if_component(void *thisptr, std::function<bool ()> checker);
+void add_py_if_component(void *thisptr, std::function<bool()> checker);
 
 
 /**
@@ -56,4 +56,5 @@ void destroy_py_if_component(void *thisptr);
 OAAPI void check();
 
 
-}} // openage::pyinterface
+} // namespace pyinterface
+} // namespace openage

--- a/libopenage/renderer/camera/camera.h
+++ b/libopenage/renderer/camera/camera.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -38,25 +38,25 @@ static const Eigen::Vector3f cam_direction{
 class Camera {
 public:
 	/**
-     * Create a new camera for the renderer.
-     *
-     * The camera uses default values. Its centered on the origin of the scene (0.0f, 0.0f, 0.0f)
-     * and has a zoom level of 1.0f.
-     *
-     * @param viewport_size Initial viewport size of the camera (width x height).
-     */
+	 * Create a new camera for the renderer.
+	 *
+	 * The camera uses default values. Its centered on the origin of the scene (0.0f, 0.0f, 0.0f)
+	 * and has a zoom level of 1.0f.
+	 *
+	 * @param viewport_size Initial viewport size of the camera (width x height).
+	 */
 	Camera(const std::shared_ptr<Renderer> &renderer,
 	       util::Vector2s viewport_size);
 
 	/**
-     * Create a new camera for the renderer.
-     *
-     * @param viewport_size Viewport size of the camera (width x height).
-     * @param scene_pos Position of the camera in the scene.
-     * @param zoom Zoom level of the camera (defaults to 1.0f).
-     * @param max_zoom_out Maximum zoom out level (defaults to 64.0f).
-     * @param default_zoom_ratio Default zoom level calibration (defaults to (1.0f / 49)).
-     */
+	 * Create a new camera for the renderer.
+	 *
+	 * @param viewport_size Viewport size of the camera (width x height).
+	 * @param scene_pos Position of the camera in the scene.
+	 * @param zoom Zoom level of the camera (defaults to 1.0f).
+	 * @param max_zoom_out Maximum zoom out level (defaults to 64.0f).
+	 * @param default_zoom_ratio Default zoom level calibration (defaults to (1.0f / 49)).
+	 */
 	Camera(const std::shared_ptr<Renderer> &renderer,
 	       util::Vector2s viewport_size,
 	       Eigen::Vector3f scene_pos,
@@ -66,68 +66,68 @@ public:
 	~Camera() = default;
 
 	/**
-     * Move the camera so that the center of its viewpoint points
-     * to the given position in the 3D scene.
-     *
-     * @param scene_pos Position in the 3D scene that the camera should center on.
-     */
+	 * Move the camera so that the center of its viewpoint points
+	 * to the given position in the 3D scene.
+	 *
+	 * @param scene_pos Position in the 3D scene that the camera should center on.
+	 */
 	void look_at_scene(Eigen::Vector3f scene_pos);
 
 	/**
-     * Move the camera so that the center of its viewpoint points
-     * to the given ingame coordinates.
-     *
-     * @param scene_pos Position of the ingame coordinates that the camera should center on.
-     */
+	 * Move the camera so that the center of its viewpoint points
+	 * to the given ingame coordinates.
+	 *
+	 * @param scene_pos Position of the ingame coordinates that the camera should center on.
+	 */
 	void look_at_coord(coord::scene3 coord_pos);
 
 	/**
-     * Move the camera position in the direction of a given vector.
-     *
-     * @param scene_pos New 3D position of the camera in the scene.
-     */
+	 * Move the camera position in the direction of a given vector.
+	 *
+	 * @param scene_pos New 3D position of the camera in the scene.
+	 */
 	void move_to(Eigen::Vector3f scene_pos);
 
 	/**
-     * Move the camera position in the direction of a given vector.
-     *
-     * @param direction Direction vector. Added to the current position.
-     * @param delta Delta for controlling the amount by which the camera is moved. The
-     *              value is multiplied with the directional vector before its applied to
-     *              the positional vector.
-     */
+	 * Move the camera position in the direction of a given vector.
+	 *
+	 * @param direction Direction vector. Added to the current position.
+	 * @param delta Delta for controlling the amount by which the camera is moved. The
+	 *              value is multiplied with the directional vector before its applied to
+	 *              the positional vector.
+	 */
 	void move_rel(Eigen::Vector3f direction, float delta = 1.0f);
 
 	/**
-      * Set the zoom level of the camera. Values smaller than 1.0f let the
-      * camera zoom in, values greater than 1.0f let the camera zoom out.
-      *
-      * The max zoom in value is 0.05f. Passing values lower than that
-      * will just set the zoom level to max zoom.
-      *
-      * For incremental zooming, use the \p zoom_in() and \p zoom_out()
-      * methods.
-      *
-      * @param zoom New zoom level.
-      */
+	 * Set the zoom level of the camera. Values smaller than 1.0f let the
+	 * camera zoom in, values greater than 1.0f let the camera zoom out.
+	 *
+	 * The max zoom in value is 0.05f. Passing values lower than that
+	 * will just set the zoom level to max zoom.
+	 *
+	 * For incremental zooming, use the \p zoom_in() and \p zoom_out()
+	 * methods.
+	 *
+	 * @param zoom New zoom level.
+	 */
 	void set_zoom(float zoom);
 
 	/**
-      * Zoom into the scene.
-      *
-      * Decreases the current zoom level.
-      *
-      * @param zoom_delta How far the camera should zoom in.
-      */
+	 * Zoom into the scene.
+	 *
+	 * Decreases the current zoom level.
+	 *
+	 * @param zoom_delta How far the camera should zoom in.
+	 */
 	void zoom_in(float zoom_delta);
 
 	/**
-      * Zoom out of the scene.
-      *
-      * Increases the current zoom level.
-      *
-      * @param zoom_delta How far the camera should zoom out.
-      */
+	 * Zoom out of the scene.
+	 *
+	 * Increases the current zoom level.
+	 *
+	 * @param zoom_delta How far the camera should zoom out.
+	 */
 	void zoom_out(float zoom_delta);
 
 	/**
@@ -139,138 +139,138 @@ public:
 	void resize(size_t width, size_t height);
 
 	/**
-      * Get the current zoom level of the camera.
-      *
-      * @return Zoom level.
-      */
+	 * Get the current zoom level of the camera.
+	 *
+	 * @return Zoom level.
+	 */
 	float get_zoom() const;
 
 	/**
-      * Get the view matrix for this camera.
-      *
-      * @return Camera view matrix.
-      */
+	 * Get the view matrix for this camera.
+	 *
+	 * @return Camera view matrix.
+	 */
 	const Eigen::Matrix4f &get_view_matrix();
 
 	/**
-      * Get the projection matrix for this camera.
-      *
-      * @return Camera projection matrix.
-      */
+	 * Get the projection matrix for this camera.
+	 *
+	 * @return Camera projection matrix.
+	 */
 	const Eigen::Matrix4f &get_projection_matrix();
 
 	/**
-     * Get the size of the camera viewport.
-     *
-     * @return Viewport size as a 2D vector (x, y).
-     */
+	 * Get the size of the camera viewport.
+	 *
+	 * @return Viewport size as a 2D vector (x, y).
+	 */
 	const util::Vector2s &get_viewport_size() const;
 
 	/**
-     * Get the corresponding 3D position of a 2D input coordinate in the viewport.
-     * The position is on the plane created by the camera's orthographic projection.
-     *
-     * This may be used to get the 3D position of a mouse click and subsequent
-     * ray casting calculations.
-     *
-     * @param coord 2D input coordinate in the viewport.
-     *
-     * @return Position of the input in the 3D scene.
-     */
+	 * Get the corresponding 3D position of a 2D input coordinate in the viewport.
+	 * The position is on the plane created by the camera's orthographic projection.
+	 *
+	 * This may be used to get the 3D position of a mouse click and subsequent
+	 * ray casting calculations.
+	 *
+	 * @param coord 2D input coordinate in the viewport.
+	 *
+	 * @return Position of the input in the 3D scene.
+	 */
 	Eigen::Vector3f get_input_pos(const coord::input &coord) const;
 
 	/**
-     * Get the uniform buffer for this camera.
-     *
-     * @return Uniform buffer.
-     */
+	 * Get the uniform buffer for this camera.
+	 *
+	 * @return Uniform buffer.
+	 */
 	const std::shared_ptr<renderer::UniformBuffer> &get_uniform_buffer() const;
 
 private:
 	/**
-     * Position in the 3D scene.
-     */
+	 * Position in the 3D scene.
+	 */
 	Eigen::Vector3f scene_pos;
 
 	/**
-     * Size of the camera viewport.
-     */
+	 * Size of the camera viewport.
+	 */
 	util::Vector2s viewport_size;
 
 	/**
-     * Zoom level.
-     *
-     * 0.0f < z < 1.0f => zoom in
-     * z = 1.0f        => default view
-     * z > 1.0f        => zoom out
-     */
+	 * Zoom level.
+	 *
+	 * 0.0f < z < 1.0f => zoom in
+	 * z = 1.0f        => default view
+	 * z > 1.0f        => zoom out
+	 */
 	float zoom;
 
 	/**
-     * Maximum possible zoom in level.
-     *
-     * Has to be above 0.0f, otherwise we get zero division errors.
-     */
+	 * Maximum possible zoom in level.
+	 *
+	 * Has to be above 0.0f, otherwise we get zero division errors.
+	 */
 	static constexpr float MAX_ZOOM_IN = 0.005f;
 
 	/**
-     * Maximum possible zoom out level.
-     *
-     * This can be set per camera.
-     */
+	 * Maximum possible zoom out level.
+	 *
+	 * This can be set per camera.
+	 */
 	float max_zoom_out;
 
 	/**
-     * Modifier that controls what the default zoom level (zoom = 1.0f)
-     * looks like. Essentially, this value is also a zoom that is pre-applied
-     * before other calculations.
-     *
-     * This value is important for calibrating the default zoom to match
-     * the pixel size of assets. For example, terrain in AoE2 has a height
-     * of 49 pixels, while in the renderer scene the height is always 1.0.
-     * Setting \p default_zoom_ratio to 1 / 49 ensure that the default zoom
-     * level matches the pixel ration of the original game.
-     */
+	 * Modifier that controls what the default zoom level (zoom = 1.0f)
+	 * looks like. Essentially, this value is also a zoom that is pre-applied
+	 * before other calculations.
+	 *
+	 * This value is important for calibrating the default zoom to match
+	 * the pixel size of assets. For example, terrain in AoE2 has a height
+	 * of 49 pixels, while in the renderer scene the height is always 1.0.
+	 * Setting \p default_zoom_ratio to 1 / 49 ensure that the default zoom
+	 * level matches the pixel ration of the original game.
+	 */
 	float default_zoom_ratio;
 
 	/**
-     * Flag set when the camera is moved.
-     *
-     * If true, the view matrix needs to be recalculated.
-     */
+	 * Flag set when the camera is moved.
+	 *
+	 * If true, the view matrix needs to be recalculated.
+	 */
 	bool moved;
 
 	/**
-     * Flag set when the camera zoom is changed.
-     *
-     * If true, the projection matrix needs to be recalculated.
-     */
+	 * Flag set when the camera zoom is changed.
+	 *
+	 * If true, the projection matrix needs to be recalculated.
+	 */
 	bool zoom_changed;
 
 	/**
-     * Flag set when the camera viewport is resized.
-     *
-     * If true, the projection matrix needs to be recalculated.
-     */
+	 * Flag set when the camera viewport is resized.
+	 *
+	 * If true, the projection matrix needs to be recalculated.
+	 */
 	bool viewport_changed;
 
 	/**
-     * Current view matrix for the camera.
-     *
-     * Cached because it may be requested many times.
-     */
+	 * Current view matrix for the camera.
+	 *
+	 * Cached because it may be requested many times.
+	 */
 	Eigen::Matrix4f view;
 
 	/**
-     * Current projection matrix for the camera.
-     *
-     * Cached because it may be requested many times.
-     */
+	 * Current projection matrix for the camera.
+	 *
+	 * Cached because it may be requested many times.
+	 */
 	Eigen::Matrix4f proj;
 
 	/**
-     * Uniform buffer for the camera matrices.
-     */
+	 * Uniform buffer for the camera matrices.
+	 */
 	std::shared_ptr<renderer::UniformBuffer> uniform_buffer;
 };
 

--- a/libopenage/renderer/color.h
+++ b/libopenage/renderer/color.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -9,7 +9,6 @@ namespace renderer {
 
 class Color {
 public:
-
 	Color();
 
 	Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
@@ -22,15 +21,13 @@ public:
 	uint8_t g;
 	uint8_t b;
 	uint8_t a;
-
 };
 
 class Colors {
 public:
-
 	static Color WHITE;
 	static Color BLACK;
-
 };
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/font/font.h
+++ b/libopenage/renderer/font/font.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -68,8 +68,8 @@ struct font_description {
 	font_description(std::string font_file,
 	                 unsigned int size,
 	                 font_direction direction = font_direction::left_to_right,
-	                 std::string language="en",
-	                 std::string script="Latin");
+	                 std::string language = "en",
+	                 std::string script = "Latin");
 
 	/**
 	 * Constructs a font_description instance.
@@ -89,11 +89,9 @@ struct font_description {
 	bool operator==(const font_description &other) const;
 
 	bool operator!=(const font_description &other) const;
-
 };
 
 class Font {
-
 public:
 	/**
 	 * Create a font instance from the description.
@@ -189,14 +187,14 @@ private:
 
 	// The HarfBuzz font instance that drives the operations of this font
 	hb_font_t *hb_font;
-
 };
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage
 
 namespace std {
 
-template<>
+template <>
 struct hash<openage::renderer::font_description> {
 	size_t operator()(const openage::renderer::font_description &fd) const {
 		size_t hash = std::hash<std::type_index>()(std::type_index(typeid(openage::renderer::font_description)));
@@ -206,4 +204,4 @@ struct hash<openage::renderer::font_description> {
 	}
 };
 
-}
+} // namespace std

--- a/libopenage/renderer/font/font_manager.h
+++ b/libopenage/renderer/font/font_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -14,7 +14,6 @@ namespace openage {
 namespace renderer {
 
 class FreeTypeLibrary {
-
 public:
 	FT_Library ft_library;
 
@@ -36,13 +35,11 @@ public:
 	FreeTypeLibrary(FreeTypeLibrary &&other) = delete;
 
 	FreeTypeLibrary &operator=(FreeTypeLibrary &&other) = delete;
-
 };
 
 class Font;
 
 class FontManager {
-
 public:
 	/**
 	 * Gets the filepath of a particular font family and style.
@@ -80,7 +77,7 @@ public:
 	 * @param size: The size of the font in points.
 	 * @returns The pointer to font instance.
 	 */
-	Font *get_font(const char* font_file, unsigned int size);
+	Font *get_font(const char *font_file, unsigned int size);
 
 private:
 	// The freetype library instance
@@ -88,7 +85,7 @@ private:
 
 	// Font cache. the hash of font's description is used as the key
 	std::unordered_map<size_t, std::unique_ptr<Font>> fonts;
-
 };
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/font/glyph_atlas.h
+++ b/libopenage/renderer/font/glyph_atlas.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,7 +24,6 @@ namespace renderer {
  * glyph atlas can be easily modified.
  */
 class GlyphAtlas {
-
 public:
 	/**
 	 * Datastructure for a single atlas entry
@@ -129,7 +128,7 @@ private:
 
 	// List of shelves currently used in the atlas
 	std::vector<GlyphAtlas::Shelf> shelves;
-
 };
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/geometry.h
+++ b/libopenage/renderer/geometry.h
@@ -1,10 +1,10 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#include <vector>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include <vector>
 
 
 namespace openage {
@@ -30,13 +30,13 @@ public:
 	/// In a meshed geometry, updates the vertex data. The size and type of the vertex data has to be the same as before.
 	/// If the mesh is indexed, indices will stay the same.
 	/// @throws if there is a size mismatch between the new and old vertex data
-	void update_verts(std::vector<uint8_t> const& verts);
+	void update_verts(std::vector<uint8_t> const &verts);
 
 	/// In a meshed geometry, updates the vertex data starting from the offset-th vertex. The type of the vertex
 	/// data has to be the same as it was on initializing the geometry. The size plus the offset cannot exceed the
 	/// previous size of the vertex data. If the mesh is indexed, indices will stay the same.
 	/// @throws if there is a size mismatch between the new and old vertex data
-	virtual void update_verts_offset(std::vector<uint8_t> const& verts, size_t offset) = 0;
+	virtual void update_verts_offset(std::vector<uint8_t> const &verts, size_t offset) = 0;
 
 protected:
 	/// Initialize the geometry to a given type.
@@ -46,4 +46,5 @@ private:
 	geometry_t type;
 };
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/gui/gui.h
+++ b/libopenage/renderer/gui/gui.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -47,10 +47,10 @@ public:
 	virtual ~GUI() = default;
 
 	/**
-     * Get the input handler of the GUI.
-     *
-     * @return Input handler of the GUI.
-     */
+	 * Get the input handler of the GUI.
+	 *
+	 * @return Input handler of the GUI.
+	 */
 	std::shared_ptr<qtgui::GuiInput> get_input_handler() const;
 
 	/**

--- a/libopenage/renderer/gui/guisys/link/gui_item.h
+++ b/libopenage/renderer/gui/guisys/link/gui_item.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -222,8 +222,7 @@ public:
 	 * Sets up a factory for the type T.
 	 */
 	explicit GuiItemCoreInstantiator(GuiItemBase *item_base) :
-		GuiItemMethods<T> {}
-	{
+		GuiItemMethods<T>{} {
 		using namespace std::placeholders;
 
 		item_base->instantiate_core_func = std::bind(&GuiItemCoreInstantiator::instantiate_core, this);
@@ -298,10 +297,7 @@ public:
 	 */
 	explicit GuiItem(GuiItemBase *item_base) :
 		GuiItemOrigin<T>{},
-		GuiItemCoreInstantiator<T> {
-		item_base
-	}
-	{
+		GuiItemCoreInstantiator<T>{item_base} {
 	}
 };
 
@@ -311,8 +307,7 @@ class GuiItemInterface : public GuiItemOrigin<T>
 public:
 	explicit GuiItemInterface() :
 		GuiItemOrigin<T>{},
-		GuiItemMethods<T> {}
-	{
+		GuiItemMethods<T>{} {
 	}
 };
 
@@ -356,10 +351,7 @@ public:
 
 	Inherits(QObject *parent = nullptr) :
 		Shadow<T>{parent},
-		GuiItemCoreInstantiator<P> {
-		this
-	}
-	{
+		GuiItemCoreInstantiator<P>{this} {
 	}
 
 	virtual ~Inherits() {

--- a/libopenage/renderer/gui/guisys/link/gui_item_list_model.h
+++ b/libopenage/renderer/gui/guisys/link/gui_item_list_model.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -20,10 +20,7 @@ template <typename T>
 class GuiItemListModel : public GuiItem<T> {
 public:
 	explicit GuiItemListModel(GuiItemBase *item_base) :
-		GuiItem<T> {
-		item_base
-	}
-	{
+		GuiItem<T>{item_base} {
 		item_base->on_core_adopted_func = std::bind(&GuiItemListModel::on_core_adopted, this);
 	}
 

--- a/libopenage/renderer/gui/guisys/private/gui_engine_impl.h
+++ b/libopenage/renderer/gui/guisys/private/gui_engine_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -37,8 +37,8 @@ public:
 	static GuiQmlEngineImpl *impl(GuiQmlEngine *engine);
 
 	/**
-	* Get the underlying QQmlEngine object.
-	*/
+	 * Get the underlying QQmlEngine object.
+	 */
 	std::shared_ptr<QQmlEngine> get_qml_engine();
 
 	/**

--- a/libopenage/renderer/opengl/context.h
+++ b/libopenage/renderer/opengl/context.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,7 +16,7 @@ class GlShaderProgram;
 
 /**
  * Stores information about context capabilities and limitations.
-*/
+ */
 struct gl_context_spec {
 	/// The maximum number of vertex attributes in a shader.
 	size_t max_vertex_attributes;
@@ -67,14 +67,14 @@ public:
 	std::shared_ptr<QOpenGLContext> get_raw_context() const;
 
 	/**
-     * Get the ID of the default framebuffer used for displaying to
-     * the window.
-     *
-     * This value may change on every frame, so it should be called every
-     * time the default framebuffer is bound.
-     *
-     * @return ID of the default (display) framebuffer.
-     */
+	 * Get the ID of the default framebuffer used for displaying to
+	 * the window.
+	 *
+	 * This value may change on every frame, so it should be called every
+	 * time the default framebuffer is bound.
+	 *
+	 * @return ID of the default (display) framebuffer.
+	 */
 	unsigned int get_default_framebuffer_id();
 
 	/**
@@ -122,29 +122,29 @@ public:
 	void set_current_program(const std::shared_ptr<GlShaderProgram> &prog);
 
 	/**
-     * Get a free uniform buffer binding point that is not bound to any buffer.
-     *
-     * The number of available binding points is limited by the OpenGL implementation.
-     * When the context is created, there are \p capabilities.max_uniform_buffer_bindings
-     * free binding points available.
-     *
-     * @return Binding point ID.
-     *
-     * @throw Error if no binding point is available.
-     */
+	 * Get a free uniform buffer binding point that is not bound to any buffer.
+	 *
+	 * The number of available binding points is limited by the OpenGL implementation.
+	 * When the context is created, there are \p capabilities.max_uniform_buffer_bindings
+	 * free binding points available.
+	 *
+	 * @return Binding point ID.
+	 *
+	 * @throw Error if no binding point is available.
+	 */
 	size_t get_uniform_buffer_binding();
 
 	/**
-     * Free a buffer binding point, indicating that newly created buffers can use it.
-     *
-     * When calling this function, it must be ensured that the binding point is not
-     * assigned to any buffer or shader. Otherwise, reassigning the binding point
-     * can corrupt the uniform data.
-     *
-     * @param binding_point Binding point ID.
-     *
-     * @throw Error if the binding point is not valid.
-     */
+	 * Free a buffer binding point, indicating that newly created buffers can use it.
+	 *
+	 * When calling this function, it must be ensured that the binding point is not
+	 * assigned to any buffer or shader. Otherwise, reassigning the binding point
+	 * can corrupt the uniform data.
+	 *
+	 * @param binding_point Binding point ID.
+	 *
+	 * @throw Error if the binding point is not valid.
+	 */
 	void free_uniform_buffer_binding(size_t binding_point);
 
 	/**
@@ -181,8 +181,8 @@ private:
 	std::weak_ptr<GlShaderProgram> last_program;
 
 	/**
-     * Store the currently active binding points for uniform buffers.
-     */
+	 * Store the currently active binding points for uniform buffers.
+	 */
 	std::vector<bool> uniform_buffer_bindings;
 };
 

--- a/libopenage/renderer/opengl/debug.h
+++ b/libopenage/renderer/opengl/debug.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -32,7 +32,7 @@ public:
 
 	/**
 	 * Stop logging OpenGL debug messages.
-	*/
+	 */
 	void stop();
 
 public slots:

--- a/libopenage/renderer/opengl/framebuffer.h
+++ b/libopenage/renderer/opengl/framebuffer.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,12 +16,12 @@ class GlTexture2d;
  */
 enum class gl_framebuffer_t {
 	/**
-     * The actual window. This is visible to the user after swapping front and back buffers.
-     */
+	 * The actual window. This is visible to the user after swapping front and back buffers.
+	 */
 	display,
 	/**
-     * A bunch of textures. These can be color texture, depth textures, etc.
-     */
+	 * A bunch of textures. These can be color texture, depth textures, etc.
+	 */
 	textures,
 };
 
@@ -33,48 +33,48 @@ enum class gl_framebuffer_t {
 class GlFramebuffer final : public GlSimpleObject {
 public:
 	/**
-     * Construct a framebuffer pointing at the default framebuffer - the window.
-     *
-     * Drawing into this framebuffer draws onto the screen.
-     *
-     * @param context OpenGL context used for drawing.
-     */
+	 * Construct a framebuffer pointing at the default framebuffer - the window.
+	 *
+	 * Drawing into this framebuffer draws onto the screen.
+	 *
+	 * @param context OpenGL context used for drawing.
+	 */
 	GlFramebuffer(const std::shared_ptr<GlContext> &context);
 
 	/**
-     * Construct a framebuffer pointing at the given textures.
-     *
-     * Texture are attached to points specific to their pixel format,
-     * e.g. a depth texture will be set as the depth target.
-     *
-     * @param context OpenGL context used for drawing.
-     * @param textures Textures targeted by the framebuffer. They are automatically
-     *                 attached to the correct attachement points depending on their type.
-     */
+	 * Construct a framebuffer pointing at the given textures.
+	 *
+	 * Texture are attached to points specific to their pixel format,
+	 * e.g. a depth texture will be set as the depth target.
+	 *
+	 * @param context OpenGL context used for drawing.
+	 * @param textures Textures targeted by the framebuffer. They are automatically
+	 *                 attached to the correct attachement points depending on their type.
+	 */
 	GlFramebuffer(const std::shared_ptr<GlContext> &context,
 	              std::vector<std::shared_ptr<GlTexture2d>> const &textures);
 
 	/**
-     * Get the type of this framebuffer.
-     *
-     * @return Framebuffer type.
-     */
+	 * Get the type of this framebuffer.
+	 *
+	 * @return Framebuffer type.
+	 */
 	gl_framebuffer_t get_type() const;
 
 	/**
-     * Bind this framebuffer to \p GL_READ_FRAMEBUFFER.
-     */
+	 * Bind this framebuffer to \p GL_READ_FRAMEBUFFER.
+	 */
 	void bind_read() const;
 
 	/**
-     * Bind this framebuffer to \p GL_DRAW_FRAMEBUFFER.
-     */
+	 * Bind this framebuffer to \p GL_DRAW_FRAMEBUFFER.
+	 */
 	void bind_write() const;
 
 private:
 	/**
-     * Type of this framebuffer.
-     */
+	 * Type of this framebuffer.
+	 */
 	gl_framebuffer_t type;
 };
 

--- a/libopenage/renderer/opengl/render_target.h
+++ b/libopenage/renderer/opengl/render_target.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -22,8 +22,8 @@ class GlTexture2d;
  */
 enum class gl_render_target_t {
 	/**
-     * Render into a framebuffer.
-     */
+	 * Render into a framebuffer.
+	 */
 	framebuffer,
 	// TODO renderbuffers mixed with textures
 };
@@ -35,24 +35,24 @@ enum class gl_render_target_t {
 class GlRenderTarget final : public RenderTarget {
 public:
 	/**
-     * Construct a render target pointed at the default framebuffer - the window.
-     *
-     * @param context OpenGL context used for drawing.
-     * @param width Current width of the window.
-     * @param height Current height of the window.
-     */
+	 * Construct a render target pointed at the default framebuffer - the window.
+	 *
+	 * @param context OpenGL context used for drawing.
+	 * @param width Current width of the window.
+	 * @param height Current height of the window.
+	 */
 	GlRenderTarget(const std::shared_ptr<GlContext> &context,
 	               size_t width,
 	               size_t height);
 
 	/**
-     * Construct a render target pointing at the given textures.
-     * Texture are attached to points specific to their pixel format,
-     * e.g. a depth texture will be set as the depth target.
-     *
-     * @param context OpenGL context used for drawing.
-     * @param textures Texture attachements.
-     */
+	 * Construct a render target pointing at the given textures.
+	 * Texture are attached to points specific to their pixel format,
+	 * e.g. a depth texture will be set as the depth target.
+	 *
+	 * @param context OpenGL context used for drawing.
+	 * @param textures Texture attachements.
+	 */
 	GlRenderTarget(const std::shared_ptr<GlContext> &context,
 	               std::vector<std::shared_ptr<GlTexture2d>> const &textures);
 
@@ -64,52 +64,52 @@ public:
 	resources::Texture2dData into_data() override;
 
 	/**
-     * Get the targeted textures.
-     *
-     * @return Textures drawn into by the render target.
-     */
+	 * Get the targeted textures.
+	 *
+	 * @return Textures drawn into by the render target.
+	 */
 	std::vector<std::shared_ptr<Texture2d>> get_texture_targets() override;
 
 	/**
-     * Resize the render target to the specified dimensions.
-     *
-     * This is used to scale the viewport to the correct size when
-     * binding the render target with write access.
-     *
-     * @param width New width.
-     * @param height New height.
-     */
+	 * Resize the render target to the specified dimensions.
+	 *
+	 * This is used to scale the viewport to the correct size when
+	 * binding the render target with write access.
+	 *
+	 * @param width New width.
+	 * @param height New height.
+	 */
 	void resize(size_t width, size_t height);
 
 	/**
-     * Bind this render target to be drawn into.
-     */
+	 * Bind this render target to be drawn into.
+	 */
 	void bind_write() const;
 
 	/**
-     * Bind this render target to be read from.
-     */
+	 * Bind this render target to be read from.
+	 */
 	void bind_read() const;
 
 private:
 	/**
-     * Type of this render target.
-     */
+	 * Type of this render target.
+	 */
 	gl_render_target_t type;
 
 	/**
-     * Size of the window or the texture targets.
-     */
+	 * Size of the window or the texture targets.
+	 */
 	std::pair<size_t, size_t> size;
 
 	/**
-     * For framebuffer target type, the framebuffer.
-     */
+	 * For framebuffer target type, the framebuffer.
+	 */
 	std::optional<GlFramebuffer> framebuffer;
 
 	/**
-     * Target textures if the render target is a textured fbo.
-     */
+	 * Target textures if the render target is a textured fbo.
+	 */
 	std::optional<std::vector<std::shared_ptr<GlTexture2d>>> textures;
 };
 

--- a/libopenage/renderer/opengl/shader_data.h
+++ b/libopenage/renderer/opengl/shader_data.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -18,9 +18,9 @@ struct GlUniform {
 	GLenum type;
 
 	/**
-     * Location of the uniform for use with glUniform and glGetUniform.
+	 * Location of the uniform for use with glUniform and glGetUniform.
 	 * NOT the same as the uniform index.
-     */
+	 */
 	GLuint location;
 };
 
@@ -31,27 +31,27 @@ struct GlInBlockUniform {
 	GLenum type;
 
 	/**
-     * Offset relative to the beginning of the block at which this uniform is placed.
-     */
+	 * Offset relative to the beginning of the block at which this uniform is placed.
+	 */
 	size_t offset;
 
 	/**
-     * The size in bytes of the whole uniform. If the uniform is an array,
+	 * The size in bytes of the whole uniform. If the uniform is an array,
 	 * the size of the whole array.
-     */
+	 */
 	size_t size;
 
 	/**
-     * Only relevant for arrays and matrices.
+	 * Only relevant for arrays and matrices.
 	 * In arrays, specifies the distance between the start of each element.
 	 * In row-major matrices, specifies the distance between the start of each row.
 	 * In column-major matrices, specifies the distance between the start of each column.
-     */
+	 */
 	size_t stride;
 
 	/**
-     * Only relevant for arrays. The number of elements in the array.
-     */
+	 * Only relevant for arrays. The number of elements in the array.
+	 */
 	size_t count;
 };
 
@@ -62,19 +62,19 @@ struct GlUniformBlock {
 	GLuint index;
 
 	/**
-     * Size of the entire block. How uniforms are packed within depends
+	 * Size of the entire block. How uniforms are packed within depends
 	 * on the block layout and is described in corresponding GlUniforms.
-     */
+	 */
 	size_t data_size;
 
 	/**
-     * Maps uniform names within this block to their descriptions.
-     */
+	 * Maps uniform names within this block to their descriptions.
+	 */
 	std::unordered_map<std::string, GlInBlockUniform> uniforms;
 
 	/**
-     * The binding point assigned to this block.
-     */
+	 * The binding point assigned to this block.
+	 */
 	GLuint binding_point;
 };
 

--- a/libopenage/renderer/opengl/shader_program.h
+++ b/libopenage/renderer/opengl/shader_program.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -30,38 +30,38 @@ class GlShaderProgram final : public ShaderProgram
 	, public GlSimpleObject {
 public:
 	/**
-     * Tries to create a shader program from the given sources.
+	 * Tries to create a shader program from the given sources.
 	 * Throws an exception on compile/link errors.
-     */
+	 */
 	explicit GlShaderProgram(const std::shared_ptr<GlContext> &,
 	                         const std::vector<resources::ShaderSource> &);
 
 	/**
-     * Bind this program as the currently used one in the OpenGL context.
-     */
+	 * Bind this program as the currently used one in the OpenGL context.
+	 */
 	void use();
 
 	/**
-     * Check if this program is currently in use in the OpenGL context.
-     *
-     * @return true if the program is in use, false otherwise.
-     */
+	 * Check if this program is currently in use in the OpenGL context.
+	 *
+	 * @return true if the program is in use, false otherwise.
+	 */
 	bool in_use() const;
 
 	/**
-     * Updates the uniform values with the given input specification.
-     *
-     * @param input The uniform input specification.
-     */
+	 * Updates the uniform values with the given input specification.
+	 *
+	 * @param input The uniform input specification.
+	 */
 	void update_uniforms(std::shared_ptr<GlUniformInput> const &unif_in);
 
 	/**
-     * Get the uniform block with the given name.
-     *
-     * @param block_name Name of the uniform block.
-     *
-     * @return Uniform block.
-     */
+	 * Get the uniform block with the given name.
+	 *
+	 * @param block_name Name of the uniform block.
+	 *
+	 * @return Uniform block.
+	 */
 	const GlUniformBlock &get_uniform_block(const char *block_name) const;
 
 	uniform_id_t get_uniform_id(const char *name) override;
@@ -69,12 +69,12 @@ public:
 	bool has_uniform(const char *name) override;
 
 	/**
-     * Binds a uniform block in the shader program to the same binding point as
-     * the given uniform buffer.
-     *
-     * @param buffer Uniform buffer to bind.
-     * @param block_name Name of the uniform block in the shader program.
-     */
+	 * Binds a uniform block in the shader program to the same binding point as
+	 * the given uniform buffer.
+	 *
+	 * @param buffer Uniform buffer to bind.
+	 * @param block_name Name of the uniform block in the shader program.
+	 */
 	void bind_uniform_buffer(const char *block_name,
 	                         std::shared_ptr<UniformBuffer> const &) override;
 

--- a/libopenage/renderer/opengl/uniform_buffer.h
+++ b/libopenage/renderer/opengl/uniform_buffer.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,17 +27,17 @@ public:
 	                GLenum usage = GL_DYNAMIC_DRAW);
 
 	/**
-     * Get the binding point of the buffer.
-     *
-     * @return Binding point ID.
-     */
+	 * Get the binding point of the buffer.
+	 *
+	 * @return Binding point ID.
+	 */
 	GLuint get_binding_point() const;
 
 	/**
-     * Set the binding point of the buffer.
-     *
-     * @param binding_point Binding point ID.
-     */
+	 * Set the binding point of the buffer.
+	 *
+	 * @param binding_point Binding point ID.
+	 */
 	void set_binding_point(GLuint binding_point);
 
 	void update_uniforms(std::shared_ptr<UniformBufferInput> const &unif_in) override;
@@ -45,8 +45,8 @@ public:
 	bool has_uniform(const char *) override;
 
 	/**
-     * Bind the buffer.
-     */
+	 * Bind the buffer.
+	 */
 	void bind() const;
 
 protected:
@@ -70,34 +70,34 @@ protected:
 
 private:
 	/**
-     * Update a uniform value in a uniform buffer input object.
-     *
-     * Note that the uniform buffer itself is not updated by this. Data is only uploaded
-     * to the buffer when \p update_uniforms is eventually called.
-     *
-     * @param in Uniform buffer input object.
-     * @param name Name of the uniform.
-     * @param val Pointer to the value to update the uniform with.
-     * @param type Type of the uniform.
-     */
+	 * Update a uniform value in a uniform buffer input object.
+	 *
+	 * Note that the uniform buffer itself is not updated by this. Data is only uploaded
+	 * to the buffer when \p update_uniforms is eventually called.
+	 *
+	 * @param in Uniform buffer input object.
+	 * @param name Name of the uniform.
+	 * @param val Pointer to the value to update the uniform with.
+	 * @param type Type of the uniform.
+	 */
 	void set_unif(std::shared_ptr<UniformBufferInput> const &in,
 	              const char *name,
 	              void const *val,
 	              GLenum type);
 
 	/**
-     * Uniform definitions inside the buffer.
-     */
+	 * Uniform definitions inside the buffer.
+	 */
 	std::unordered_map<std::string, GlInBlockUniform> uniforms;
 
 	/**
-     * Size of the buffer (in bytes).
-     */
+	 * Size of the buffer (in bytes).
+	 */
 	size_t data_size;
 
 	/**
-     * Binding point of the buffer.
-     */
+	 * Binding point of the buffer.
+	 */
 	GLuint binding_point;
 };
 

--- a/libopenage/renderer/opengl/uniform_input.h
+++ b/libopenage/renderer/opengl/uniform_input.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,18 +27,18 @@ public:
 	GlUniformInput(std::shared_ptr<ShaderProgram> const &);
 
 	/**
-     * We store uniform updates lazily. They are only actually uploaded to GPU
+	 * We store uniform updates lazily. They are only actually uploaded to GPU
 	 * when a draw call is made.
-     *
-     * \p update_offs maps the uniform IDs to where their
+	 *
+	 * \p update_offs maps the uniform IDs to where their
 	 * value is in \p update_data in terms of a byte-wise offset. This is only a partial
 	 * valuation, so not all uniforms have to be present here.
-     */
+	 */
 	std::unordered_map<uniform_id_t, size_t> update_offs;
 
 	/**
-     * Buffer containing untyped uniform update data.
-     */
+	 * Buffer containing untyped uniform update data.
+	 */
 	std::vector<uint8_t> update_data;
 };
 
@@ -50,18 +50,18 @@ public:
 	GlUniformBufferInput(std::shared_ptr<UniformBuffer> const &);
 
 	/**
-     * We store uniform updates lazily. They are only actually uploaded to GPU
+	 * We store uniform updates lazily. They are only actually uploaded to GPU
 	 * when a draw call is made.
-     *
-     * \p update_offs maps the uniform names to where their
+	 *
+	 * \p update_offs maps the uniform names to where their
 	 * value is in \p update_data in terms of a byte-wise offset. This is only a partial
 	 * valuation, so not all uniforms have to be present here.
-     */
+	 */
 	std::unordered_map<std::string, size_t> update_offs;
 
 	/**
-     * Buffer containing untyped uniform update data.
-     */
+	 * Buffer containing untyped uniform update data.
+	 */
 	std::vector<uint8_t> update_data;
 };
 

--- a/libopenage/renderer/render_factory.h
+++ b/libopenage/renderer/render_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,45 +27,45 @@ class WorldRenderEntity;
 class RenderFactory {
 public:
 	/**
-     * Create a new factory for render entities.
-     *
-     * @param terrain_renderer Terrain renderer.
-     * @param world_renderer World renderer.
-     */
+	 * Create a new factory for render entities.
+	 *
+	 * @param terrain_renderer Terrain renderer.
+	 * @param world_renderer World renderer.
+	 */
 	RenderFactory(const std::shared_ptr<terrain::TerrainRenderStage> terrain_renderer,
 	              const std::shared_ptr<world::WorldRenderStage> world_renderer);
 	~RenderFactory() = default;
 
 	/**
-     * Create a new terrain render entity and register it at the terrain renderer.
-     *
-     * Render entities for terrain are associated with chunks, so a new render entity
-     * will result in the creation of a new chunk in the renderer.
-     *
-     * Size/offset of the chunk in the game simulation should match size/offset
-     * in the renderer.
-     *
-     * @return Render entity for pushing terrain updates.
-     */
+	 * Create a new terrain render entity and register it at the terrain renderer.
+	 *
+	 * Render entities for terrain are associated with chunks, so a new render entity
+	 * will result in the creation of a new chunk in the renderer.
+	 *
+	 * Size/offset of the chunk in the game simulation should match size/offset
+	 * in the renderer.
+	 *
+	 * @return Render entity for pushing terrain updates.
+	 */
 	std::shared_ptr<terrain::TerrainRenderEntity> add_terrain_render_entity(const util::Vector2s chunk_size,
 	                                                                        const coord::tile_delta chunk_offset);
 
 	/**
-     * Create a new world render entity and register it at the world renderer.
-     *
-     * @return Render entity for pushing terrain updates.
-     */
+	 * Create a new world render entity and register it at the world renderer.
+	 *
+	 * @return Render entity for pushing terrain updates.
+	 */
 	std::shared_ptr<world::WorldRenderEntity> add_world_render_entity();
 
 private:
 	/**
-     * Render stage for terrain drawing.
-     */
+	 * Render stage for terrain drawing.
+	 */
 	std::shared_ptr<terrain::TerrainRenderStage> terrain_renderer;
 
 	/**
-     * Render stage for game entity drawing.
-     */
+	 * Render stage for game entity drawing.
+	 */
 	std::shared_ptr<world::WorldRenderStage> world_renderer;
 };
 

--- a/libopenage/renderer/resources/animation/angle_info.h
+++ b/libopenage/renderer/resources/animation/angle_info.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -14,9 +14,9 @@ class FrameInfo;
  * Describe whether/how the frame is mirrored
  */
 enum class flip_type {
-	NONE, // do not flip
+	NONE,   // do not flip
 	FLIP_X, // flip across x axis
-	FLIP_Y // flip across y axis
+	FLIP_Y  // flip across y axis
 };
 
 /**
@@ -32,7 +32,7 @@ public:
 	 * @param angle_start Rotation in degress at which the frames are displayed.
 	 * @param frames Frame information.
 	 * @param mirror_from Mirror frames from another angle instead of using uniquely
-     *                    defined frames.
+	 *                    defined frames.
 	 */
 	AngleInfo(const float angle_start,
 	          std::vector<std::shared_ptr<FrameInfo>> &frames,
@@ -50,10 +50,10 @@ public:
 	float get_angle_start() const;
 
 	/**
-     * Check if the angle is mirrored from another angle.
-     *
-     * @return true if a mirrored angle has been defined, else false.
-     */
+	 * Check if the angle is mirrored from another angle.
+	 *
+	 * @return true if a mirrored angle has been defined, else false.
+	 */
 	bool is_mirrored() const;
 
 	/**
@@ -88,18 +88,18 @@ public:
 
 private:
 	/**
-     * Starting rotation in degress at which the frames are displayed.
-     */
+	 * Starting rotation in degress at which the frames are displayed.
+	 */
 	float angle_start;
 
 	/**
-     * Frame information.
-     */
+	 * Frame information.
+	 */
 	std::vector<std::shared_ptr<FrameInfo>> frames;
 
 	/**
-     * Mirrored angle information.
-     */
+	 * Mirrored angle information.
+	 */
 	std::shared_ptr<AngleInfo> mirror_from = nullptr;
 
 	/**

--- a/libopenage/renderer/resources/animation/frame_info.h
+++ b/libopenage/renderer/resources/animation/frame_info.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,9 +16,9 @@ public:
 	 * Create a 2D Frame Info.
 	 *
 	 * @param texture_idx Index of the texture containing the frame in the
-     *                    Animation2dInfo object.
+	 *                    Animation2dInfo object.
 	 * @param subtexture_idx Index of the subtexture containing the frame
-     *                    in the Texture2dInfo object.
+	 *                    in the Texture2dInfo object.
 	 */
 	FrameInfo(const size_t texture_idx,
 	          const size_t subtexture_idx);
@@ -42,13 +42,13 @@ public:
 
 private:
 	/**
-     * Index of the texture containing the frame in the Animation2dInfo object.
-     */
+	 * Index of the texture containing the frame in the Animation2dInfo object.
+	 */
 	size_t texture_idx;
 
 	/**
-     * Index of the subtexture containing the frame in the Texture2dInfo object.
-     */
+	 * Index of the subtexture containing the frame in the Texture2dInfo object.
+	 */
 	size_t subtexture_idx;
 };
 

--- a/libopenage/renderer/resources/animation/layer_info.h
+++ b/libopenage/renderer/resources/animation/layer_info.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,9 +12,9 @@ class AngleInfo;
 class FrameTiming;
 
 enum class display_mode {
-	OFF, // Only show first frame
+	OFF,  // Only show first frame
 	ONCE, // Play loop once
-	LOOP // Loop indefinitely
+	LOOP  // Loop indefinitely
 };
 
 /**
@@ -95,10 +95,10 @@ public:
 	const std::shared_ptr<AngleInfo> &get_direction_angle(float direction) const;
 
 	/**
-     * Get the frame timing information of this layer.
-     *
-     * @return Frame timing information.
-     */
+	 * Get the frame timing information of this layer.
+	 *
+	 * @return Frame timing information.
+	 */
 	const std::shared_ptr<FrameTiming> &get_frame_timing() const;
 
 private:

--- a/libopenage/renderer/resources/assets/asset_manager.h
+++ b/libopenage/renderer/resources/assets/asset_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -36,32 +36,32 @@ class Texture2dInfo;
 class AssetManager {
 public:
 	/**
-     * Create a new asset manager.
-     *
-     * @param renderer The openage renderer instance.
-     * @param asset_base_dir Base path for all assets.
-     */
+	 * Create a new asset manager.
+	 *
+	 * @param renderer The openage renderer instance.
+	 * @param asset_base_dir Base path for all assets.
+	 */
 	AssetManager(const std::shared_ptr<Renderer> &renderer,
 	             const util::Path &asset_base_dir);
 	~AssetManager() = default;
 
 	/**
-     * Prevent accidental copy or assignment because it would defeat the
-     * point of a persistent cache.
-     */
+	 * Prevent accidental copy or assignment because it would defeat the
+	 * point of a persistent cache.
+	 */
 	AssetManager(const AssetManager &) = delete;
 	AssetManager &operator=(const AssetManager &) = delete;
 
 	/**
-     * Get the corresponding asset for the specified path.
-     *
-     * If the asset does not exist in the cache yet, it will be loaded
-     * using the given path.
-     *
-     * @param path Path to the asset resource.
-     *
-     * @return Texture resource at the given path.
-     */
+	 * Get the corresponding asset for the specified path.
+	 *
+	 * If the asset does not exist in the cache yet, it will be loaded
+	 * using the given path.
+	 *
+	 * @param path Path to the asset resource.
+	 *
+	 * @return Texture resource at the given path.
+	 */
 	const std::shared_ptr<Animation2dInfo> &request_animation(const util::Path &path);
 	const std::shared_ptr<BlendPatternInfo> &request_blpattern(const util::Path &path);
 	const std::shared_ptr<BlendTableInfo> &request_bltable(const util::Path &path);
@@ -70,16 +70,16 @@ public:
 	const std::shared_ptr<Texture2dInfo> &request_texture(const util::Path &path);
 
 	/**
-     * Get the corresponding asset for a path string relative to the
-     * asset base directory.
-     *
-     * If the asset does not exist in the cache yet, it will be loaded
-     * using the given path.
-     *
-     * @param path Relative path to the asset resource (from the asset base dir).
-     *
-     * @return Texture resource at the given path.
-     */
+	 * Get the corresponding asset for a path string relative to the
+	 * asset base directory.
+	 *
+	 * If the asset does not exist in the cache yet, it will be loaded
+	 * using the given path.
+	 *
+	 * @param path Relative path to the asset resource (from the asset base dir).
+	 *
+	 * @return Texture resource at the given path.
+	 */
 	const std::shared_ptr<Animation2dInfo> &request_animation(const std::string &rel_path);
 	const std::shared_ptr<BlendPatternInfo> &request_blpattern(const std::string &rel_path);
 	const std::shared_ptr<BlendTableInfo> &request_bltable(const std::string &rel_path);
@@ -95,11 +95,11 @@ public:
 	using placeholder_texture_t = std::optional<std::pair<util::Path, std::shared_ptr<Texture2dInfo>>>;
 
 	/**
-     * Set a placeholder asset that is returned in case a regular request cannot
-     * find the requested asset.
-     *
-     * @param path Path to the placeholder asset resource.
-     */
+	 * Set a placeholder asset that is returned in case a regular request cannot
+	 * find the requested asset.
+	 *
+	 * @param path Path to the placeholder asset resource.
+	 */
 	void set_placeholder_animation(const util::Path &path);
 	void set_placeholder_blpattern(const util::Path &path);
 	void set_placeholder_bltable(const util::Path &path);
@@ -108,10 +108,10 @@ public:
 	void set_placeholder_texture(const util::Path &path);
 
 	/**
-     * Get the placeholder asset for a specific asset type.
-     *
-     * @return Placeholder asset resource.
-     */
+	 * Get the placeholder asset for a specific asset type.
+	 *
+	 * @return Placeholder asset resource.
+	 */
 	const placeholder_anim_t &get_placeholder_animation();
 	const placeholder_blpattern_t &get_placeholder_blpattern();
 	const placeholder_bltable_t &get_placeholder_bltable();
@@ -120,39 +120,39 @@ public:
 	const placeholder_texture_t &get_placeholder_texture();
 
 	/**
-      * Get the texture manager for accessing cached image resources.
-      *
-      * @return Texture manager.
-      */
+	 * Get the texture manager for accessing cached image resources.
+	 *
+	 * @return Texture manager.
+	 */
 	const std::shared_ptr<TextureManager> &get_texture_manager();
 
 private:
 	/**
-     * openage renderer.
-     */
+	 * openage renderer.
+	 */
 	std::shared_ptr<Renderer> renderer;
 
 	/**
-     * Cache of already loaded assets.
-     */
+	 * Cache of already loaded assets.
+	 */
 	std::shared_ptr<AssetCache> cache;
 
 	/**
-     * Manages individual textures/image resources used by the
-     * high level asset formats cached by the asset manager.
-     */
+	 * Manages individual textures/image resources used by the
+	 * high level asset formats cached by the asset manager.
+	 */
 	std::shared_ptr<TextureManager> texture_manager;
 
 	/**
-     * Base path for all assets.
-     *
-     * TODO: This should be the mount point of modpacks?
-     */
+	 * Base path for all assets.
+	 *
+	 * TODO: This should be the mount point of modpacks?
+	 */
 	util::Path asset_base_dir;
 
 	/**
-     * Placeholder assets that can be used if a resource is not found.
-     */
+	 * Placeholder assets that can be used if a resource is not found.
+	 */
 	placeholder_anim_t placeholder_animation;
 	placeholder_blpattern_t placeholder_blpattern;
 	placeholder_bltable_t placeholder_bltable;

--- a/libopenage/renderer/resources/assets/cache.h
+++ b/libopenage/renderer/resources/assets/cache.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,19 +27,19 @@ class Texture2dInfo;
 class AssetCache {
 public:
 	/**
-     * Create a new asset cache.
-     */
+	 * Create a new asset cache.
+	 */
 	AssetCache() = default;
 	~AssetCache() = default;
 
 	/**
-     * Get the corresponding asset for the specified path.
-     *
-     * @param path Path to the asset resource.
-     *
-     * @return Asset resource at the given path.
+	 * Get the corresponding asset for the specified path.
+	 *
+	 * @param path Path to the asset resource.
+	 *
+	 * @return Asset resource at the given path.
 	 * @throw Error if the resource is not in the cache.
-     */
+	 */
 	const std::shared_ptr<Animation2dInfo> &get_animation(const util::Path &path);
 	const std::shared_ptr<BlendPatternInfo> &get_blpattern(const util::Path &path);
 	const std::shared_ptr<BlendTableInfo> &get_bltable(const util::Path &path);
@@ -49,12 +49,12 @@ public:
 	// TODO: use std::optional<std::shared_ptr<Texture2dInfo>>
 
 	/**
-     * Map a specific asset info to the given path and add it to the cache.
-     * Overwrites existing references if the path already exists in the cache.
-     *
-     * @param path Path to the asset resource.
-     * @param info Existing asset object.
-     */
+	 * Map a specific asset info to the given path and add it to the cache.
+	 * Overwrites existing references if the path already exists in the cache.
+	 *
+	 * @param path Path to the asset resource.
+	 * @param info Existing asset object.
+	 */
 	void add_animation(const util::Path &path, const std::shared_ptr<Animation2dInfo> info);
 	void add_blpattern(const util::Path &path, const std::shared_ptr<BlendPatternInfo> info);
 	void add_bltable(const util::Path &path, const std::shared_ptr<BlendTableInfo> info);
@@ -63,10 +63,10 @@ public:
 	void add_texture(const util::Path &path, const std::shared_ptr<Texture2dInfo> info);
 
 	/**
-     * Remove an asset reference from the cache.
-     *
-     * @param path Path to the asset resource.
-     */
+	 * Remove an asset reference from the cache.
+	 *
+	 * @param path Path to the asset resource.
+	 */
 	void remove_animation(const util::Path &path);
 	void remove_blpattern(const util::Path &path);
 	void remove_bltable(const util::Path &path);
@@ -75,12 +75,12 @@ public:
 	void remove_texture(const util::Path &path);
 
 	/**
-     * Check if an asset reference is in the cache.
-     *
-     * @param path Path to the asset resource.
+	 * Check if an asset reference is in the cache.
+	 *
+	 * @param path Path to the asset resource.
 	 *
 	 * @return true if the resource is cached, else false.
-     */
+	 */
 	bool check_animation_cache(const util::Path &path);
 	bool check_blpattern_cache(const util::Path &path);
 	bool check_bltable_cache(const util::Path &path);
@@ -97,33 +97,33 @@ private:
 	using texture_cache_t = std::unordered_map<util::Path, std::shared_ptr<Texture2dInfo>>;
 
 	/**
-     * Cache of already loaded animations.
-     */
+	 * Cache of already loaded animations.
+	 */
 	anim_cache_t loaded_animations;
 
 	/**
-     * Cache of already loaded blending patterns.
-     */
+	 * Cache of already loaded blending patterns.
+	 */
 	blpattern_cache_t loaded_blpatterns;
 
 	/**
-     * Cache of already loaded blending tables.
-     */
+	 * Cache of already loaded blending tables.
+	 */
 	bltable_cache_t loaded_bltables;
 
 	/**
-     * Cache of already loaded colour palettes.
-     */
+	 * Cache of already loaded colour palettes.
+	 */
 	palette_cache_t loaded_palettes;
 
 	/**
-     * Cache of already loaded terrains.
-     */
+	 * Cache of already loaded terrains.
+	 */
 	terrain_cache_t loaded_terrains;
 
 	/**
-     * Cache of already loaded textures.
-     */
+	 * Cache of already loaded textures.
+	 */
 	texture_cache_t loaded_textures;
 };
 

--- a/libopenage/renderer/resources/assets/texture_manager.h
+++ b/libopenage/renderer/resources/assets/texture_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -26,89 +26,89 @@ namespace resources {
 class TextureManager {
 public:
 	/**
-     * Create a new texture manager.
-     *
-     * @param renderer The openage renderer instance.
-     */
+	 * Create a new texture manager.
+	 *
+	 * @param renderer The openage renderer instance.
+	 */
 	TextureManager(const std::shared_ptr<Renderer> &renderer);
 	~TextureManager() = default;
 
 	/**
-     * Prevent accidental copy or assignment because it would defeat the
-     * point of a persistent cache.
-     */
+	 * Prevent accidental copy or assignment because it would defeat the
+	 * point of a persistent cache.
+	 */
 	TextureManager(const TextureManager &) = delete;
 	TextureManager &operator=(const TextureManager &) = delete;
 
 	/**
-     * Get the corresponding texture for the specified path.
-     *
-     * If the texture does not exist in the cache yet, it will be loaded
-     * using the given path.
-     *
-     * @param path Path to the texture resource.
-     *
-     * @return Texture resource at the given path.
-     */
+	 * Get the corresponding texture for the specified path.
+	 *
+	 * If the texture does not exist in the cache yet, it will be loaded
+	 * using the given path.
+	 *
+	 * @param path Path to the texture resource.
+	 *
+	 * @return Texture resource at the given path.
+	 */
 	const std::shared_ptr<Texture2d> &request(const util::Path &path);
 
 	/**
-     * Load the texture at the given path. Does nothing if the path
-     * already exists in the cache.
-     *
-     * @param path Path to the texture resource.
-     */
+	 * Load the texture at the given path. Does nothing if the path
+	 * already exists in the cache.
+	 *
+	 * @param path Path to the texture resource.
+	 */
 	void add(const util::Path &path);
 
 	/**
-     * Assign a specific texture to the given path. Overwrites existing
-     * textures references if the path already exists in the cache.
-     *
-     * @param path Path to the texture resource.
-     * @param texture Existing texture object.
-     */
+	 * Assign a specific texture to the given path. Overwrites existing
+	 * textures references if the path already exists in the cache.
+	 *
+	 * @param path Path to the texture resource.
+	 * @param texture Existing texture object.
+	 */
 	void add(const util::Path &path,
 	         const std::shared_ptr<Texture2d> &texture);
 
 	/**
-     * Remove a texture reference from the cache.
-     *
-     * @param path Path to the texture resource.
-     */
+	 * Remove a texture reference from the cache.
+	 *
+	 * @param path Path to the texture resource.
+	 */
 	void remove(const util::Path &path);
 
 	/**
-     * Set the placeholder texture.
-     *
-     * @param path Path to the texture resource.
-     */
+	 * Set the placeholder texture.
+	 *
+	 * @param path Path to the texture resource.
+	 */
 	void set_placeholder(const util::Path &path);
 
 	using placeholder_t = std::optional<std::pair<util::Path, std::shared_ptr<Texture2d>>>;
 
 	/**
-     * Get the placeholder texture.
-     *
-     * @return Placeholder texture. Can be \p nullptr.
-     */
+	 * Get the placeholder texture.
+	 *
+	 * @return Placeholder texture. Can be \p nullptr.
+	 */
 	const placeholder_t &get_placeholder() const;
 
 private:
 	/**
-     * openage renderer.
-     */
+	 * openage renderer.
+	 */
 	std::shared_ptr<Renderer> renderer;
 
 	using texture_cache_t = std::unordered_map<util::Path, std::shared_ptr<Texture2d>>;
 
 	/**
-     * Cache of already created textures.
-     */
+	 * Cache of already created textures.
+	 */
 	texture_cache_t loaded;
 
 	/**
-     * Placeholder texture to use if a texture could not be loaded.
-     */
+	 * Placeholder texture to use if a texture could not be loaded.
+	 */
 	placeholder_t placeholder;
 };
 

--- a/libopenage/renderer/resources/buffer_info.h
+++ b/libopenage/renderer/resources/buffer_info.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -81,71 +81,71 @@ static constexpr auto STD140_INPUT_SIZE = datastructure::create_const_map<ubo_in
 class UniformBufferInfo {
 public:
 	/**
-     * Create a new uniform buffer definition.
-     *
-     * @param layout Layout of the uniform block targeted by the buffer.
-     * @param inputs Uniform definitions inside the uniform block.
-     */
+	 * Create a new uniform buffer definition.
+	 *
+	 * @param layout Layout of the uniform block targeted by the buffer.
+	 * @param inputs Uniform definitions inside the uniform block.
+	 */
 	UniformBufferInfo(ubo_layout_t layout, const std::vector<UBOInput> &inputs);
 
 	/**
-     * Create a new uniform buffer definition.
-     *
-     * @param layout Layout of the uniform block targeted by the buffer.
-     * @param inputs Uniform definitions inside the uniform block.
-     */
+	 * Create a new uniform buffer definition.
+	 *
+	 * @param layout Layout of the uniform block targeted by the buffer.
+	 * @param inputs Uniform definitions inside the uniform block.
+	 */
 	UniformBufferInfo(ubo_layout_t layout, std::vector<UBOInput> &&inputs);
 
 	/**
-     * Get the layout of the uniform block targeted by the buffer.
-     *
-     * @return Uniform block layout.
-     */
+	 * Get the layout of the uniform block targeted by the buffer.
+	 *
+	 * @return Uniform block layout.
+	 */
 	ubo_layout_t get_layout() const;
 
 	/**
-     * Get the uniform definitions inside the uniform block.
-     *
-     * @return Uniform definitions.
-     */
+	 * Get the uniform definitions inside the uniform block.
+	 *
+	 * @return Uniform definitions.
+	 */
 	const std::vector<UBOInput> &get_inputs() const;
 
 	/**
-     * Get the total size of the uniform block (in bytes).
-     *
-     * @return Size of the uniform block (in bytes).
-     */
+	 * Get the total size of the uniform block (in bytes).
+	 *
+	 * @return Size of the uniform block (in bytes).
+	 */
 	size_t get_size() const;
 
 	/**
-     * Get the size of a single uniform input (in bytes).
-     *
-     * @param input Uniform input type.
-     * @param layout Layout of the uniform block targeted by the buffer.
-     *
-     * @return Size of the uniform input (in bytes).
-     */
+	 * Get the size of a single uniform input (in bytes).
+	 *
+	 * @param input Uniform input type.
+	 * @param layout Layout of the uniform block targeted by the buffer.
+	 *
+	 * @return Size of the uniform input (in bytes).
+	 */
 	static size_t get_size(const UBOInput &input, ubo_layout_t layout = ubo_layout_t::STD140);
 
 	/**
-     * Get the stride size of a uniform input in an array (in bytes).
-     *
-     * @param input Uniform input type.
-     * @param layout Layout of the uniform block targeted by the buffer.
-     *
-     * @return Size of the uniform input (in bytes).
-     */
+	 * Get the stride size of a uniform input in an array (in bytes).
+	 *
+	 * @param input Uniform input type.
+	 * @param layout Layout of the uniform block targeted by the buffer.
+	 *
+	 * @return Size of the uniform input (in bytes).
+	 */
 	static size_t get_stride_size(ubo_input_t input, ubo_layout_t layout = ubo_layout_t::STD140);
 
 private:
 	/**
-     * Uniform block layout.
-     */
+	 * Uniform block layout.
+	 */
 	ubo_layout_t layout;
 
 	/**
-     * Uniform definitions.
-     */
+	 * Uniform definitions.
+	 */
 	std::vector<UBOInput> inputs;
 };
 

--- a/libopenage/renderer/resources/frame_timing.h
+++ b/libopenage/renderer/resources/frame_timing.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -20,86 +20,86 @@ public:
 	using keyframe_t = time::time_t;
 
 	/**
-     * Create a new frame timing sequence.
-     *
-     * @param total_length Total length of the sequence (in seconds).
-     * @param keyframes Time of each frame (in seconds). Expected to be sorted.
-     */
+	 * Create a new frame timing sequence.
+	 *
+	 * @param total_length Total length of the sequence (in seconds).
+	 * @param keyframes Time of each frame (in seconds). Expected to be sorted.
+	 */
 	FrameTiming(const time::time_t &total_length,
 	            const std::vector<keyframe_t> &&keyframes);
 
 	~FrameTiming() = default;
 
 	/**
-     * Set the total length of the frame timing sequence.
-     *
-     * @param total_length Total length of the sequence (in seconds).
-     */
+	 * Set the total length of the frame timing sequence.
+	 *
+	 * @param total_length Total length of the sequence (in seconds).
+	 */
 	void set_total_length(const time::time_t &total_length);
 
 	/**
-     * Insert a new keyframe into the sequence.
-     *
-     * Insertion complexity is linear (O(n)), so it should be avoided during rendering
-     * when possible. Prefer to create several alternative sequence instead if the
-     * timing needs to be changed.
-     *
-     * @param time Time of the new keyframe (in seconds).
-     */
+	 * Insert a new keyframe into the sequence.
+	 *
+	 * Insertion complexity is linear (O(n)), so it should be avoided during rendering
+	 * when possible. Prefer to create several alternative sequence instead if the
+	 * timing needs to be changed.
+	 *
+	 * @param time Time of the new keyframe (in seconds).
+	 */
 	void insert(const time::time_t &time);
 
 	/**
-     * Get the index of the frame in the sequence that should be displayed at the
-     * given time (closest frame with t <= time).
-     *
-     * @param time Time in the sequence (in seconds).
-     * @return Frame index in the sequence.
-     */
+	 * Get the index of the frame in the sequence that should be displayed at the
+	 * given time (closest frame with t <= time).
+	 *
+	 * @param time Time in the sequence (in seconds).
+	 * @return Frame index in the sequence.
+	 */
 	size_t get_frame(const time::time_t &time) const;
 
 	/**
-     * Get the index of the frame in the sequence that should be displayed at a specified
-     * time. This method is intended for looping frame sequences.
-     *
-     * Sequence time is determined from the modulus of the time difference between
-     * \p current (current simulation time) and \p start (time when the sequence
-     * was first started):
-     *
-     * time = (current - start) % total_length
-     *
-     * @param current Current simulation time (in seconds).
-     * @param start Start time of the sequence (in seconds).
-     * @return Frame index in the sequence.
-     */
+	 * Get the index of the frame in the sequence that should be displayed at a specified
+	 * time. This method is intended for looping frame sequences.
+	 *
+	 * Sequence time is determined from the modulus of the time difference between
+	 * \p current (current simulation time) and \p start (time when the sequence
+	 * was first started):
+	 *
+	 * time = (current - start) % total_length
+	 *
+	 * @param current Current simulation time (in seconds).
+	 * @param start Start time of the sequence (in seconds).
+	 * @return Frame index in the sequence.
+	 */
 	size_t get_frame(const time::time_t &current, const time::time_t &start) const;
 
 	/**
-     * Get the number of frames in the sequence.
-     *
-     * @return Number of frames.
-     */
+	 * Get the number of frames in the sequence.
+	 *
+	 * @return Number of frames.
+	 */
 	size_t size() const;
 
 private:
 	/**
-     * Search for the closest frame index with t <= time.
-     *
-     * Uses binary search to find the frame index. Complexity is therefore
-     * O(log_2(this->keyframes.size())).
-     *
-     * @param time Time in the sequence (in seconds).
-     * @return Frame index in the sequence.
-     */
+	 * Search for the closest frame index with t <= time.
+	 *
+	 * Uses binary search to find the frame index. Complexity is therefore
+	 * O(log_2(this->keyframes.size())).
+	 *
+	 * @param time Time in the sequence (in seconds).
+	 * @return Frame index in the sequence.
+	 */
 	size_t search_frame(const time::time_t &time) const;
 
 	/**
-     * Time of each frame in the sequence relative to the sequence start (in seconds).
-     */
+	 * Time of each frame in the sequence relative to the sequence start (in seconds).
+	 */
 	std::vector<keyframe_t> keyframes;
 
 	/**
-     * Total length of the sequence (in seconds).
-     */
+	 * Total length of the sequence (in seconds).
+	 */
 	time::time_t total_length;
 };
 

--- a/libopenage/renderer/resources/mesh_data.cpp
+++ b/libopenage/renderer/resources/mesh_data.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "mesh_data.h"
 
@@ -35,11 +35,18 @@ size_t vertex_input_count(vertex_input_t in) {
 	return vin_count.get(in);
 }
 
-VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs, vertex_layout_t layout, vertex_primitive_t primitive) :
-	inputs(std::move(inputs)), layout(layout), primitive(primitive) {}
+VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs,
+                                 vertex_layout_t layout,
+                                 vertex_primitive_t primitive) :
+	inputs(std::move(inputs)),
+	layout(layout), primitive(primitive) {}
 
-VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs, vertex_layout_t layout, vertex_primitive_t primitive, index_t index_type) :
-	inputs(std::move(inputs)), layout(layout), primitive(primitive), index_type(index_type) {}
+VertexInputInfo::VertexInputInfo(std::vector<vertex_input_t> inputs,
+                                 vertex_layout_t layout,
+                                 vertex_primitive_t primitive,
+                                 index_t index_type) :
+	inputs(std::move(inputs)),
+	layout(layout), primitive(primitive), index_type(index_type) {}
 
 void VertexInputInfo::add_shader_input_map(std::unordered_map<size_t, size_t> &&in_map) {
 	for (auto mapping : in_map) {
@@ -105,12 +112,30 @@ VertexInputInfo MeshData::get_info() const {
 /// Vertices of a quadrilateral filling the whole screen.
 /// Format: (pos, tex_coords) = (x, y, u, v)
 static constexpr const std::array<float, 16> QUAD_DATA_CENTERED = {
-	{-1.0f, 1.0f, 0.0f, 1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 0.0f}};
+	// clang-format off
+	// prevent clang-format from putting this matrix on single line
+	{
+		-1.0f,  1.0f, 0.0f, 1.0f,
+		-1.0f, -1.0f, 0.0f, 0.0f,
+		 1.0f,  1.0f, 1.0f, 1.0f,
+		 1.0f, -1.0f, 1.0f, 0.0f
+	}
+	// clang-format on
+};
 
 /// Vertices of a quad from (0, 0) to (1, 1)
 /// Format: (pos, tex_coords) = (x, y, u, v)
 static constexpr const std::array<float, 16> QUAD_DATA_UNIT = {
-	{0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f}};
+	// clang-format off
+	// prevent clang-format from putting this matrix on single line
+	{
+		0.0f, 1.0f, 0.0f, 1.0f,
+		0.0f, 0.0f, 0.0f, 0.0f,
+		1.0f, 1.0f, 1.0f, 1.0f,
+		1.0f, 0.0f, 1.0f, 0.0f
+	}
+	// clang-format on
+};
 
 
 namespace {
@@ -154,11 +179,29 @@ MeshData MeshData::make_quad(float sidelength, bool centered) {
 	if (centered) {
 		float halfsidelength = sidelength / 2;
 		positions = {
-			{-halfsidelength, halfsidelength, 0.0f, 1.0f, -halfsidelength, -halfsidelength, 0.0f, 0.0f, halfsidelength, halfsidelength, 1.0f, 1.0f, halfsidelength, -halfsidelength, 1.0f, 0.0f}};
+			// clang-format off
+			// prevent clang-format from putting this matrix on single line
+			{
+				-halfsidelength,  halfsidelength, 0.0f, 1.0f,
+				-halfsidelength, -halfsidelength, 0.0f, 0.0f,
+				 halfsidelength,  halfsidelength, 1.0f, 1.0f,
+				 halfsidelength, -halfsidelength, 1.0f, 0.0f
+			}
+			// clang-format on
+		};
 	}
 	else {
 		positions = {
-			{0.0f, sidelength, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, sidelength, sidelength, 1.0f, 1.0f, sidelength, 0.0f, 1.0f, 0.0f}};
+			// clang-format off
+			// prevent clang-format from putting this matrix on single line
+			{
+				0.0f,       sidelength, 0.0f, 1.0f,
+				0.0f,       0.0f,       0.0f, 0.0f,
+				sidelength, sidelength, 1.0f, 1.0f,
+				sidelength, 0.0f,       1.0f, 0.0f
+			}
+			// clang-format on
+		};
 	}
 
 	return create_float_mesh(positions);
@@ -174,11 +217,28 @@ MeshData MeshData::make_quad(float width, float height, bool centered) {
 		float halfwidth = width / 2;
 		float halfheight = height / 2;
 		positions = {
-			{-halfwidth, halfheight, 0.0f, 1.0f, -halfwidth, -halfheight, 0.0f, 0.0f, halfwidth, halfheight, 1.0f, 1.0f, halfwidth, -halfheight, 1.0f, 0.0f}};
+			{
+				// clang-format off
+				// prevent clang-format from putting this matrix on single line
+				-halfwidth,  halfheight, 0.0f, 1.0f,
+				-halfwidth, -halfheight, 0.0f, 0.0f,
+				 halfwidth,  halfheight, 1.0f, 1.0f,
+				 halfwidth, -halfheight, 1.0f, 0.0f
+				// clang-format on
+			}};
 	}
 	else {
 		positions = {
-			{0.0f, height, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, width, height, 1.0f, 1.0f, width, 0.0f, 1.0f, 0.0f}};
+			// clang-format off
+			// prevent clang-format from putting this matrix on single line
+			{
+				0.0f,  height, 0.0f, 1.0f,
+				0.0f,  0.0f,   0.0f, 0.0f,
+				width, height, 1.0f, 1.0f,
+				width, 0.0f,   1.0f, 0.0f
+			}
+			// clang-format on
+		};
 	}
 
 	return create_float_mesh(positions);

--- a/libopenage/renderer/resources/palette_info.h
+++ b/libopenage/renderer/resources/palette_info.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -34,17 +34,17 @@ public:
 	~PaletteInfo() = default;
 
 	/**
-     * Get a color in the palette with a specified index.
-     *
-     * @return Normalized RGBA color vector.
-     */
+	 * Get a color in the palette with a specified index.
+	 *
+	 * @return Normalized RGBA color vector.
+	 */
 	Eigen::Vector4f get_color(size_t idx);
 
 	/**
-     * Get the colors of the palette.
-     *
-     * @return List of normalized RGBA colors.
-     */
+	 * Get the colors of the palette.
+	 *
+	 * @return List of normalized RGBA colors.
+	 */
 	const std::vector<Eigen::Vector4f> get_colors();
 
 private:

--- a/libopenage/renderer/resources/terrain/blendtable_info.h
+++ b/libopenage/renderer/resources/terrain/blendtable_info.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -29,8 +29,8 @@ public:
 
 	/**
 	 * Get the blending lookup table.
-     *
-     * @return Lookup table for blending patterns.
+	 *
+	 * @return Lookup table for blending patterns.
 	 */
 	const std::vector<size_t> &get_table() const;
 

--- a/libopenage/renderer/resources/terrain/frame_info.h
+++ b/libopenage/renderer/resources/terrain/frame_info.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,9 +17,9 @@ public:
 	 * Create a 2D Frame Info.
 	 *
 	 * @param texture_idx Index of the texture containing the frame in the
-     *                    TerrainInfo object.
+	 *                    TerrainInfo object.
 	 * @param subtexture_idx Index of the subtexture containing the frame
-     *                       in the Texture2dInfo object.
+	 *                       in the Texture2dInfo object.
 	 * @param priority Blending priority.
 	 * @param priority Blend mode index.
 	 */
@@ -61,27 +61,27 @@ public:
 
 private:
 	/**
-     * Index of the texture containing the frame in the TerrainInfo object.
-     */
+	 * Index of the texture containing the frame in the TerrainInfo object.
+	 */
 	size_t texture_idx;
 
 	/**
-     * Index of the subtexture containing the frame in the Texture2dInfo object.
-     */
+	 * Index of the subtexture containing the frame in the Texture2dInfo object.
+	 */
 	size_t subtexture_idx;
 
 	/**
-     * Decides which blending table of the two adjacent terrain textures is selected.
-     *
-     * If two adjacent terrains have equal priority, the blending table of the terrain
-     * with a lower x coordinate value is selected. If the x coordinate value is also
-     * equal, the blending table of the terrain with the lowest y coordinate is selected.
-     */
+	 * Decides which blending table of the two adjacent terrain textures is selected.
+	 *
+	 * If two adjacent terrains have equal priority, the blending table of the terrain
+	 * with a lower x coordinate value is selected. If the x coordinate value is also
+	 * equal, the blending table of the terrain with the lowest y coordinate is selected.
+	 */
 	size_t priority;
 
 	/**
-     * Used for looking up the blending pattern index in a blending table.
-     */
+	 * Used for looking up the blending pattern index in a blending table.
+	 */
 	std::optional<size_t> blend_mode;
 };
 

--- a/libopenage/renderer/resources/texture_info.h
+++ b/libopenage/renderer/resources/texture_info.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -162,8 +162,8 @@ public:
 	/**
 	 * Get the coordinates of a specific subtexture inside the main texture.
 	 * Coordinates are returned as normalized values (floats in range 0.0 to 1.0).
-     *
-     * @deprecated Use \p get_subtex_tile_params() instead.
+	 *
+	 * @deprecated Use \p get_subtex_tile_params() instead.
 	 *
 	 * @param subidx Index of the subtexture.
 	 *

--- a/libopenage/renderer/resources/texture_subinfo.h
+++ b/libopenage/renderer/resources/texture_subinfo.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,8 +24,8 @@ public:
 	 * @param h Height of subtexture.
 	 * @param cx Vertical anchor of subtexture.
 	 * @param cy Horizontal anchor of subtexture.
-     * @param atlas_width Width of the texture atlas containing the subtexture.
-     * @param atlas_height Height of the texture atlas containing the subtexture.
+	 * @param atlas_width Width of the texture atlas containing the subtexture.
+	 * @param atlas_height Height of the texture atlas containing the subtexture.
 	 */
 	Texture2dSubInfo(int32_t x,
 	                 int32_t y,
@@ -39,52 +39,52 @@ public:
 	Texture2dSubInfo() = default;
 
 	/**
-     * Get the position of the subtexture within the atlas.
-     *
-     * @return Pixel coordinates as 2-dimensional Eigen vector: (x, y)
-     */
+	 * Get the position of the subtexture within the atlas.
+	 *
+	 * @return Pixel coordinates as 2-dimensional Eigen vector: (x, y)
+	 */
 	const Eigen::Vector2i &get_pos() const;
 
 	/**
-     * Get the size of the subtexture.
-     *
-     * @return Pixel coordinates as 2-dimensional Eigen vector: (width, height)
-     */
+	 * Get the size of the subtexture.
+	 *
+	 * @return Pixel coordinates as 2-dimensional Eigen vector: (width, height)
+	 */
 	const Eigen::Vector2<uint32_t> &get_size() const;
 
 	/**
-     * Get the position of the subtexture anchor.
-     *
-     * @return Anchor coordinates as 2-dimensional Eigen vector: (x, y)
-     */
+	 * Get the position of the subtexture anchor.
+	 *
+	 * @return Anchor coordinates as 2-dimensional Eigen vector: (x, y)
+	 */
 	const Eigen::Vector2i &get_anchor_pos() const;
 
 	/**
-     * Get the normalized shader parameters of the subtexture. Use in the shader
-     * to sample the subtexture from the atlas.
-     *
-     * Values are in range (0.0, 1.0) and can be passed directly to a shader uniform.
-     * These parameters pre-computed and should be used whenever possible.
-     *
-     * @return Tile parameters as 4-dimensional Eigen vector: (x, y, width, height)
-     */
+	 * Get the normalized shader parameters of the subtexture. Use in the shader
+	 * to sample the subtexture from the atlas.
+	 *
+	 * Values are in range (0.0, 1.0) and can be passed directly to a shader uniform.
+	 * These parameters pre-computed and should be used whenever possible.
+	 *
+	 * @return Tile parameters as 4-dimensional Eigen vector: (x, y, width, height)
+	 */
 	const Eigen::Vector4f &get_tile_params() const;
 
 	/**
-     * Get the anchor parameters of the subtexture center. Used in the model matrix
-     * to calculate the offset position for displaying the subtexture inside
-     * the OpenGL viewport.
-     *
-     * The parameters represent the pixel distance of the anchor point to the subtexture
-     * center, multiplied by 2 to account for the normalized viewport size (which is 2.0
-     * because it spans from -1.0 to 1.0).
-     *
-     * To get the normalized offset distance, the parameters have to be divided by the
-     * viewport size and then multiplied by additional scaling factors (e.g. from the
-     * animation).
-     *
-     * @return Parameters as 2-dimensional Eigen vector: (x, y)
-     */
+	 * Get the anchor parameters of the subtexture center. Used in the model matrix
+	 * to calculate the offset position for displaying the subtexture inside
+	 * the OpenGL viewport.
+	 *
+	 * The parameters represent the pixel distance of the anchor point to the subtexture
+	 * center, multiplied by 2 to account for the normalized viewport size (which is 2.0
+	 * because it spans from -1.0 to 1.0).
+	 *
+	 * To get the normalized offset distance, the parameters have to be divided by the
+	 * viewport size and then multiplied by additional scaling factors (e.g. from the
+	 * animation).
+	 *
+	 * @return Parameters as 2-dimensional Eigen vector: (x, y)
+	 */
 	const Eigen::Vector2i &get_anchor_params() const;
 
 private:
@@ -104,13 +104,13 @@ private:
 	Eigen::Vector2i anchor_pos;
 
 	/**
-     * Pre-computed normalized coordinates of the subtexture.
-     */
+	 * Pre-computed normalized coordinates of the subtexture.
+	 */
 	Eigen::Vector4f tile_params;
 
 	/**
-     * Pre-computed normalized coordinates of the subtexture anchor.
-     */
+	 * Pre-computed normalized coordinates of the subtexture anchor.
+	 */
 	Eigen::Vector2i anchor_params;
 };
 

--- a/libopenage/renderer/shader_program.h
+++ b/libopenage/renderer/shader_program.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -45,12 +45,12 @@ public:
 	virtual bool has_uniform(const char *name) = 0;
 
 	/**
-     * Binds a uniform block in the shader program to the same binding point as
-     * the given uniform buffer.
-     *
-     * @param buffer Uniform buffer to bind.
-     * @param block_name Name of the uniform block in the shader program.
-     */
+	 * Binds a uniform block in the shader program to the same binding point as
+	 * the given uniform buffer.
+	 *
+	 * @param buffer Uniform buffer to bind.
+	 * @param block_name Name of the uniform block in the shader program.
+	 */
 	virtual void bind_uniform_buffer(const char *block_name,
 	                                 std::shared_ptr<UniformBuffer> const &) = 0;
 

--- a/libopenage/renderer/stages/camera/manager.h
+++ b/libopenage/renderer/stages/camera/manager.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -44,63 +44,63 @@ enum class ZoomDirection {
 class CameraManager {
 public:
 	/**
-     * Create a new camera manager.
-     *
-     * @param camera Camera to manage.
-     */
+	 * Create a new camera manager.
+	 *
+	 * @param camera Camera to manage.
+	 */
 	CameraManager(const std::shared_ptr<renderer::camera::Camera> &camera);
 	~CameraManager() = default;
 
 	/**
-     * Update the camera position and zoom level.
-     *
-     * Additionally updates the camera uniform buffer with the view and projection
-     * matrices.
-     */
+	 * Update the camera position and zoom level.
+	 *
+	 * Additionally updates the camera uniform buffer with the view and projection
+	 * matrices.
+	 */
 	void update();
 
 	/**
-     * Move into the given direction for the current frame.
-     *
-     * @param direction Move direction.
-     * @param delta Move speed, i.e. a distance multiplier.
-     */
+	 * Move into the given direction for the current frame.
+	 *
+	 * @param direction Move direction.
+	 * @param delta Move speed, i.e. a distance multiplier.
+	 */
 	void move_frame(MoveDirection direction, float speed = 1.0f);
 
 	/**
-     * Zoom into the given direction for the current frame.
-     *
-     * @param direction Zoom direction.
-     * @param delta Zoom speed, i.e. a distance multiplier.
-     */
+	 * Zoom into the given direction for the current frame.
+	 *
+	 * @param direction Zoom direction.
+	 * @param delta Zoom speed, i.e. a distance multiplier.
+	 */
 	void zoom_frame(ZoomDirection direction, float speed = 1.0f);
 
 	/**
-     * Set the move directions of the camera.
-     *
-     * @param directions Bitfield of the move directions.
-     */
+	 * Set the move directions of the camera.
+	 *
+	 * @param directions Bitfield of the move directions.
+	 */
 	void set_move_motion_dirs(int directions);
 
 	/**
-     * Set the zoom direction of the camera.
-     *
-     * @param direction Zoom direction.
-     */
+	 * Set the zoom direction of the camera.
+	 *
+	 * @param direction Zoom direction.
+	 */
 	void set_zoom_motion_dir(int direction);
 
 	/**
-     * Set the move speed of the camera.
-     *
-     * @param speed Speed of the camera.
-     */
+	 * Set the move speed of the camera.
+	 *
+	 * @param speed Speed of the camera.
+	 */
 	void set_move_motion_speed(float speed);
 
 	/**
-     * Set the zoom speed of the camera.
-     *
-     * @param speed Speed of the camera.
-     */
+	 * Set the zoom speed of the camera.
+	 *
+	 * @param speed Speed of the camera.
+	 */
 	void set_zoom_motion_speed(float speed);
 
 private:
@@ -110,38 +110,38 @@ private:
 	void update_motion();
 
 	/**
-     * Update the camera uniform buffer.
-     */
+	 * Update the camera uniform buffer.
+	 */
 	void update_uniforms();
 
 	/**
-     * Camera.
-     */
+	 * Camera.
+	 */
 	std::shared_ptr<renderer::camera::Camera> camera;
 
 	/**
-     * Bitfield of the current move motion directions.
-     */
+	 * Bitfield of the current move motion directions.
+	 */
 	int move_motion_directions;
 
 	/**
-     * Bitfield of the current zoom motion direction.
-     */
+	 * Bitfield of the current zoom motion direction.
+	 */
 	int zoom_motion_direction;
 
 	/**
-     * Move motion speed of the camera.
-     */
+	 * Move motion speed of the camera.
+	 */
 	float move_motion_speed;
 
 	/**
-     * Zoom motion speed of the camera.
-     */
+	 * Zoom motion speed of the camera.
+	 */
 	float zoom_motion_speed;
 
 	/**
-     * Uniform buffer input for the camera.
-     */
+	 * Uniform buffer input for the camera.
+	 */
 	std::shared_ptr<renderer::UniformBufferInput> uniforms;
 };
 

--- a/libopenage/renderer/stages/hud/object.h
+++ b/libopenage/renderer/stages/hud/object.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -34,62 +34,62 @@ class HudDragRenderEntity;
 class HudDragObject {
 public:
 	/**
-     * Create a new object for the HUD render stage.
-     *
-     * @param asset_manager Asset manager for loading resources.
-     */
+	 * Create a new object for the HUD render stage.
+	 *
+	 * @param asset_manager Asset manager for loading resources.
+	 */
 	HudDragObject(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager);
 	~HudDragObject() = default;
 
 	/**
-     * Set the world render entity.
-     *
-     * @param entity New world render entity.
-     */
+	 * Set the world render entity.
+	 *
+	 * @param entity New world render entity.
+	 */
 	void set_render_entity(const std::shared_ptr<HudDragRenderEntity> &entity);
 
 	/**
-     * Set the current camera of the scene.
-     *
-     * @param camera Camera object viewing the scene.
-     */
+	 * Set the current camera of the scene.
+	 *
+	 * @param camera Camera object viewing the scene.
+	 */
 	void set_camera(const std::shared_ptr<renderer::camera::Camera> &camera);
 
 	/**
-     * Fetch updates from the render entity.
-     *
-     * @param time Current simulation time.
-     */
+	 * Fetch updates from the render entity.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void fetch_updates(const time::time_t &time = 0.0);
 
 	/**
-     * Update the uniforms of the renderable associated with this object.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the uniforms of the renderable associated with this object.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_uniforms(const time::time_t &time = 0.0);
 
 	/**
-     * Update the geometry of the renderable associated with this object.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the geometry of the renderable associated with this object.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_geometry(const time::time_t &time = 0.0);
 
 	/**
-     * Check whether a new renderable needs to be created for this mesh.
-     *
-     * If true, the old renderable should be removed from the render pass.
-     * The updated uniforms and geometry should be passed to this mesh.
-     * Afterwards, clear the requirement flag with \p clear_requires_renderable().
-     *
-     * @return true if a new renderable is required, else false.
-     */
+	 * Check whether a new renderable needs to be created for this mesh.
+	 *
+	 * If true, the old renderable should be removed from the render pass.
+	 * The updated uniforms and geometry should be passed to this mesh.
+	 * Afterwards, clear the requirement flag with \p clear_requires_renderable().
+	 *
+	 * @return true if a new renderable is required, else false.
+	 */
 	bool requires_renderable();
 
 	/**
-     * Indicate to this mesh that a new renderable has been created.
-     */
+	 * Indicate to this mesh that a new renderable has been created.
+	 */
 	void clear_requires_renderable();
 
 	/**
@@ -105,28 +105,28 @@ public:
 	void clear_changed_flag();
 
 	/**
-     * Set the reference to the uniform inputs of the renderable
-     * associated with this object. Relevant uniforms are updated
-     * when calling \p update().
-     *
-     * @param uniforms Uniform inputs of this object's renderable.
-     */
+	 * Set the reference to the uniform inputs of the renderable
+	 * associated with this object. Relevant uniforms are updated
+	 * when calling \p update().
+	 *
+	 * @param uniforms Uniform inputs of this object's renderable.
+	 */
 	void set_uniforms(const std::shared_ptr<renderer::UniformInput> &uniforms);
 
 	/**
-     * Set the geometry of the renderable associated with this object.
-     *
-     * The geometry is updated when calling \p update().
-     *
-     * @param geometry Geometry of this object's renderable.
-     */
+	 * Set the geometry of the renderable associated with this object.
+	 *
+	 * The geometry is updated when calling \p update().
+	 *
+	 * @param geometry Geometry of this object's renderable.
+	 */
 	void set_geometry(const std::shared_ptr<renderer::Geometry> &geometry);
 
 private:
 	/**
-     * Stores whether a new renderable for this object needs to be created
-     * for the render pass.
-     */
+	 * Stores whether a new renderable for this object needs to be created
+	 * for the render pass.
+	 */
 	bool require_renderable;
 
 	/**
@@ -150,23 +150,23 @@ private:
 	std::shared_ptr<HudDragRenderEntity> render_entity;
 
 	/**
-     * Position of the dragged corner.
-     */
+	 * Position of the dragged corner.
+	 */
 	curve::Continuous<coord::input> drag_pos;
 
 	/**
-     * Position of the start corner.
-     */
+	 * Position of the start corner.
+	 */
 	coord::input drag_start;
 
 	/**
-     * Shader uniforms for the renderable in the HUD render pass.
-     */
+	 * Shader uniforms for the renderable in the HUD render pass.
+	 */
 	std::shared_ptr<renderer::UniformInput> uniforms;
 
 	/**
-     * Geometry of the renderable in the HUD render pass.
-     */
+	 * Geometry of the renderable in the HUD render pass.
+	 */
 	std::shared_ptr<renderer::Geometry> geometry;
 
 	/**

--- a/libopenage/renderer/stages/hud/render_entity.h
+++ b/libopenage/renderer/stages/hud/render_entity.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,19 +19,19 @@ namespace openage::renderer::hud {
 class HudDragRenderEntity {
 public:
 	/**
-     * Create a new render entity for drag selection in the HUD.
-     *
-     * @param drag_start Position of the start corner.
-     */
+	 * Create a new render entity for drag selection in the HUD.
+	 *
+	 * @param drag_start Position of the start corner.
+	 */
 	HudDragRenderEntity(const coord::input drag_start);
 	~HudDragRenderEntity() = default;
 
 	/**
 	 * Update the render entity with information from the gamestate
-     * or input system.
-     *
-     * @param drag_pos Position of the dragged corner.
-     * @param time Current simulation time.
+	 * or input system.
+	 *
+	 * @param drag_pos Position of the dragged corner.
+	 * @param time Current simulation time.
 	 */
 	void update(const coord::input drag_pos,
 	            const time::time_t time = 0.0);
@@ -44,17 +44,17 @@ public:
 	time::time_t get_update_time();
 
 	/**
-     * Get the position of the dragged corner.
-     *
-     * @return Coordinates of the dragged corner.
-     */
+	 * Get the position of the dragged corner.
+	 *
+	 * @return Coordinates of the dragged corner.
+	 */
 	const curve::Continuous<coord::input> &get_drag_pos();
 
 	/**
-     * Get the position of the start corner.
-     *
-     * @return Coordinates of the start corner.
-     */
+	 * Get the position of the start corner.
+	 *
+	 * @return Coordinates of the start corner.
+	 */
 	const coord::input &get_drag_start();
 
 	/**
@@ -83,13 +83,13 @@ private:
 	time::time_t last_update;
 
 	/**
-     * Position of the dragged corner.
-     */
+	 * Position of the dragged corner.
+	 */
 	curve::Continuous<coord::input> drag_pos;
 
 	/**
-     * Position of the start corner.
-     */
+	 * Position of the start corner.
+	 */
 	coord::input drag_start;
 
 	/**

--- a/libopenage/renderer/stages/hud/render_stage.h
+++ b/libopenage/renderer/stages/hud/render_stage.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -42,15 +42,15 @@ class HudDragRenderEntity;
 class HudRenderStage {
 public:
 	/**
-     * Create a new render stage for the HUD.
-     *
-     * @param window openage window targeted for rendering.
-     * @param renderer openage low-level renderer.
-     * @param camera Camera used for the rendered scene.
-     * @param shaderdir Directory containing the shader source files.
-     * @param asset_manager Asset manager for loading resources.
-     * @param clock Simulation clock for timing animations.
-     */
+	 * Create a new render stage for the HUD.
+	 *
+	 * @param window openage window targeted for rendering.
+	 * @param renderer openage low-level renderer.
+	 * @param camera Camera used for the rendered scene.
+	 * @param shaderdir Directory containing the shader source files.
+	 * @param asset_manager Asset manager for loading resources.
+	 * @param clock Simulation clock for timing animations.
+	 */
 	HudRenderStage(const std::shared_ptr<Window> &window,
 	               const std::shared_ptr<renderer::Renderer> &renderer,
 	               const std::shared_ptr<renderer::camera::Camera> &camera,
@@ -74,10 +74,10 @@ public:
 	void add_drag_entity(const std::shared_ptr<HudDragRenderEntity> entity);
 
 	/**
-     * Remove the render object for drag selection.
-     *
-     * @param render_entity Render entity to remove.
-     */
+	 * Remove the render object for drag selection.
+	 *
+	 * @param render_entity Render entity to remove.
+	 */
 	void remove_drag_entity();
 
 	/**
@@ -87,7 +87,7 @@ public:
 
 	/**
 	 * Resize the FBO for the HUD rendering. This basically updates the output
-     * texture size.
+	 * texture size.
 	 *
 	 * @param width New width of the FBO.
 	 * @param height New height of the FBO.

--- a/libopenage/renderer/stages/screen/render_stage.h
+++ b/libopenage/renderer/stages/screen/render_stage.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -25,12 +25,12 @@ namespace screen {
 class ScreenRenderStage {
 public:
 	/**
-     * Create a new render stage for drawing to the screen.
-     *
-     * @param window openage window targeted for rendering.
-     * @param renderer openage low-level renderer.
-     * @param shaderdir Directory containing the shader source files.
-     */
+	 * Create a new render stage for drawing to the screen.
+	 *
+	 * @param window openage window targeted for rendering.
+	 * @param renderer openage low-level renderer.
+	 * @param shaderdir Directory containing the shader source files.
+	 */
 	ScreenRenderStage(const std::shared_ptr<Window> &window,
 	                  const std::shared_ptr<renderer::Renderer> &renderer,
 	                  const util::Path &shaderdir);

--- a/libopenage/renderer/stages/skybox/render_stage.h
+++ b/libopenage/renderer/stages/skybox/render_stage.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,12 +27,12 @@ namespace skybox {
 class SkyboxRenderStage {
 public:
 	/**
-     * Create a new render stage for the skybox.
-     *
-     * @param window openage window targeted for rendering.
-     * @param renderer openage low-level renderer.
-     * @param shaderdir Directory containing the shader source files.
-     */
+	 * Create a new render stage for the skybox.
+	 *
+	 * @param window openage window targeted for rendering.
+	 * @param renderer openage low-level renderer.
+	 * @param shaderdir Directory containing the shader source files.
+	 */
 	SkyboxRenderStage(const std::shared_ptr<Window> &window,
 	                  const std::shared_ptr<renderer::Renderer> &renderer,
 	                  const util::Path &shaderdir);
@@ -46,26 +46,26 @@ public:
 	std::shared_ptr<renderer::RenderPass> get_render_pass();
 
 	/**
-     * Set the color used for the skybox using integer values
-     * for each channel (0 to 255).
-     *
-     * @param col RGBA color value.
-     */
+	 * Set the color used for the skybox using integer values
+	 * for each channel (0 to 255).
+	 *
+	 * @param col RGBA color value.
+	 */
 	void set_color(const Eigen::Vector4i col);
 	void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 	/**
-     * Set the color used for the skybox using float values
-     * for each channel (0.0 to 1.0).
-     *
-     * @param col RGBA color value.
-     */
+	 * Set the color used for the skybox using float values
+	 * for each channel (0.0 to 1.0).
+	 *
+	 * @param col RGBA color value.
+	 */
 	void set_color(const Eigen::Vector4f col);
 	void set_color(float r, float g, float b, float a);
 
 	/**
 	 * Resize the FBO for the skybox rendering. This basically updates the output
-     * texture size.
+	 * texture size.
 	 *
 	 * @param width New width of the FBO.
 	 * @param height New height of the FBO.
@@ -103,13 +103,13 @@ private:
 	std::shared_ptr<renderer::Texture2d> output_texture;
 
 	/**
-     * Background color.
-     */
+	 * Background color.
+	 */
 	Eigen::Vector4f bg_color;
 
 	/**
-     * Stores background color uniform for the shader.
-     */
+	 * Stores background color uniform for the shader.
+	 */
 	std::shared_ptr<renderer::UniformInput> color_unif;
 };
 

--- a/libopenage/renderer/stages/terrain/chunk.h
+++ b/libopenage/renderer/stages/terrain/chunk.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,10 +27,10 @@ class TerrainRenderEntity;
 class TerrainChunk {
 public:
 	/**
-     * Create a new terrain chunk.
-     *
-     * @param asset_manager Asset manager for loading textures.
-     */
+	 * Create a new terrain chunk.
+	 *
+	 * @param asset_manager Asset manager for loading textures.
+	 */
 	TerrainChunk(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager,
 	             const util::Vector2s size,
 	             const coord::scene2_delta offset);
@@ -38,47 +38,47 @@ public:
 	~TerrainChunk() = default;
 
 	/**
-     * Set the terrain render entity for vertex updates of this mesh.
-     *
-     * @param entity New terrain render entity.
-     * @param size Size of the chunk in tiles.
-     * @param offset Offset of the chunk from origin in tiles.
-     */
+	 * Set the terrain render entity for vertex updates of this mesh.
+	 *
+	 * @param entity New terrain render entity.
+	 * @param size Size of the chunk in tiles.
+	 * @param offset Offset of the chunk from origin in tiles.
+	 */
 	void set_render_entity(const std::shared_ptr<TerrainRenderEntity> &entity);
 
 	/**
-     * Fetch updates from the render entity.
-     *
-     * @param time Current simulation time.
-     */
+	 * Fetch updates from the render entity.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void fetch_updates(const time::time_t &time = 0.0);
 
 	/**
-     * Update the uniforms of the meshes.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the uniforms of the meshes.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_uniforms(const time::time_t &time = 0.0);
 
 	/**
-     * Get the meshes composing the terrain.
-     *
-     * @return Vector of terrain meshes.
-     */
+	 * Get the meshes composing the terrain.
+	 *
+	 * @return Vector of terrain meshes.
+	 */
 	const std::vector<std::shared_ptr<TerrainRenderMesh>> &get_meshes() const;
 
 	/**
-     * Get the size of the chunk in tiles.
-     *
-     * @return Size of the chunk (in tiles).
-     */
+	 * Get the size of the chunk in tiles.
+	 *
+	 * @return Size of the chunk (in tiles).
+	 */
 	util::Vector2s &get_size();
 
 	/**
-     * Get the offset of the chunk from origin in tiles.
-     *
-     * @return Offset of the chunk (in tiles).
-     */
+	 * Get the offset of the chunk from origin in tiles.
+	 *
+	 * @return Offset of the chunk (in tiles).
+	 */
 	coord::scene2_delta &get_offset();
 
 private:
@@ -90,13 +90,13 @@ private:
 	std::shared_ptr<TerrainRenderMesh> create_mesh();
 
 	/**
-     * Size of the chunk in tiles (width x height).
-     */
+	 * Size of the chunk in tiles (width x height).
+	 */
 	util::Vector2s size;
 
 	/**
-     * Offset of the chunk from origin in tiles (x, y).
-     */
+	 * Offset of the chunk from origin in tiles (x, y).
+	 */
 	coord::scene2_delta offset;
 
 	/**
@@ -107,13 +107,13 @@ private:
 
 	/**
 	 * Asset manager for central accessing and loading textures.
-     */
+	 */
 	std::shared_ptr<renderer::resources::AssetManager> asset_manager;
 
 	/**
-     * Source for ingame terrain coordinates. These coordinates are translated into
-     * our render vertex mesh when \p update() is called.
-     */
+	 * Source for ingame terrain coordinates. These coordinates are translated into
+	 * our render vertex mesh when \p update() is called.
+	 */
 	std::shared_ptr<TerrainRenderEntity> render_entity;
 };
 

--- a/libopenage/renderer/stages/terrain/mesh.h
+++ b/libopenage/renderer/stages/terrain/mesh.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -30,21 +30,21 @@ namespace terrain {
 class TerrainRenderMesh {
 public:
 	/**
-     * Create a new terrain render mesh with empty values.
-     *
-     * Mesh and texture need to be set before the terrain mesh becomes renderable.
-     *
-     * @param asset_manager Asset manager for central accessing and loading textures.
-     */
+	 * Create a new terrain render mesh with empty values.
+	 *
+	 * Mesh and texture need to be set before the terrain mesh becomes renderable.
+	 *
+	 * @param asset_manager Asset manager for central accessing and loading textures.
+	 */
 	TerrainRenderMesh(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager);
 
 	/**
-     * Create a new terrain render mesh.
-     *
-     * @param asset_manager Asset manager for central accessing and loading textures.
-     * @param info Terrain info for the renderable.
-     * @param mesh Vertex data of the mesh.
-     */
+	 * Create a new terrain render mesh.
+	 *
+	 * @param asset_manager Asset manager for central accessing and loading textures.
+	 * @param info Terrain info for the renderable.
+	 * @param mesh Vertex data of the mesh.
+	 */
 	TerrainRenderMesh(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager,
 	                  const curve::Discrete<std::string> &terrain_path,
 	                  renderer::resources::MeshData &&mesh);
@@ -52,69 +52,69 @@ public:
 	~TerrainRenderMesh() = default;
 
 	/**
-     * Set the reference to the uniform inputs of the renderable
-     * associated with this mesh. Relevant uniforms are updated
-     * when calling \p update().
-     *
-     * @param uniforms Uniform inputs of this mesh's renderable.
-     */
+	 * Set the reference to the uniform inputs of the renderable
+	 * associated with this mesh. Relevant uniforms are updated
+	 * when calling \p update().
+	 *
+	 * @param uniforms Uniform inputs of this mesh's renderable.
+	 */
 	void set_uniforms(const std::shared_ptr<renderer::UniformInput> &uniforms);
 
 	/**
-     * Get the reference to the uniform inputs of the mesh's renderable.
-     *
-     * @return Uniform inputs of the renderable.
-     */
+	 * Get the reference to the uniform inputs of the mesh's renderable.
+	 *
+	 * @return Uniform inputs of the renderable.
+	 */
 	const std::shared_ptr<renderer::UniformInput> &get_uniforms();
 
 	/**
-     * Set the vertex mesh for the terrain.
-     *
-     * @param mesh Mesh for creating a renderer geometry object.
-     */
+	 * Set the vertex mesh for the terrain.
+	 *
+	 * @param mesh Mesh for creating a renderer geometry object.
+	 */
 	void set_mesh(renderer::resources::MeshData &&mesh);
 
 	/**
-     * Get the vertex mesh for the terrain.
-     *
-     * @return Mesh for creating a renderer geometry object.
-     */
+	 * Get the vertex mesh for the terrain.
+	 *
+	 * @return Mesh for creating a renderer geometry object.
+	 */
 	const renderer::resources::MeshData &get_mesh();
 
 	/**
-     * Set the terrain info that is drawn onto the mesh.
-     *
-     * @param texture Terrain info.
-     */
+	 * Set the terrain info that is drawn onto the mesh.
+	 *
+	 * @param texture Terrain info.
+	 */
 	void set_terrain_path(const curve::Discrete<std::string> &info);
 
 	/**
-     * Update the uniforms of the renderable associated with this object.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the uniforms of the renderable associated with this object.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_uniforms(const time::time_t &time = 0.0);
 
 	/**
-     * Check whether a new renderable needs to be created for this mesh.
-     *
-     * If true, the old renderable should be removed from the render pass.
-     * The updated uniforms and geometry should be passed to this mesh.
-     * Afterwards, clear the requirement flag with \p clear_requires_renderable().
-     *
-     * @return true if a new renderable is required, else false.
-     */
+	 * Check whether a new renderable needs to be created for this mesh.
+	 *
+	 * If true, the old renderable should be removed from the render pass.
+	 * The updated uniforms and geometry should be passed to this mesh.
+	 * Afterwards, clear the requirement flag with \p clear_requires_renderable().
+	 *
+	 * @return true if a new renderable is required, else false.
+	 */
 	bool requires_renderable();
 
 	/**
-     * Indicate to this mesh that a new renderable has been created.
-     */
+	 * Indicate to this mesh that a new renderable has been created.
+	 */
 	void clear_requires_renderable();
 
 	/**
 	 * Create the model transformation matrix for rendering.
-     *
-     * @param offset Offset of the terrain mesh to the scene origin.
+	 *
+	 * @param offset Offset of the terrain mesh to the scene origin.
 	 */
 	void create_model_matrix(const coord::scene2_delta &offset);
 
@@ -132,9 +132,9 @@ public:
 
 private:
 	/**
-     * Stores whether a new renderable for this mesh needs to be created
-     * for the render pass.
-     */
+	 * Stores whether a new renderable for this mesh needs to be created
+	 * for the render pass.
+	 */
 	bool require_renderable;
 
 	/**
@@ -144,27 +144,27 @@ private:
 
 	/**
 	 * Asset manager for central accessing and loading textures.
-     */
+	 */
 	std::shared_ptr<renderer::resources::AssetManager> asset_manager;
 
 	/**
-     * Terrain information for the renderables.
-     */
+	 * Terrain information for the renderables.
+	 */
 	curve::Discrete<std::shared_ptr<renderer::resources::TerrainInfo>> terrain_info;
 
 	/**
-     * Shader uniforms for the renderable in the terrain render pass.
-     */
+	 * Shader uniforms for the renderable in the terrain render pass.
+	 */
 	std::shared_ptr<renderer::UniformInput> uniforms;
 
 	/**
-     * Pre-transformation vertices for the terrain model.
-     */
+	 * Pre-transformation vertices for the terrain model.
+	 */
 	renderer::resources::MeshData mesh;
 
 	/**
-     * Transformation matrix for the terrain model.
-     */
+	 * Transformation matrix for the terrain model.
+	 */
 	Eigen::Matrix4f model_matrix;
 };
 } // namespace terrain

--- a/libopenage/renderer/stages/terrain/model.h
+++ b/libopenage/renderer/stages/terrain/model.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -32,50 +32,50 @@ class TerrainChunk;
 class TerrainRenderModel {
 public:
 	/**
-     * Create a new model for the terrain.
-     *
-     * @param asset_manager Asset manager for loading resources.
-     */
+	 * Create a new model for the terrain.
+	 *
+	 * @param asset_manager Asset manager for loading resources.
+	 */
 	TerrainRenderModel(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager);
 	~TerrainRenderModel() = default;
 
 	/**
-     * Add a new chunk to the terrain model.
-     *
-     * @param entity Render entity of the chunk.
-     * @param chunk_size Size of the chunk in tiles.
-     * @param chunk_offset Offset of the chunk from origin in tiles.
-     */
+	 * Add a new chunk to the terrain model.
+	 *
+	 * @param entity Render entity of the chunk.
+	 * @param chunk_size Size of the chunk in tiles.
+	 * @param chunk_offset Offset of the chunk from origin in tiles.
+	 */
 	void add_chunk(const std::shared_ptr<TerrainRenderEntity> &entity,
 	               const util::Vector2s chunk_size,
 	               const coord::scene2_delta chunk_offset);
 
 	/**
-     * Set the current camera of the scene.
-     *
-     * @param camera Camera object viewing the scene.
-     */
+	 * Set the current camera of the scene.
+	 *
+	 * @param camera Camera object viewing the scene.
+	 */
 	void set_camera(const std::shared_ptr<renderer::camera::Camera> &camera);
 
 	/**
-     * Fetch updates from the render entity.
-     *
-     * @param time Current simulation time.
-     */
+	 * Fetch updates from the render entity.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void fetch_updates(const time::time_t &time = 0.0);
 
 	/**
-     * Update the uniforms of the renderable associated with this object.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the uniforms of the renderable associated with this object.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_uniforms(const time::time_t &time = 0.0);
 
 	/**
-     * Get the chunks composing the terrain.
-     *
-     * @return Chunks of the terrain.
-     */
+	 * Get the chunks composing the terrain.
+	 *
+	 * @return Chunks of the terrain.
+	 */
 	const std::vector<std::shared_ptr<TerrainChunk>> &get_chunks() const;
 
 private:
@@ -91,7 +91,7 @@ private:
 
 	/**
 	 * Asset manager for central accessing and loading textures.
-     */
+	 */
 	std::shared_ptr<renderer::resources::AssetManager> asset_manager;
 };
 

--- a/libopenage/renderer/stages/terrain/render_entity.h
+++ b/libopenage/renderer/stages/terrain/render_entity.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -28,15 +28,15 @@ public:
 	using tiles_t = std::vector<std::pair<terrain_elevation_t, std::string>>;
 
 	/**
-     * Update a single tile of the displayed terrain (chunk) with information from the
-     * gamestate.
+	 * Update a single tile of the displayed terrain (chunk) with information from the
+	 * gamestate.
 	 *
 	 * @param size Size of the terrain in tiles (width x length)
 	 * @param pos Position of the tile in the chunk.
 	 * @param elevation Height of terrain tile.
 	 * @param terrain_path Path to the terrain definition.
-     * @param time Simulation time of the update.
-     */
+	 * @param time Simulation time of the update.
+	 */
 	void update_tile(const util::Vector2s size,
 	                 const coord::tile &pos,
 	                 const terrain_elevation_t elevation,
@@ -44,38 +44,38 @@ public:
 	                 const time::time_t time = 0.0);
 
 	/**
-     * Update the full grid of the displayed terrain (chunk) with information from the
-     * gamestate.
+	 * Update the full grid of the displayed terrain (chunk) with information from the
+	 * gamestate.
 	 *
 	 * @param size Size of the terrain in tiles (width x length)
 	 * @param tiles Animation data for each tile (elevation, terrain path).
-     * @param time Simulation time of the update.
-     */
+	 * @param time Simulation time of the update.
+	 */
 	void update(const util::Vector2s size,
 	            const tiles_t tiles,
 	            const time::time_t time = 0.0);
 
 	/**
-     * Get the vertices of the terrain.
-     *
-     * @return Vector of vertex coordinates.
-     */
+	 * Get the vertices of the terrain.
+	 *
+	 * @return Vector of vertex coordinates.
+	 */
 	const std::vector<coord::scene3> &get_vertices();
 
 	/**
-     * Get the texture mapping for the terrain.
-     *
-     * TODO: Return the actual mapping.
-     *
-     * @return Texture mapping of textures to vertex area.
-     */
+	 * Get the texture mapping for the terrain.
+	 *
+	 * TODO: Return the actual mapping.
+	 *
+	 * @return Texture mapping of textures to vertex area.
+	 */
 	const curve::Discrete<std::string> &get_terrain_path();
 
 	/**
-     * Get the number of vertices on each side of the terrain.
-     *
-     * @return Vector with width as first element and height as second element.
-     */
+	 * Get the number of vertices on each side of the terrain.
+	 *
+	 * @return Vector with width as first element and height as second element.
+	 */
 	const util::Vector2s &get_size();
 
 	/**
@@ -100,8 +100,8 @@ private:
 	bool changed;
 
 	/**
-     * Chunk dimensions (width x height).
-     */
+	 * Chunk dimensions (width x height).
+	 */
 	util::Vector2s size;
 
 	/**

--- a/libopenage/renderer/stages/terrain/render_stage.h
+++ b/libopenage/renderer/stages/terrain/render_stage.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -42,15 +42,15 @@ class TerrainRenderModel;
 class TerrainRenderStage {
 public:
 	/**
-     * Create a new render stage for the terrain.
-     *
-     * @param window openage window targeted for rendering.
-     * @param renderer openage low-level renderer.
-     * @param camera Camera used for the rendered scene.
-     * @param shaderdir Directory containing the shader source files.
-     * @param asset_manager Asset manager for loading resources.
-     * @param clock Simulation clock for timing animations.
-     */
+	 * Create a new render stage for the terrain.
+	 *
+	 * @param window openage window targeted for rendering.
+	 * @param renderer openage low-level renderer.
+	 * @param camera Camera used for the rendered scene.
+	 * @param shaderdir Directory containing the shader source files.
+	 * @param asset_manager Asset manager for loading resources.
+	 * @param clock Simulation clock for timing animations.
+	 */
 	TerrainRenderStage(const std::shared_ptr<Window> &window,
 	                   const std::shared_ptr<renderer::Renderer> &renderer,
 	                   const std::shared_ptr<renderer::camera::Camera> &camera,
@@ -68,8 +68,8 @@ public:
 
 	/**
 	 * Add a new render entity to the terrain renderer.
-     *
-     * This creates a new terrain chunk and add it to the model.
+	 *
+	 * This creates a new terrain chunk and add it to the model.
 	 *
 	 * @param render_entity New render entity.
 	 */
@@ -84,7 +84,7 @@ public:
 
 	/**
 	 * Resize the FBO for the terrain rendering. This basically updates the output
-     * texture size.
+	 * texture size.
 	 *
 	 * @param width New width of the FBO.
 	 * @param height New height of the FBO.

--- a/libopenage/renderer/stages/world/object.h
+++ b/libopenage/renderer/stages/world/object.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -37,39 +37,39 @@ class WorldRenderEntity;
 class WorldObject {
 public:
 	/**
-     * Create a new object for the World render stage.
-     *
-     * @param asset_manager Asset manager for loading resources.
-     */
+	 * Create a new object for the World render stage.
+	 *
+	 * @param asset_manager Asset manager for loading resources.
+	 */
 	WorldObject(const std::shared_ptr<renderer::resources::AssetManager> &asset_manager);
 	~WorldObject() = default;
 
 	/**
-     * Set the world render entity.
-     *
-     * @param entity New world render entity.
-     */
+	 * Set the world render entity.
+	 *
+	 * @param entity New world render entity.
+	 */
 	void set_render_entity(const std::shared_ptr<WorldRenderEntity> &entity);
 
 	/**
-     * Set the current camera of the scene.
-     *
-     * @param camera Camera object viewing the scene.
-     */
+	 * Set the current camera of the scene.
+	 *
+	 * @param camera Camera object viewing the scene.
+	 */
 	void set_camera(const std::shared_ptr<renderer::camera::Camera> &camera);
 
 	/**
-     * Fetch updates from the render entity.
-     *
-     * @param time Current simulation time.
-     */
+	 * Fetch updates from the render entity.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void fetch_updates(const time::time_t &time = 0.0);
 
 	/**
-     * Update the uniforms of the renderable associated with this object.
-     *
-     * @param time Current simulation time.
-     */
+	 * Update the uniforms of the renderable associated with this object.
+	 *
+	 * @param time Current simulation time.
+	 */
 	void update_uniforms(const time::time_t &time = 0.0);
 
 	/**
@@ -80,26 +80,26 @@ public:
 	uint32_t get_id();
 
 	/**
-     * Get the quad for creating the geometry.
-     *
-     * @return Mesh for creating a renderer geometry object.
-     */
+	 * Get the quad for creating the geometry.
+	 *
+	 * @return Mesh for creating a renderer geometry object.
+	 */
 	static const renderer::resources::MeshData get_mesh();
 
 	/**
-     * Check whether a new renderable needs to be created for this mesh.
-     *
-     * If true, the old renderable should be removed from the render pass.
-     * The updated uniforms and geometry should be passed to this mesh.
-     * Afterwards, clear the requirement flag with \p clear_requires_renderable().
-     *
-     * @return true if a new renderable is required, else false.
-     */
+	 * Check whether a new renderable needs to be created for this mesh.
+	 *
+	 * If true, the old renderable should be removed from the render pass.
+	 * The updated uniforms and geometry should be passed to this mesh.
+	 * Afterwards, clear the requirement flag with \p clear_requires_renderable().
+	 *
+	 * @return true if a new renderable is required, else false.
+	 */
 	bool requires_renderable();
 
 	/**
-     * Indicate to this mesh that a new renderable has been created.
-     */
+	 * Indicate to this mesh that a new renderable has been created.
+	 */
 	void clear_requires_renderable();
 
 	/**
@@ -115,12 +115,12 @@ public:
 	void clear_changed_flag();
 
 	/**
-     * Set the reference to the uniform inputs of the renderable
-     * associated with this object. Relevant uniforms are updated
-     * when calling \p update().
-     *
-     * @param uniforms Uniform inputs of this object's renderable.
-     */
+	 * Set the reference to the uniform inputs of the renderable
+	 * associated with this object. Relevant uniforms are updated
+	 * when calling \p update().
+	 *
+	 * @param uniforms Uniform inputs of this object's renderable.
+	 */
 	void set_uniforms(const std::shared_ptr<renderer::UniformInput> &uniforms);
 
 	/**
@@ -136,9 +136,9 @@ public:
 
 private:
 	/**
-     * Stores whether a new renderable for this object needs to be created
-     * for the render pass.
-     */
+	 * Stores whether a new renderable for this object needs to be created
+	 * for the render pass.
+	 */
 	bool require_renderable;
 
 	/**
@@ -173,18 +173,18 @@ private:
 	curve::Continuous<coord::scene3> position;
 
 	/**
-     * Angle of the object.
-     */
+	 * Angle of the object.
+	 */
 	curve::Segmented<coord::phys_angle_t> angle;
 
 	/**
-     * Animation information for the renderables.
-     */
+	 * Animation information for the renderables.
+	 */
 	curve::Discrete<std::shared_ptr<renderer::resources::Animation2dInfo>> animation_info;
 
 	/**
-     * Shader uniforms for the renderable in the terrain render pass.
-     */
+	 * Shader uniforms for the renderable in the terrain render pass.
+	 */
 	std::shared_ptr<renderer::UniformInput> uniforms;
 
 	/**

--- a/libopenage/renderer/stages/world/render_entity.h
+++ b/libopenage/renderer/stages/world/render_entity.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -32,7 +32,7 @@ public:
 	 *
 	 * @param ref_id Game entity ID.
 	 * @param position Position of the game entity inside the game world.
-     * @param angle Angle of the game entity inside the game world.
+	 * @param angle Angle of the game entity inside the game world.
 	 * @param animation_path Path to the animation definition.
 	 * @param time Simulation time of the update.
 	 */
@@ -44,7 +44,7 @@ public:
 
 	/**
 	 * This function is for DEBUGGING and should not be used.
-     *
+	 *
 	 * Update the render entity with information from the gamestate.
 	 *
 	 * @param ref_id Game entity ID.
@@ -72,17 +72,17 @@ public:
 	const curve::Continuous<coord::scene3> &get_position();
 
 	/**
-     * Get the angle of the entity inside the game world.
-     *
-     * @return Angle curve of the entity.
-     */
+	 * Get the angle of the entity inside the game world.
+	 *
+	 * @return Angle curve of the entity.
+	 */
 	const curve::Segmented<coord::phys_angle_t> &get_angle();
 
 	/**
-     * Get the animation definition path.
-     *
-     * @return Path to the animation definition file.
-     */
+	 * Get the animation definition path.
+	 *
+	 * @return Path to the animation definition file.
+	 */
 	const curve::Discrete<std::string> &get_animation_path();
 
 	/**
@@ -124,8 +124,8 @@ private:
 	curve::Continuous<coord::scene3> position;
 
 	/**
-     * Angle of the entity inside the game world.
-     */
+	 * Angle of the entity inside the game world.
+	 */
 	curve::Segmented<coord::phys_angle_t> angle;
 
 	/**

--- a/libopenage/renderer/stages/world/render_stage.h
+++ b/libopenage/renderer/stages/world/render_stage.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -40,15 +40,15 @@ class WorldObject;
 class WorldRenderStage {
 public:
 	/**
-     * Create a new render stage for the game world.
-     *
-     * @param window openage window targeted for rendering.
-     * @param renderer openage low-level renderer.
-     * @param camera Camera used for the rendered scene.
-     * @param shaderdir Directory containing the shader source files.
-     * @param asset_manager Asset manager for loading resources.
-     * @param clock Simulation clock for timing animations.
-     */
+	 * Create a new render stage for the game world.
+	 *
+	 * @param window openage window targeted for rendering.
+	 * @param renderer openage low-level renderer.
+	 * @param camera Camera used for the rendered scene.
+	 * @param shaderdir Directory containing the shader source files.
+	 * @param asset_manager Asset manager for loading resources.
+	 * @param clock Simulation clock for timing animations.
+	 */
 	WorldRenderStage(const std::shared_ptr<Window> &window,
 	                 const std::shared_ptr<renderer::Renderer> &renderer,
 	                 const std::shared_ptr<renderer::camera::Camera> &camera,
@@ -78,7 +78,7 @@ public:
 
 	/**
 	 * Resize the FBO for the world rendering. This basically updates the output
-     * texture size.
+	 * texture size.
 	 *
 	 * @param width New width of the FBO.
 	 * @param height New height of the FBO.
@@ -144,12 +144,12 @@ private:
 	std::shared_ptr<time::Clock> clock;
 
 	/**
-     * Default geometry for every world object.
-     *
-     * Since all world objects are sprites, their mesh is always quad
-     * with the same vertex info. Reusing the geometry allows us to
-     * use the same vetrex buffer for every object.
-     */
+	 * Default geometry for every world object.
+	 *
+	 * Since all world objects are sprites, their mesh is always quad
+	 * with the same vertex info. Reusing the geometry allows us to
+	 * use the same vetrex buffer for every object.
+	 */
 	const std::shared_ptr<renderer::Geometry> default_geometry;
 
 	/**

--- a/libopenage/renderer/texture.h
+++ b/libopenage/renderer/texture.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,7 +15,7 @@ public:
 	virtual ~Texture2d();
 
 	/// Returns the texture information.
-	const resources::Texture2dInfo& get_info() const;
+	const resources::Texture2dInfo &get_info() const;
 
 	/// Copies this texture's data from graphics hardware into a CPU-accessible
 	/// Texture2dData buffer.
@@ -23,14 +23,15 @@ public:
 
 	/// Uploads the provided data into the GPU texture storage. The format has
 	/// to match the format this Texture was originally created with.
-	virtual void upload(resources::Texture2dData const&) = 0;
+	virtual void upload(resources::Texture2dData const &) = 0;
 
 protected:
 	/// Constructs the base with the given information.
-	Texture2d(const resources::Texture2dInfo&);
+	Texture2d(const resources::Texture2dInfo &);
 
 	/// Information about the size, format, etc. of this texture.
 	resources::Texture2dInfo info;
 };
 
-}}
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/types.h
+++ b/libopenage/renderer/types.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -12,4 +12,4 @@ namespace openage::renderer {
  */
 using uniform_id_t = uint32_t;
 
-}
+} // namespace openage::renderer

--- a/libopenage/renderer/uniform_buffer.h
+++ b/libopenage/renderer/uniform_buffer.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,10 +21,10 @@ public:
 	virtual ~UniformBuffer() = default;
 
 	/**
-     * Update the uniforms in the buffer.
-     *
-     * @param unif_in Uniform input to update the buffer with.
-     */
+	 * Update the uniforms in the buffer.
+	 *
+	 * @param unif_in Uniform input to update the buffer with.
+	 */
 	virtual void update_uniforms(std::shared_ptr<UniformBufferInput> const &unif_in) = 0;
 
 	/**

--- a/libopenage/renderer/uniform_input.h
+++ b/libopenage/renderer/uniform_input.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -53,7 +53,7 @@ public:
 /**
  * Abstract base for uniform input. Besides the uniform values, it stores information about
  * which shader program the input was created for.
-*/
+ */
 class UniformInput : public DataInput
 	, public std::enable_shared_from_this<UniformInput> {
 protected:

--- a/libopenage/renderer/vulkan/graphics_device.h
+++ b/libopenage/renderer/vulkan/graphics_device.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -57,7 +57,7 @@ public:
 	/// Given a physical device and a list of queue family indices in that device, instantiates
 	/// a logical device with a queue per each of the families. The device has to support the
 	/// swapchain extension.
-	VlkGraphicsDevice(VkPhysicalDevice dev, std::vector<uint32_t> const& q_fams);
+	VlkGraphicsDevice(VkPhysicalDevice dev, std::vector<uint32_t> const &q_fams);
 
 	VkPhysicalDevice get_physical_device() const;
 	VkDevice get_device() const;
@@ -68,4 +68,6 @@ public:
 	~VlkGraphicsDevice();
 };
 
-}}} // openage::renderer::vulkan
+} // namespace vulkan
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/vulkan/loader.h
+++ b/libopenage/renderer/vulkan/loader.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -28,19 +28,19 @@ public:
 	/// Part of VK_EXT_debug_report, allows setting a callback for debug events.
 	VkResult vkCreateDebugReportCallbackEXT(
 		VkInstance instance,
-		const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-		const VkAllocationCallbacks* pAllocator,
-		VkDebugReportCallbackEXT* pCallback
-	);
+		const VkDebugReportCallbackCreateInfoEXT *pCreateInfo,
+		const VkAllocationCallbacks *pAllocator,
+		VkDebugReportCallbackEXT *pCallback);
 
 
 	/// Part of VK_EXT_debug_report, destroys the debug callback object.
 	void vkDestroyDebugReportCallbackEXT(
 		VkInstance instance,
 		VkDebugReportCallbackEXT callback,
-		const VkAllocationCallbacks* pAllocator
-	);
+		const VkAllocationCallbacks *pAllocator);
 #endif
 };
 
-}}} // openage::renderer::vulkan
+} // namespace vulkan
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/vulkan/render_target.h
+++ b/libopenage/renderer/vulkan/render_target.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -158,9 +158,9 @@ public:
 };
 
 class VlkFramebuffer final : public RenderTarget {
-	//std::vector<VkImageView> attachments;
-	//VkFramebuffer framebuffer;
-	//VkViewport viewport;
+	// std::vector<VkImageView> attachments;
+	// VkFramebuffer framebuffer;
+	// VkViewport viewport;
 
 public:
 	VlkFramebuffer(VkRenderPass /*pass*/, std::vector<VkImageView> const & /*attachments*/) {

--- a/libopenage/renderer/vulkan/renderer.h
+++ b/libopenage/renderer/vulkan/renderer.h
@@ -1,11 +1,11 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <vulkan/vulkan.h>
 
-#include "../renderer.h"
 #include "../../util/path.h"
+#include "../renderer.h"
 
 #include "graphics_device.h"
 
@@ -21,12 +21,13 @@ class VlkRenderer {
 	VkSurfaceKHR surface;
 
 public:
-	VlkRenderer(VkInstance instance, VkSurfaceKHR surface)
-		: instance(instance)
-		, surface(surface) {}
+	VlkRenderer(VkInstance instance, VkSurfaceKHR surface) :
+		instance(instance), surface(surface) {}
 
 	/// Testing function that draws a triangle. Not part of the final renderer implementation.
-	void do_the_thing(util::Path& dir);
+	void do_the_thing(util::Path &dir);
 };
 
-}}} // openage::renderer::vulkan
+} // namespace vulkan
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/vulkan/util.h
+++ b/libopenage/renderer/vulkan/util.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,7 +8,7 @@
 
 
 template <typename R, typename R2>
-std::vector<R> vk_do_ritual(R2 (*func)(uint32_t*, R*)) {
+std::vector<R> vk_do_ritual(R2 (*func)(uint32_t *, R *)) {
 	uint32_t count = 0;
 	func(&count, nullptr);
 	std::vector<R> ret(count);
@@ -18,7 +18,7 @@ std::vector<R> vk_do_ritual(R2 (*func)(uint32_t*, R*)) {
 }
 
 template <typename T, typename T2, typename R, typename R2>
-std::vector<R> vk_do_ritual(R2 (*func)(T, uint32_t*, R*), T2&& a) {
+std::vector<R> vk_do_ritual(R2 (*func)(T, uint32_t *, R *), T2 &&a) {
 	uint32_t count = 0;
 	func(std::forward<T2>(a), &count, nullptr);
 	std::vector<R> ret(count);
@@ -28,7 +28,7 @@ std::vector<R> vk_do_ritual(R2 (*func)(T, uint32_t*, R*), T2&& a) {
 }
 
 template <typename T, typename T2, typename U, typename U2, typename R, typename R2>
-std::vector<R> vk_do_ritual(R2 (*func)(T, U, uint32_t*, R*), T2&& a, U2&& b) {
+std::vector<R> vk_do_ritual(R2 (*func)(T, U, uint32_t *, R *), T2 &&a, U2 &&b) {
 	uint32_t count = 0;
 	func(std::forward<T2>(a), std::forward<U2>(b), &count, nullptr);
 	std::vector<R> ret(count);
@@ -38,7 +38,7 @@ std::vector<R> vk_do_ritual(R2 (*func)(T, U, uint32_t*, R*), T2&& a, U2&& b) {
 }
 
 template <typename T, typename T2, typename U, typename U2, typename V, typename V2, typename R, typename R2>
-std::vector<R> vk_do_ritual(R2 (*func)(T, U, V, uint32_t*, R*), T2&& a, U2&& b, V2&& c) {
+std::vector<R> vk_do_ritual(R2 (*func)(T, U, V, uint32_t *, R *), T2 &&a, U2 &&b, V2 &&c) {
 	uint32_t count = 0;
 	func(std::forward<T2>(a), std::forward<U2>(b), std::forward<V2>(c), &count, nullptr);
 	std::vector<R> ret(count);
@@ -47,7 +47,7 @@ std::vector<R> vk_do_ritual(R2 (*func)(T, U, V, uint32_t*, R*), T2&& a, U2&& b, 
 	return ret;
 }
 
-#define VK_CALL_CHECKED(fun, ...)                                       \
+#define VK_CALL_CHECKED(fun, ...) \
 	{ \
 		VkResult res = fun(__VA_ARGS__); \
 		if (res != VK_SUCCESS) { \

--- a/libopenage/rng/rng.h
+++ b/libopenage/rng/rng.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,13 +21,13 @@ public:
 	 */
 	explicit RNG(uint64_t seed);
 
-        [[maybe_unused]] /**
+	/**
 	 * Initializes the rng using data from the buffer pointed to by data
 	 * @param data The buffer that contains data for seeding the rng
 	 * @param count The number of bytes in the buffer
 	 * @throws Error if 0 bytes are passed
 	 */
-	RNG(const void *data, size_t count);
+	[[maybe_unused]] RNG(const void *data, size_t count);
 
 
 	/**
@@ -73,7 +73,7 @@ public:
 	/**
 	 * Retrieves a random value from the generator
 	 */
-	inline uint64_t operator ()() {
+	inline uint64_t operator()() {
 		return this->random();
 	}
 
@@ -189,13 +189,13 @@ private:
  * Reads the rng from a stream
  * @throws Error if reading from the stream fails
  */
-std::istream &operator >>(std::istream &instream, RNG &inrng);
+std::istream &operator>>(std::istream &instream, RNG &inrng);
 
 /**
  * Writes the rng state to a stream
  * @throws Error if writing data fails
  */
-std::ostream &operator <<(std::ostream &ostream, const RNG &inrng);
+std::ostream &operator<<(std::ostream &ostream, const RNG &inrng);
 
 
 /**

--- a/libopenage/testing/testing.h
+++ b/libopenage/testing/testing.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -53,12 +53,15 @@ bool fail(const log::message &msg);
 			if (test_result_left != (right)) { \
 				TESTFAILMSG("unexpected value: " << (test_result_left)); \
 			} \
-		} catch (::openage::testing::TestError &e) { \
+		} \
+		catch (::openage::testing::TestError & e) { \
 			throw; \
-		} catch (::openage::error::Error &e) { \
+		} \
+		catch (::openage::error::Error & e) { \
 			TESTFAILMSG("unexpected exception: " << e); \
 		} \
-	} while (0)
+	} \
+	while (0)
 
 
 /**
@@ -69,16 +72,18 @@ bool fail(const log::message &msg);
 	do { \
 		try { \
 			auto &&test_result_left = (left); \
-			if ((test_result_left < (right - epsilon)) or \
-			    (test_result_left > (right + epsilon))) { \
+			if ((test_result_left < (right - epsilon)) or (test_result_left > (right + epsilon))) { \
 				TESTFAILMSG("unexpected value: " << (test_result_left)); \
 			} \
-		} catch (::openage::testing::TestError &e) { \
+		} \
+		catch (::openage::testing::TestError & e) { \
 			throw; \
-		} catch (::openage::error::Error &e) { \
+		} \
+		catch (::openage::error::Error & e) { \
 			TESTFAILMSG("unexpected exception: " << e); \
 		} \
-	} while (0)
+	} \
+	while (0)
 
 
 /**
@@ -89,13 +94,15 @@ bool fail(const log::message &msg);
 		bool expr_has_thrown = false; \
 		try { \
 			expression; \
-		} catch (::openage::error::Error &e) { \
+		} \
+		catch (::openage::error::Error & e) { \
 			expr_has_thrown = true; \
 		} \
 		if (not expr_has_thrown) { \
 			TESTFAILMSG("no exception"); \
 		} \
-	} while (0)
+	} \
+	while (0)
 
 
 /**
@@ -105,10 +112,13 @@ bool fail(const log::message &msg);
 	do { \
 		try { \
 			expression; \
-		} catch (::openage::error::Error &e) { \
+		} \
+		catch (::openage::error::Error & e) { \
 			TESTFAILMSG("unexpected exception"); \
 		} \
-	} while (0)
+	} \
+	while (0)
 
 
-}} // openage::testing
+} // namespace testing
+} // namespace openage

--- a/libopenage/testing/testlist.h
+++ b/libopenage/testing/testlist.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,4 +21,5 @@ namespace testing {
 OAAPI void run_method(const std::string &name);
 
 
-}} // openage::testing
+} // namespace testing
+} // namespace openage

--- a/libopenage/time/clock.h
+++ b/libopenage/time/clock.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -38,20 +38,20 @@ public:
 	~Clock() = default;
 
 	/**
-     * Get the current state of the clock.
-     */
+	 * Get the current state of the clock.
+	 */
 	ClockState get_state();
 
 	/**
-     * Update the simulation time.
-     */
+	 * Update the simulation time.
+	 */
 	void update_time();
 
 	/**
 	 * Get the current simulation time (in seconds).
-     *
-     * The returned value has a precision of milliseconds, so it is
-     * accurate to three decimal places.
+	 *
+	 * The returned value has a precision of milliseconds, so it is
+	 * accurate to three decimal places.
 	 *
 	 * @return Time passed (in seconds).
 	 */
@@ -59,28 +59,28 @@ public:
 
 	/**
 	 * Get the current simulation time without speed adjustments.
-     *
-     * The returned value has a precision of milliseconds, so it is
-     * accurate to three decimal places.
+	 *
+	 * The returned value has a precision of milliseconds, so it is
+	 * accurate to three decimal places.
 	 *
 	 * @return Time passed (in seconds).
 	 */
 	time::time_t get_real_time();
 
 	/**
-     * Get the current speed of the clock.
+	 * Get the current speed of the clock.
 	 *
 	 * @return Speed of the clock.
-     */
+	 */
 	speed_t get_speed();
 
 	/**
-     * Set the speed of the clock.
+	 * Set the speed of the clock.
 	 *
 	 * Simulation time is updated before changing speed.
-     *
-     * @param speed New speed of the clock.
-     */
+	 *
+	 * @param speed New speed of the clock.
+	 */
 	void set_speed(speed_t speed);
 
 	/**
@@ -109,8 +109,8 @@ public:
 
 private:
 	/**
-     * Status of the clock (init, running, stopped, ...).
-     */
+	 * Status of the clock (init, running, stopped, ...).
+	 */
 	ClockState state;
 
 	/**
@@ -119,29 +119,29 @@ private:
 	uint16_t max_tick_time;
 
 	/**
-     * How fast time passes relative to real time.
-     */
+	 * How fast time passes relative to real time.
+	 */
 	speed_t speed;
 
 	/**
-     * Last point in time where the clock was updated.
-     */
+	 * Last point in time where the clock was updated.
+	 */
 	timepoint_t last_check;
 
 	/**
-     * Start of the simulation in real time.
-     */
+	 * Start of the simulation in real time.
+	 */
 	timepoint_t start_time;
 
 	/**
-     * Stores how much time has passed inside the simulation (in milliseconds).
-     */
+	 * Stores how much time has passed inside the simulation (in milliseconds).
+	 */
 	time::time_t sim_time;
 
 	/**
-     * Stores how much time has passed inside the simulation (in milliseconds)
+	 * Stores how much time has passed inside the simulation (in milliseconds)
 	 * _without_ speed adjustments (i.e. it acts as if speed = 1.0).
-     */
+	 */
 	time::time_t sim_real_time;
 
 	/**

--- a/libopenage/time/time_loop.h
+++ b/libopenage/time/time_loop.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,20 +15,20 @@ class Clock;
 class TimeLoop {
 public:
 	/**
-     * Create a new time loop with default values.
-     */
+	 * Create a new time loop with default values.
+	 */
 	TimeLoop();
 
 	/**
-     * Create a new time loop from an existing and clock.
-     */
+	 * Create a new time loop from an existing and clock.
+	 */
 	TimeLoop(const std::shared_ptr<Clock> clock);
 	~TimeLoop() = default;
 
 	/**
 	 * Run the time loop.
-     *
-     * Updates the clock and dispatches events that happened.
+	 *
+	 * Updates the clock and dispatches events that happened.
 	 */
 	void run();
 
@@ -43,10 +43,10 @@ public:
 	void stop();
 
 	/**
-     * Get the clock used by this time loop.
-     *
-     * @return Simulation clock.
-     */
+	 * Get the clock used by this time loop.
+	 *
+	 * @return Simulation clock.
+	 */
 	const std::shared_ptr<Clock> get_clock();
 
 private:
@@ -56,8 +56,8 @@ private:
 	bool running;
 
 	/**
-     * Manage time and speed inside the simulation.
-     */
+	 * Manage time and speed inside the simulation.
+	 */
 	std::shared_ptr<Clock> clock;
 
 	/**

--- a/libopenage/util/algorithm.h
+++ b/libopenage/util/algorithm.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -13,7 +13,7 @@ namespace util {
 /**
  * std::for_each except just on containers.
  */
-template<class Container, class Function>
+template <class Container, class Function>
 inline Function for_each(Container &&container, Function &&func) {
 	// why cpp why...
 	return std::for_each(std::begin(std::forward<Container>(container)),
@@ -24,7 +24,7 @@ inline Function for_each(Container &&container, Function &&func) {
 /**
  * Filters items from a container which satisfy a certain predicate.
  */
-template<class Container, class Function>
+template <class Container, class Function>
 inline void remove_from(Container &container, Function &&func) {
 	container.erase(std::remove_if(std::begin(container),
 	                               std::end(container),

--- a/libopenage/util/compiler.h
+++ b/libopenage/util/compiler.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -18,6 +18,8 @@
 /**
  * DLL entry-point decorations.
  */
+// clang-format off
+// otherwise clang-format removes indentation
 #if defined(_WIN32)
 	#if defined(libopenage_EXPORTS)
 		#define OAAPI __declspec(dllexport)
@@ -40,18 +42,21 @@
 		#define HAVE_SSIZE_T 1
 	#endif // HAVE_SSIZE_T
 #endif // _MSC_VER
+// clang-format on
 
 
 /**
  * Software breakpoint if you're too lazy
  * to add it in gdb but instead wanna add it into the code directly.
  */
+// clang-format off
 #ifdef _WIN32
 	#define BREAKPOINT __debugbreak()
 #else
 	#include <signal.h>
 	#define BREAKPOINT raise(SIGTRAP)
 #endif
+// clang-format on
 
 
 /**
@@ -89,7 +94,7 @@ std::string demangle(const char *symbol);
  *
  * pxd: string symbol_name(const void *addr) except +
  */
-OAAPI std::string symbol_name(const void *addr, bool require_exact_addr=true, bool no_pure_addrs=false);
+OAAPI std::string symbol_name(const void *addr, bool require_exact_addr = true, bool no_pure_addrs = false);
 
 
 /**
@@ -129,4 +134,5 @@ std::string typestring(const T &ref) {
 }
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/compress/bitstream.h
+++ b/libopenage/util/compress/bitstream.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -20,7 +20,7 @@ namespace compress {
  *
  * See lzxd.h for documentation.
  */
-using read_callback_t = std::function<size_t (unsigned char *buf, size_t size)>;
+using read_callback_t = std::function<size_t(unsigned char *buf, size_t size)>;
 
 
 /**
@@ -65,7 +65,7 @@ using read_callback_t = std::function<size_t (unsigned char *buf, size_t size)>;
  * Calling the modeswitch methods while already in the respective mode does
  * nothing.
  */
-template<unsigned int inbuf_size>
+template <unsigned int inbuf_size>
 class BitStream {
 public:
 	/**
@@ -148,7 +148,8 @@ private:
 			if (read_bytes == 0) [[unlikely]] {
 				if (this->eof) {
 					throw Error(MSG(err) << "Unexpected EOF in the middle of a block");
-				} else {
+				}
+				else {
 					read_bytes = 2;
 					this->inbuf[0] = 0;
 					this->inbuf[1] = 0;
@@ -156,7 +157,7 @@ private:
 				}
 			}
 
-			if (read_bytes > (int) inbuf_size) [[unlikely]] {
+			if (read_bytes > (int)inbuf_size) [[unlikely]] {
 				throw Error(MSG(err) << "read() returned more data than requested");
 			}
 
@@ -174,7 +175,7 @@ private:
 	/*
 	 * allow our friend HuffmanTable to directly use ensure_bits, peek_bits and remove_bits.
 	 */
-	template<unsigned maxsymbols_p, unsigned tablebits_p, bool allow_empty>
+	template <unsigned maxsymbols_p, unsigned tablebits_p, bool allow_empty>
 	friend class HuffmanTable;
 
 	/**
@@ -266,7 +267,7 @@ private:
 	 *
 	 * If min_discard is given, at least that amount of bits is discarded.
 	 */
-	void align_bitstream(unsigned int min_discard=0) {
+	void align_bitstream(unsigned int min_discard = 0) {
 		unsigned int nbits = this->stream_position % 16;
 		if (nbits != 0) {
 			nbits = 16 - nbits;
@@ -292,8 +293,7 @@ private:
 	}
 
 public:
-	BitStream(read_callback_t read_callback)
-		:
+	BitStream(read_callback_t read_callback) :
 		eof{false},
 		read_callback{read_callback},
 		i_ptr{inbuf},
@@ -302,7 +302,6 @@ public:
 		bits_left{0},
 		stream_position{0},
 		bitstream_mode{true} {
-
 		static_assert(inbuf_size >= 2, "inbuf size must be at least 2");
 		static_assert(inbuf_size % 2 == 0, "inbuf size must be even");
 	}
@@ -368,8 +367,8 @@ public:
 	unsigned int read_4bytes_le() {
 		unsigned int result;
 
-		result  = this->read_single_byte() <<  0;
-		result |= this->read_single_byte() <<  8;
+		result = this->read_single_byte() << 0;
+		result |= this->read_single_byte() << 8;
 		result |= this->read_single_byte() << 16;
 		result |= this->read_single_byte() << 24;
 
@@ -404,7 +403,7 @@ public:
 	 * Discards 1 to 16 bits to align the bitstream first.
 	 */
 	void switch_to_bytestream_mode() {
-		if (! this->bitstream_mode) {
+		if (!this->bitstream_mode) {
 			return;
 		}
 
@@ -433,4 +432,6 @@ public:
 };
 
 
-}}} // openage::util::compress
+} // namespace compress
+} // namespace util
+} // namespace openage

--- a/libopenage/util/compress/lzxd.h
+++ b/libopenage/util/compress/lzxd.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -54,8 +54,8 @@ public:
 	 *                           resets, such as in CAB LZX streams.
 	 */
 	LZXDecompressor(read_callback_t read_callback,
-	                unsigned int window_bits=21,
-	                unsigned int reset_interval=0);
+	                unsigned int window_bits = 21,
+	                unsigned int reset_interval = 0);
 
 	/**
 	 * Frees the internally-allocated LZXDStream object.
@@ -83,8 +83,10 @@ private:
 	LZXDecompressor(const LZXDecompressor &other) = delete;
 	LZXDecompressor(LZXDecompressor &&other) = delete;
 
-	LZXDecompressor &operator =(const LZXDecompressor &other) = delete;
-	LZXDecompressor &operator =(LZXDecompressor &&other) = delete;
+	LZXDecompressor &operator=(const LZXDecompressor &other) = delete;
+	LZXDecompressor &operator=(LZXDecompressor &&other) = delete;
 };
 
-}}} // openage::util::compress
+} // namespace compress
+} // namespace util
+} // namespace openage

--- a/libopenage/util/constexpr.h
+++ b/libopenage/util/constexpr.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2018 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,7 +15,7 @@ namespace openage::util::constexpr_ {
  * Returns true IFF the string literals have equal content.
  */
 constexpr bool streq(const char *a, const char *b) {
-	for (;*a == *b; ++a, ++b) {
+	for (; *a == *b; ++a, ++b) {
 		if (*a == '\0') {
 			return true;
 		}
@@ -60,10 +60,12 @@ constexpr truncated_string_literal get_prefix(const char *str, const char *suffi
 	if (strlen(str) < strlen(suffix)) {
 		// suffix is longer than str
 		throw false;
-	} else if (streq(str + (strlen(str) - strlen(suffix)), suffix)) {
+	}
+	else if (streq(str + (strlen(str) - strlen(suffix)), suffix)) {
 		// str ends with suffix
 		return truncated_string_literal{str, strlen(str) - strlen(suffix)};
-	} else {
+	}
+	else {
 		throw false;
 	}
 }
@@ -97,7 +99,8 @@ constexpr bool has_prefix(const char *str, const truncated_string_literal prefix
 constexpr const char *strip_prefix(const char *str, const truncated_string_literal prefix) {
 	if (has_prefix(str, prefix)) {
 		return str + prefix.length;
-	} else {
+	}
+	else {
 		return str;
 	}
 }

--- a/libopenage/util/constinit_vector.h
+++ b/libopenage/util/constinit_vector.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -20,10 +20,11 @@ namespace util {
  * be pretty uncommon; there generally are better ways of guaranteeing dynamic
  * initialization order, such as static function variables).
  */
-template<typename T>
+template <typename T>
 class ConstInitVector {
 public:
-	constexpr ConstInitVector() noexcept : data{nullptr}, capacity{16}, count{0} {}
+	constexpr ConstInitVector() noexcept :
+		data{nullptr}, capacity{16}, count{0} {}
 
 
 	~ConstInitVector() {
@@ -43,8 +44,8 @@ public:
 	 */
 	ConstInitVector(const ConstInitVector<T> &other) = delete;
 	ConstInitVector(ConstInitVector<T> &&other) = delete;
-	ConstInitVector &operator =(const ConstInitVector<T> &other) = delete;
-	ConstInitVector &operator =(ConstInitVector<T> &&other) = delete;
+	ConstInitVector &operator=(const ConstInitVector<T> &other) = delete;
+	ConstInitVector &operator=(ConstInitVector<T> &&other) = delete;
 
 
 	void push_back(const T &val) {
@@ -60,7 +61,7 @@ public:
 			size_t newcapacity = capacity * 2;
 			T *newdata = alloc.allocate(newcapacity);
 			for (size_t i = 0; i < this->capacity; i++) {
-				new(static_cast<void *>(&newdata[i])) T(std::move_if_noexcept(this->data[i]));
+				new (static_cast<void *>(&newdata[i])) T(std::move_if_noexcept(this->data[i]));
 				(this->data[i]).~T();
 			}
 			alloc.deallocate(this->data, this->capacity);
@@ -69,7 +70,7 @@ public:
 		}
 
 		// add val at the end.
-		new(static_cast<void *>(&this->data[this->count])) T(val);
+		new (static_cast<void *>(&this->data[this->count])) T(val);
 		this->count += 1;
 	}
 
@@ -78,7 +79,7 @@ public:
 	 * The returned reference is invalid if n >= this->size().
 	 * It may be invalidated by a call to push_back().
 	 */
-	const T &operator[] (size_t idx) const {
+	const T &operator[](size_t idx) const {
 		return this->data[idx];
 	}
 
@@ -97,4 +98,5 @@ private:
 };
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/enum.h
+++ b/libopenage/util/enum.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -43,45 +43,46 @@ namespace util {
  *     const char *name
  *     NumericType numeric
  */
-template<typename DerivedType, typename NumericType=int>
+template <typename DerivedType, typename NumericType = int>
 class OAAPI EnumValue {
 public:
-	constexpr EnumValue(const char *value_name, NumericType numeric_value): name(value_name), numeric(numeric_value) {}
+	constexpr EnumValue(const char *value_name, NumericType numeric_value) :
+		name(value_name), numeric(numeric_value) {}
 
 	// enum values cannot be copied
 	EnumValue(const EnumValue &other) = delete;
-	EnumValue &operator =(const EnumValue &other) = delete;
+	EnumValue &operator=(const EnumValue &other) = delete;
 
 	// an explicit deletion of the implicitly defined copy constructor and assignment operator
 	// will implicitly delete the implicitly defined move constructor and assignment operator.
 	// yay for C++
 
 	// enum values are equal if the pointers are equal.
-	constexpr bool operator ==(const DerivedType &other) const {
+	constexpr bool operator==(const DerivedType &other) const {
 		return (this == &other);
 	}
 
-	constexpr bool operator !=(const DerivedType &other) const {
+	constexpr bool operator!=(const DerivedType &other) const {
 		return !(*this == other);
 	}
 
-	constexpr bool operator <=(const DerivedType &other) const {
+	constexpr bool operator<=(const DerivedType &other) const {
 		return this->numeric <= other.numeric;
 	}
 
-	constexpr bool operator <(const DerivedType &other) const {
+	constexpr bool operator<(const DerivedType &other) const {
 		return this->numeric < other.numeric;
 	}
 
-	constexpr bool operator >=(const DerivedType &other) const {
+	constexpr bool operator>=(const DerivedType &other) const {
 		return this->numeric >= other.numeric;
 	}
 
-	constexpr bool operator >(const DerivedType &other) const {
+	constexpr bool operator>(const DerivedType &other) const {
 		return this->numeric > other.numeric;
 	}
 
-	friend std::ostream &operator <<(std::ostream &os, const DerivedType &arg) {
+	friend std::ostream &operator<<(std::ostream &os, const DerivedType &arg) {
 		os << util::typestring<DerivedType>() << "::" << arg.name;
 		return os;
 	}
@@ -122,49 +123,50 @@ public:
  *     bool operator <=(Enum[DerivedType] other) except +
  *     bool operator >=(Enum[DerivedType] other) except +
  */
-template<typename DerivedType>
+template <typename DerivedType>
 class OAAPI Enum {
 	using this_type = Enum<DerivedType>;
 
 public:
 	// disallow the empty constructor to ensure that value is always a valid pointer.
 	constexpr Enum() = delete;
-	constexpr Enum(const DerivedType &value) : value{&value} {}
+	constexpr Enum(const DerivedType &value) :
+		value{&value} {}
 
 	constexpr explicit operator const DerivedType &() const {
 		return *this->value;
 	}
 
-	constexpr Enum &operator =(const DerivedType &value) {
+	constexpr Enum &operator=(const DerivedType &value) {
 		this->value = &value;
 		return *this;
 	}
 
-	constexpr const DerivedType *operator ->() const {
+	constexpr const DerivedType *operator->() const {
 		return this->value;
 	}
 
-	constexpr bool operator ==(const this_type &other) const {
+	constexpr bool operator==(const this_type &other) const {
 		return *this->value == *other.value;
 	}
 
-	constexpr bool operator !=(const this_type &other) const {
+	constexpr bool operator!=(const this_type &other) const {
 		return *this->value != *other.value;
 	}
 
-	constexpr bool operator <=(const this_type &other) const {
+	constexpr bool operator<=(const this_type &other) const {
 		return *this->value <= *other.value;
 	}
 
-	constexpr bool operator <(const this_type &other) const {
+	constexpr bool operator<(const this_type &other) const {
 		return *this->value < *other.value;
 	}
 
-	constexpr bool operator >=(const this_type &other) const {
+	constexpr bool operator>=(const this_type &other) const {
 		return *this->value >= *other.value;
 	}
 
-	constexpr bool operator >(const this_type &other) const {
+	constexpr bool operator>(const this_type &other) const {
 		return *this->value > *other.value;
 	}
 
@@ -172,7 +174,7 @@ public:
 		return *this->value;
 	}
 
-	friend std::ostream &operator <<(std::ostream &os, const this_type &arg) {
+	friend std::ostream &operator<<(std::ostream &os, const this_type &arg) {
 		os << *arg.value;
 		return os;
 	}
@@ -181,4 +183,5 @@ protected:
 	const DerivedType *value;
 };
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/enum_test.h
+++ b/libopenage/util/enum_test.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -48,4 +48,6 @@ struct OAAPI testenum : Enum<testenum_value> {
 	static constexpr testenum_value bar{{"bar", 2}, "barrrrrrrrrrrrrrrrr"};
 };
 
-}}} // openage::util::tests
+} // namespace tests
+} // namespace util
+} // namespace openage

--- a/libopenage/util/externalsstream.h
+++ b/libopenage/util/externalsstream.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include <iostream>
 #include <string>
@@ -43,8 +43,7 @@ public:
 	/**
 	 * Creates a stream without a valid accumulator.
 	 */
-	explicit ExternalOStringStream()
-		:
+	explicit ExternalOStringStream() :
 		std::ostream{&this->buf} {}
 
 	/**
@@ -60,4 +59,5 @@ private:
 };
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fds.h
+++ b/libopenage/util/fds.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -89,4 +89,5 @@ public:
 #endif
 };
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -56,7 +56,7 @@ public:
 	/**
 	 * Open a filesystem path.
 	 */
-	File(const std::string &path, mode_t mode=mode_t::R);
+	File(const std::string &path, mode_t mode = mode_t::R);
 
 	/**
 	 * Create a file from an already created filelike.
@@ -77,7 +77,7 @@ public:
 	 * Read data from the file and return a string.
 	 * If max is negative, return the full remaining file.
 	 */
-	std::string read(ssize_t max=-1);
+	std::string read(ssize_t max = -1);
 
 	/**
 	 * Read data from the file into a buffer,
@@ -87,11 +87,11 @@ public:
 	 *
 	 * Returns the number of bytes that were read.
 	 */
-	size_t read_to(void *buf, ssize_t max=-1);
+	size_t read_to(void *buf, ssize_t max = -1);
 	bool readable();
 	void write(const std::string &data);
 	bool writable();
-	void seek(ssize_t offset, seek_t how=seek_t::SET);
+	void seek(ssize_t offset, seek_t how = seek_t::SET);
 	bool seekable();
 	size_t tell();
 	void close();
@@ -104,7 +104,8 @@ public:
 protected:
 	std::shared_ptr<filelike::FileLike> filelike;
 
-	friend std::ostream &operator <<(std::ostream &stream, const File &file);
+	friend std::ostream &operator<<(std::ostream &stream, const File &file);
 };
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/filelike/filelike.h
+++ b/libopenage/util/filelike/filelike.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -46,9 +46,9 @@ public:
 	 * Don't change the numbers, they're used from Cython.
 	 */
 	enum class seek_t : int {
-		SET = 0,  //!< offset from file beginning
-		CUR = 1,  //!< offset from current position
-		END = 2   //!< offset from file end
+		SET = 0, //!< offset from file beginning
+		CUR = 1, //!< offset from current position
+		END = 2  //!< offset from file end
 	};
 
 	/**
@@ -70,8 +70,8 @@ public:
 
 	virtual ~FileLike() = default;
 
-	virtual std::string read(ssize_t max=-1) = 0;
-	virtual size_t read_to(void *buf, ssize_t max=-1) = 0;
+	virtual std::string read(ssize_t max = -1) = 0;
+	virtual size_t read_to(void *buf, ssize_t max = -1) = 0;
 
 	virtual bool readable() = 0;
 
@@ -79,7 +79,7 @@ public:
 
 	virtual bool writable() = 0;
 
-	virtual void seek(ssize_t offset, seek_t how=seek_t::SET) = 0;
+	virtual void seek(ssize_t offset, seek_t how = seek_t::SET) = 0;
 	virtual bool seekable() = 0;
 	virtual size_t tell() = 0;
 	virtual void close() = 0;
@@ -93,4 +93,6 @@ public:
 };
 
 
-}}} // openage::util::filelike
+} // namespace filelike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/filelike/native.h
+++ b/libopenage/util/filelike/native.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,7 +19,7 @@ namespace filelike {
  */
 class Native : public FileLike {
 public:
-	Native(const std::string &path, mode_t mode=mode_t::R);
+	Native(const std::string &path, mode_t mode = mode_t::R);
 	virtual ~Native();
 
 	std::string read(ssize_t max) override;
@@ -31,7 +31,7 @@ public:
 
 	bool writable() override;
 
-	void seek(ssize_t offset, seek_t how=seek_t::SET) override;
+	void seek(ssize_t offset, seek_t how = seek_t::SET) override;
 	bool seekable() override;
 	size_t tell() override;
 	void close() override;
@@ -48,4 +48,6 @@ protected:
 	std::fstream file;
 };
 
-}}} // openage::util::filelike
+} // namespace filelike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/filelike/python.h
+++ b/libopenage/util/filelike/python.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -41,7 +41,7 @@ public:
 
 	bool writable() override;
 
-	void seek(ssize_t offset, seek_t how=seek_t::SET) override;
+	void seek(ssize_t offset, seek_t how = seek_t::SET) override;
 	bool seekable() override;
 	size_t tell() override;
 	void close() override;
@@ -95,4 +95,6 @@ extern OAAPI pyinterface::PyIfFunc<void, PyObject *> pyx_file_flush;
 extern OAAPI pyinterface::PyIfFunc<ssize_t, PyObject *> pyx_file_size;
 
 
-}}} // openage::util::filelike
+} // namespace filelike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fixed_point.h
+++ b/libopenage/util/fixed_point.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -261,13 +261,13 @@ public:
 	/**
 	 * Factory function to get a fixed-point number from a fixed-point number of different type.
 	 */
-	template <typename other_int_type, unsigned int other_fractional_bits, typename std::enable_if<(fractional_bits > other_fractional_bits)>::type* = nullptr>
+	template <typename other_int_type, unsigned int other_fractional_bits, typename std::enable_if<(fractional_bits > other_fractional_bits)>::type * = nullptr>
 	static constexpr FixedPoint from_fixedpoint(const FixedPoint<other_int_type, other_fractional_bits> &other) {
 		return FixedPoint::from_raw_value(
 			safe_shift<fractional_bits - other_fractional_bits, int_type>(static_cast<int_type>(other.get_raw_value())));
 	}
 
-	template <typename other_int_type, unsigned int other_fractional_bits, typename std::enable_if<(fractional_bits <= other_fractional_bits)>::type* = nullptr>
+	template <typename other_int_type, unsigned int other_fractional_bits, typename std::enable_if<(fractional_bits <= other_fractional_bits)>::type * = nullptr>
 	static constexpr FixedPoint from_fixedpoint(const FixedPoint<other_int_type, other_fractional_bits> &other) {
 		return FixedPoint::from_raw_value(
 			static_cast<int_type>(other.get_raw_value() / safe_shiftleft<other_fractional_bits - fractional_bits, other_int_type>(1)));

--- a/libopenage/util/fps.h
+++ b/libopenage/util/fps.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -34,4 +34,5 @@ private:
 	Timer frame_timer;
 };
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fslike/directory.h
+++ b/libopenage/util/fslike/directory.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,7 +23,7 @@ namespace fslike {
  */
 class Directory : public FSLike {
 public:
-	Directory(std::string basepath, bool create_if_missing=false);
+	Directory(std::string basepath, bool create_if_missing = false);
 
 	bool is_file(const Path::parts_t &parts) override;
 	bool is_dir(const Path::parts_t &parts) override;
@@ -60,4 +60,6 @@ protected:
 	std::string basepath;
 };
 
-}}} // openage::util::fslike
+} // namespace fslike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fslike/fslike.h
+++ b/libopenage/util/fslike/fslike.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -104,4 +104,6 @@ public:
 	virtual std::ostream &repr(std::ostream &) = 0;
 };
 
-}}} // openage::util::fslike
+} // namespace fslike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fslike/native.h
+++ b/libopenage/util/fslike/native.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -13,4 +13,6 @@ namespace fslike {
 constexpr char PATHSEP = '/';
 
 
-}}} // openage::util::fslike
+} // namespace fslike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fslike/python.h
+++ b/libopenage/util/fslike/python.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -76,65 +76,67 @@ protected:
 
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_is_file
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_is_file;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_is_file;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_is_dir
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_is_dir;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_is_dir;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_writable
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_writable;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_writable;
 
 // pxd: PyIfFunc2[vector[string], PyObjectPtr, const vector[string]] pyx_fs_list
-extern OAAPI pyinterface::PyIfFunc<std::vector<std::string>, PyObject *, const std::vector<std::string>&> pyx_fs_list;
+extern OAAPI pyinterface::PyIfFunc<std::vector<std::string>, PyObject *, const std::vector<std::string> &> pyx_fs_list;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_mkdirs
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_mkdirs;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_mkdirs;
 
 // pxd: PyIfFunc2[File, PyObjectPtr, const vector[string]] pyx_fs_open_r
-extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string>&> pyx_fs_open_r;
+extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string> &> pyx_fs_open_r;
 
 // pxd: PyIfFunc2[File, PyObjectPtr, const vector[string]] pyx_fs_open_w
-extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string>&> pyx_fs_open_w;
+extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string> &> pyx_fs_open_w;
 
 // pxd: PyIfFunc2[File, PyObjectPtr, const vector[string]] pyx_fs_open_rw
-extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string>&> pyx_fs_open_rw;
+extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string> &> pyx_fs_open_rw;
 
 // pxd: PyIfFunc2[File, PyObjectPtr, const vector[string]] pyx_fs_open_a
-extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string>&> pyx_fs_open_a;
+extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string> &> pyx_fs_open_a;
 
 // pxd: PyIfFunc2[File, PyObjectPtr, const vector[string]] pyx_fs_open_ar
-extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string>&> pyx_fs_open_ar;
+extern OAAPI pyinterface::PyIfFunc<File, PyObject *, const std::vector<std::string> &> pyx_fs_open_ar;
 
 // pxd: PyIfFunc2[Path, PyObjectPtr, const vector[string]] pyx_fs_resolve_r
-extern OAAPI pyinterface::PyIfFunc<Path, PyObject *, const std::vector<std::string>&> pyx_fs_resolve_r;
+extern OAAPI pyinterface::PyIfFunc<Path, PyObject *, const std::vector<std::string> &> pyx_fs_resolve_r;
 
 // pxd: PyIfFunc2[Path, PyObjectPtr, const vector[string]] pyx_fs_resolve_w
-extern OAAPI pyinterface::PyIfFunc<Path, PyObject *, const std::vector<std::string>&> pyx_fs_resolve_w;
+extern OAAPI pyinterface::PyIfFunc<Path, PyObject *, const std::vector<std::string> &> pyx_fs_resolve_w;
 
 // pxd: PyIfFunc2[PyObjectRef, PyObjectPtr, const vector[string]] pyx_fs_get_native_path
-extern OAAPI pyinterface::PyIfFunc<py::Obj, PyObject *, const std::vector<std::string>&> pyx_fs_get_native_path;
+extern OAAPI pyinterface::PyIfFunc<py::Obj, PyObject *, const std::vector<std::string> &> pyx_fs_get_native_path;
 
 // pxd: PyIfFunc3[bool, PyObjectPtr, const vector[string], const vector[string]] pyx_fs_rename
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&, const std::vector<std::string>&> pyx_fs_rename;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &, const std::vector<std::string> &> pyx_fs_rename;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_rmdir
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_rmdir;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_rmdir;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_touch
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_touch;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_touch;
 
 // pxd: PyIfFunc2[bool, PyObjectPtr, const vector[string]] pyx_fs_unlink
-extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string>&> pyx_fs_unlink;
+extern OAAPI pyinterface::PyIfFunc<bool, PyObject *, const std::vector<std::string> &> pyx_fs_unlink;
 
 // pxd: PyIfFunc2[int, PyObjectPtr, const vector[string]] pyx_fs_get_mtime
-extern OAAPI pyinterface::PyIfFunc<int, PyObject *, const std::vector<std::string>&> pyx_fs_get_mtime;
+extern OAAPI pyinterface::PyIfFunc<int, PyObject *, const std::vector<std::string> &> pyx_fs_get_mtime;
 
 // pxd: PyIfFunc2[uint64_t, PyObjectPtr, const vector[string]] pyx_fs_get_filesize
-extern OAAPI pyinterface::PyIfFunc<uint64_t, PyObject *, const std::vector<std::string>&> pyx_fs_get_filesize;
+extern OAAPI pyinterface::PyIfFunc<uint64_t, PyObject *, const std::vector<std::string> &> pyx_fs_get_filesize;
 
 
 // pxd: PyIfFunc1[bool, PyObjectPtr] pyx_fs_is_fslike_directory
 extern OAAPI pyinterface::PyIfFunc<bool, PyObject *> pyx_fs_is_fslike_directory;
 
 
-}}} // openage::util::fslike
+} // namespace fslike
+} // namespace util
+} // namespace openage

--- a/libopenage/util/hash.h
+++ b/libopenage/util/hash.h
@@ -1,10 +1,10 @@
-// Copyright 2015-2021 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstdlib>
-#include <array>
 #include <typeindex>
 #include <typeinfo>
 
@@ -17,7 +17,7 @@ namespace util {
 
 template <typename T>
 size_t type_hash() {
-    return std::hash<std::type_index>()(std::type_index(typeid(T)));
+	return std::hash<std::type_index>()(std::type_index(typeid(T)));
 }
 
 /**
@@ -27,7 +27,6 @@ size_t type_hash() {
  * hash1 and hash2 during a single run of a program.
  */
 size_t hash_combine(size_t hash1, size_t hash2);
-
 
 
 /** \class Siphash
@@ -49,7 +48,7 @@ public:
 	 * @param k Key to use with this hasher.
 	 * @return Reference to itself, for method chaining.
 	 */
-	Siphash& set_key(std::array<uint8_t, 16> key);
+	Siphash &set_key(std::array<uint8_t, 16> key);
 
 
 	/**
@@ -81,4 +80,5 @@ private:
 };
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/init.h
+++ b/libopenage/util/init.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -23,7 +23,7 @@ namespace util {
  */
 class OnInit {
 public:
-	explicit OnInit(std::function<void ()> code) {
+	explicit OnInit(std::function<void()> code) {
 		code();
 	}
 
@@ -34,8 +34,8 @@ private:
 	OnInit(const OnInit &) = delete;
 	OnInit(OnInit &&) = delete;
 
-	OnInit &operator =(const OnInit &) = delete;
-	OnInit &operator =(OnInit &&) = delete;
+	OnInit &operator=(const OnInit &) = delete;
+	OnInit &operator=(OnInit &&) = delete;
 };
 
 
@@ -47,8 +47,7 @@ private:
  */
 class OnDeInit {
 public:
-	explicit OnDeInit(std::function<void ()> code)
-		:
+	explicit OnDeInit(std::function<void()> code) :
 		code{code} {}
 
 
@@ -57,15 +56,16 @@ public:
 	}
 
 private:
-	std::function<void ()> code;
+	std::function<void()> code;
 
 	// nope.
 	OnDeInit(const OnDeInit &) = delete;
 	OnDeInit(OnDeInit &&) = delete;
 
-	OnDeInit &operator =(const OnDeInit &) = delete;
-	OnDeInit &operator =(OnDeInit &&) = delete;
+	OnDeInit &operator=(const OnDeInit &) = delete;
+	OnDeInit &operator=(OnDeInit &&) = delete;
 };
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/language.h
+++ b/libopenage/util/language.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -16,16 +16,16 @@ namespace util {
  * Simple wrapper type that contains a function pointer.
  * Needed as workaround for http://stackoverflow.com/questions/31040075
  */
-template<typename ReturnType, typename ... ArgTypes>
+template <typename ReturnType, typename... ArgTypes>
 class FunctionPtr {
 public:
 	/**
 	 * Implicit conversion from raw type.
 	 */
-	FunctionPtr(ReturnType (*ptr)(ArgTypes ...)) :
+	FunctionPtr(ReturnType (*ptr)(ArgTypes...)) :
 		ptr{ptr} {}
 
-	ReturnType (*ptr)(ArgTypes ...);
+	ReturnType (*ptr)(ArgTypes...);
 };
 
 
@@ -34,8 +34,9 @@ public:
  * readers, compilers and linters that you are, in fact, ignoring the
  * function's return value on purpose.
  */
-template<typename T>
+template <typename T>
 inline void ignore_result(T /* unused result */) {}
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/macro/concat.h
+++ b/libopenage/util/macro/concat.h
@@ -1,23 +1,24 @@
-// Copyright 2013-2017 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#define CONCAT_1(OP, X)       (X)
-#define CONCAT_2(OP, X, Y)    (X) OP (Y)
-#define CONCAT_3(OP, X, Y, Z) (X) OP (Y) OP (Z)
+#define CONCAT_1(OP, X) (X)
+#define CONCAT_2(OP, X, Y) (X) OP(Y)
+#define CONCAT_3(OP, X, Y, Z) (X) OP(Y) OP(Z)
 
 #define CONCAT_N(_1, _2, _3, NAME, ...) NAME
 
 #ifdef _MSC_VER
 #define CONCAT_COUNT_ARGS_IMPL(args) CONCAT_N args
-#define CONCAT_COUNT_ARGS(...)       CONCAT_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
+#define CONCAT_COUNT_ARGS(...) CONCAT_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
 #define CONCAT_HELPER2(count) CONCAT_##count
 #define CONCAT_HELPER1(count) CONCAT_HELPER2(count)
-#define CONCAT_HELPER(count)  CONCAT_HELPER1(count)
+#define CONCAT_HELPER(count) CONCAT_HELPER1(count)
 #define CONCAT_GLUE(x, y) x y
 #define CONCAT(OP, ...) CONCAT_GLUE(CONCAT_HELPER(CONCAT_COUNT_ARGS(__VA_ARGS__)), (OP, __VA_ARGS__))
 #else
 #define CONCAT(OP, ...) CONCAT_N(__VA_ARGS__, \
-	CONCAT_3, CONCAT_2, CONCAT_1 \
-	) (OP, __VA_ARGS__)
+	                             CONCAT_3, \
+	                             CONCAT_2, \
+	                             CONCAT_1)(OP, __VA_ARGS__)
 #endif

--- a/libopenage/util/macro/loop.h
+++ b/libopenage/util/macro/loop.h
@@ -1,23 +1,24 @@
-// Copyright 2013-2017 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#define LOOP_1(MACRO, X)       MACRO(X)
-#define LOOP_2(MACRO, X, Y)    MACRO(X), MACRO(Y)
+#define LOOP_1(MACRO, X) MACRO(X)
+#define LOOP_2(MACRO, X, Y) MACRO(X), MACRO(Y)
 #define LOOP_3(MACRO, X, Y, Z) MACRO(X), MACRO(Y), MACRO(Z)
 
 #define LOOP_N(_1, _2, _3, NAME, ...) NAME
 
 #ifdef _MSC_VER
 #define LOOP_COUNT_ARGS_IMPL(args) LOOP_N args
-#define LOOP_COUNT_ARGS(...)       LOOP_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
+#define LOOP_COUNT_ARGS(...) LOOP_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
 #define LOOP_HELPER2(count) LOOP_##count
 #define LOOP_HELPER1(count) LOOP_HELPER2(count)
-#define LOOP_HELPER(count)  LOOP_HELPER1(count)
+#define LOOP_HELPER(count) LOOP_HELPER1(count)
 #define LOOP_GLUE(x, y) x y
 #define LOOP(MACRO, ...) LOOP_GLUE(LOOP_HELPER(LOOP_COUNT_ARGS(__VA_ARGS__)), (MACRO, __VA_ARGS__))
 #else
 #define LOOP(MACRO, ...) LOOP_N(__VA_ARGS__, \
-	LOOP_3, LOOP_2, LOOP_1 \
-	) (MACRO, __VA_ARGS__)
+	                            LOOP_3, \
+	                            LOOP_2, \
+	                            LOOP_1)(MACRO, __VA_ARGS__)
 #endif

--- a/libopenage/util/math.h
+++ b/libopenage/util/math.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -7,15 +7,16 @@
 namespace openage {
 namespace math {
 
-template<typename T>
+template <typename T>
 T square(T arg) {
 	return arg * arg;
 }
 
 
-template<typename T>
+template <typename T>
 T hypot3(T x, T y, T z) {
 	return sqrt(x * x + y * y + z * z);
 }
 
-}} // openage::util
+} // namespace math
+} // namespace openage

--- a/libopenage/util/math_constants.h
+++ b/libopenage/util/math_constants.h
@@ -1,14 +1,16 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
-#include <numbers>
 #include <limits>
+#include <numbers>
 
 namespace openage {
 namespace math {
 
 // TODO: use std::numbers instead of these where appropriate
+// clang-format off
+// keep equal signs aligned for readability
 constexpr double E            = std::numbers::e;  //!< e
 constexpr double LOG2E        = std::numbers::log2e;  //!< log_2 e
 constexpr double LOG10E       = std::numbers::log10e; //!< log_10 e
@@ -25,9 +27,11 @@ constexpr double DEGSPERRAD   = 0.017453292519943295769; //!< tau/360
 constexpr double RADSPERDEG   = 57.29577951308232087679; //!< 360/tau
 constexpr double SQRT_2       = std::numbers::sqrt2;  //!< sqrt(2)
 constexpr double INV_SQRT_2   = 0.707106781186547524401; //!< 1/sqrt(2)
+// clang-format on
 
 constexpr unsigned int UINT_INF = std::numeric_limits<unsigned int>::max();
 constexpr int INT_INF = std::numeric_limits<int>::max();
 constexpr double DOUBLE_INF = std::numeric_limits<double>::max();
 
-}} // openage::math
+} // namespace math
+} // namespace openage

--- a/libopenage/util/misc.h
+++ b/libopenage/util/misc.h
@@ -1,14 +1,14 @@
-// Copyright 2013-2023 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <algorithm>
-#include <limits.h>
 #include <cmath>
 #include <cstring>
+#include <limits.h>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "../error/error.h"
 #include "compiler.h"
@@ -28,13 +28,13 @@ extern std::string empty_string;
  * modulo operation that guarantees to return positive values.
  */
 template <typename T>
-constexpr
-T mod(T x, T m) {
+constexpr T mod(T x, T m) {
 	T r = x % m;
 
 	if (r < 0) {
 		return r + m;
-	} else {
+	}
+	else {
 		return r;
 	}
 }
@@ -43,13 +43,13 @@ T mod(T x, T m) {
  * compiletime defined modulo function.
  */
 template <typename T, unsigned int modulo>
-constexpr
-T mod(T x) {
+constexpr T mod(T x) {
 	T r = x % modulo;
 
 	if (r < 0) {
 		return r + modulo;
-	} else {
+	}
+	else {
 		return r;
 	}
 }
@@ -59,10 +59,9 @@ T mod(T x) {
  * compiletime defined rotate left function
  */
 template <typename T, int amount>
-constexpr
-T rol(T x) {
-	static_assert(sizeof(T)*CHAR_BIT > amount && amount > 0, "invalid rotation amount");
-	return (x << amount) | (x >> (sizeof(T)*CHAR_BIT - amount));
+constexpr T rol(T x) {
+	static_assert(sizeof(T) * CHAR_BIT > amount && amount > 0, "invalid rotation amount");
+	return (x << amount) | (x >> (sizeof(T) * CHAR_BIT - amount));
 }
 
 
@@ -71,8 +70,7 @@ T rol(T x) {
  * which always rounds to -inf
  */
 template <typename T>
-constexpr
-inline T div(T x, T m) {
+constexpr inline T div(T x, T m) {
 	return (x - mod<T>(x, m)) / m;
 }
 
@@ -84,7 +82,7 @@ inline T div(T x, T m) {
  */
 template <typename T>
 struct less {
-	bool operator ()(const T x, const T y) const {
+	bool operator()(const T x, const T y) const {
 		return *x < *y;
 	}
 };
@@ -108,7 +106,7 @@ static constexpr size_t uint64_s = 8;
  * @return Input data as a 64 bit number.
  */
 inline uint64_t
-array8_to_uint64(const uint8_t *start, size_t count, bool big_endian=false) {
+array8_to_uint64(const uint8_t *start, size_t count, bool big_endian = false) {
 	if (count > uint64_s) {
 		throw Error(MSG(err) << "Tried to copy more than " << uint64_s << " bytes");
 	}
@@ -142,7 +140,7 @@ array8_to_uint64(const uint8_t *start, size_t count, bool big_endian=false) {
  * @return Input data as a 8 bit number array.
  */
 inline std::vector<uint8_t>
-uint64_to_array8(const uint64_t value, bool big_endian=false) {
+uint64_to_array8(const uint64_t value, bool big_endian = false) {
 	std::vector<uint8_t> result(uint64_s, 0);
 
 	if (big_endian) {
@@ -187,7 +185,7 @@ inline constexpr size_t array64_size(size_t count) {
  * @return Input data as a 64 bit number vector.
  */
 inline std::vector<uint64_t>
-array8_to_array64(const uint8_t *start, size_t count, bool big_endian=false) {
+array8_to_array64(const uint8_t *start, size_t count, bool big_endian = false) {
 	size_t size{array64_size(count)};
 	std::vector<uint64_t> result(size, 0);
 
@@ -197,8 +195,7 @@ array8_to_array64(const uint8_t *start, size_t count, bool big_endian=false) {
 		result[i] = array8_to_uint64(
 			start + (i * uint64_s),
 			std::min(rem_bytes, uint64_s),
-			big_endian
-		);
+			big_endian);
 	}
 	return result;
 }
@@ -219,7 +216,7 @@ array8_to_array64(const uint8_t *start, size_t count, bool big_endian=false) {
  * @return Input data as a 8 bit number vector.
  */
 inline std::vector<uint8_t>
-array64_to_array8(const uint64_t *start, size_t count, bool big_endian=false) {
+array64_to_array8(const uint64_t *start, size_t count, bool big_endian = false) {
 	std::vector<uint8_t> result;
 	result.reserve(count * uint64_s);
 
@@ -274,7 +271,8 @@ void vector_remove_swap_end(std::vector<T> &vec, size_t idx) {
 	else if (idx < vec.size()) {
 		std::swap(vec[idx], vec.back());
 		vec.pop_back();
-	} else {
+	}
+	else {
 		return;
 	}
 }
@@ -287,9 +285,8 @@ void vector_remove_swap_end(std::vector<T> &vec, size_t idx) {
  */
 template <typename T>
 struct SharedPtrLess {
-	bool operator ()(const std::shared_ptr<T> &left,
-	                 const std::shared_ptr<T> &right) {
-
+	bool operator()(const std::shared_ptr<T> &left,
+	                const std::shared_ptr<T> &right) {
 		if (not left or not right) [[unlikely]] {
 			return false;
 		}

--- a/libopenage/util/os.h
+++ b/libopenage/util/os.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,7 +24,7 @@ std::string self_exec_filename();
 /**
  * tries to xdg-open the file
  */
-int execute_file(const char *path, bool background=true);
+int execute_file(const char *path, bool background = true);
 
 } // namespace os
 } // namespace openage

--- a/libopenage/util/pty.h
+++ b/libopenage/util/pty.h
@@ -1,16 +1,16 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #ifdef __APPLE__
-#  include <util.h>
+#include <util.h>
 #elif defined(__FreeBSD__)
-#  include <sys/types.h>
-#  include <sys/ioctl.h>
-#  include <termios.h>
-#  include <libutil.h>
+#include <libutil.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <termios.h>
 #elif _WIN32
 // TODO not yet implemented
 #else
-#  include <pty.h>
+#include <pty.h>
 #endif

--- a/libopenage/util/quaternion.h
+++ b/libopenage/util/quaternion.h
@@ -1,11 +1,11 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <cmath>
 
-#include "matrix.h"
 #include "math_constants.h"
+#include "matrix.h"
 #include "vector.h"
 
 #include "../error/error.h"
@@ -35,15 +35,13 @@ public:
 
 	static constexpr T default_eps = 1e-4;
 
-	Quaternion(T w, T x, T y, T z)
-		:
+	Quaternion(T w, T x, T y, T z) :
 		w{w}, x{x}, y{y}, z{z} {}
 
 	/**
 	 * Create a identity quaternion.
 	 */
-	Quaternion()
-		:
+	Quaternion() :
 		w{1}, x{0}, y{0}, z{0} {}
 
 	/**
@@ -62,9 +60,8 @@ public:
 	 * max diagonal entry <=> max (|x|, |y|, |z|)
 	 * which is larger than |w| and >= 1/2
 	 */
-	template <size_t N=4>
+	template <size_t N = 4>
 	Quaternion(const Matrix<N, N, T> &mat) {
-
 		static_assert(N == 3 or N == 4, "only 3 and 4 dimensional matrices can be converted to a quaternion!");
 
 		T trace = mat.trace();
@@ -72,7 +69,8 @@ public:
 
 		if (N == 4) {
 			trace_cmp -= mat[3][3];
-		} else {
+		}
+		else {
 			trace += 1.0;
 		}
 
@@ -111,14 +109,15 @@ public:
 
 			if (N == 4) {
 				trace_ordered += mat[3][3];
-			} else {
+			}
+			else {
 				trace_ordered += 1.0;
 			}
 
 			T trace_root = std::sqrt(trace_ordered);
 
-			*ptrs[n0] = trace_root * 0.5;   // = w
-			trace_root = 0.5 / trace_root;  // = 1/4w
+			*ptrs[n0] = trace_root * 0.5;  // = w
+			trace_root = 0.5 / trace_root; // = 1/4w
 
 			*ptrs[n1] = (mat[n0][n1] + mat[n1][n0]) * trace_root;
 			*ptrs[n2] = (mat[n2][n0] + mat[n0][n2]) * trace_root;
@@ -134,8 +133,8 @@ public:
 
 	Quaternion(const this_type &other) = default;
 	Quaternion(this_type &&other) = default;
-	Quaternion &operator =(const this_type &other) = default;
-	Quaternion &operator =(this_type &&other) = default;
+	Quaternion &operator=(const this_type &other) = default;
+	Quaternion &operator=(this_type &&other) = default;
 
 	virtual ~Quaternion() = default;
 
@@ -148,8 +147,7 @@ public:
 			std::cos(rot),
 			axis[0] * std::sin(rot),
 			axis[1] * std::sin(rot),
-			axis[2] * std::sin(rot)
-		};
+			axis[2] * std::sin(rot)};
 		return q;
 	}
 
@@ -240,15 +238,15 @@ public:
 	/**
 	 * Test if the rotation of both quaternions is the same.
 	 */
-	bool equals(const this_type &other, T eps=default_eps) const {
+	bool equals(const this_type &other, T eps = default_eps) const {
 		T ori = this->dot(other);
-		return (1 - (ori*ori)) < eps;
+		return (1 - (ori * ori)) < eps;
 	}
 
 	/**
 	 * Test if both quaternion store the same numbers.
 	 */
-	bool equals_number(const this_type &other, T eps=default_eps) const {
+	bool equals_number(const this_type &other, T eps = default_eps) const {
 		bool result = true;
 		(this->w - other.w) < eps or (result = false);
 		(this->x - other.x) < eps or (result = false);
@@ -261,7 +259,7 @@ public:
 	 * Test rotation equality with another quaternion
 	 * with given precision in radians.
 	 */
-	bool equals_rad(const this_type &other, T rad_eps=default_eps) const {
+	bool equals_rad(const this_type &other, T rad_eps = default_eps) const {
 		T ori = this->dot(other);
 		T angle = std::acos((2.0 * (ori * ori)) - 1.0);
 
@@ -272,7 +270,7 @@ public:
 	 * Test rotation equality with another quaternion
 	 * with given precision in degree.
 	 */
-	bool equals_deg(const this_type &other, T deg_eps=default_eps) const {
+	bool equals_deg(const this_type &other, T deg_eps = default_eps) const {
 		return this->equals_rad(other, deg_eps * math::RADSPERDEG);
 	}
 
@@ -280,27 +278,29 @@ public:
 	 * Generate the corresponding rotation matrix.
 	 */
 	Matrix3t<T> to_matrix() const {
-		T x2  = this->x * 2;
-		T y2  = this->y * 2;
-		T z2  = this->z * 2;
+		T x2 = this->x * 2;
+		T y2 = this->y * 2;
+		T z2 = this->z * 2;
 
 		T x2w = x2 * this->w;
 		T y2w = y2 * this->w;
 		T z2w = z2 * this->w;
 
-		T x3  = x2 * this->x;
+		T x3 = x2 * this->x;
 		T y2x = y2 * this->x;
 		T z2x = z2 * this->x;
 
-		T y3  = y2 * this->y;
+		T y3 = y2 * this->y;
 		T z2y = z2 * this->y;
-		T z3  = z2 * this->z;
+		T z3 = z2 * this->z;
 
+		// clang-format off
 		Matrix3t<T> m{
 			1.0 - (y3 + z3), y2x - z2w, z2x + y2w,
 			y2x + z2w, 1.0 - (x3 + z3), z2y - x2w,
 			z2x - y2w, z2y + x2w, 1.0 - (x3 + y3)
 		};
+		// clang-format on
 
 		return m;
 	}
@@ -308,7 +308,7 @@ public:
 	/**
 	 * Transforms a vector by this quaternion.
 	 */
-	Vector3t<T> operator *(const Vector3t<T> &vec) const {
+	Vector3t<T> operator*(const Vector3t<T> &vec) const {
 		Vector3t<T> axis{this->x, this->y, this->z};
 
 		Vector3t<T> axis_vec_normal = axis.cross_product(vec);
@@ -320,7 +320,7 @@ public:
 		return vec + axis_vec_normal + axis_vec_inplane;
 	}
 
-	const this_type &operator +=(const this_type &other) {
+	const this_type &operator+=(const this_type &other) {
 		this->w += other.w;
 		this->x += other.x;
 		this->y += other.y;
@@ -329,13 +329,13 @@ public:
 		return *this;
 	}
 
-	this_type operator +(const this_type &other) const {
+	this_type operator+(const this_type &other) const {
 		this_type q{*this};
 		q += other;
 		return q;
 	}
 
-	const this_type &operator -=(const this_type &other) {
+	const this_type &operator-=(const this_type &other) {
 		this->w -= other.w;
 		this->x -= other.x;
 		this->y -= other.y;
@@ -344,13 +344,13 @@ public:
 		return *this;
 	}
 
-	this_type operator -(const this_type &other) const {
+	this_type operator-(const this_type &other) const {
 		this_type q{*this};
 		q -= other;
 		return q;
 	}
 
-	const this_type &operator *=(const T &fac) {
+	const this_type &operator*=(const T &fac) {
 		this->w *= fac;
 		this->x *= fac;
 		this->y *= fac;
@@ -359,21 +359,21 @@ public:
 		return *this;
 	}
 
-	this_type operator *(const T &fac) const {
+	this_type operator*(const T &fac) const {
 		this_type q{*this};
 		q *= fac;
 		return q;
 	}
 
-	const this_type &operator *=(const this_type &other) {
-		T w_new = (this->w * other.w - this->x * other.x -
-		           this->y * other.y - this->z * other.z);
-		T x_new = (this->w * other.x + this->x * other.w +
-		           this->y * other.z - this->z * other.y);
-		T y_new = (this->w * other.y - this->x * other.z +
-		           this->y * other.w + this->z * other.x);
-		T z_new = (this->w * other.z + this->x * other.y -
-		           this->y * other.x + this->z * other.w);
+	const this_type &operator*=(const this_type &other) {
+		T w_new = (this->w * other.w - this->x * other.x
+		           - this->y * other.y - this->z * other.z);
+		T x_new = (this->w * other.x + this->x * other.w
+		           + this->y * other.z - this->z * other.y);
+		T y_new = (this->w * other.y - this->x * other.z
+		           + this->y * other.w + this->z * other.x);
+		T z_new = (this->w * other.z + this->x * other.y
+		           - this->y * other.x + this->z * other.w);
 
 		this->w = w_new;
 		this->x = x_new;
@@ -383,13 +383,13 @@ public:
 		return *this;
 	}
 
-	this_type operator *(const this_type &other) const {
+	this_type operator*(const this_type &other) const {
 		this_type q{*this};
 		q *= other;
 		return q;
 	}
 
-	const this_type &operator /=(const T &fac) {
+	const this_type &operator/=(const T &fac) {
 		this->w /= fac;
 		this->x /= fac;
 		this->y /= fac;
@@ -398,28 +398,25 @@ public:
 		return *this;
 	}
 
-	this_type operator /(const T &fac) const {
+	this_type operator/(const T &fac) const {
 		this_type q{*this};
 		q /= fac;
 		return q;
 	}
 
-	const this_type operator -() const {
+	const this_type operator-() const {
 		return this_type{-this->w, -this->x, -this->y, -this->z};
 	}
 
-	bool operator ==(const this_type &other) const {
-		return ((this->w == other.w) and
-		        (this->x == other.x) and
-		        (this->y == other.y) and
-		        (this->z == other.z));
+	bool operator==(const this_type &other) const {
+		return ((this->w == other.w) and (this->x == other.x) and (this->y == other.y) and (this->z == other.z));
 	}
 
-	bool operator !=(const this_type &other) const {
-		return not (*this == other);
+	bool operator!=(const this_type &other) const {
+		return not(*this == other);
 	}
 
-	friend std::ostream &operator <<(std::ostream &o, const this_type &q) {
+	friend std::ostream &operator<<(std::ostream &o, const this_type &q) {
 		o << "Quaternion(" << q.w << ", " << q.x;
 		o << ", " << q.y << ", " << q.z << ")";
 		return o;
@@ -435,4 +432,5 @@ protected:
 using Quaternionf = Quaternion<float>;
 using Quaterniond = Quaternion<double>;
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/signal.h
+++ b/libopenage/util/signal.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,8 +6,8 @@
 
 // TODO: change these to ifndef __linux ?
 #ifdef __APPLE__
-	typedef void (*sighandler_t)(int);
+typedef void (*sighandler_t)(int);
 #endif
 #ifdef _WIN32
-	typedef void (*sighandler_t)(int);
+typedef void (*sighandler_t)(int);
 #endif

--- a/libopenage/util/stringformatter.h
+++ b/libopenage/util/stringformatter.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -88,15 +88,14 @@ private:
  * As an optimization, instead of creating a new ExternalOStringStream object,
  * CachableOSStream.acquire() is used internally.
  */
-template<typename ChildType>
+template <typename ChildType>
 class StringFormatter {
 public:
 	/**
 	 * @param buffer
 	 *     All input data is appended to this object.
 	 */
-	StringFormatter(std::string &output)
-		:
+	StringFormatter(std::string &output) :
 		output{&output},
 		stream_ptr{nullptr} {}
 
@@ -115,11 +114,10 @@ public:
 		:
 		output{other.output},
 		stream_ptr{other.stream_ptr} {
-
 		other.stream_ptr = nullptr;
 	}
 
-	StringFormatter<ChildType> &operator =(StringFormatter<ChildType> &&other) noexcept {
+	StringFormatter<ChildType> &operator=(StringFormatter<ChildType> &&other) noexcept {
 		this->output = other.output;
 
 		this->stream_ptr = other.stream_ptr;
@@ -129,11 +127,11 @@ public:
 
 	// no copy construction!
 	StringFormatter(const StringFormatter &) = delete;
-	StringFormatter &operator =(const StringFormatter &) = delete;
+	StringFormatter &operator=(const StringFormatter &) = delete;
 
 	// These methods allow usage like an ostream object.
-	template<typename T>
-	ChildType &operator <<(const T &t) {
+	template <typename T>
+	ChildType &operator<<(const T &t) {
 		if (this->should_format()) {
 			this->ensure_stream_obj();
 			this->stream_ptr->stream << t;
@@ -142,7 +140,7 @@ public:
 	}
 
 
-	ChildType &operator <<(std::ios &(*x)(std::ios &)) {
+	ChildType &operator<<(std::ios &(*x)(std::ios &)) {
 		if (this->should_format()) {
 			this->ensure_stream_obj();
 			this->stream_ptr->stream << x;
@@ -151,7 +149,7 @@ public:
 	}
 
 
-	ChildType &operator <<(std::ostream &(*x)(std::ostream &)) {
+	ChildType &operator<<(std::ostream &(*x)(std::ostream &)) {
 		if (this->should_format()) {
 			this->ensure_stream_obj();
 			this->stream_ptr->stream << x;
@@ -162,7 +160,7 @@ public:
 
 	// Optimizations to prevent needless stream-acquiring if just a simple
 	// string is printed.
-	ChildType &operator <<(const char *s) {
+	ChildType &operator<<(const char *s) {
 		if (this->should_format()) {
 			this->output->append(s);
 		}
@@ -170,7 +168,7 @@ public:
 	}
 
 
-	ChildType &operator <<(const std::string &s) {
+	ChildType &operator<<(const std::string &s) {
 		if (this->should_format()) {
 			this->output->append(s);
 		}
@@ -192,8 +190,8 @@ public:
 
 
 	// Allow direct inputting of stuff that's wrapped in the C++11 pointer types.
-	template<typename T>
-	ChildType &operator <<(const std::unique_ptr<T> &ptr) {
+	template <typename T>
+	ChildType &operator<<(const std::unique_ptr<T> &ptr) {
 		if (this->should_format()) {
 			*this << ptr.get();
 		}
@@ -201,8 +199,8 @@ public:
 	}
 
 
-	template<typename T>
-	ChildType &operator <<(const std::shared_ptr<T> &ptr) {
+	template <typename T>
+	ChildType &operator<<(const std::shared_ptr<T> &ptr) {
 		if (this->should_format()) {
 			*this << ptr.get();
 		}
@@ -221,8 +219,8 @@ public:
 	}
 
 	/**
-	* Returns if formatting should actually occur.
-	*/
+	 * Returns if formatting should actually occur.
+	 */
 	virtual bool should_format() const {
 		return true;
 	}
@@ -269,14 +267,12 @@ class Formatter : public StringFormatter<Formatter> {};
  */
 class FString : public StringFormatter<FString> {
 public:
-	FString()
-		:
+	FString() :
 		StringFormatter<FString>{this->buffer} {}
 
 	// allow assignment and construction from std::string.
 
-	FString(const std::string &other)
-		:
+	FString(const std::string &other) :
 		StringFormatter<FString>{this->buffer},
 		buffer{other} {}
 
@@ -285,12 +281,12 @@ public:
 		StringFormatter<FString>{this->buffer},
 		buffer{std::move(other)} {}
 
-	FString &operator =(const std::string &other) {
+	FString &operator=(const std::string &other) {
 		this->buffer = other;
 		return *this;
 	}
 
-	FString &operator =(std::string &&other) noexcept {
+	FString &operator=(std::string &&other) noexcept {
 		this->buffer = std::move(other);
 		return *this;
 	}
@@ -305,7 +301,7 @@ public:
 		return this->buffer;
 	}
 
-	operator std::string () && {
+	operator std::string() && {
 		return std::move(this->buffer);
 	}
 
@@ -319,4 +315,5 @@ public:
 };
 
 
-}} // namespace openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/strings.h
+++ b/libopenage/util/strings.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2018 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -11,7 +11,7 @@
 #include <vector>
 
 #if defined(__GNUC__)
-#define ATTRIBUTE_FORMAT(i, j) __attribute__ ((format (printf, i, j)))
+#define ATTRIBUTE_FORMAT(i, j) __attribute__((format(printf, i, j)))
 #else
 #define ATTRIBUTE_FORMAT(i, j)
 #endif
@@ -24,14 +24,14 @@ namespace util {
  * Quick-formatter for floats when working with string streams.
  * Usage: cout << FormatFloat{1.0, 10};
  */
-template<unsigned decimals, unsigned w=0>
+template <unsigned decimals, unsigned w = 0>
 struct FloatFixed {
 	float value;
 };
 
 
-template<unsigned decimals, unsigned w>
-std::ostream &operator <<(std::ostream &os, FloatFixed<decimals, w> f) {
+template <unsigned decimals, unsigned w>
+std::ostream &operator<<(std::ostream &os, FloatFixed<decimals, w> f) {
 	static_assert(decimals < 50, "Refusing to print float with >= 50 decimals");
 	static_assert(w < 70, "Refusing to print float with a width >= 70");
 
@@ -84,7 +84,7 @@ bool string_matches_pattern(const char *str, const char *pattern);
  * Split a string at a delimiter, push the result back in an iterator.
  * Why doesn't the fucking standard library have std::string::split(delimiter)?
  */
-template<typename ret_t>
+template <typename ret_t>
 void split(const std::string &txt, char delimiter, ret_t result) {
 	std::stringstream splitter;
 	splitter.str(txt);
@@ -113,6 +113,8 @@ std::vector<std::string> split(const std::string &txt, char delim);
  * to literal X, including the deliminiter.
  */
 std::vector<std::string> split_escape(const std::string &txt,
-                                      char delim, size_t size_hint=0);
+                                      char delim,
+                                      size_t size_hint = 0);
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/subprocess.h
+++ b/libopenage/util/subprocess.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2017 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -40,8 +40,8 @@ std::string which(const char *name);
  *                           the existing file is overwritten.
  */
 int call(const std::vector<const char *> &argv,
-         bool wait=false,
-         const char *redirect_stdout_to=nullptr);
+         bool wait = false,
+         const char *redirect_stdout_to = nullptr);
 
 } // namespace subprocess
 } // namespace openage

--- a/libopenage/util/thread_id.h
+++ b/libopenage/util/thread_id.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,4 +15,5 @@ namespace util {
  */
 size_t get_current_thread_id();
 
-}} // namespace openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/timer.h
+++ b/libopenage/util/timer.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2016 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -31,12 +31,12 @@ public:
 	/**
 	 * creates the timer, in either stopped or running state.
 	 */
-	Timer(bool stopped=true);
+	Timer(bool stopped = true);
 
 	/**
 	 * resets the timer, in either stopped or running state.
 	 */
-	void reset(bool stopped=true);
+	void reset(bool stopped = true);
 
 	/**
 	 * stops/pauses the timer.
@@ -66,4 +66,5 @@ public:
 };
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/timing.h
+++ b/libopenage/util/timing.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,4 +27,5 @@ time_nsec_t get_monotonic_time();
  */
 time_nsec_t get_real_time();
 
-}} // namespace openage::timing
+} // namespace timing
+} // namespace openage

--- a/libopenage/util/unicode.h
+++ b/libopenage/util/unicode.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2016 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -107,4 +107,5 @@ size_t utf8_last_char_size(char *str);
  */
 void utf8_pop_back(std::string &str);
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/variable.h
+++ b/libopenage/util/variable.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -15,23 +15,23 @@ public:
 	/**
 	 * sets the type and value
 	 */
-	template<class T, class V> void set(const V &value);
+	template <class T, class V>
+	void set(const V &value);
 
 	/**
 	 * returns the stored value
 	 * throws an exception if the template
 	 * does not match the set type
 	 */
-	template<class T> const T &get() const;
-
+	template <class T>
+	const T &get() const;
 };
 
 
-template<class T>
+template <class T>
 class Variable : public VariableBase {
 public:
-	Variable(const T &initial_value)
-		:
+	Variable(const T &initial_value) :
 		value(initial_value) {}
 
 
@@ -50,15 +50,16 @@ public:
 };
 
 
-template<class T>
+template <class T>
 const T &VariableBase::get() const {
 	return dynamic_cast<const Variable<T> &>(*this).get();
 }
 
-template<class T, class V>
-void VariableBase::set(const V& value) {
+template <class T, class V>
+void VariableBase::set(const V &value) {
 	return dynamic_cast<Variable<T> &>(*this).set(value);
 }
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/vector.h
+++ b/libopenage/util/vector.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -21,7 +21,7 @@ namespace openage::util {
  * N = dimensions
  * T = underlying single value type (double, float, ...)
  */
-template<size_t N, typename T>
+template <size_t N, typename T>
 class Vector : public std::array<T, N> {
 public:
 	static_assert(N > 0, "0-dimensional vector not allowed");
@@ -45,18 +45,16 @@ public:
 	/**
 	 * Constructor for initialisation with N T values
 	 */
-	template<typename ... Ts>
-	Vector(Ts ... args)
-		:
+	template <typename... Ts>
+	Vector(Ts... args) :
 		std::array<T, N>{static_cast<T>(args)...} {
-
 		static_assert(sizeof...(args) == N, "not all values supplied.");
 	}
 
 	/**
 	 * Cast every value to NT and return the new Vector.
 	 */
-	template<typename NT>
+	template <typename NT>
 	Vector<N, NT> casted() const {
 		Vector<N, NT> ret;
 		std::copy(std::begin(*this), std::end(*this), std::begin(ret));
@@ -66,7 +64,7 @@ public:
 	/**
 	 * Equality test with given precision.
 	 */
-	bool equals(const this_type &other, T eps=default_eps) {
+	bool equals(const this_type &other, T eps = default_eps) {
 		for (size_t i = 0; i < N; i++) {
 			T diff = std::abs((*this)[i] - other[i]);
 			if (diff >= eps) {
@@ -79,7 +77,7 @@ public:
 	/**
 	 * Vector addition with assignment
 	 */
-	this_type &operator +=(const this_type &other) {
+	this_type &operator+=(const this_type &other) {
 		for (size_t i = 0; i < N; i++) {
 			(*this)[i] += other[i];
 		}
@@ -89,7 +87,7 @@ public:
 	/**
 	 * Vector addition
 	 */
-	this_type operator +(const this_type &other) const {
+	this_type operator+(const this_type &other) const {
 		this_type res(*this);
 		res += other;
 		return res;
@@ -98,7 +96,7 @@ public:
 	/**
 	 * Vector subtraction with assignment
 	 */
-	this_type &operator -=(const this_type &other) {
+	this_type &operator-=(const this_type &other) {
 		for (size_t i = 0; i < N; i++) {
 			(*this)[i] -= other[i];
 		}
@@ -108,7 +106,7 @@ public:
 	/**
 	 * Vector subtraction
 	 */
-	this_type operator -(const this_type &other) const {
+	this_type operator-(const this_type &other) const {
 		this_type res(*this);
 		res -= other;
 		return res;
@@ -117,7 +115,7 @@ public:
 	/**
 	 * Scalar multiplication with assignment
 	 */
-	this_type &operator *=(T a) {
+	this_type &operator*=(T a) {
 		for (size_t i = 0; i < N; i++) {
 			(*this)[i] *= a;
 		}
@@ -127,7 +125,7 @@ public:
 	/**
 	 * Scalar multiplication
 	 */
-	this_type operator *(T a) const {
+	this_type operator*(T a) const {
 		this_type res(*this);
 		res *= a;
 		return res;
@@ -136,7 +134,7 @@ public:
 	/**
 	 * Scalar division with assignment
 	 */
-	this_type &operator /=(T a) {
+	this_type &operator/=(T a) {
 		for (size_t i = 0; i < N; i++) {
 			(*this)[i] /= a;
 		}
@@ -146,7 +144,7 @@ public:
 	/**
 	 * Scalar division
 	 */
-	this_type operator /(T a) const {
+	this_type operator/(T a) const {
 		this_type res(*this);
 		res /= a;
 		return res;
@@ -181,50 +179,50 @@ public:
 	/**
 	 * Cross-product of two 3-dimensional vectors
 	 */
-	template<typename U=this_type>
-	typename std::enable_if<N==3, U>::type
-	/*Vector<N>*/ cross_product(const this_type &other) const {
+	template <typename U = this_type>
+	typename std::enable_if<N == 3, U>::type
+	/*Vector<N>*/
+	cross_product(const this_type &other) const {
 		return this_type(
 			((*this)[1] * other[2] - (*this)[2] * other[1]),
 			((*this)[2] * other[0] - (*this)[0] * other[2]),
-			((*this)[0] * other[1] - (*this)[1] * other[0])
-		);
+			((*this)[0] * other[1] - (*this)[1] * other[0]));
 	}
 
 	/**
 	 * Scalar multiplication with swapped arguments
 	 */
-	friend this_type operator *(T a, const this_type &v) {
+	friend this_type operator*(T a, const this_type &v) {
 		return v * a;
 	}
 
 	/**
 	 * Print to output stream using '<<'
 	 */
-	friend std::ostream &operator <<(std::ostream &o, const this_type &v) {
+	friend std::ostream &operator<<(std::ostream &o, const this_type &v) {
 		o << "(";
-		for (size_t i = 0; i < N-1; i++) {
+		for (size_t i = 0; i < N - 1; i++) {
 			o << v[i] << ", ";
 		}
-		o << v[N-1] << ")";
+		o << v[N - 1] << ")";
 		return o;
 	}
 };
 
 
-template<typename T=float>
+template <typename T = float>
 using Vector2t = Vector<2, T>;
 
-template<typename T=float>
+template <typename T = float>
 using Vector3t = Vector<3, T>;
 
-template<typename T=float>
+template <typename T = float>
 using Vector4t = Vector<4, T>;
 
-template<size_t N>
+template <size_t N>
 using Vectorf = Vector<N, float>;
 
-template<size_t N>
+template <size_t N>
 using Vectord = Vector<N, double>;
 
 using Vector2f = Vector<2, float>;
@@ -247,4 +245,4 @@ using Vector2ss = Vector<2, ssize_t>;
 using Vector3ss = Vector<3, ssize_t>;
 using Vector4ss = Vector<4, ssize_t>;
 
-} // openage::util
+} // namespace openage::util

--- a/libopenage/versions/versions.h
+++ b/libopenage/versions/versions.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2020 the openage authors. See copying.md for legal info.
+// Copyright 2020-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,6 +19,6 @@ namespace openage::versions {
  * pxd:
  * map[string,string] get_version_numbers() except +
  */
-OAAPI std::map<std::string,std::string> get_version_numbers();
+OAAPI std::map<std::string, std::string> get_version_numbers();
 
 } // namespace openage::versions


### PR DESCRIPTION
Changes `clang-format` settings to

- `AlignTrailingComments: true`
- `ReflowComments: true`

This should solve my inconsistent tab usage in docstrings.

I also reformatted the whole codebase, so everything should conform to the clang-format rules now. 99% of changes in this PR are the tab issues, the others are for files that were not formatted with the clang-format rules before. In some situations I turned clang-format off for better readability, e.g. when an array is used as a 2-dimensional matrix.