### PR TITLE
Move subtex scaling to shader

### DIFF
--- a/assets/shaders/terrain.vert.glsl
+++ b/assets/shaders/terrain.vert.glsl
@@ -7,9 +7,17 @@ out vec2 tex_pos;
 
 uniform mat4 model;
 
+// camera parameters for transforming the object position
+// and scaling the subtex to the correct size
 layout (std140) uniform camera {
-    mat4 view;
-    mat4 proj;
+    // view matrix (world to view space)
+    mat4  view;
+    // projection matrix (view to clip space)
+    mat4  proj;
+    // inverse zoom factor (1.0 / zoom)
+    float inv_zoom;
+    // inverse viewport size (1.0 / viewport size)
+    vec2  inv_viewport_size;
 };
 
 void main() {

--- a/assets/shaders/world2d.vert.glsl
+++ b/assets/shaders/world2d.vert.glsl
@@ -42,25 +42,25 @@ uniform bool flip_y;
 // match the subtex dimensions
 // uniform vec2 scale;
 
-uniform float scalefactor;
+uniform float scale;
 uniform float zoom;
 uniform vec2 screen_size;
 uniform vec2 subtex_size;
-uniform vec2 anchor;
+uniform vec2 anchor_offset;
 
 void main() {
     // translate the position of the object from world space to clip space
     // this is the position where we want to draw the subtex in 2D
 	vec4 obj_clip_pos = proj * view * model * vec4(obj_world_position, 1.0);
 
-    float obj_scale = scalefactor * inv_zoom;
+    float obj_scale = scale * inv_zoom;
     vec2 obj_scale_vec = vec2(
-        obj_scale * (subtex_size.x * inv_viewport_size.x),
-        obj_scale * (subtex_size.y * inv_viewport_size.y)
+        obj_scale * subtex_size.x * inv_viewport_size.x,
+        obj_scale * subtex_size.y * inv_viewport_size.y
     );
     vec2 obj_anchor_vec = vec2(
-        obj_scale * (anchor.x * inv_viewport_size.x),
-        obj_scale * (anchor.y * inv_viewport_size.y)
+        obj_scale * anchor_offset.x * inv_viewport_size.x,
+        obj_scale * anchor_offset.y * inv_viewport_size.y
     );
 
     // if the subtex is flipped, we also need to flip the anchor offset

--- a/assets/shaders/world2d.vert.glsl
+++ b/assets/shaders/world2d.vert.glsl
@@ -55,12 +55,12 @@ void main() {
 
     float obj_scale = scalefactor * inv_zoom;
     vec2 obj_scale_vec = vec2(
-        obj_scale * (subtex_size.x / screen_size.x),
-        obj_scale * (subtex_size.y / screen_size.y)
+        obj_scale * (subtex_size.x * inv_viewport_size.x),
+        obj_scale * (subtex_size.y * inv_viewport_size.y)
     );
     vec2 obj_anchor_vec = vec2(
-        obj_scale * (anchor.x / screen_size.x),
-        obj_scale * (anchor.y / screen_size.y)
+        obj_scale * (anchor.x * inv_viewport_size.x),
+        obj_scale * (anchor.y * inv_viewport_size.y)
     );
 
     // if the subtex is flipped, we also need to flip the anchor offset

--- a/assets/shaders/world2d.vert.glsl
+++ b/assets/shaders/world2d.vert.glsl
@@ -36,21 +36,37 @@ uniform bool flip_y;
 
 // offset from the subtex anchor
 // moves the subtex relative to the subtex center
-uniform vec2 anchor_offset;
+// uniform vec2 anchor_offset;
 
 // scales the vertex positions so that they
 // match the subtex dimensions
-uniform vec2 scale;
+// uniform vec2 scale;
+
+uniform float scalefactor;
+uniform float zoom;
+uniform vec2 screen_size;
+uniform vec2 subtex_size;
+uniform vec2 anchor;
 
 void main() {
     // translate the position of the object from world space to clip space
     // this is the position where we want to draw the subtex in 2D
 	vec4 obj_clip_pos = proj * view * model * vec4(obj_world_position, 1.0);
 
+    float obj_scale = scalefactor * inv_zoom;
+    vec2 obj_scale_vec = vec2(
+        obj_scale * (subtex_size.x / screen_size.x),
+        obj_scale * (subtex_size.y / screen_size.y)
+    );
+    vec2 obj_anchor_vec = vec2(
+        obj_scale * (anchor.x / screen_size.x),
+        obj_scale * (anchor.y / screen_size.y)
+    );
+
     // if the subtex is flipped, we also need to flip the anchor offset
     // essentially, we invert the coordinates for the flipped axis
-    float anchor_x = float(flip_x) * -1.0 * anchor_offset.x + float(!flip_x) * anchor_offset.x;
-    float anchor_y = float(flip_y) * -1.0 * anchor_offset.y + float(!flip_y) * anchor_offset.y;
+    float anchor_x = float(flip_x) * -1.0 * obj_anchor_vec.x + float(!flip_x) * obj_anchor_vec.x;
+    float anchor_y = float(flip_y) * -1.0 * obj_anchor_vec.y + float(!flip_y) * obj_anchor_vec.y;
 
     // offset the clip position by the offset of the subtex anchor
     // imagine this as pinning the subtex to the object position at the subtex anchor point
@@ -58,8 +74,8 @@ void main() {
 
     // create a move matrix for positioning the vertices
     // uses the scale and the transformed object position in clip space
-    mat4 move = mat4(scale.x,        0.0,            0.0,            0.0,
-                     0.0,            scale.y,        0.0,            0.0,
+    mat4 move = mat4(obj_scale_vec.x,        0.0,            0.0,            0.0,
+                     0.0,            obj_scale_vec.y,        0.0,            0.0,
                      0.0,            0.0,            1.0,            0.0,
                      obj_clip_pos.x, obj_clip_pos.y, obj_clip_pos.z, 1.0);
 

--- a/assets/shaders/world2d.vert.glsl
+++ b/assets/shaders/world2d.vert.glsl
@@ -5,10 +5,17 @@ layout(location=1) in vec2 uv;
 
 out vec2 vert_uv;
 
-// transformation for object (not vertex!) position to clip space
+// camera parameters for transforming the object position
+// and scaling the subtex to the correct size
 layout (std140) uniform camera {
-    mat4 view;
-    mat4 proj;
+    // view matrix (world to view space)
+    mat4  view;
+    // projection matrix (view to clip space)
+    mat4  proj;
+    // inverse zoom factor (1.0 / zoom)
+    float inv_zoom;
+    // inverse viewport size (1.0 / viewport size)
+    vec2  inv_viewport_size;
 };
 
 // can be used to move the object position in world space _before_
@@ -51,9 +58,9 @@ void main() {
 
     // create a move matrix for positioning the vertices
     // uses the scale and the transformed object position in clip space
-    mat4 move = mat4(scale.x, 0.0, 0.0, 0.0,
-                     0.0, scale.y, 0.0, 0.0,
-                     0.0, 0.0, 1.0, 0.0,
+    mat4 move = mat4(scale.x,        0.0,            0.0,            0.0,
+                     0.0,            scale.y,        0.0,            0.0,
+                     0.0,            0.0,            1.0,            0.0,
                      obj_clip_pos.x, obj_clip_pos.y, obj_clip_pos.z, 1.0);
 
     // calculate the final vertex position

--- a/assets/shaders/world2d.vert.glsl
+++ b/assets/shaders/world2d.vert.glsl
@@ -65,17 +65,11 @@ void main() {
     // Scale the subtex vertices
     // we have to account for the viewport size to get the correct dimensions
     // and then scale the subtex to the zoom factor to get the correct size
-    vec2 vert_scale = vec2(
-        zoom_scale * subtex_size.x * inv_viewport_size.x,
-        zoom_scale * subtex_size.y * inv_viewport_size.y
-    );
+    vec2 vert_scale = zoom_scale * subtex_size * inv_viewport_size;
 
     // Scale the anchor offset with the same method as above
     // to get the correct anchor position in the viewport
-    vec2 anchor_scale = vec2(
-        zoom_scale * anchor_offset.x * inv_viewport_size.x,
-        zoom_scale * anchor_offset.y * inv_viewport_size.y
-    );
+    vec2 anchor_scale = zoom_scale * anchor_offset * inv_viewport_size;
 
     // if the subtex is flipped, we also need to flip the anchor offset
     // essentially, we invert the coordinates for the flipped axis

--- a/libopenage/renderer/camera/camera.cpp
+++ b/libopenage/renderer/camera/camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "camera.h"
 
@@ -28,10 +28,7 @@ Camera::Camera(const std::shared_ptr<Renderer> &renderer,
 	proj{Eigen::Matrix4f::Identity()} {
 	this->look_at_scene(Eigen::Vector3f(0.0f, 0.0f, 0.0f));
 
-	resources::UBOInput view_input{"view", resources::ubo_input_t::M4F32};
-	resources::UBOInput proj_input{"proj", resources::ubo_input_t::M4F32};
-	auto ubo_info = resources::UniformBufferInfo{resources::ubo_layout_t::STD140, {view_input, proj_input}};
-	this->uniform_buffer = renderer->add_uniform_buffer(ubo_info);
+	this->init_uniform_buffer(renderer);
 
 	log::log(INFO << "Created new camera at position "
 	              << "(" << this->scene_pos[0]
@@ -55,10 +52,7 @@ Camera::Camera(const std::shared_ptr<Renderer> &renderer,
 	viewport_changed{true},
 	view{Eigen::Matrix4f::Identity()},
 	proj{Eigen::Matrix4f::Identity()} {
-	resources::UBOInput view_input{"view", resources::ubo_input_t::M4F32};
-	resources::UBOInput proj_input{"proj", resources::ubo_input_t::M4F32};
-	auto ubo_info = resources::UniformBufferInfo{resources::ubo_layout_t::STD140, {view_input, proj_input}};
-	this->uniform_buffer = renderer->add_uniform_buffer(ubo_info);
+	this->init_uniform_buffer(renderer);
 
 	log::log(INFO << "Created new camera at position "
 	              << "(" << this->scene_pos[0]
@@ -267,6 +261,17 @@ Eigen::Vector3f Camera::get_input_pos(const coord::input &coord) const {
 
 const std::shared_ptr<renderer::UniformBuffer> &Camera::get_uniform_buffer() const {
 	return this->uniform_buffer;
+}
+
+void Camera::init_uniform_buffer(const std::shared_ptr<Renderer> &renderer) {
+	resources::UBOInput view_input{"view", resources::ubo_input_t::M4F32};
+	resources::UBOInput proj_input{"proj", resources::ubo_input_t::M4F32};
+	resources::UBOInput inv_zoom_input{"inv_zoom", resources::ubo_input_t::F32};
+	resources::UBOInput inv_viewport_size{"inv_viewport_size", resources::ubo_input_t::V2F32};
+	auto ubo_info = resources::UniformBufferInfo{
+		resources::ubo_layout_t::STD140,
+		{view_input, proj_input, inv_zoom_input, inv_viewport_size}};
+	this->uniform_buffer = renderer->add_uniform_buffer(ubo_info);
 }
 
 } // namespace openage::renderer::camera

--- a/libopenage/renderer/camera/camera.h
+++ b/libopenage/renderer/camera/camera.h
@@ -43,6 +43,7 @@ public:
 	 * The camera uses default values. Its centered on the origin of the scene (0.0f, 0.0f, 0.0f)
 	 * and has a zoom level of 1.0f.
 	 *
+	 * @param renderer openage renderer instance.
 	 * @param viewport_size Initial viewport size of the camera (width x height).
 	 */
 	Camera(const std::shared_ptr<Renderer> &renderer,
@@ -51,6 +52,7 @@ public:
 	/**
 	 * Create a new camera for the renderer.
 	 *
+	 * @param renderer openage renderer instance.
 	 * @param viewport_size Viewport size of the camera (width x height).
 	 * @param scene_pos Position of the camera in the scene.
 	 * @param zoom Zoom level of the camera (defaults to 1.0f).
@@ -187,6 +189,13 @@ public:
 	const std::shared_ptr<renderer::UniformBuffer> &get_uniform_buffer() const;
 
 private:
+	/**
+	 * Create the uniform buffer for the camera.
+	 *
+	 * @param renderer openage renderer instance.
+	 */
+	void init_uniform_buffer(const std::shared_ptr<Renderer> &renderer);
+
 	/**
 	 * Position in the 3D scene.
 	 */

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -49,7 +49,14 @@ void renderer_stresstest_0(const util::Path &path) {
 		"view",
 		camera->get_view_matrix(),
 		"proj",
-		camera->get_projection_matrix());
+		camera->get_projection_matrix(),
+		"inv_zoom",
+		1.0f / camera->get_zoom());
+	auto viewport_size = camera->get_viewport_size();
+	Eigen::Vector2f viewport_size_vec{
+		1.0f / static_cast<float>(viewport_size[0]),
+		1.0f / static_cast<float>(viewport_size[1])};
+	cam_unifs->update("inv_viewport_size", viewport_size_vec);
 	camera->get_uniform_buffer()->update_uniforms(cam_unifs);
 
 	// Render stages

--- a/libopenage/renderer/opengl/renderer.cpp
+++ b/libopenage/renderer/opengl/renderer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "renderer.h"
 
@@ -33,10 +33,10 @@ GlRenderer::GlRenderer(const std::shared_ptr<GlContext> &ctx,
 	// global GL alpha blending settings
 	// glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glBlendFuncSeparate(
-		GL_SRC_ALPHA, // source (overlaying) RGB factor
+		GL_SRC_ALPHA,           // source (overlaying) RGB factor
 		GL_ONE_MINUS_SRC_ALPHA, // destination (underlying) RGB factor
-		GL_ONE, // source (overlaying) alpha factor
-		GL_ONE_MINUS_SRC_ALPHA // destination (underlying) alpha factor
+		GL_ONE,                 // source (overlaying) alpha factor
+		GL_ONE_MINUS_SRC_ALPHA  // destination (underlying) alpha factor
 	);
 
 	// global GL depth testing settings
@@ -90,6 +90,11 @@ std::shared_ptr<UniformBuffer> GlRenderer::add_uniform_buffer(resources::Uniform
 	size_t offset = 0;
 	for (auto const &input : inputs) {
 		auto type = GL_UBO_INPUT_TYPE.get(input.type);
+		auto size = resources::UniformBufferInfo::get_size(input, info.get_layout());
+
+		// align offset to the size of the type
+		offset += offset % size;
+
 		uniforms.emplace(
 			std::make_pair(input.name,
 		                   GlInBlockUniform{type,
@@ -97,7 +102,8 @@ std::shared_ptr<UniformBuffer> GlRenderer::add_uniform_buffer(resources::Uniform
 		                                    resources::UniformBufferInfo::get_size(input, info.get_layout()),
 		                                    resources::UniformBufferInfo::get_stride_size(input.type, info.get_layout()),
 		                                    input.count}));
-		offset += resources::UniformBufferInfo::get_size(input, info.get_layout());
+
+		offset += size;
 	}
 
 	return std::make_shared<GlUniformBuffer>(this->gl_context,

--- a/libopenage/renderer/opengl/shader_program.cpp
+++ b/libopenage/renderer/opengl/shader_program.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 the openage authors. See copying.md for legal info.
+// Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 #include "shader_program.h"
 
@@ -445,7 +445,12 @@ void GlShaderProgram::bind_uniform_buffer(const char *block_name, std::shared_pt
 	auto gl_buffer = std::dynamic_pointer_cast<GlUniformBuffer>(buffer);
 	auto &block = this->uniform_blocks[block_name];
 
-	// TODO: Check if the uniform buffer matches the block definition
+	// Check if the uniform buffer matches the block definition
+	for (auto const &pair : block.uniforms) {
+		auto const &unif = pair.second;
+		ENSURE(gl_buffer->has_uniform(pair.first.c_str()),
+		       "Uniform buffer does not contain uniform '" << pair.first << "' required by block " << block_name);
+	}
 
 	block.binding_point = gl_buffer->get_binding_point();
 	glUniformBlockBinding(*this->handle, block.index, block.binding_point);

--- a/libopenage/renderer/resources/buffer_info.cpp
+++ b/libopenage/renderer/resources/buffer_info.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "buffer_info.h"
 
@@ -27,7 +27,13 @@ const std::vector<UBOInput> &UniformBufferInfo::get_inputs() const {
 size_t UniformBufferInfo::get_size() const {
 	size_t size = 0;
 	for (const auto &input : this->inputs) {
-		size += this->get_size(input, this->layout);
+		// size of the input type
+		size_t input_size = this->get_size(input, this->layout);
+
+		// inputs must additionally be aligned to a multiple of their size
+		size_t align_size = size % input_size;
+
+		size += input_size + align_size;
 	}
 	return size;
 }

--- a/libopenage/renderer/stages/camera/manager.cpp
+++ b/libopenage/renderer/stages/camera/manager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "manager.h"
 
@@ -97,11 +97,25 @@ void CameraManager::update_motion() {
 }
 
 void CameraManager::update_uniforms() {
+	// transformation matrices
 	this->uniforms->update(
 		"view",
-		camera->get_view_matrix(),
+		this->camera->get_view_matrix(),
 		"proj",
-		camera->get_projection_matrix());
+		this->camera->get_projection_matrix());
+
+	// zoom scaling
+	this->uniforms->update(
+		"inv_zoom",
+		1.0f / this->camera->get_zoom());
+
+	auto viewport_size = this->camera->get_viewport_size();
+	Eigen::Vector2f viewport_size_vec{
+		1.0f / static_cast<float>(viewport_size[0]),
+		1.0f / static_cast<float>(viewport_size[1])};
+	this->uniforms->update("inv_viewport_size", viewport_size_vec);
+
+	// update the uniform buffer
 	this->camera->get_uniform_buffer()->update_uniforms(this->uniforms);
 }
 

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -157,7 +157,7 @@ void WorldObject::update_uniforms(const time::time_t &time) {
 		scale * (static_cast<float>(anchor[1]) / screen_size[1])};
 	// this->uniforms->update(this->anchor_offset, anchor_offset);
 
-	this->uniforms->update("scalefactor", animation_info->get_scalefactor());
+	this->uniforms->update(this->scale, animation_info->get_scalefactor());
 	// this->uniforms->update("zoom", this->camera->get_zoom());
 	Eigen::Vector2f screen_size_vec{
 		static_cast<float>(screen_size[0]),
@@ -166,11 +166,11 @@ void WorldObject::update_uniforms(const time::time_t &time) {
 	Eigen::Vector2f subtex_size_vec{
 		static_cast<float>(subtex_size[0]),
 		static_cast<float>(subtex_size[1])};
-	this->uniforms->update("subtex_size", subtex_size_vec);
+	this->uniforms->update(this->subtex_size, subtex_size_vec);
 	Eigen::Vector2f anchor_vec{
 		static_cast<float>(anchor[0]),
 		static_cast<float>(anchor[1])};
-	this->uniforms->update("anchor", anchor_vec);
+	this->uniforms->update(this->anchor_offset, anchor_vec);
 }
 
 uint32_t WorldObject::get_id() {

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -138,39 +138,25 @@ void WorldObject::update_uniforms(const time::time_t &time) {
 	auto coords = tex_info->get_subtex_info(subtex_idx).get_tile_params();
 	this->uniforms->update(this->tile_params, coords);
 
-	// scale and keep width x height ratio of texture
-	// when the viewport size changes
-	auto scale = animation_info->get_scalefactor() / this->camera->get_zoom();
-	auto screen_size = this->camera->get_viewport_size();
+	// Animation scale factor
+	// Scales the subtex up or down in the shader
+	auto scale = animation_info->get_scalefactor();
+	this->uniforms->update(this->scale, scale);
+
+	// Subtexture size in pixels
 	auto subtex_size = tex_info->get_subtex_info(subtex_idx).get_size();
-
-	// Scaling with viewport size and zoom
-	auto scale_vec = Eigen::Vector2f{
-		scale * (static_cast<float>(subtex_size[0]) / screen_size[0]),
-		scale * (static_cast<float>(subtex_size[1]) / screen_size[1])};
-	// this->uniforms->update(this->scale, scale_vec);
-
-	// Move subtexture in scene so that its anchor point is at the object's position
-	auto anchor = tex_info->get_subtex_info(subtex_idx).get_anchor_params();
-	auto anchor_offset = Eigen::Vector2f{
-		scale * (static_cast<float>(anchor[0]) / screen_size[0]),
-		scale * (static_cast<float>(anchor[1]) / screen_size[1])};
-	// this->uniforms->update(this->anchor_offset, anchor_offset);
-
-	this->uniforms->update(this->scale, animation_info->get_scalefactor());
-	// this->uniforms->update("zoom", this->camera->get_zoom());
-	Eigen::Vector2f screen_size_vec{
-		static_cast<float>(screen_size[0]),
-		static_cast<float>(screen_size[1])};
-	// this->uniforms->update("screen_size", screen_size_vec);
 	Eigen::Vector2f subtex_size_vec{
 		static_cast<float>(subtex_size[0]),
 		static_cast<float>(subtex_size[1])};
 	this->uniforms->update(this->subtex_size, subtex_size_vec);
-	Eigen::Vector2f anchor_vec{
+
+	// Anchor point offset (in pixels)
+	// moves the subtex in the shader so that the anchor point is at the object's position
+	auto anchor = tex_info->get_subtex_info(subtex_idx).get_anchor_params();
+	Eigen::Vector2f anchor_offset{
 		static_cast<float>(anchor[0]),
 		static_cast<float>(anchor[1])};
-	this->uniforms->update(this->anchor_offset, anchor_vec);
+	this->uniforms->update(this->anchor_offset, anchor_offset);
 }
 
 uint32_t WorldObject::get_id() {

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "object.h"
 
@@ -162,7 +162,7 @@ void WorldObject::update_uniforms(const time::time_t &time) {
 	Eigen::Vector2f screen_size_vec{
 		static_cast<float>(screen_size[0]),
 		static_cast<float>(screen_size[1])};
-	this->uniforms->update("screen_size", screen_size_vec);
+	// this->uniforms->update("screen_size", screen_size_vec);
 	Eigen::Vector2f subtex_size_vec{
 		static_cast<float>(subtex_size[0]),
 		static_cast<float>(subtex_size[1])};

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -148,14 +148,29 @@ void WorldObject::update_uniforms(const time::time_t &time) {
 	auto scale_vec = Eigen::Vector2f{
 		scale * (static_cast<float>(subtex_size[0]) / screen_size[0]),
 		scale * (static_cast<float>(subtex_size[1]) / screen_size[1])};
-	this->uniforms->update(this->scale, scale_vec);
+	// this->uniforms->update(this->scale, scale_vec);
 
 	// Move subtexture in scene so that its anchor point is at the object's position
 	auto anchor = tex_info->get_subtex_info(subtex_idx).get_anchor_params();
 	auto anchor_offset = Eigen::Vector2f{
 		scale * (static_cast<float>(anchor[0]) / screen_size[0]),
 		scale * (static_cast<float>(anchor[1]) / screen_size[1])};
-	this->uniforms->update(this->anchor_offset, anchor_offset);
+	// this->uniforms->update(this->anchor_offset, anchor_offset);
+
+	this->uniforms->update("scalefactor", animation_info->get_scalefactor());
+	// this->uniforms->update("zoom", this->camera->get_zoom());
+	Eigen::Vector2f screen_size_vec{
+		static_cast<float>(screen_size[0]),
+		static_cast<float>(screen_size[1])};
+	this->uniforms->update("screen_size", screen_size_vec);
+	Eigen::Vector2f subtex_size_vec{
+		static_cast<float>(subtex_size[0]),
+		static_cast<float>(subtex_size[1])};
+	this->uniforms->update("subtex_size", subtex_size_vec);
+	Eigen::Vector2f anchor_vec{
+		static_cast<float>(anchor[0]),
+		static_cast<float>(anchor[1])};
+	this->uniforms->update("anchor", anchor_vec);
 }
 
 uint32_t WorldObject::get_id() {

--- a/libopenage/renderer/stages/world/object.h
+++ b/libopenage/renderer/stages/world/object.h
@@ -131,8 +131,6 @@ public:
 	inline static uniform_id_t flip_y;
 	inline static uniform_id_t tex;
 	inline static uniform_id_t tile_params;
-	// inline static uniform_id_t scale;
-	// inline static uniform_id_t anchor_offset;
 	inline static uniform_id_t scale;
 	inline static uniform_id_t subtex_size;
 	inline static uniform_id_t anchor_offset;

--- a/libopenage/renderer/stages/world/object.h
+++ b/libopenage/renderer/stages/world/object.h
@@ -131,7 +131,10 @@ public:
 	inline static uniform_id_t flip_y;
 	inline static uniform_id_t tex;
 	inline static uniform_id_t tile_params;
+	// inline static uniform_id_t scale;
+	// inline static uniform_id_t anchor_offset;
 	inline static uniform_id_t scale;
+	inline static uniform_id_t subtex_size;
 	inline static uniform_id_t anchor_offset;
 
 private:

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -135,8 +135,6 @@ void WorldRenderStage::init_uniform_ids() {
 	WorldObject::flip_y = this->display_shader->get_uniform_id("flip_y");
 	WorldObject::tex = this->display_shader->get_uniform_id("tex");
 	WorldObject::tile_params = this->display_shader->get_uniform_id("tile_params");
-	// WorldObject::scale = this->display_shader->get_uniform_id("scale");
-	// WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");
 	WorldObject::scale = this->display_shader->get_uniform_id("scale");
 	WorldObject::subtex_size = this->display_shader->get_uniform_id("subtex_size");
 	WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -137,6 +137,9 @@ void WorldRenderStage::init_uniform_ids() {
 	WorldObject::tile_params = this->display_shader->get_uniform_id("tile_params");
 	// WorldObject::scale = this->display_shader->get_uniform_id("scale");
 	// WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");
+	WorldObject::scale = this->display_shader->get_uniform_id("scale");
+	WorldObject::subtex_size = this->display_shader->get_uniform_id("subtex_size");
+	WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");
 }
 
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -135,8 +135,8 @@ void WorldRenderStage::init_uniform_ids() {
 	WorldObject::flip_y = this->display_shader->get_uniform_id("flip_y");
 	WorldObject::tex = this->display_shader->get_uniform_id("tex");
 	WorldObject::tile_params = this->display_shader->get_uniform_id("tile_params");
-	WorldObject::scale = this->display_shader->get_uniform_id("scale");
-	WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");
+	// WorldObject::scale = this->display_shader->get_uniform_id("scale");
+	// WorldObject::anchor_offset = this->display_shader->get_uniform_id("anchor_offset");
 }
 
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "render_stage.h"
 


### PR DESCRIPTION
Move the scaling of subtextures (i.e. handling of zoom, animation scaling, etc.) to the world shader.

Camera zoom and viewport size are send via the camera's uniform buffer, so these variables are now requested only once per frame. The world object's have to send an additional `float` as a uniform, but no longer have to calculate the scaling themselves which roughly halves the cycles spent on creating these uniform values.

The PR also fixes a bug in the alignment of uniforms in the uniform buffer that was previously not discovered. Uniforms where not properly aligned to a multiple of their size which resulted in the created buffer being too small and using the wrong offsets. This should now be fixed.