### PR TITLE
Turn off vsync for renderer stresstest

### DIFF
--- a/libopenage/input/tests.cpp
+++ b/libopenage/input/tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "error/error.h"
 #include "log/log.h"
@@ -14,7 +14,8 @@ void action_demo() {
 	auto qtapp = std::make_shared<renderer::gui::GuiApplicationWithLogger>();
 
 	// create a window where we get our inputs from
-	renderer::opengl::GlWindow window("openage input test", 800, 600);
+
+	renderer::opengl::GlWindow window("openage input test");
 
 	// manager that receives window inputs
 	// the manager creates its own global context with ID "main"

--- a/libopenage/main/demo/pong/gui.cpp
+++ b/libopenage/main/demo/pong/gui.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #include "gui.h"
 
@@ -6,8 +6,8 @@
 #include <eigen3/Eigen/Dense>
 #include <vector>
 
-#include "main/demo/pong/gamestate.h"
 #include "log/log.h"
+#include "main/demo/pong/gamestate.h"
 #include "renderer/geometry.h"
 #include "renderer/opengl/context.h"
 #include "renderer/opengl/shader.h"
@@ -34,7 +34,7 @@ const std::vector<PongEvent> &Gui::get_inputs(const std::shared_ptr<PongPlayer> 
 
 	/*
 	for (all inputs from window) {
-		add key to inputs vector;
+	    add key to inputs vector;
 	}
 	*/
 
@@ -78,7 +78,7 @@ constexpr const int max_log_msgs = 10;
 
 
 Gui::Gui() :
-	window{"openage engine test", 800, 600},
+	window{"openage engine test", {800, 600}},
 	renderer{window.make_renderer()} {
 	auto vshader_src = renderer::resources::ShaderSource(
 		renderer::resources::shader_lang_t::glsl,
@@ -199,7 +199,7 @@ void Gui::draw(const std::shared_ptr<PongState> &state, const time::time_t &now)
 	auto ball_pos = state->ball->position->get(now);
 	auto ball_pos_matrix = Eigen::Affine3f::Identity();
 	ball_pos_matrix.prescale(Eigen::Vector3f(ball_size, ball_size, 1.0f));
-	//ball_pos_matrix.prerotate(Eigen::AngleAxisf(45.0f * math::PI / 180.0f, Eigen::Vector3f::UnitZ()));
+	// ball_pos_matrix.prerotate(Eigen::AngleAxisf(45.0f * math::PI / 180.0f, Eigen::Vector3f::UnitZ()));
 	ball_pos_matrix.pretranslate(Eigen::Vector3f(ball_pos[0], ball_pos[1], 0.0f));
 	this->ball.uniform->update("pos", ball_pos_matrix.matrix());
 

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 the openage authors. See copying.md for legal info.
+// Copyright 2019-2024 the openage authors. See copying.md for legal info.
 
 #include "presenter.h"
 
@@ -93,8 +93,13 @@ std::shared_ptr<qtgui::GuiApplication> Presenter::init_window_system() {
 void Presenter::init_graphics(bool debug) {
 	log::log(INFO << "Presenter: Initializing graphics subsystems...");
 
+	// Start up rendering framework
 	this->gui_app = this->init_window_system();
-	this->window = renderer::Window::create("openage presenter test", 1024, 768, debug);
+
+	// Window and renderer
+	renderer::window_settings settings;
+	settings.debug = debug;
+	this->window = renderer::Window::create("openage presenter test", 1024, 768, settings);
 	this->renderer = this->window->make_renderer();
 
 	// Asset mangement
@@ -190,10 +195,10 @@ void Presenter::init_gui() {
 
 	this->gui = std::make_shared<renderer::gui::GUI>(
 		this->gui_app, // Qt application wrapper
-		this->window, // window for the gui
+		this->window,  // window for the gui
 		qml_root_file, // entry qml file, absolute path.
-		qml_root, // directory to watch for qml file changes
-		qml_assets, // qml data: Engine *, the data directory, ...
+		qml_root,      // directory to watch for qml file changes
+		qml_assets,    // qml data: Engine *, the data directory, ...
 		this->renderer // openage renderer
 	);
 

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -98,8 +98,10 @@ void Presenter::init_graphics(bool debug) {
 
 	// Window and renderer
 	renderer::window_settings settings;
+	settings.width = 1024;
+	settings.height = 768;
 	settings.debug = debug;
-	this->window = renderer::Window::create("openage presenter test", 1024, 768, settings);
+	this->window = renderer::Window::create("openage presenter test", settings);
 	this->renderer = this->window->make_renderer();
 
 	// Asset mangement

--- a/libopenage/renderer/demo/demo_0.cpp
+++ b/libopenage/renderer/demo/demo_0.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_0.h"
 
@@ -13,7 +13,9 @@ namespace openage::renderer::tests {
 void renderer_demo_0(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	opengl::GlWindow window("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	opengl::GlWindow window("openage renderer test", 800, 600, settings);
 	auto renderer = window.make_renderer();
 
 	auto shaderdir = path / "assets" / "test" / "shaders";

--- a/libopenage/renderer/demo/demo_0.cpp
+++ b/libopenage/renderer/demo/demo_0.cpp
@@ -14,8 +14,10 @@ void renderer_demo_0(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	opengl::GlWindow window("openage renderer test", 800, 600, settings);
+	opengl::GlWindow window("openage renderer test", settings);
 	auto renderer = window.make_renderer();
 
 	auto shaderdir = path / "assets" / "test" / "shaders";

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_1.h"
 
@@ -19,7 +19,9 @@ namespace openage::renderer::tests {
 void renderer_demo_1(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	opengl::GlWindow window("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	opengl::GlWindow window("openage renderer test", 800, 600, settings);
 	auto renderer = window.make_renderer();
 
 	auto shaderdir = path / "assets" / "test" / "shaders";

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -20,8 +20,10 @@ void renderer_demo_1(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	opengl::GlWindow window("openage renderer test", 800, 600, settings);
+	opengl::GlWindow window("openage renderer test", settings);
 	auto renderer = window.make_renderer();
 
 	auto shaderdir = path / "assets" / "test" / "shaders";

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -23,8 +23,10 @@ void renderer_demo_2(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	opengl::GlWindow window("openage renderer test", 800, 600, settings);
+	opengl::GlWindow window("openage renderer test", settings);
 	auto renderer = window.make_renderer();
 
 	/* Load texture file standalone. */

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_2.h"
 
@@ -22,7 +22,9 @@ namespace openage::renderer::tests {
 void renderer_demo_2(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	opengl::GlWindow window("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	opengl::GlWindow window("openage renderer test", 800, 600, settings);
 	auto renderer = window.make_renderer();
 
 	/* Load texture file standalone. */
@@ -150,10 +152,10 @@ void renderer_demo_2(const util::Path &path) {
 	                                    1.0f));
 
 	/* Pass uniforms to the shaders.
-		mv          : The upscaling matrix
-		offset_tile : Subtexture coordinates (as floats relative to texture image size)
-		u_id        : Identifier
-		tex         : OpenGL texture reference
+	    mv          : The upscaling matrix
+	    offset_tile : Subtexture coordinates (as floats relative to texture image size)
+	    u_id        : Identifier
+	    tex         : OpenGL texture reference
 	*/
 	auto obj1_unifs = obj_shader->new_uniform_input(
 		"mv",

--- a/libopenage/renderer/demo/demo_3.cpp
+++ b/libopenage/renderer/demo/demo_3.cpp
@@ -29,8 +29,10 @@ void renderer_demo_3(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 800, 600, settings);
+	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", settings);
 	auto renderer = window->make_renderer();
 
 	// Clock required by world renderer for timing animation frames

--- a/libopenage/renderer/demo/demo_3.cpp
+++ b/libopenage/renderer/demo/demo_3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_3.h"
 
@@ -28,7 +28,9 @@ namespace openage::renderer::tests {
 void renderer_demo_3(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 800, 600, settings);
 	auto renderer = window->make_renderer();
 
 	// Clock required by world renderer for timing animation frames

--- a/libopenage/renderer/demo/demo_4.cpp
+++ b/libopenage/renderer/demo/demo_4.cpp
@@ -21,8 +21,10 @@ void renderer_demo_4(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	opengl::GlWindow window("openage renderer test", 800, 600, settings);
+	opengl::GlWindow window("openage renderer test", settings);
 	auto renderer = window.make_renderer();
 
 	/* Clock for timed display */

--- a/libopenage/renderer/demo/demo_4.cpp
+++ b/libopenage/renderer/demo/demo_4.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_4.h"
 
@@ -20,7 +20,9 @@ namespace openage::renderer::tests {
 void renderer_demo_4(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	opengl::GlWindow window("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	opengl::GlWindow window("openage renderer test", 800, 600, settings);
 	auto renderer = window.make_renderer();
 
 	/* Clock for timed display */
@@ -97,10 +99,10 @@ void renderer_demo_4(const util::Path &path) {
 	                                    1.0f));
 
 	/* Pass uniforms to the shaders.
-		mv          : The upscaling matrix
-		offset_tile : Subtexture coordinates (as floats relative to texture image size)
-		u_id        : Identifier
-		tex         : OpenGL texture reference
+	    mv          : The upscaling matrix
+	    offset_tile : Subtexture coordinates (as floats relative to texture image size)
+	    u_id        : Identifier
+	    tex         : OpenGL texture reference
 	*/
 	auto obj1_unifs = obj_shader->new_uniform_input(
 		"mv",

--- a/libopenage/renderer/demo/demo_5.cpp
+++ b/libopenage/renderer/demo/demo_5.cpp
@@ -23,8 +23,10 @@ void renderer_demo_5(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 800;
+	settings.height = 600;
 	settings.debug = true;
-	opengl::GlWindow window("openage renderer test", 800, 600, settings);
+	opengl::GlWindow window("openage renderer test", settings);
 	auto renderer = window.make_renderer();
 	auto size = window.get_size();
 

--- a/libopenage/renderer/demo/demo_5.cpp
+++ b/libopenage/renderer/demo/demo_5.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "demo_5.h"
 
@@ -22,7 +22,9 @@ namespace openage::renderer::tests {
 void renderer_demo_5(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	opengl::GlWindow window("openage renderer test", 800, 600, true);
+	window_settings settings;
+	settings.debug = true;
+	opengl::GlWindow window("openage renderer test", 800, 600, settings);
 	auto renderer = window.make_renderer();
 	auto size = window.get_size();
 

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -29,9 +29,11 @@ void renderer_stresstest_0(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.width = 1024;
+	settings.height = 768;
 	settings.vsync = false;
 	settings.debug = true;
-	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 1024, 768, settings);
+	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", settings);
 	auto renderer = window->make_renderer();
 
 	// Clock required by world renderer for timing animation frames

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -29,6 +29,7 @@ void renderer_stresstest_0(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
 	window_settings settings;
+	settings.vsync = false;
 	settings.debug = true;
 	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 1024, 768, settings);
 	auto renderer = window->make_renderer();

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "stresstest_0.h"
 
@@ -28,7 +28,9 @@ namespace openage::renderer::tests {
 void renderer_stresstest_0(const util::Path &path) {
 	auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
 
-	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 1024, 768, true);
+	window_settings settings;
+	settings.debug = true;
+	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 1024, 768, settings);
 	auto renderer = window->make_renderer();
 
 	// Clock required by world renderer for timing animation frames

--- a/libopenage/renderer/opengl/context.h
+++ b/libopenage/renderer/opengl/context.h
@@ -86,7 +86,7 @@ public:
 	 * Activate or deactivate VSync for this context.
 	 *
 	 * TODO: This currently does not work at runtime. vsync must be set before
-	 * the QApplication is created.
+	 * the QWindow is created.
 	 *
 	 * @param on \p true to activate VSync, \p false to deactivate.
 	 */

--- a/libopenage/renderer/opengl/window.cpp
+++ b/libopenage/renderer/opengl/window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #include "window.h"
 
@@ -20,7 +20,7 @@ namespace openage::renderer::opengl {
 GlWindow::GlWindow(const std::string &title,
                    size_t width,
                    size_t height,
-                   bool debug) :
+                   window_settings settings) :
 	Window{width, height} {
 	if (QGuiApplication::instance() == nullptr) {
 		// Qt windows need to attach to a QtGuiApplication
@@ -40,6 +40,10 @@ GlWindow::GlWindow(const std::string &title,
 	format.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
 	format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
 
+	if (not settings.vsync) {
+		format.setSwapInterval(0);
+	}
+
 	format.setMajorVersion(gl_specs.major_version);
 	format.setMinorVersion(gl_specs.minor_version);
 
@@ -47,7 +51,7 @@ GlWindow::GlWindow(const std::string &title,
 	format.setDepthBufferSize(24);
 	format.setStencilBufferSize(8);
 
-	if (debug) {
+	if (settings.debug) {
 		format.setOption(QSurfaceFormat::DebugContext);
 	}
 
@@ -55,7 +59,7 @@ GlWindow::GlWindow(const std::string &title,
 	this->window->setFormat(format);
 	this->window->create();
 
-	this->context = std::make_shared<GlContext>(this->window, debug);
+	this->context = std::make_shared<GlContext>(this->window, settings.debug);
 	if (not this->context->get_raw_context()->isValid()) {
 		throw Error{MSG(err) << "Failed to create Qt OpenGL context."};
 	}

--- a/libopenage/renderer/opengl/window.cpp
+++ b/libopenage/renderer/opengl/window.cpp
@@ -18,10 +18,8 @@
 namespace openage::renderer::opengl {
 
 GlWindow::GlWindow(const std::string &title,
-                   size_t width,
-                   size_t height,
                    window_settings settings) :
-	Window{width, height} {
+	Window{settings.width, settings.height} {
 	if (QGuiApplication::instance() == nullptr) {
 		// Qt windows need to attach to a QtGuiApplication
 		throw Error{MSG(err) << "Failed to create Qt window: QGuiApplication has not been created yet."};
@@ -31,7 +29,7 @@ GlWindow::GlWindow(const std::string &title,
 	this->window = std::make_shared<QWindow>();
 
 	this->window->setTitle(QString::fromStdString(title));
-	this->window->resize(width, height);
+	this->window->resize(settings.width, settings.height);
 
 	this->window->setSurfaceType(QSurface::OpenGLSurface);
 

--- a/libopenage/renderer/opengl/window.h
+++ b/libopenage/renderer/opengl/window.h
@@ -25,13 +25,9 @@ public:
 	 * Create a shiny window with the given title.
 	 *
 	 * @param title The window title.
-	 * @param width Width (in pixels).
-	 * @param height Height (in pixels).
 	 * @param settings Settings for creating the window.
 	 */
 	GlWindow(const std::string &title,
-	         size_t width,
-	         size_t height,
 	         window_settings settings = {});
 	~GlWindow();
 

--- a/libopenage/renderer/opengl/window.h
+++ b/libopenage/renderer/opengl/window.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the openage authors. See copying.md for legal info.
+// Copyright 2018-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -27,12 +27,12 @@ public:
 	 * @param title The window title.
 	 * @param width Width (in pixels).
 	 * @param height Height (in pixels).
-	 * @param debug If true, enable OpenGL debug logging.
+	 * @param settings Settings for creating the window.
 	 */
 	GlWindow(const std::string &title,
 	         size_t width,
 	         size_t height,
-	         bool debug = false);
+	         window_settings settings = {});
 	~GlWindow();
 
 	void set_size(size_t width, size_t height) override;

--- a/libopenage/renderer/types.h
+++ b/libopenage/renderer/types.h
@@ -12,4 +12,14 @@ namespace openage::renderer {
  */
 using uniform_id_t = uint32_t;
 
+/**
+ * Graphics API types.
+ */
+enum class graphics_api_t {
+	DEFAULT,
+	OPENGL,
+	VULKAN,
+};
+
+
 } // namespace openage::renderer

--- a/libopenage/renderer/window.cpp
+++ b/libopenage/renderer/window.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<Window> Window::create(const std::string &title,
 	// currently we only have a functional GL window
 	// TODO: support other renderer windows
 	//       and add some selection mechanism.
-	return std::make_shared<opengl::GlWindow>(title, width, height, settings.debug);
+	return std::make_shared<opengl::GlWindow>(title, width, height, settings);
 }
 
 

--- a/libopenage/renderer/window.cpp
+++ b/libopenage/renderer/window.cpp
@@ -11,13 +11,11 @@
 namespace openage::renderer {
 
 std::shared_ptr<Window> Window::create(const std::string &title,
-                                       size_t width,
-                                       size_t height,
                                        window_settings settings) {
 	// currently we only have a functional GL window
 	// TODO: support other renderer windows
 	//       and add some selection mechanism.
-	return std::make_shared<opengl::GlWindow>(title, width, height, settings);
+	return std::make_shared<opengl::GlWindow>(title, settings);
 }
 
 

--- a/libopenage/renderer/window.cpp
+++ b/libopenage/renderer/window.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "window.h"
 
@@ -13,11 +13,11 @@ namespace openage::renderer {
 std::shared_ptr<Window> Window::create(const std::string &title,
                                        size_t width,
                                        size_t height,
-                                       bool debug) {
+                                       window_settings settings) {
 	// currently we only have a functional GL window
 	// TODO: support other renderer windows
 	//       and add some selection mechanism.
-	return std::make_shared<opengl::GlWindow>(title, width, height, debug);
+	return std::make_shared<opengl::GlWindow>(title, width, height, settings.debug);
 }
 
 

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -25,6 +25,10 @@ class WindowEventHandler;
  * Settings for creating a window.
  */
 struct window_settings {
+	// Width of the window in pixels.
+	size_t width = 1024;
+	// Height of the window in pixels.
+	size_t height = 768;
 	// Graphics API to use in the window's renderer.
 	graphics_api_t backend = graphics_api_t::DEFAULT;
 	// If true, enable vsync.
@@ -43,15 +47,11 @@ public:
 	 * Create a new Window instance for displaying stuff.
 	 *
 	 * @param title Window title shown in the Desktop Environment.
-	 * @param width Width in pixels.
-	 * @param height Height in pixels.
 	 * @param settings Settings for creating the window.
 	 *
 	 * @return The created Window instance.
 	 */
 	static std::shared_ptr<Window> create(const std::string &title,
-	                                      size_t width,
-	                                      size_t height,
 	                                      window_settings settings = {});
 
 	virtual ~Window() = default;

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -6,10 +6,11 @@
 #include <memory>
 #include <vector>
 
-#include "../util/vector.h"
-#include "renderer.h"
-
 #include <QObject>
+
+#include "renderer/renderer.h"
+#include "renderer/types.h"
+#include "util/vector.h"
 
 QT_FORWARD_DECLARE_CLASS(QWindow)
 QT_FORWARD_DECLARE_CLASS(QKeyEvent)
@@ -20,6 +21,22 @@ namespace openage::renderer {
 
 class WindowEventHandler;
 
+/**
+ * Settings for creating a window.
+ */
+struct window_settings {
+	// Graphics API to use in the window's renderer.
+	graphics_api_t backend = graphics_api_t::DEFAULT;
+	// If true, enable vsync.
+	bool vsync = true;
+	// If true, enable debug logging for the selected backend.
+	bool debug = false;
+};
+
+
+/**
+ * Represents a window that can be used to display graphics.
+ */
 class Window {
 public:
 	/**
@@ -28,14 +45,14 @@ public:
 	 * @param title Window title shown in the Desktop Environment.
 	 * @param width Width in pixels.
 	 * @param height Height in pixels.
-	 * @param debug If true, enable OpenGL debug logging.
+	 * @param settings Settings for creating the window.
 	 *
 	 * @return The created Window instance.
 	 */
 	static std::shared_ptr<Window> create(const std::string &title,
 	                                      size_t width,
 	                                      size_t height,
-	                                      bool debug = false);
+	                                      window_settings settings = {});
 
 	virtual ~Window() = default;
 


### PR DESCRIPTION
We didn't gave any vsync settings in the Qt renderer previously, so I added them again. There's also a new `window_settings` struct that can be extended with flags or other types of configuration data.

The stresstest for the renderer now runs with unlimited FPS by default. It didn't really go under 60 FPS anymore, so this makes the frame dropoff a bit more obvious for now.