### PR TITLE
Log creation of OpenGL objects

### DIFF
--- a/libopenage/renderer/opengl/framebuffer.cpp
+++ b/libopenage/renderer/opengl/framebuffer.cpp
@@ -1,6 +1,8 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "framebuffer.h"
+
+#include "log/log.h"
 
 #include "renderer/opengl/context.h"
 #include "renderer/opengl/texture.h"
@@ -12,6 +14,7 @@ GlFramebuffer::GlFramebuffer(const std::shared_ptr<GlContext> &context) :
 	GlSimpleObject(context,
                    [](GLuint /*handle*/) {}),
 	type{gl_framebuffer_t::display} {
+	log::log(MSG(dbg) << "Created OpenGL framebuffer with display target");
 }
 
 // TODO the validity of this object is contingent
@@ -51,6 +54,8 @@ GlFramebuffer::GlFramebuffer(const std::shared_ptr<GlContext> &context,
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
 		throw Error(MSG(err) << "Could not create OpenGL framebuffer.");
 	}
+
+	log::log(MSG(dbg) << "Created OpenGL framebuffer with texture targets");
 }
 
 gl_framebuffer_t GlFramebuffer::get_type() const {

--- a/libopenage/renderer/opengl/render_pass.cpp
+++ b/libopenage/renderer/opengl/render_pass.cpp
@@ -1,13 +1,18 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #include "render_pass.h"
+
+#include "log/log.h"
+
 
 namespace openage::renderer::opengl {
 
 GlRenderPass::GlRenderPass(std::vector<Renderable> renderables,
                            const std::shared_ptr<RenderTarget> &target) :
 	RenderPass(renderables, target),
-	is_optimised(false) {}
+	is_optimised(false) {
+	log::log(MSG(dbg) << "Created OpenGL render pass");
+}
 
 const std::vector<Renderable> &GlRenderPass::get_renderables() const {
 	return this->renderables;

--- a/libopenage/renderer/opengl/render_target.cpp
+++ b/libopenage/renderer/opengl/render_target.cpp
@@ -1,17 +1,21 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "render_target.h"
 
 #include "error/error.h"
+#include "log/log.h"
 
 #include "renderer/opengl/texture.h"
+
 
 namespace openage::renderer::opengl {
 
 GlRenderTarget::GlRenderTarget(const std::shared_ptr<GlContext> &context, size_t width, size_t height) :
 	type(gl_render_target_t::framebuffer),
 	size(width, height),
-	framebuffer(context) {}
+	framebuffer(context) {
+	log::log(MSG(dbg) << "Created OpenGL render target for default framebuffer");
+}
 
 GlRenderTarget::GlRenderTarget(const std::shared_ptr<GlContext> &context,
                                const std::vector<std::shared_ptr<GlTexture2d>> &textures) :
@@ -20,6 +24,8 @@ GlRenderTarget::GlRenderTarget(const std::shared_ptr<GlContext> &context,
 	textures(textures) {
 	// TODO: Check if the textures are all the same size
 	this->size = this->textures.value().at(0)->get_info().get_size();
+
+	log::log(MSG(dbg) << "Created OpenGL render target for textures");
 }
 
 resources::Texture2dData GlRenderTarget::into_data() {
@@ -40,7 +46,7 @@ std::vector<std::shared_ptr<Texture2d>> GlRenderTarget::get_texture_targets() {
 	if (this->framebuffer->get_type() == gl_framebuffer_t::display) {
 		return textures;
 	}
-	//else upcast pointers
+	// else upcast pointers
 	for (auto tex : this->textures.value()) {
 		auto new_ptr = dynamic_pointer_cast<Texture2d>(tex);
 		textures.push_back(new_ptr);

--- a/libopenage/renderer/opengl/texture.cpp
+++ b/libopenage/renderer/opengl/texture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "texture.h"
 
@@ -54,7 +54,8 @@ GlTexture2d::GlTexture2d(const std::shared_ptr<GlContext> &context,
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-	log::log(MSG(dbg) << "Created OpenGL texture from data");
+	log::log(MSG(dbg) << "Created OpenGL texture from data (size: "
+	                  << size.first << "x" << size.second << ")");
 }
 
 GlTexture2d::GlTexture2d(const std::shared_ptr<GlContext> &context,
@@ -70,7 +71,7 @@ GlTexture2d::GlTexture2d(const std::shared_ptr<GlContext> &context,
 
 	auto fmt_in_out = GL_PIXEL_FORMAT.get(this->info.get_format());
 
-	auto dims = this->info.get_size();
+	auto size = this->info.get_size();
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT, this->info.get_row_alignment());
 
@@ -78,8 +79,8 @@ GlTexture2d::GlTexture2d(const std::shared_ptr<GlContext> &context,
 		GL_TEXTURE_2D,
 		0,
 		std::get<0>(fmt_in_out),
-		dims.first,
-		dims.second,
+		size.first,
+		size.second,
 		0,
 		std::get<1>(fmt_in_out),
 		std::get<2>(fmt_in_out),
@@ -89,7 +90,8 @@ GlTexture2d::GlTexture2d(const std::shared_ptr<GlContext> &context,
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-	log::log(MSG(dbg) << "Created OpenGL texture from parameters");
+	log::log(MSG(dbg) << "Created OpenGL texture from info parameters (size: "
+	                  << size.first << "x" << size.second << ")");
 }
 
 resources::Texture2dData GlTexture2d::into_data() {

--- a/libopenage/renderer/opengl/texture_array.cpp
+++ b/libopenage/renderer/opengl/texture_array.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #include "texture_array.h"
 
@@ -31,20 +31,22 @@ GlTexture2dArray::GlTexture2dArray(const std::shared_ptr<GlContext> &context,
 	size_t i = 0;
 	for (auto const &tex : data) {
 		glTexSubImage3D(GL_TEXTURE_2D_ARRAY,
-		                0, // mipmap number
-		                0,
-		                0,
-		                i, // xoffset, yoffset, zoffset
-		                size.first,
-		                size.second,
-		                1, // width, height, depth
+		                0,                       // mipmap number
+		                0,                       // xoffset
+		                0,                       // yoffset
+		                i,                       // zoffset
+		                size.first,              // width
+		                size.second,             // height,
+		                1,                       // depth
 		                std::get<1>(fmt_in_out), // format
 		                std::get<2>(fmt_in_out), // type
-		                tex.get_data() // data
+		                tex.get_data()           // data
 		);
 
 		i += 1;
 	}
+
+	log::log(MSG(dbg) << "Created OpenGL texture array from data");
 }
 
 GlTexture2dArray::GlTexture2dArray(const std::shared_ptr<GlContext> &context,
@@ -65,22 +67,22 @@ GlTexture2dArray::GlTexture2dArray(const std::shared_ptr<GlContext> &context,
 
 	// Create empty image
 	glTexImage3D(GL_TEXTURE_2D_ARRAY,
-	             0, // mipmap level
+	             0,                       // mipmap level
 	             std::get<0>(fmt_in_out), // gpu texel format
-	             size.first, // width
-	             size.second, // height
-	             n_layers, // depth
-	             0, // border
+	             size.first,              // width
+	             size.second,             // height
+	             n_layers,                // depth
+	             0,                       // border
 	             std::get<1>(fmt_in_out), // cpu pixel format
 	             std::get<2>(fmt_in_out), // cpu pixel type
-	             nullptr // data
+	             nullptr                  // data
 	);
 
 	// TODO these are outdated, use sampler settings
 	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-	log::log(MSG(dbg) << "Created an OpenGL texture array.");
+	log::log(MSG(dbg) << "Created OpenGL texture array from info parameters");
 }
 
 void GlTexture2dArray::upload(size_t layer, resources::Texture2dData const &data) {
@@ -101,10 +103,10 @@ void GlTexture2dArray::upload(size_t layer, resources::Texture2dData const &data
 	                layer, // xoffset, yoffset, zoffset
 	                size.first,
 	                size.second,
-	                1, // width, height, depth
+	                1,                       // width, height, depth
 	                std::get<1>(fmt_in_out), // format
 	                std::get<2>(fmt_in_out), // type
-	                data.get_data() // data
+	                data.get_data()          // data
 	);
 }
 

--- a/libopenage/renderer/opengl/uniform_buffer.cpp
+++ b/libopenage/renderer/opengl/uniform_buffer.cpp
@@ -1,8 +1,10 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "uniform_buffer.h"
 
 #include "error/error.h"
+#include "log/log.h"
+
 #include "renderer/opengl/context.h"
 #include "renderer/opengl/lookup.h"
 #include "renderer/opengl/texture.h"
@@ -32,6 +34,10 @@ GlUniformBuffer::GlUniformBuffer(const std::shared_ptr<GlContext> &context,
 	glBufferData(GL_UNIFORM_BUFFER, this->data_size, NULL, usage);
 
 	glBindBufferRange(GL_UNIFORM_BUFFER, this->binding_point, *this->handle, 0, this->data_size);
+
+	log::log(MSG(dbg) << "Created OpenGL uniform buffer (size: "
+	                  << this->data_size << ", binding point: "
+	                  << this->binding_point << ")");
 }
 
 GLuint GlUniformBuffer::get_binding_point() const {


### PR DESCRIPTION
Logs the creation of several OpenGL objects that were previously silently created.

- Frambuffers
- Render passes
- Render targets
- Textures from data
- Texture arrays
- Uniform buffers