### PR TITLE
Port curve container types to `std::vector`

### DIFF
--- a/libopenage/curve/base_curve.h
+++ b/libopenage/curve/base_curve.h
@@ -194,7 +194,7 @@ protected:
 	/**
 	 * Cache the index of the last accessed element (usually the end).
 	 */
-	mutable typename KeyframeContainer<T>::index_t last_element;
+	mutable typename KeyframeContainer<T>::elem_ptr last_element;
 };
 
 

--- a/libopenage/curve/continuous.h
+++ b/libopenage/curve/continuous.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -48,7 +48,7 @@ void Continuous<T>::set_last(const time::time_t &at, const T &value) {
 	auto hint = this->container.last(at, this->last_element);
 
 	// erase all same-time entries
-	while (hint->time == at) {
+	while (this->container.get(hint).time() == at) {
 		hint--;
 	}
 

--- a/libopenage/curve/discrete.h
+++ b/libopenage/curve/discrete.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -55,7 +55,7 @@ template <typename T>
 T Discrete<T>::get(const time::time_t &time) const {
 	auto e = this->container.last(time, this->last_element);
 	this->last_element = e; // TODO if Caching?
-	return e->value;
+	return this->container.get(e).val();
 }
 
 
@@ -78,7 +78,9 @@ template <typename T>
 std::pair<time::time_t, T> Discrete<T>::get_time(const time::time_t &time) const {
 	auto e = this->container.last(time, this->last_element);
 	this->last_element = e;
-	return std::make_pair(e->time, e->value);
+
+	auto elem = this->container.get(e);
+	return std::make_pair(elem.time, elem.value);
 }
 
 
@@ -89,12 +91,13 @@ std::optional<std::pair<time::time_t, T>> Discrete<T>::get_previous(const time::
 
 	// if we're not at the container head
 	// go back one entry.
-	if (e == std::begin(this->container)) {
+	if (e == 0) {
 		return {};
 	}
 
 	e--;
-	return std::make_pair(e->time, e->value);
+	auto elem = this->container.get(e);
+	return std::make_pair(elem.time(), elem.val());
 }
 
 } // namespace openage::curve

--- a/libopenage/curve/discrete_mod.h
+++ b/libopenage/curve/discrete_mod.h
@@ -93,7 +93,7 @@ void DiscreteMod<T>::erase(const time::time_t &at) {
 	BaseCurve<T>::erase(at);
 
 	if (this->time_length == at) {
-		this->time_length = this->last_element->time;
+		this->time_length = this->container.get(this->container.size() - 1).time();
 	}
 }
 

--- a/libopenage/curve/keyframe.h
+++ b/libopenage/curve/keyframe.h
@@ -27,16 +27,26 @@ public:
 	 * New, default-constructed element at the given time
 	 */
 	Keyframe(const time::time_t &time) :
-		time{time} {}
+		timestamp{time} {}
 
 	/**
 	 * New element fron time and value
 	 */
 	Keyframe(const time::time_t &time, const T &value) :
-		time{time},
+		timestamp{time},
 		value{value} {}
 
-	const time::time_t time = time::TIME_MIN;
+	const time::time_t &time() const {
+		return this->timestamp;
+	}
+
+	const T &val() const {
+		return this->value;
+	}
+
+private:
+	time::time_t timestamp = time::TIME_MIN;
+
 	T value = T{};
 };
 

--- a/libopenage/curve/keyframe.h
+++ b/libopenage/curve/keyframe.h
@@ -33,21 +33,40 @@ public:
 	 * New element fron time and value
 	 */
 	Keyframe(const time::time_t &time, const T &value) :
-		timestamp{time},
-		value{value} {}
+		value{value},
+		timestamp{time} {}
 
+	/**
+	 * Get the time of this keyframe.
+	 *
+	 * @return Keyframe time.
+	 */
 	const time::time_t &time() const {
 		return this->timestamp;
 	}
 
+	/**
+	 * Get the value of this keyframe.
+	 *
+	 * @return Keyframe value.
+	 */
 	const T &val() const {
 		return this->value;
 	}
 
-private:
-	time::time_t timestamp = time::TIME_MIN;
-
+public:
+	/**
+	 * Value of the keyframe.
+	 *
+	 * Can be modified by the curve if necessary.
+	 */
 	T value = T{};
+
+private:
+	/**
+	 * Time of the keyframe.
+	 */
+	time::time_t timestamp = time::TIME_MIN;
 };
 
 } // namespace openage::curve

--- a/libopenage/curve/keyframe_container.h
+++ b/libopenage/curve/keyframe_container.h
@@ -40,7 +40,7 @@ public:
 	/**
 	 * The index type to access elements in the container
 	 */
-	using index_t = typename container_t::size_type;
+	using elem_ptr = typename container_t::size_type;
 
 	/**
 	 * The iterator type to access elements in the container
@@ -76,7 +76,7 @@ public:
 	 */
 	size_t size() const;
 
-	const keyframe_t &get(const index_t &idx) const {
+	const keyframe_t &get(const elem_ptr &idx) const {
 		return this->container.at(idx);
 	}
 
@@ -84,8 +84,8 @@ public:
 	 * Get the last element in the curve which is at or before the given time.
 	 * (i.e. elem->time <= time). Given a hint where to start the search.
 	 */
-	index_t last(const time::time_t &time,
-	             const index_t &hint) const;
+	elem_ptr last(const time::time_t &time,
+	              const elem_ptr &hint) const;
 
 	/**
 	 * Get the last element with elem->time <= time, without a hint where to start
@@ -95,7 +95,7 @@ public:
 	 * no chance for you to have a hint (or the container is known to be nearly
 	 * empty)
 	 */
-	index_t last(const time::time_t &time) const {
+	elem_ptr last(const time::time_t &time) const {
 		return this->last(time, this->container.size());
 	}
 
@@ -103,14 +103,14 @@ public:
 	 * Get the last element in the curve which is before the given time.
 	 * (i.e. elem->time < time). Given a hint where to start the search.
 	 */
-	index_t last_before(const time::time_t &time,
-	                    const index_t &hint) const;
+	elem_ptr last_before(const time::time_t &time,
+	                     const elem_ptr &hint) const;
 
 	/**
 	 * Get the last element with elem->time < time, without a hint where to start
 	 * searching.
 	 */
-	index_t last_before(const time::time_t &time) const {
+	elem_ptr last_before(const time::time_t &time) const {
 		return this->last_before(time, this->container.size());
 	}
 
@@ -121,7 +121,7 @@ public:
 	 * This function is not recommended for use, whenever possible, keep a hint
 	 * to insert the data.
 	 */
-	index_t insert_before(const keyframe_t &value) {
+	elem_ptr insert_before(const keyframe_t &value) {
 		return this->insert_before(value, this->container.size());
 	}
 
@@ -132,7 +132,7 @@ public:
 	 * history size. If there is a keyframe with identical time, this will
 	 * insert the new keyframe before the old one.
 	 */
-	index_t insert_before(const keyframe_t &value, const index_t &hint);
+	elem_ptr insert_before(const keyframe_t &value, const elem_ptr &hint);
 
 	/**
 	 * Create and insert a new element without submitting a hint. The search is
@@ -140,7 +140,7 @@ public:
 	 * discouraged, use it only, if your really do not have the possibility to
 	 * get a hint.
 	 */
-	index_t insert_before(const time::time_t &time, const T &value) {
+	elem_ptr insert_before(const time::time_t &time, const T &value) {
 		return this->insert_before(keyframe_t(time, value), this->container.size());
 	}
 
@@ -149,7 +149,7 @@ public:
 	 * If there is a value with identical time, this will insert the new value
 	 * before the old one.
 	 */
-	index_t insert_before(const time::time_t &time, const T &value, const index_t &hint) {
+	elem_ptr insert_before(const time::time_t &time, const T &value, const elem_ptr &hint) {
 		return this->insert_before(keyframe_t(time, value), hint);
 	}
 
@@ -160,9 +160,9 @@ public:
 	 * `overwrite_all` == true -> overwrite all same-time elements.
 	 * `overwrite_all` == false -> overwrite the last of the time-conflict elements.
 	 */
-	index_t insert_overwrite(const keyframe_t &value,
-	                         const index_t &hint,
-	                         bool overwrite_all = false);
+	elem_ptr insert_overwrite(const keyframe_t &value,
+	                          const elem_ptr &hint,
+	                          bool overwrite_all = false);
 
 	/**
 	 * Insert a new value at given time which will overwrite the last of the
@@ -170,7 +170,7 @@ public:
 	 * from the end of the data. The use of this function is discouraged, use it
 	 * only, if your really do not have the possibility to get a hint.
 	 */
-	index_t insert_overwrite(const time::time_t &time, const T &value) {
+	elem_ptr insert_overwrite(const time::time_t &time, const T &value) {
 		return this->insert_overwrite(keyframe_t(time, value),
 		                              this->container.size());
 	}
@@ -182,10 +182,10 @@ public:
 	 * Provide a insertion hint to abbreviate the search for the
 	 * insertion point.
 	 */
-	index_t insert_overwrite(const time::time_t &time,
-	                         const T &value,
-	                         const index_t &hint,
-	                         bool overwrite_all = false) {
+	elem_ptr insert_overwrite(const time::time_t &time,
+	                          const T &value,
+	                          const elem_ptr &hint,
+	                          bool overwrite_all = false) {
 		return this->insert_overwrite(keyframe_t(time, value), hint, overwrite_all);
 	}
 
@@ -194,7 +194,7 @@ public:
 	 * conflict. Give an approximate insertion location to minimize runtime on
 	 * big-history curves.
 	 */
-	index_t insert_after(const keyframe_t &value, const index_t &hint);
+	elem_ptr insert_after(const keyframe_t &value, const elem_ptr &hint);
 
 	/**
 	 * Insert a new value at given time which will be prepended to the block of
@@ -202,7 +202,7 @@ public:
 	 * time from the end of the data. The use of this function is discouraged,
 	 * use it only, if your really do not have the possibility to get a hint.
 	 */
-	index_t insert_after(const time::time_t &time, const T &value) {
+	elem_ptr insert_after(const time::time_t &time, const T &value) {
 		return this->insert_after(keyframe_t(time, value),
 		                          this->container.size());
 	}
@@ -211,27 +211,27 @@ public:
 	 * Create and insert a new element, which is added after a previous element with
 	 * identical time. Provide a insertion hint to abbreviate the search for the insertion point.
 	 */
-	index_t insert_after(const time::time_t &time, const T &value, const index_t &hint) {
+	elem_ptr insert_after(const time::time_t &time, const T &value, const elem_ptr &hint) {
 		return this->insert_after(keyframe_t(time, value), hint);
 	}
 
 	/**
 	 * Erase all elements that come after this last valid element.
 	 */
-	index_t erase_after(index_t last_valid);
+	elem_ptr erase_after(elem_ptr last_valid);
 
 	/**
 	 * Erase a single element from the curve.
 	 * Returns the element after the deleted one.
 	 */
-	index_t erase(index_t it);
+	elem_ptr erase(elem_ptr it);
 
 	/**
 	 * Erase all elements with given time.
 	 * Variant without hint, starts the search at the end of the container.
 	 * Returns the iterator after the deleted elements.
 	 */
-	index_t erase(const time::time_t &time) {
+	elem_ptr erase(const time::time_t &time) {
 		return this->erase(time, this->container.size());
 	}
 
@@ -244,8 +244,8 @@ public:
 	 * Or, if no elements with this time exist,
 	 * the iterator to the first element after the requested time is returned
 	 */
-	index_t erase(const time::time_t &time,
-	              const index_t &hint) {
+	elem_ptr erase(const time::time_t &time,
+	               const elem_ptr &hint) {
 		return this->erase_group(time, this->last(time, hint));
 	}
 
@@ -285,8 +285,8 @@ public:
 	 *              Using the default value replaces ALL keyframes of \p this with
 	 *              the keyframes of \p other.
 	 */
-	index_t sync(const KeyframeContainer<T> &other,
-	             const time::time_t &start = time::TIME_MIN);
+	elem_ptr sync(const KeyframeContainer<T> &other,
+	              const time::time_t &start = time::TIME_MIN);
 
 	/**
 	 * Copy keyframes from another container (with a different element type) to this container.
@@ -301,9 +301,9 @@ public:
 	 *              the keyframes of \p other.
 	 */
 	template <typename O>
-	index_t sync(const KeyframeContainer<O> &other,
-	             const std::function<T(const O &)> &converter,
-	             const time::time_t &start = time::TIME_MIN);
+	elem_ptr sync(const KeyframeContainer<O> &other,
+	              const std::function<T(const O &)> &converter,
+	              const time::time_t &start = time::TIME_MIN);
 
 	/**
 	 * Debugging method to be used from gdb to understand bugs better.
@@ -319,8 +319,8 @@ private:
 	 * Erase elements with this time.
 	 * The iterator has to point to the last element of the same-time group.
 	 */
-	index_t erase_group(const time::time_t &time,
-	                    const index_t &last_elem);
+	elem_ptr erase_group(const time::time_t &time,
+	                     const elem_ptr &last_elem);
 
 	/**
 	 * The data store.
@@ -360,11 +360,11 @@ size_t KeyframeContainer<T>::size() const {
  * that determines the curve value for a searched time.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::last(const time::time_t &time,
-                           const KeyframeContainer<T>::index_t &hint) const {
-	index_t at = hint;
-	const index_t end = this->container.size();
+                           const KeyframeContainer<T>::elem_ptr &hint) const {
+	elem_ptr at = hint;
+	const elem_ptr end = this->container.size();
 
 	if (at != end and this->container.at(at).time() <= time) {
 		// walk to the right until the time is larget than the searched
@@ -394,11 +394,11 @@ KeyframeContainer<T>::last(const time::time_t &time,
  * first element that matches the search time.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::last_before(const time::time_t &time,
-                                  const KeyframeContainer<T>::index_t &hint) const {
-	index_t at = hint;
-	const index_t end = this->container.size();
+                                  const KeyframeContainer<T>::elem_ptr &hint) const {
+	elem_ptr at = hint;
+	const elem_ptr end = this->container.size();
 
 	if (at != end and this->container.at(at).time() < time) {
 		// walk to the right until the time is larget than the searched
@@ -423,10 +423,10 @@ KeyframeContainer<T>::last_before(const time::time_t &time,
  * Determine where to insert based on time, and insert.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::insert_before(const KeyframeContainer<T>::keyframe_t &e,
-                                    const KeyframeContainer<T>::index_t &hint) {
-	index_t at = this->last(e.time(), hint);
+                                    const KeyframeContainer<T>::elem_ptr &hint) {
+	elem_ptr at = this->last(e.time(), hint);
 
 	if (at == this->container.size()) {
 		this->container.push_back(e);
@@ -449,12 +449,12 @@ KeyframeContainer<T>::insert_before(const KeyframeContainer<T>::keyframe_t &e,
  * Determine where to insert based on time, and insert, overwriting value(s) with same time.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::insert_overwrite(const KeyframeContainer<T>::keyframe_t &e,
-                                       const KeyframeContainer<T>::index_t &hint,
+                                       const KeyframeContainer<T>::elem_ptr &hint,
                                        bool overwrite_all) {
-	index_t at = this->last(e.time(), hint);
-	const index_t end = this->container.size();
+	elem_ptr at = this->last(e.time(), hint);
+	const elem_ptr end = this->container.size();
 
 	if (overwrite_all) {
 		at = this->erase_group(e.time(), at);
@@ -479,11 +479,11 @@ KeyframeContainer<T>::insert_overwrite(const KeyframeContainer<T>::keyframe_t &e
  * If there is a time conflict, insert after the existing element.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::insert_after(const KeyframeContainer<T>::keyframe_t &e,
-                                   const KeyframeContainer<T>::index_t &hint) {
-	index_t at = this->last(e.time(), hint);
-	const index_t end = this->container.size();
+                                   const KeyframeContainer<T>::elem_ptr &hint) {
+	elem_ptr at = this->last(e.time(), hint);
+	const elem_ptr end = this->container.size();
 
 	if (at != end) {
 		++at;
@@ -498,12 +498,12 @@ KeyframeContainer<T>::insert_after(const KeyframeContainer<T>::keyframe_t &e,
  * Go from the end to the last_valid element, and call erase on all of them
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
-KeyframeContainer<T>::erase_after(KeyframeContainer<T>::index_t last_valid) {
+typename KeyframeContainer<T>::elem_ptr
+KeyframeContainer<T>::erase_after(KeyframeContainer<T>::elem_ptr last_valid) {
 	// exclude the last_valid element from deletion
 	if (last_valid != this->container.size()) {
 		// Delete everything to the end.
-		const index_t delete_start = last_valid + 1;
+		const elem_ptr delete_start = last_valid + 1;
 		this->container.erase(this->begin() + delete_start, this->end());
 	}
 
@@ -515,19 +515,19 @@ KeyframeContainer<T>::erase_after(KeyframeContainer<T>::index_t last_valid) {
  * Delete the element from the list and call delete on it.
  */
 template <typename T>
-typename KeyframeContainer<T>::index_t
-KeyframeContainer<T>::erase(KeyframeContainer<T>::index_t e) {
+typename KeyframeContainer<T>::elem_ptr
+KeyframeContainer<T>::erase(KeyframeContainer<T>::elem_ptr e) {
 	this->container.erase(this->begin() + e);
 	return e;
 }
 
 
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::sync(const KeyframeContainer<T> &other,
                            const time::time_t &start) {
 	// Delete elements after start time
-	index_t at = this->last_before(start, this->container.size());
+	elem_ptr at = this->last_before(start, this->container.size());
 	at = this->erase_after(at);
 
 	auto at_other = 1; // always skip the first element (because it's the default value)
@@ -545,12 +545,12 @@ KeyframeContainer<T>::sync(const KeyframeContainer<T> &other,
 
 template <typename T>
 template <typename O>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::sync(const KeyframeContainer<O> &other,
                            const std::function<T(const O &)> &converter,
                            const time::time_t &start) {
 	// Delete elements after start time
-	index_t at = this->last_before(start, this->container.size());
+	elem_ptr at = this->last_before(start, this->container.size());
 	at = this->erase_after(at);
 
 	auto at_other = 1; // always skip the first element (because it's the default value)
@@ -567,9 +567,9 @@ KeyframeContainer<T>::sync(const KeyframeContainer<O> &other,
 
 
 template <typename T>
-typename KeyframeContainer<T>::index_t
+typename KeyframeContainer<T>::elem_ptr
 KeyframeContainer<T>::erase_group(const time::time_t &time,
-                                  const KeyframeContainer<T>::index_t &last_elem) {
+                                  const KeyframeContainer<T>::elem_ptr &last_elem) {
 	size_t at = last_elem;
 
 	// if the time what we're looking for

--- a/libopenage/curve/keyframe_container.h
+++ b/libopenage/curve/keyframe_container.h
@@ -34,17 +34,18 @@ public:
 
 	/**
 	 * The underlaying container type.
-	 *
-	 * The most important property of this container is the iterator validity on
-	 * insert and remove.
 	 */
-	using container_t = std::list<keyframe_t>;
+	using container_t = std::vector<keyframe_t>;
+
+	/**
+	 * The index type to access elements in the container
+	 */
+	using index_t = typename container_t::size_type;
 
 	/**
 	 * The iterator type to access elements in the container
 	 */
 	using iterator = typename container_t::const_iterator;
-	using const_iterator = typename container_t::const_iterator;
 
 	/**
 	 * Create a new container.
@@ -75,12 +76,16 @@ public:
 	 */
 	size_t size() const;
 
+	const keyframe_t &get(const index_t &idx) const {
+		return this->container.at(idx);
+	}
+
 	/**
 	 * Get the last element in the curve which is at or before the given time.
 	 * (i.e. elem->time <= time). Given a hint where to start the search.
 	 */
-	iterator last(const time::time_t &time,
-	              const iterator &hint) const;
+	index_t last(const time::time_t &time,
+	             const index_t &hint) const;
 
 	/**
 	 * Get the last element with elem->time <= time, without a hint where to start
@@ -90,23 +95,23 @@ public:
 	 * no chance for you to have a hint (or the container is known to be nearly
 	 * empty)
 	 */
-	iterator last(const time::time_t &time) const {
-		return this->last(time, std::end(this->container));
+	index_t last(const time::time_t &time) const {
+		return this->last(time, this->container.size());
 	}
 
 	/**
 	 * Get the last element in the curve which is before the given time.
 	 * (i.e. elem->time < time). Given a hint where to start the search.
 	 */
-	iterator last_before(const time::time_t &time,
-	                     const iterator &hint) const;
+	index_t last_before(const time::time_t &time,
+	                    const index_t &hint) const;
 
 	/**
 	 * Get the last element with elem->time < time, without a hint where to start
 	 * searching.
 	 */
-	iterator last_before(const time::time_t &time) const {
-		return this->last_before(time, std::end(this->container));
+	index_t last_before(const time::time_t &time) const {
+		return this->last_before(time, this->container.size());
 	}
 
 	/**
@@ -116,8 +121,8 @@ public:
 	 * This function is not recommended for use, whenever possible, keep a hint
 	 * to insert the data.
 	 */
-	iterator insert_before(const keyframe_t &value) {
-		return this->insert_before(value, std::end(this->container));
+	index_t insert_before(const keyframe_t &value) {
+		return this->insert_before(value, this->container.size());
 	}
 
 	/**
@@ -127,7 +132,7 @@ public:
 	 * history size. If there is a keyframe with identical time, this will
 	 * insert the new keyframe before the old one.
 	 */
-	iterator insert_before(const keyframe_t &value, const iterator &hint);
+	index_t insert_before(const keyframe_t &value, const index_t &hint);
 
 	/**
 	 * Create and insert a new element without submitting a hint. The search is
@@ -135,8 +140,8 @@ public:
 	 * discouraged, use it only, if your really do not have the possibility to
 	 * get a hint.
 	 */
-	iterator insert_before(const time::time_t &time, const T &value) {
-		return this->insert_before(keyframe_t(time, value), std::end(this->container));
+	index_t insert_before(const time::time_t &time, const T &value) {
+		return this->insert_before(keyframe_t(time, value), this->container.size());
 	}
 
 	/**
@@ -144,7 +149,7 @@ public:
 	 * If there is a value with identical time, this will insert the new value
 	 * before the old one.
 	 */
-	iterator insert_before(const time::time_t &time, const T &value, const iterator &hint) {
+	index_t insert_before(const time::time_t &time, const T &value, const index_t &hint) {
 		return this->insert_before(keyframe_t(time, value), hint);
 	}
 
@@ -155,9 +160,9 @@ public:
 	 * `overwrite_all` == true -> overwrite all same-time elements.
 	 * `overwrite_all` == false -> overwrite the last of the time-conflict elements.
 	 */
-	iterator insert_overwrite(const keyframe_t &value,
-	                          const iterator &hint,
-	                          bool overwrite_all = false);
+	index_t insert_overwrite(const keyframe_t &value,
+	                         const index_t &hint,
+	                         bool overwrite_all = false);
 
 	/**
 	 * Insert a new value at given time which will overwrite the last of the
@@ -165,9 +170,9 @@ public:
 	 * from the end of the data. The use of this function is discouraged, use it
 	 * only, if your really do not have the possibility to get a hint.
 	 */
-	iterator insert_overwrite(const time::time_t &time, const T &value) {
+	index_t insert_overwrite(const time::time_t &time, const T &value) {
 		return this->insert_overwrite(keyframe_t(time, value),
-		                              std::end(this->container));
+		                              this->container.size());
 	}
 
 	/**
@@ -177,10 +182,10 @@ public:
 	 * Provide a insertion hint to abbreviate the search for the
 	 * insertion point.
 	 */
-	iterator insert_overwrite(const time::time_t &time,
-	                          const T &value,
-	                          const iterator &hint,
-	                          bool overwrite_all = false) {
+	index_t insert_overwrite(const time::time_t &time,
+	                         const T &value,
+	                         const index_t &hint,
+	                         bool overwrite_all = false) {
 		return this->insert_overwrite(keyframe_t(time, value), hint, overwrite_all);
 	}
 
@@ -189,7 +194,7 @@ public:
 	 * conflict. Give an approximate insertion location to minimize runtime on
 	 * big-history curves.
 	 */
-	iterator insert_after(const keyframe_t &value, const iterator &hint);
+	index_t insert_after(const keyframe_t &value, const index_t &hint);
 
 	/**
 	 * Insert a new value at given time which will be prepended to the block of
@@ -197,37 +202,37 @@ public:
 	 * time from the end of the data. The use of this function is discouraged,
 	 * use it only, if your really do not have the possibility to get a hint.
 	 */
-	iterator insert_after(const time::time_t &time, const T &value) {
+	index_t insert_after(const time::time_t &time, const T &value) {
 		return this->insert_after(keyframe_t(time, value),
-		                          std::end(this->container));
+		                          this->container.size());
 	}
 
 	/**
 	 * Create and insert a new element, which is added after a previous element with
 	 * identical time. Provide a insertion hint to abbreviate the search for the insertion point.
 	 */
-	iterator insert_after(const time::time_t &time, const T &value, const iterator &hint) {
+	index_t insert_after(const time::time_t &time, const T &value, const index_t &hint) {
 		return this->insert_after(keyframe_t(time, value), hint);
 	}
 
 	/**
 	 * Erase all elements that come after this last valid element.
 	 */
-	iterator erase_after(iterator last_valid);
+	index_t erase_after(index_t last_valid);
 
 	/**
 	 * Erase a single element from the curve.
 	 * Returns the element after the deleted one.
 	 */
-	iterator erase(iterator it);
+	index_t erase(index_t it);
 
 	/**
 	 * Erase all elements with given time.
 	 * Variant without hint, starts the search at the end of the container.
 	 * Returns the iterator after the deleted elements.
 	 */
-	iterator erase(const time::time_t &time) {
-		return this->erase(time, std::end(this->container));
+	index_t erase(const time::time_t &time) {
+		return this->erase(time, this->container.size());
 	}
 
 	/**
@@ -239,8 +244,8 @@ public:
 	 * Or, if no elements with this time exist,
 	 * the iterator to the first element after the requested time is returned
 	 */
-	iterator erase(const time::time_t &time,
-	               const iterator &hint) {
+	index_t erase(const time::time_t &time,
+	              const index_t &hint) {
 		return this->erase_group(time, this->last(time, hint));
 	}
 
@@ -280,8 +285,8 @@ public:
 	 *              Using the default value replaces ALL keyframes of \p this with
 	 *              the keyframes of \p other.
 	 */
-	iterator sync(const KeyframeContainer<T> &other,
-	              const time::time_t &start = time::TIME_MIN);
+	index_t sync(const KeyframeContainer<T> &other,
+	             const time::time_t &start = time::TIME_MIN);
 
 	/**
 	 * Copy keyframes from another container (with a different element type) to this container.
@@ -296,9 +301,9 @@ public:
 	 *              the keyframes of \p other.
 	 */
 	template <typename O>
-	iterator sync(const KeyframeContainer<O> &other,
-	              const std::function<T(const O &)> &converter,
-	              const time::time_t &start = time::TIME_MIN);
+	index_t sync(const KeyframeContainer<O> &other,
+	             const std::function<T(const O &)> &converter,
+	             const time::time_t &start = time::TIME_MIN);
 
 	/**
 	 * Debugging method to be used from gdb to understand bugs better.
@@ -314,8 +319,8 @@ private:
 	 * Erase elements with this time.
 	 * The iterator has to point to the last element of the same-time group.
 	 */
-	iterator erase_group(const time::time_t &time,
-	                     const iterator &last_elem);
+	index_t erase_group(const time::time_t &time,
+	                    const index_t &last_elem);
 
 	/**
 	 * The data store.
@@ -355,28 +360,28 @@ size_t KeyframeContainer<T>::size() const {
  * that determines the curve value for a searched time.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator KeyframeContainer<T>::last(const time::time_t &time,
-                                                                   const iterator &hint) const {
-	iterator e = hint;
-	auto end = std::end(this->container);
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::last(const time::time_t &time,
+                           const KeyframeContainer<T>::index_t &hint) const {
+	index_t at = hint;
+	const index_t end = this->container.size();
 
-	if (e != end and e->time <= time) {
+	if (at != end and this->container.at(at).time() <= time) {
 		// walk to the right until the time is larget than the searched
-		// then go one to the left to get the last item with <= requested time
-		while (e != end && e->time <= time) {
-			e++;
+		while (at != end and this->container.at(at).time() <= time) {
+			++at;
 		}
-		e--;
+		// go one back, because we want the last element that is <= time
+		--at;
 	}
-	else { // e == end or e->time > time
-		// walk to the left until the element time is smaller than or equal to the searched time
-		auto begin = std::begin(this->container);
-		while (e != begin and (e == end or e->time > time)) {
-			e--;
+	else { // idx == end or idx->time > time
+		// walk to the left until the element time is smaller than the searched time
+		while (at > 0 and (at == end or this->container.at(at).time() > time)) {
+			--at;
 		}
 	}
 
-	return e;
+	return at;
 }
 
 
@@ -389,28 +394,28 @@ typename KeyframeContainer<T>::iterator KeyframeContainer<T>::last(const time::t
  * first element that matches the search time.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator KeyframeContainer<T>::last_before(const time::time_t &time,
-                                                                          const iterator &hint) const {
-	iterator e = hint;
-	auto end = std::end(this->container);
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::last_before(const time::time_t &time,
+                                  const KeyframeContainer<T>::index_t &hint) const {
+	index_t at = hint;
+	const index_t end = this->container.size();
 
-	if (e != end and e->time < time) {
+	if (at != end and this->container.at(at).time() < time) {
 		// walk to the right until the time is larget than the searched
-		// then go one to the left to get the last item with <= requested time
-		while (e != end && e->time <= time) {
-			e++;
+		while (at != end and this->container.at(at).time() <= time) {
+			++at;
 		}
-		e--;
+		// go one back, because we want the last element that is <= time
+		--at;
 	}
-	else { // e == end or e->time > time
+	else { // idx == end or idx->time > time
 		// walk to the left until the element time is smaller than the searched time
-		auto begin = std::begin(this->container);
-		while (e != begin and (e == end or e->time >= time)) {
-			e--;
+		while (at > 0 and (at == end or this->container.at(at).time() >= time)) {
+			--at;
 		}
 	}
 
-	return e;
+	return at;
 }
 
 
@@ -418,21 +423,25 @@ typename KeyframeContainer<T>::iterator KeyframeContainer<T>::last_before(const 
  * Determine where to insert based on time, and insert.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator
+typename KeyframeContainer<T>::index_t
 KeyframeContainer<T>::insert_before(const KeyframeContainer<T>::keyframe_t &e,
-                                    const KeyframeContainer<T>::iterator &hint) {
-	iterator at = this->last(e.time, hint);
-	// seek over all same-time elements, so we can insert before the first one
-	while (at != std::begin(this->container) and at->time == e.time) {
-		--at;
+                                    const KeyframeContainer<T>::index_t &hint) {
+	index_t at = this->last(e.time(), hint);
+
+	if (at == this->container.size()) {
+		this->container.push_back(e);
+		return at;
 	}
 
-	// the above while-loop overshoots and selects the first non-equal element.
-	// set iterator one to the right, i.e. on the first same-value
-	if (at != std::end(this->container)) {
-		++at;
+	// seek over all same-time elements, so we can insert before the first one
+	while (this->container.at(at).time() == e.time() and at > 0) {
+		at--;
 	}
-	return this->container.insert(at, e);
+
+	++at;
+
+	this->container.insert(this->begin() + at, e);
+	return at;
 }
 
 
@@ -440,26 +449,28 @@ KeyframeContainer<T>::insert_before(const KeyframeContainer<T>::keyframe_t &e,
  * Determine where to insert based on time, and insert, overwriting value(s) with same time.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator
-KeyframeContainer<T>::insert_overwrite(
-	const KeyframeContainer<T>::keyframe_t &e,
-	const KeyframeContainer<T>::iterator &hint,
-	bool overwrite_all) {
-	iterator at = this->last(e.time, hint);
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::insert_overwrite(const KeyframeContainer<T>::keyframe_t &e,
+                                       const KeyframeContainer<T>::index_t &hint,
+                                       bool overwrite_all) {
+	index_t at = this->last(e.time(), hint);
+	const index_t end = this->container.size();
 
 	if (overwrite_all) {
-		at = this->erase_group(e.time, at);
+		at = this->erase_group(e.time(), at);
 	}
-	else if (at != std::end(this->container)) {
+	else if (at != end) {
 		// overwrite the same-time element
-		if (at->time == e.time) {
-			at = this->container.erase(at);
+		if (this->get(at).time() == e.time()) {
+			this->container.erase(this->begin() + at);
 		}
 		else {
 			++at;
 		}
 	}
-	return this->container.insert(at, e);
+
+	this->container.insert(this->begin() + at, e);
+	return at;
 }
 
 
@@ -468,16 +479,18 @@ KeyframeContainer<T>::insert_overwrite(
  * If there is a time conflict, insert after the existing element.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator
-KeyframeContainer<T>::insert_after(
-	const KeyframeContainer<T>::keyframe_t &e,
-	const KeyframeContainer<T>::iterator &hint) {
-	iterator at = this->last(e.time, hint);
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::insert_after(const KeyframeContainer<T>::keyframe_t &e,
+                                   const KeyframeContainer<T>::index_t &hint) {
+	index_t at = this->last(e.time(), hint);
+	const index_t end = this->container.size();
 
-	if (at != std::end(this->container)) {
+	if (at != end) {
 		++at;
 	}
-	return this->container.insert(at, e);
+
+	this->container.insert(this->begin() + at, e);
+	return at;
 }
 
 
@@ -485,17 +498,15 @@ KeyframeContainer<T>::insert_after(
  * Go from the end to the last_valid element, and call erase on all of them
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator
-KeyframeContainer<T>::erase_after(KeyframeContainer<T>::iterator last_valid) {
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::erase_after(KeyframeContainer<T>::index_t last_valid) {
 	// exclude the last_valid element from deletion
-	if (last_valid != this->container.end()) {
-		++last_valid;
+	if (last_valid != this->container.size()) {
+		// Delete everything to the end.
+		const index_t delete_start = last_valid + 1;
+		this->container.erase(this->begin() + delete_start, this->end());
 	}
 
-	// Delete everything to the end.
-	while (last_valid != this->container.end()) {
-		last_valid = this->container.erase(last_valid);
-	}
 	return last_valid;
 }
 
@@ -504,79 +515,73 @@ KeyframeContainer<T>::erase_after(KeyframeContainer<T>::iterator last_valid) {
  * Delete the element from the list and call delete on it.
  */
 template <typename T>
-typename KeyframeContainer<T>::iterator
-KeyframeContainer<T>::erase(KeyframeContainer<T>::iterator e) {
-	return this->container.erase(e);
+typename KeyframeContainer<T>::index_t
+KeyframeContainer<T>::erase(KeyframeContainer<T>::index_t e) {
+	this->container.erase(this->begin() + e);
+	return e;
 }
 
 
 template <typename T>
-typename KeyframeContainer<T>::iterator
+typename KeyframeContainer<T>::index_t
 KeyframeContainer<T>::sync(const KeyframeContainer<T> &other,
                            const time::time_t &start) {
 	// Delete elements after start time
-	iterator at = this->last_before(start, this->end());
+	index_t at = this->last_before(start, this->container.size());
 	at = this->erase_after(at);
 
-	auto at_other = other.begin();
-	++at_other; // always skip the first element (because it's the default value)
+	auto at_other = 1; // always skip the first element (because it's the default value)
 
 	// Copy all elements from other with time >= start
-	while (at_other != other.end()) {
-		if (at_other->time >= start) {
-			at = this->insert_after(*at_other, at);
+	for (size_t i = at_other; i < other.size(); i++) {
+		if (other.get(i).time() >= start) {
+			at = this->insert_after(other.get(i), at);
 		}
-		++at_other;
 	}
 
-	return at;
+	return this->container.size();
 }
 
 
 template <typename T>
 template <typename O>
-typename KeyframeContainer<T>::iterator
+typename KeyframeContainer<T>::index_t
 KeyframeContainer<T>::sync(const KeyframeContainer<O> &other,
                            const std::function<T(const O &)> &converter,
                            const time::time_t &start) {
 	// Delete elements after start time
-	iterator at = this->last_before(start, this->end());
+	index_t at = this->last_before(start, this->container.size());
 	at = this->erase_after(at);
 
-	auto at_other = other.begin();
-	++at_other; // always skip the first element (because it's the default value)
+	auto at_other = 1; // always skip the first element (because it's the default value)
 
 	// Copy all elements from other with time >= start
-	while (at_other != other.end()) {
-		if (at_other->time >= start) {
-			// Convert the value to the type of this container
-			at = this->insert_after(at_other->time, converter(at_other->value), at);
+	for (size_t i = at_other; i < other.size(); i++) {
+		if (other.get(i).time() >= start) {
+			at = this->insert_after(keyframe_t(other.get(i).time(), converter(other.get(i).val())), at);
 		}
-		++at_other;
 	}
 
-	return at;
+	return this->container.size();
 }
 
 
 template <typename T>
-typename KeyframeContainer<T>::iterator
+typename KeyframeContainer<T>::index_t
 KeyframeContainer<T>::erase_group(const time::time_t &time,
-                                  const iterator &last_elem) {
-	iterator at = last_elem;
+                                  const KeyframeContainer<T>::index_t &last_elem) {
+	size_t at = last_elem;
 
 	// if the time what we're looking for
 	// erase elements until all element with that time are purged
-	while (at != std::end(this->container) and at->time == time) {
-		at = this->container.erase(at);
-		if (at != std::begin(this->container)) [[likely]] {
-			--at;
-		}
+	while (at != this->container.size() and this->container.at(at).time() == time) {
+		this->container.erase(this->container.begin() + at);
+		--at;
 	}
 
 	// we have to cancel one --at in order to return
 	// the element after the group we deleted.
-	if (at != std::end(this->container)) {
+	if (at != this->container.size()) {
 		++at;
 	}
 

--- a/libopenage/curve/queue.h
+++ b/libopenage/curve/queue.h
@@ -69,7 +69,7 @@ public:
 	/**
 	 * The index type to access elements in the container
 	 */
-	using index_t = typename container_t::size_type;
+	using elem_ptr = typename container_t::size_type;
 
 	/**
 	 * The iterator type to access elements in the container
@@ -229,7 +229,7 @@ private:
 	 * @param time The time to kill at.
 	 * @param at The index of the element to kill.
 	 */
-	void kill(const time::time_t &time, index_t at);
+	void kill(const time::time_t &time, elem_ptr at);
 
 	/**
 	 * Get the first alive element inserted at t <= time.
@@ -238,7 +238,7 @@ private:
 	 *
 	 * @return Index of the first alive element or end() if no such element exists.
 	 */
-	index_t first_alive(const time::time_t &time) const;
+	elem_ptr first_alive(const time::time_t &time) const;
 
 	/**
 	 * Identifier for the container
@@ -265,13 +265,13 @@ private:
 	 *
 	 * All positions before the index are guaranteed to be dead at t >= last_change.
 	 */
-	index_t front_start;
+	elem_ptr front_start;
 };
 
 
 template <class T>
-typename Queue<T>::index_t Queue<T>::first_alive(const time::time_t &time) const {
-	index_t hint = 0;
+typename Queue<T>::elem_ptr Queue<T>::first_alive(const time::time_t &time) const {
+	elem_ptr hint = 0;
 
 	// check if the access is later than the last change
 	if (this->last_change <= time) {
@@ -295,7 +295,7 @@ typename Queue<T>::index_t Queue<T>::first_alive(const time::time_t &time) const
 
 template <typename T>
 const T &Queue<T>::front(const time::time_t &time) const {
-	index_t at = this->first_alive(time);
+	elem_ptr at = this->first_alive(time);
 	ENSURE(at < this->container.size(),
 	       "Tried accessing front at " << time << " but index " << at << " is invalid. "
 	                                   << "The queue may be empty."
@@ -310,7 +310,7 @@ const T &Queue<T>::front(const time::time_t &time) const {
 
 template <class T>
 const T &Queue<T>::pop_front(const time::time_t &time) {
-	index_t at = this->first_alive(time);
+	elem_ptr at = this->first_alive(time);
 	ENSURE(at < this->container.size(),
 	       "Tried accessing front at " << time << " but index " << at << " is invalid. "
 	                                   << "The queue may be empty."
@@ -393,7 +393,7 @@ void Queue<T>::erase(const CurveIterator<T, Queue<T>> &it) {
 
 template <class T>
 void Queue<T>::kill(const time::time_t &time,
-                    index_t at) {
+                    elem_ptr at) {
 	this->container[at].set_dead(time);
 }
 
@@ -401,7 +401,7 @@ void Queue<T>::kill(const time::time_t &time,
 template <typename T>
 QueueFilterIterator<T, Queue<T>> Queue<T>::insert(const time::time_t &time,
                                                   const T &e) {
-	index_t at = this->container.size();
+	elem_ptr at = this->container.size();
 	while (at > 0) {
 		--at;
 		if (this->container.at(at).alive() <= time) {
@@ -444,7 +444,7 @@ QueueFilterIterator<T, Queue<T>> Queue<T>::insert(const time::time_t &time,
 
 template <typename T>
 void Queue<T>::clear(const time::time_t &time) {
-	index_t at = this->first_alive(time);
+	elem_ptr at = this->first_alive(time);
 
 	// no elements alive at t <= time
 	// so we don't have any changes

--- a/libopenage/curve/segmented.h
+++ b/libopenage/curve/segmented.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -62,7 +62,7 @@ void Segmented<T>::set_last_jump(const time::time_t &at, const T &leftval, const
 	auto hint = this->container.last(at, this->last_element);
 
 	// erase all one same-time values
-	while (hint->time == at) {
+	while (this->container.get(hint).time() == at) {
 		hint--;
 	}
 

--- a/libopenage/curve/tests/curve_types.cpp
+++ b/libopenage/curve/tests/curve_types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include <iterator>
 #include <list>
@@ -27,8 +27,8 @@ void curve_types() {
 		auto p0 = c.insert_before(0, 0);
 		auto p1 = c.insert_before(1, 1);
 		auto p2 = c.insert_before(10, 2);
-		auto pa = std::begin(c);
-		auto pe = std::end(c);
+		auto ib = 0;
+		auto ie = c.size();
 
 		// now contains: [-inf: 0, 0:0, 1:1, 10:2]
 
@@ -36,133 +36,133 @@ void curve_types() {
 
 		{
 			auto it = c.begin();
-			TESTEQUALS(it->value, 0);
-			TESTEQUALS(it->time, time::TIME_MIN);
-			TESTEQUALS((++it)->time, 0);
-			TESTEQUALS(it->value, 0);
-			TESTEQUALS((++it)->time, 1);
-			TESTEQUALS(it->value, 1);
-			TESTEQUALS((++it)->time, 10);
-			TESTEQUALS(it->value, 2);
+			TESTEQUALS(it->val(), 0);
+			TESTEQUALS(it->time(), time::TIME_MIN);
+			TESTEQUALS((++it)->time(), 0);
+			TESTEQUALS(it->val(), 0);
+			TESTEQUALS((++it)->time(), 1);
+			TESTEQUALS(it->val(), 1);
+			TESTEQUALS((++it)->time(), 10);
+			TESTEQUALS(it->val(), 2);
 		}
 
 		// last function tests without hints
-		TESTEQUALS(c.last(0)->value, 0);
-		TESTEQUALS(c.last(1)->value, 1);
-		TESTEQUALS(c.last(5)->value, 1);
-		TESTEQUALS(c.last(10)->value, 2);
-		TESTEQUALS(c.last(47)->value, 2);
+		TESTEQUALS(c.get(c.last(0)).val(), 0);
+		TESTEQUALS(c.get(c.last(1)).val(), 1);
+		TESTEQUALS(c.get(c.last(5)).val(), 1);
+		TESTEQUALS(c.get(c.last(10)).val(), 2);
+		TESTEQUALS(c.get(c.last(47)).val(), 2);
 
 		// last() with hints.
-		TESTEQUALS(c.last(0, pa)->value, 0);
-		TESTEQUALS(c.last(1, pa)->value, 1);
-		TESTEQUALS(c.last(5, pa)->value, 1);
-		TESTEQUALS(c.last(10, pa)->value, 2);
-		TESTEQUALS(c.last(47, pa)->value, 2);
+		TESTEQUALS(c.get(c.last(0, ib)).val(), 0);
+		TESTEQUALS(c.get(c.last(1, ib)).val(), 1);
+		TESTEQUALS(c.get(c.last(5, ib)).val(), 1);
+		TESTEQUALS(c.get(c.last(10, ib)).val(), 2);
+		TESTEQUALS(c.get(c.last(47, ib)).val(), 2);
 
-		TESTEQUALS(c.last(0, p0)->value, 0);
-		TESTEQUALS(c.last(1, p0)->value, 1);
-		TESTEQUALS(c.last(5, p0)->value, 1);
-		TESTEQUALS(c.last(10, p0)->value, 2);
-		TESTEQUALS(c.last(47, p0)->value, 2);
+		TESTEQUALS(c.get(c.last(0, p0)).val(), 0);
+		TESTEQUALS(c.get(c.last(1, p0)).val(), 1);
+		TESTEQUALS(c.get(c.last(5, p0)).val(), 1);
+		TESTEQUALS(c.get(c.last(10, p0)).val(), 2);
+		TESTEQUALS(c.get(c.last(47, p0)).val(), 2);
 
-		TESTEQUALS(c.last(0, p1)->value, 0);
-		TESTEQUALS(c.last(1, p1)->value, 1);
-		TESTEQUALS(c.last(5, p1)->value, 1);
-		TESTEQUALS(c.last(10, p1)->value, 2);
-		TESTEQUALS(c.last(47, p1)->value, 2);
+		TESTEQUALS(c.get(c.last(0, p1)).val(), 0);
+		TESTEQUALS(c.get(c.last(1, p1)).val(), 1);
+		TESTEQUALS(c.get(c.last(5, p1)).val(), 1);
+		TESTEQUALS(c.get(c.last(10, p1)).val(), 2);
+		TESTEQUALS(c.get(c.last(47, p1)).val(), 2);
 
-		TESTEQUALS(c.last(0, p2)->value, 0);
-		TESTEQUALS(c.last(1, p2)->value, 1);
-		TESTEQUALS(c.last(5, p2)->value, 1);
-		TESTEQUALS(c.last(10, p2)->value, 2);
-		TESTEQUALS(c.last(47, p2)->value, 2);
+		TESTEQUALS(c.get(c.last(0, p2)).val(), 0);
+		TESTEQUALS(c.get(c.last(1, p2)).val(), 1);
+		TESTEQUALS(c.get(c.last(5, p2)).val(), 1);
+		TESTEQUALS(c.get(c.last(10, p2)).val(), 2);
+		TESTEQUALS(c.get(c.last(47, p2)).val(), 2);
 
-		TESTEQUALS(c.last(0, pe)->value, 0);
-		TESTEQUALS(c.last(1, pe)->value, 1);
-		TESTEQUALS(c.last(5, pe)->value, 1);
-		TESTEQUALS(c.last(10, pe)->value, 2);
-		TESTEQUALS(c.last(47, pe)->value, 2);
+		TESTEQUALS(c.get(c.last(0, ie)).val(), 0);
+		TESTEQUALS(c.get(c.last(1, ie)).val(), 1);
+		TESTEQUALS(c.get(c.last(5, ie)).val(), 1);
+		TESTEQUALS(c.get(c.last(10, ie)).val(), 2);
+		TESTEQUALS(c.get(c.last(47, ie)).val(), 2);
 
 		// Now test the basic erase() function
 		// Delete the 1-element, new values should be [-inf:0, 0:0, 10:2]
 		c.erase(c.last(1));
 
-		TESTEQUALS(c.last(1)->value, 0);
-		TESTEQUALS(c.last(5)->value, 0);
-		TESTEQUALS(c.last(47)->value, 2);
+		TESTEQUALS(c.get(c.last(1)).val(), 0);
+		TESTEQUALS(c.get(c.last(5)).val(), 0);
+		TESTEQUALS(c.get(c.last(47)).val(), 2);
 
 		// should do nothing, since we delete all at > 99,
 		// but the last element is at 10. should still be [-inf:0, 0:0, 10:2]
 		c.erase_after(c.last(99));
-		TESTEQUALS(c.last(47)->value, 2);
+		TESTEQUALS(c.get(c.last(47)).val(), 2);
 
 		// now since 5 < 10, element with value 2 has to be gone
 		// result should be [-inf:0, 0:0]
 		c.erase_after(c.last(5));
-		TESTEQUALS(c.last(47)->value, 0);
+		TESTEQUALS(c.get(c.last(47)).val(), 0);
 
 		c.insert_overwrite(0, 42);
-		TESTEQUALS(c.last(100)->value, 42);
-		TESTEQUALS(c.last(100)->time, 0);
+		TESTEQUALS(c.get(c.last(100)).val(), 42);
+		TESTEQUALS(c.get(c.last(100)).time(), 0);
 
 		// the curve now contains [-inf:0, 0:42]
 		// let's change/add some more elements
 		c.insert_overwrite(0, 10);
-		TESTEQUALS(c.last(100)->value, 10);
+		TESTEQUALS(c.get(c.last(100)).val(), 10);
 
 		c.insert_after(0, 11);
 		c.insert_after(0, 12);
 		// now: [-inf:0, 0:10, 0:11, 0:12]
-		TESTEQUALS(c.last(0)->value, 12);
-		TESTEQUALS(c.last(10)->value, 12);
+		TESTEQUALS(c.get(c.last(0)).val(), 12);
+		TESTEQUALS(c.get(c.last(10)).val(), 12);
 
 		c.insert_before(0, 2);
 		// all the values at t=0 should be 2, 10, 11, 12
 
 		c.insert_after(1, 15);
-		TESTEQUALS(c.last(1)->value, 15);
-		TESTEQUALS(c.last(10)->value, 15);
+		TESTEQUALS(c.get(c.last(1)).val(), 15);
+		TESTEQUALS(c.get(c.last(10)).val(), 15);
 
 		c.insert_overwrite(2, 20);
-		TESTEQUALS(c.last(1)->value, 15);
-		TESTEQUALS(c.last(2)->value, 20);
-		TESTEQUALS(c.last(10)->value, 20);
+		TESTEQUALS(c.get(c.last(1)).val(), 15);
+		TESTEQUALS(c.get(c.last(2)).val(), 20);
+		TESTEQUALS(c.get(c.last(10)).val(), 20);
 
 		c.insert_before(3, 25);
-		TESTEQUALS(c.last(1)->value, 15);
-		TESTEQUALS(c.last(2)->value, 20);
-		TESTEQUALS(c.last(3)->value, 25);
-		TESTEQUALS(c.last(10)->value, 25);
+		TESTEQUALS(c.get(c.last(1)).val(), 15);
+		TESTEQUALS(c.get(c.last(2)).val(), 20);
+		TESTEQUALS(c.get(c.last(3)).val(), 25);
+		TESTEQUALS(c.get(c.last(10)).val(), 25);
 
 		// now it should be [-inf: 0, 0: 2, 0: 10, 0: 11, 0: 12, 1: 15, 2: 20,
 		// 3: 25]
 
 		{
 			auto it = c.begin();
-			TESTEQUALS(it->time, time::TIME_MIN);
-			TESTEQUALS(it->value, 0);
+			TESTEQUALS(it->time(), time::TIME_MIN);
+			TESTEQUALS(it->val(), 0);
 
-			TESTEQUALS((++it)->time, 0);
-			TESTEQUALS(it->value, 2);
+			TESTEQUALS((++it)->time(), 0);
+			TESTEQUALS(it->val(), 2);
 
-			TESTEQUALS((++it)->time, 0);
-			TESTEQUALS(it->value, 10);
+			TESTEQUALS((++it)->time(), 0);
+			TESTEQUALS(it->val(), 10);
 
-			TESTEQUALS((++it)->time, 0);
-			TESTEQUALS(it->value, 11);
+			TESTEQUALS((++it)->time(), 0);
+			TESTEQUALS(it->val(), 11);
 
-			TESTEQUALS((++it)->time, 0);
-			TESTEQUALS(it->value, 12);
+			TESTEQUALS((++it)->time(), 0);
+			TESTEQUALS(it->val(), 12);
 
-			TESTEQUALS((++it)->time, 1);
-			TESTEQUALS(it->value, 15);
+			TESTEQUALS((++it)->time(), 1);
+			TESTEQUALS(it->val(), 15);
 
-			TESTEQUALS((++it)->time, 2);
-			TESTEQUALS(it->value, 20);
+			TESTEQUALS((++it)->time(), 2);
+			TESTEQUALS(it->val(), 20);
 
-			TESTEQUALS((++it)->time, 3);
-			TESTEQUALS(it->value, 25);
+			TESTEQUALS((++it)->time(), 3);
+			TESTEQUALS(it->val(), 25);
 		}
 
 		// TODO: test c.insert_overwrite and c.insert_after
@@ -170,17 +170,17 @@ void curve_types() {
 		KeyframeContainer<int> c2;
 		c2.sync(c, 1);
 		// now c2 should be [-inf: 0, 1: 15, 2: 20, 3: 25]
-		TESTEQUALS(c2.last(0)->value, 0);
-		TESTEQUALS(c2.last(1)->value, 15);
-		TESTEQUALS(c2.last(2)->value, 20);
-		TESTEQUALS(c2.last(3)->value, 25);
-		TESTEQUALS(c2.last(10)->value, 25);
+		TESTEQUALS(c2.get(c2.last(0)).val(), 0);
+		TESTEQUALS(c2.get(c2.last(1)).val(), 15);
+		TESTEQUALS(c2.get(c2.last(2)).val(), 20);
+		TESTEQUALS(c2.get(c2.last(3)).val(), 25);
+		TESTEQUALS(c2.get(c2.last(10)).val(), 25);
 		TESTEQUALS(c2.size(), 4);
 
 		c.clear();
 		// now it should be [-inf: 0]
-		TESTEQUALS(c.last(0)->value, 0);
-		TESTEQUALS(c.last(1)->value, 0);
+		TESTEQUALS(c.get(c.last(0)).val(), 0);
+		TESTEQUALS(c.get(c.last(1)).val(), 0);
 		TESTEQUALS(c.size(), 1);
 	}
 


### PR DESCRIPTION
So far, we have used `std::list` as the underlying type for curve containers. Lists are nice because they offer constant time insertions and erasure from anywhere in the data structure and have stable iterators, i.e. changing the list doesn't invaliate the iterators.

However, these properties may not be as important for our applications and `std::vector` could be better for performance under these assumptions:

- As elements in the curve are sorted by simulation time, insertions will like be at the end of the container in normal gameplay situations
- Random access for reading elements is likely used more than insertion/removal
- Copying the curve container, e.g. when passing the curve over thread boundaries, would put the the contigious memory layout of `std::vector` at an advantage over `std::list`

This PR changes the underlying container type of `KeyframeContainer` and `Queue` to `std::vector` to show that its usage is possible with minimal changes.