### PR TITLE
Coordinate types pretty print

### DIFF
--- a/etc/gdb_pretty/printers.py
+++ b/etc/gdb_pretty/printers.py
@@ -92,8 +92,8 @@ def printer_regex(regex: str):
     return _register_printer
 
 
-@printer_regex('^openage::coord::((phys|scene)2|(chunk|tile))(_delta)?')
-class CoordNeSePrinter:
+@printer_regex('^openage::coord::(camhud|chunk|input|phys|scene|term|tile|viewport)(2|3)?(_delta)?')
+class CoordPrinter:
     """
     Pretty printer for openage::coord::CoordNeSe.
 
@@ -113,85 +113,12 @@ class CoordNeSePrinter:
         """
         Get the displayed children of the coord.
         """
-        yield ('ne', self.__val['ne'])
-        yield ('se', self.__val['se'])
-
-
-@printer_regex('^openage::coord::(chunk|phys|scene|tile)3(_delta)?')
-class CoordNeSeUpPrinter:
-    """
-    Pretty printer for openage::coord::CoordNeSeUp.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
-    """
-
-    def __init__(self, val: gdb.Value):
-        self.__val = val
-
-    def to_string(self):
-        """
-        Get the coord as a string.
-        """
-        return self.__val.type.name
-
-    def children(self):
-        """
-        Get the displayed children of the coord.
-        """
-        yield ('ne', self.__val['ne'])
-        yield ('se', self.__val['se'])
-        yield ('up', self.__val['up'])
-
-
-@printer_regex('^openage::coord::(camhud|viewport|input|term)(_delta)?')
-class CoordXYPrinter:
-    """
-    Pretty printer for openage::coord::CoordXY.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
-    """
-
-    def __init__(self, val: gdb.Value):
-        self.__val = val
-
-    def to_string(self):
-        """
-        Get the coord as a string.
-        """
-        return self.__val.type.name
-
-    def children(self):
-        """
-        Get the displayed children of the coord.
-        """
-        yield ('x', self.__val['x'])
-        yield ('y', self.__val['y'])
-
-
-@printer_regex('^openage::coord::(camhud|viewport|input|term)3(_delta)?')
-class CoordXYZPrinter:
-    """
-    Pretty printer for openage::coord::CoordXYZ.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
-    """
-
-    def __init__(self, val: gdb.Value):
-        self.__val = val
-
-    def to_string(self):
-        """
-        Get the coord as a string.
-        """
-        return self.__val.type.name
-
-    def children(self):
-        """
-        Get the displayed children of the coord.
-        """
-        yield ('x', self.__val['x'])
-        yield ('y', self.__val['y'])
-        yield ('z', self.__val['z'])
+        # Each coord type has one parent which is either
+        # of CoordNeSe, CoordNeSeUp, CoordXY, CoordXYZ
+        # From this parent we can get the fields
+        parent_type = self.__val.type.fields()[0].type
+        for child in parent_type.fields():
+            yield (child.name, self.__val[child.name])
 
 
 @printer_typedef('openage::time::time_t')

--- a/etc/gdb_pretty/printers.py
+++ b/etc/gdb_pretty/printers.py
@@ -143,6 +143,57 @@ class CoordNeSeUpPrinter:
         yield ('up', self.__val['up'])
 
 
+@printer_regex('^openage::coord::(camhud|viewport|input|term)(_delta)?')
+class CoordXYPrinter:
+    """
+    Pretty printer for openage::coord::CoordXY.
+
+    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
+    """
+
+    def __init__(self, val: gdb.Value):
+        self.__val = val
+
+    def to_string(self):
+        """
+        Get the coord as a string.
+        """
+        return self.__val.type.name
+
+    def children(self):
+        """
+        Get the displayed children of the coord.
+        """
+        yield ('x', self.__val['x'])
+        yield ('y', self.__val['y'])
+
+
+@printer_regex('^openage::coord::(camhud|viewport|input|term)3(_delta)?')
+class CoordXYZPrinter:
+    """
+    Pretty printer for openage::coord::CoordXYZ.
+
+    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
+    """
+
+    def __init__(self, val: gdb.Value):
+        self.__val = val
+
+    def to_string(self):
+        """
+        Get the coord as a string.
+        """
+        return self.__val.type.name
+
+    def children(self):
+        """
+        Get the displayed children of the coord.
+        """
+        yield ('x', self.__val['x'])
+        yield ('y', self.__val['y'])
+        yield ('z', self.__val['z'])
+
+
 @printer_typedef('openage::time::time_t')
 class TimePrinter:
     """
@@ -286,7 +337,6 @@ class KeyframePrinter:
         yield ('value', self.__val['value'])
 
 # TODO: curve types
-# TODO: coord types
 # TODO: pathfinding types
 # TODO: input event codes
 # TODO: eigen types https://github.com/dmillard/eigengdb

--- a/etc/gdb_pretty/printers.py
+++ b/etc/gdb_pretty/printers.py
@@ -92,6 +92,57 @@ def printer_regex(regex: str):
     return _register_printer
 
 
+@printer_regex('^openage::coord::((phys|scene)2|(chunk|tile))(_delta)?')
+class CoordNeSePrinter:
+    """
+    Pretty printer for openage::coord::CoordNeSe.
+
+    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
+    """
+
+    def __init__(self, val: gdb.Value):
+        self.__val = val
+
+    def to_string(self):
+        """
+        Get the coord as a string.
+        """
+        return self.__val.type.name
+
+    def children(self):
+        """
+        Get the displayed children of the coord.
+        """
+        yield ('ne', self.__val['ne'])
+        yield ('se', self.__val['se'])
+
+
+@printer_regex('^openage::coord::(chunk|phys|scene|tile)3(_delta)?')
+class CoordNeSeUpPrinter:
+    """
+    Pretty printer for openage::coord::CoordNeSeUp.
+
+    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
+    """
+
+    def __init__(self, val: gdb.Value):
+        self.__val = val
+
+    def to_string(self):
+        """
+        Get the coord as a string.
+        """
+        return self.__val.type.name
+
+    def children(self):
+        """
+        Get the displayed children of the coord.
+        """
+        yield ('ne', self.__val['ne'])
+        yield ('se', self.__val['se'])
+        yield ('up', self.__val['up'])
+
+
 @printer_typedef('openage::time::time_t')
 class TimePrinter:
     """

--- a/etc/gdb_pretty/printers.py
+++ b/etc/gdb_pretty/printers.py
@@ -7,6 +7,8 @@ Pretty printers for GDB.
 import re
 import gdb  # type: ignore
 
+# TODO: Printers should inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
+
 
 class PrinterControl(gdb.printing.PrettyPrinter):
     """
@@ -109,8 +111,6 @@ def format_fixed_point(value: int, fractional_bits: int) -> float:
 class CoordPrinter:
     """
     Pretty printer for openage::coord types (CoordNeSe, CoordNeSeUp, CoordXY, CoordXYZ).
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
     """
 
     def __init__(self, val: gdb.Value):
@@ -150,8 +150,6 @@ class CoordPrinter:
 class TimePrinter:
     """
     Pretty printer for openage::time::time_t.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
     """
 
     def __init__(self, val: gdb.Value):
@@ -182,8 +180,6 @@ class TimePrinter:
 class FixedPointPrinter:
     """
     Pretty printer for openage::util::FixedPoint.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
     """
 
     def __init__(self, val: gdb.Value):
@@ -220,8 +216,6 @@ class FixedPointPrinter:
 class VectorPrinter:
     """
     Pretty printer for openage::util::Vector.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
     """
 
     def __init__(self, val: gdb.Value):
@@ -267,8 +261,6 @@ class VectorPrinter:
 class KeyframePrinter:
     """
     Pretty printer for openage::curve::Keyframe.
-
-    TODO: Inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
     """
 
     def __init__(self, val: gdb.Value):

--- a/libopenage/coord/coord.h.template
+++ b/libopenage/coord/coord.h.template
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -24,6 +24,9 @@ namespace coord {
  *
  * 'Absolute' and 'Relative' are the absolute and relative types of the
  * derived class (CRTP).
+ *
+ * If you change this class, remember to update the gdb pretty printers
+ * in etc/gdb_pretty/printers.py.
  */
 template<typename CoordType, typename Absolute, typename Relative>
 struct Coord${camelcase}Absolute {
@@ -87,6 +90,9 @@ struct Coord${camelcase}Absolute {
  *
  * 'Absolute' and 'Relative' are the absolute and relative types of the
  * derived class (CRTP).
+ *
+ * If you change this class, remember to update the gdb pretty printers
+ * in etc/gdb_pretty/printers.py.
  */
 template<typename CoordType, typename Absolute, typename Relative>
 struct Coord${camelcase}Relative {

--- a/libopenage/curve/keyframe.h
+++ b/libopenage/curve/keyframe.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -11,6 +11,9 @@ namespace openage::curve {
 /**
  * A element of the curvecontainer. This is especially used to keep track of
  * the value-timing.
+ *
+ * If you change this class, remember to update the gdb pretty printers
+ * in etc/gdb_pretty/printers.py.
  */
 template <typename T>
 class Keyframe {

--- a/libopenage/util/fixed_point.h
+++ b/libopenage/util/fixed_point.h
@@ -81,6 +81,9 @@ constexpr static
  * For example,
  * FixedPoint<int64_t, 32>
  * can store values from -2**32 to +2**32 with a constant precision of 2**-32.
+ *
+ * If you change this class, remember to update the gdb pretty printers
+ * in etc/gdb_pretty/printers.py.
  */
 template <typename int_type, unsigned int fractional_bits>
 class FixedPoint {

--- a/libopenage/util/vector.h
+++ b/libopenage/util/vector.h
@@ -20,6 +20,9 @@ namespace openage::util {
  *
  * N = dimensions
  * T = underlying single value type (double, float, ...)
+ *
+ * If you change this class, remember to update the gdb pretty printers
+ * in etc/gdb_pretty/printers.py.
  */
 template <size_t N, typename T>
 class Vector : public std::array<T, N> {


### PR DESCRIPTION
Depends on https://github.com/SFTtech/openage/pull/1633

This just flattens the parent hierarchy to make the parent invisible and directly show the coordinate values.