### PR TITLE
Frustum Culling

### DIFF
--- a/libopenage/renderer/camera/CMakeLists.txt
+++ b/libopenage/renderer/camera/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_sources(libopenage
 	camera.cpp
+	frustum.cpp
 )

--- a/libopenage/renderer/camera/camera.cpp
+++ b/libopenage/renderer/camera/camera.cpp
@@ -34,6 +34,7 @@ Camera::Camera(const std::shared_ptr<Renderer> &renderer,
 	auto ubo_info = resources::UniformBufferInfo{resources::ubo_layout_t::STD140, {view_input, proj_input}};
 	this->uniform_buffer = renderer->add_uniform_buffer(ubo_info);
 
+	// Make the frustum slightly bigger than the camera's view to ensure objects on the boundary get rendered
 	float real_zoom = 0.7f * this->default_zoom_ratio * this->zoom;
 	frustum.Recalculate(this->viewport_size, near_distance, far_distance, this->scene_pos, cam_direction, Eigen::Vector3f(0.0f, 1.0f, 0.0f), real_zoom);
 
@@ -66,6 +67,7 @@ Camera::Camera(const std::shared_ptr<Renderer> &renderer,
 	auto ubo_info = resources::UniformBufferInfo{resources::ubo_layout_t::STD140, {view_input, proj_input}};
 	this->uniform_buffer = renderer->add_uniform_buffer(ubo_info);
 
+	// Make the frustum slightly bigger than the camera's view to ensure objects on the boundary get rendered
 	float real_zoom = 0.7f * this->default_zoom_ratio * this->zoom;
 	frustum.Recalculate(this->viewport_size, near_distance, far_distance, this->scene_pos, cam_direction, Eigen::Vector3f(0.0f, 1.0f, 0.0f), real_zoom);
 
@@ -123,6 +125,7 @@ void Camera::move_to(Eigen::Vector3f scene_pos) {
 	this->scene_pos = scene_pos;
 	this->moved = true;
 
+	// Make the frustum slightly bigger than the camera's view to ensure objects on the boundary get rendered
 	float real_zoom = 0.7f * this->default_zoom_ratio * this->zoom;
 	frustum.Recalculate(viewport_size, near_distance, far_distance, scene_pos, cam_direction, Eigen::Vector3f(0.0f, 1.0f, 0.0f), real_zoom);
 }

--- a/libopenage/renderer/camera/camera.h
+++ b/libopenage/renderer/camera/camera.h
@@ -285,7 +285,8 @@ private:
 	std::shared_ptr<renderer::UniformBuffer> uniform_buffer;
 
 	/**
-	 * Is frustum culling enabled? If true, 
+	 * Is frustum culling enabled? If true, perform frustum culling.
+	 * If false, all frustum checks will return true
 	 */
 	bool frustum_culling;
 

--- a/libopenage/renderer/camera/camera.h
+++ b/libopenage/renderer/camera/camera.h
@@ -12,6 +12,8 @@
 #include "coord/scene.h"
 #include "util/vector.h"
 
+#include "frustum.h"
+
 namespace openage::renderer {
 class Renderer;
 class UniformBuffer;
@@ -29,6 +31,9 @@ static const Eigen::Vector3f cam_direction{
 	-0.5f,
 	-1 * (std::sqrt(6.f) / 4),
 };
+
+static const float near_distance = 0.01f;
+static const float far_distance = 100.0f;
 
 /**
  * Camera for selecting what part of the ingame world is displayed.
@@ -56,13 +61,15 @@ public:
 	 * @param zoom Zoom level of the camera (defaults to 1.0f).
 	 * @param max_zoom_out Maximum zoom out level (defaults to 64.0f).
 	 * @param default_zoom_ratio Default zoom level calibration (defaults to (1.0f / 49)).
+	 * @param frustum_culling Is frustum culling enables (defaults to false).
 	 */
 	Camera(const std::shared_ptr<Renderer> &renderer,
 	       util::Vector2s viewport_size,
 	       Eigen::Vector3f scene_pos,
 	       float zoom = 1.0f,
 	       float max_zoom_out = 64.0f,
-	       float default_zoom_ratio = 1.0f / 49);
+	       float default_zoom_ratio = 1.0f / 49,
+		   bool frustum_culling = false);
 	~Camera() = default;
 
 	/**
@@ -186,6 +193,10 @@ public:
 	 */
 	const std::shared_ptr<renderer::UniformBuffer> &get_uniform_buffer() const;
 
+	bool using_frustum_culling() const;
+
+	bool is_in_frustum(Eigen::Vector3f pos) const;
+
 private:
 	/**
 	 * Position in the 3D scene.
@@ -272,6 +283,17 @@ private:
 	 * Uniform buffer for the camera matrices.
 	 */
 	std::shared_ptr<renderer::UniformBuffer> uniform_buffer;
+
+	/**
+	 * Is frustum culling enabled? If true, 
+	 */
+	bool frustum_culling;
+
+	/**
+	 * The frustum used to cull objects
+	 * Will be recalculated regardless of whether frustum culling is enabled
+	 */
+	Frustum frustum;
 };
 
 } // namespace camera

--- a/libopenage/renderer/camera/frustum.cpp
+++ b/libopenage/renderer/camera/frustum.cpp
@@ -1,0 +1,165 @@
+// Copyright 2024-2024 the openage authors. See copying.md for legal info.
+
+#include "frustum.h"
+
+#include <array>
+#include <numbers>
+#include <string>
+#include <utility>
+
+#include "coord/pixel.h"
+#include "coord/scene.h"
+#include "renderer/renderer.h"
+#include "renderer/resources/buffer_info.h"
+
+namespace openage::renderer::camera {
+
+/*
+    Eigen::Vector3f top_face_normal;
+    float top_face_distance;
+
+    Eigen::Vector3f bottom_face_normal;
+    float bottom_face_distance;
+
+    Eigen::Vector3f right_face_normal;
+    float right_face_distance;
+
+    Eigen::Vector3f left_face_normal;
+    float left_face_distance;
+
+    Eigen::Vector3f far_face_normal;
+    float far_face_distance;
+
+    Eigen::Vector3f near_face_normal;
+    float near_face_distance;
+*/
+
+Frustum::Frustum() : 
+    top_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    top_face_distance{0.0f},
+    bottom_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    bottom_face_distance{0.0f},
+    right_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    right_face_distance{0.0f},
+    left_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    left_face_distance{0.0f},
+    far_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    far_face_distance{0.0f},
+    near_face_normal{Eigen::Vector3f(0.0f, 0.0f, 0.0f)},
+    near_face_distance{0.0f}
+{
+}
+
+void Frustum::Recalculate(util::Vector2s &viewport_size, float near_distance, float far_distance, Eigen::Vector3f &scene_pos, Eigen::Vector3f cam_direction, Eigen::Vector3f up_direction, float real_zoom) {
+    // offsets are adjusted by zoom
+	// this is the same calculation as for the projection matrix
+	float halfscreenwidth = viewport_size[0] / 2;
+	float halfscreenheight = viewport_size[1] / 2;
+
+    float halfwidth = halfscreenwidth * real_zoom;
+	float halfheight = halfscreenheight * real_zoom;
+
+    Eigen::Vector3f direction = cam_direction.normalized();
+    Eigen::Vector3f eye = scene_pos;
+	Eigen::Vector3f center = scene_pos + direction;
+
+    // calculate up (u) and right (s) vectors for camera
+	// these define the camera plane in 3D space that the input
+    Eigen::Vector3f f = center - eye;
+	f.normalize();
+	Eigen::Vector3f s = f.cross(up_direction);
+	s.normalize();
+	Eigen::Vector3f u = s.cross(f);
+	u.normalize();
+
+    Eigen::Vector3f near_position = scene_pos - direction * near_distance;
+    Eigen::Vector3f far_position = scene_pos + direction * far_distance;
+
+    Eigen::Vector3f near_top_left = near_position - s * halfwidth + u * halfheight;
+    Eigen::Vector3f near_top_right = near_position + s * halfwidth + u * halfheight;
+    Eigen::Vector3f near_bottom_left = near_position - s * halfwidth - u * halfheight;
+    Eigen::Vector3f near_bottom_right = near_position + s * halfwidth - u * halfheight;
+
+    Eigen::Vector3f far_top_left = far_position - s * halfwidth + u * halfheight;
+    Eigen::Vector3f far_top_right = far_position + s * halfwidth + u * halfheight;
+    Eigen::Vector3f far_bottom_left = far_position - s * halfwidth - u * halfheight;
+    Eigen::Vector3f far_bottom_right = far_position + s * halfwidth - u * halfheight;
+
+    this->near_face_normal = -1.0f * cam_direction.normalized();
+    this->far_face_normal = cam_direction.normalized();
+
+    this->near_face_distance = this->near_face_normal.dot(near_position) * -1.0f;
+    this->far_face_distance = this->far_face_normal.dot(far_position) * -1.0f;
+
+    this->left_face_normal = (near_bottom_left - near_top_left).cross(far_bottom_left - near_bottom_left);
+    this->right_face_normal = (far_bottom_right - near_bottom_right).cross(near_bottom_right - near_top_right);
+    this->top_face_normal = (near_top_right - near_top_left).cross(near_top_left - far_top_left);
+    this->bottom_face_normal = (near_bottom_left - far_bottom_left).cross(near_bottom_right - near_bottom_left);
+
+    log::log(INFO << "Compute near and far points");
+    log::log(INFO << "Near Top Left: " << near_top_left[0] << ", " << near_top_left[1] << ", " << near_top_left[2]);
+    log::log(INFO << "Near Top Right: " << near_top_right[0] << ", " << near_top_right[1] << ", " << near_top_right[2]);
+    log::log(INFO << "Near Bottom Left: " << near_bottom_left[0] << ", " << near_bottom_left[1] << ", " << near_bottom_left[2]);
+    log::log(INFO << "Near Bottom Right: " << near_bottom_right[0] << ", " << near_bottom_right[1] << ", " << near_bottom_right[2]);
+    log::log(INFO << "Far Top Left: " << far_top_left[0] << ", " << far_top_left[1] << ", " << far_top_left[2]);
+    log::log(INFO << "Far Top Right: " << far_top_right[0] << ", " << far_top_right[1] << ", " << far_top_right[2]);
+    log::log(INFO << "Far Bottom Left: " << far_bottom_left[0] << ", " << far_bottom_left[1] << ", " << far_bottom_left[2]);
+    log::log(INFO << "Far Bottom Right: " << far_bottom_right[0] << ", " << far_bottom_right[1] << ", " << far_bottom_right[2]);
+
+    this->left_face_normal.normalize();
+    this->right_face_normal.normalize();
+    this->top_face_normal.normalize();
+    this->bottom_face_normal.normalize();
+
+    this->left_face_distance = 1.f * this->left_face_normal.dot(near_bottom_left);
+    this->right_face_distance = 1.f * this->right_face_normal.dot(far_bottom_right);
+    this->top_face_distance = 1.f * this->top_face_normal.dot(near_top_right);
+    this->bottom_face_distance = 1.f * this->bottom_face_normal.dot(near_bottom_left);
+
+    log::log(INFO << "Computed Frustum with planes \n"
+	              << "Top: <" << this->top_face_normal[0] << ", " << this->top_face_normal[1] << ", " << this->top_face_normal[2] << ">, " << this->top_face_distance << "\n"
+	              << "Bottom: <" << this->bottom_face_normal[0] << ", " << this->bottom_face_normal[1] << ", " << this->bottom_face_normal[2] << ">, " << this->bottom_face_distance << "\n"
+	              << "Left: <" << this->left_face_normal[0] << ", " << this->left_face_normal[1] << ", " << this->left_face_normal[2] << ">, " << this->left_face_distance << "\n"
+	              << "Right: <" << this->right_face_normal[0] << ", " << this->right_face_normal[1] << ", " << this->right_face_normal[2] << ">, " << this->right_face_distance << "\n"
+	              << "Far: <" << this->far_face_normal[0] << ", " << this->far_face_normal[1] << ", " << this->far_face_normal[2] << ">, " << this->far_face_distance << "\n"
+	              << "Near: <" << this->near_face_normal[0] << ", " << this->near_face_normal[1] << ", " << this->near_face_normal[2] << ">, " << this->near_face_distance << "\n"
+    );
+}
+
+bool Frustum::is_in_frustum(Eigen::Vector3f& pos) const {
+    float distance;
+
+    distance = this->top_face_normal.dot(pos) - this->top_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    distance = this->bottom_face_normal.dot(pos) - this->bottom_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    distance = this->left_face_normal.dot(pos) - this->left_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    distance = this->right_face_normal.dot(pos) - this->right_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    distance = this->far_face_normal.dot(pos) - this->far_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    distance = this->bottom_face_normal.dot(pos) - this->bottom_face_distance;
+    if (distance < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/libopenage/renderer/camera/frustum.h
+++ b/libopenage/renderer/camera/frustum.h
@@ -1,0 +1,46 @@
+// Copyright 2024-2024 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+
+#include <eigen3/Eigen/Dense>
+
+#include "coord/pixel.h"
+#include "coord/scene.h"
+#include "util/vector.h"
+
+namespace openage::renderer::camera {
+
+class Frustum
+{
+public:
+    Frustum();
+
+    void Recalculate(util::Vector2s& viewport_size, float near_distance, float far_distance, Eigen::Vector3f& scene_pos, Eigen::Vector3f cam_direction, Eigen::Vector3f up_direction, float real_zoom);
+
+    bool is_in_frustum(Eigen::Vector3f& pos) const;
+
+private:
+    Eigen::Vector3f top_face_normal;
+    float top_face_distance;
+
+    Eigen::Vector3f bottom_face_normal;
+    float bottom_face_distance;
+
+    Eigen::Vector3f right_face_normal;
+    float right_face_distance;
+
+    Eigen::Vector3f left_face_normal;
+    float left_face_distance;
+
+    Eigen::Vector3f far_face_normal;
+    float far_face_distance;
+
+    Eigen::Vector3f near_face_normal;
+    float near_face_distance;
+
+};
+} // namespace openage::renderer::camera

--- a/libopenage/renderer/demo/CMakeLists.txt
+++ b/libopenage/renderer/demo/CMakeLists.txt
@@ -6,6 +6,7 @@ add_sources(libopenage
     demo_4.cpp
     demo_5.cpp
     stresstest_0.cpp
+    stresstest_1.cpp
 	tests.cpp
     util.cpp
 )

--- a/libopenage/renderer/demo/stresstest_1.cpp
+++ b/libopenage/renderer/demo/stresstest_1.cpp
@@ -1,0 +1,222 @@
+// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+
+#include "stresstest_1.h"
+
+#include <eigen3/Eigen/Dense>
+
+#include "coord/tile.h"
+#include "renderer/camera/camera.h"
+#include "renderer/gui/integration/public/gui_application_with_logger.h"
+#include "renderer/opengl/window.h"
+#include "renderer/render_factory.h"
+#include "renderer/resources/assets/asset_manager.h"
+#include "renderer/resources/shader_source.h"
+#include "renderer/stages/camera/manager.h"
+#include "renderer/stages/screen/render_stage.h"
+#include "renderer/stages/skybox/render_stage.h"
+#include "renderer/stages/terrain/render_entity.h"
+#include "renderer/stages/terrain/render_stage.h"
+#include "renderer/stages/world/render_entity.h"
+#include "renderer/stages/world/render_stage.h"
+#include "renderer/uniform_buffer.h"
+#include "time/clock.h"
+#include "util/fps.h"
+
+namespace openage::renderer::tests {
+void renderer_stresstest_1(const util::Path &path) {
+    auto qtapp = std::make_shared<gui::GuiApplicationWithLogger>();
+
+	auto window = std::make_shared<opengl::GlWindow>("openage renderer test", 1024, 768, true);
+	auto renderer = window->make_renderer();
+
+	// Clock required by world renderer for timing animation frames
+	auto clock = std::make_shared<time::Clock>();
+
+	// Camera
+	// our viewport into the game world
+	// on this one, enable frustum culling
+	auto camera = std::make_shared<renderer::camera::Camera>(renderer,
+	                                                         window->get_size(),
+	                                                         Eigen::Vector3f{17.0f, 10.0f, 7.0f},
+															 1.f,
+															 64.f,
+															 1.f / 49.f,
+															 true);
+	auto cam_unifs = camera->get_uniform_buffer()->create_empty_input();
+	cam_unifs->update(
+		"view",
+		camera->get_view_matrix(),
+		"proj",
+		camera->get_projection_matrix());
+	camera->get_uniform_buffer()->update_uniforms(cam_unifs);
+
+    // Render stages
+	// every stage use a different subrenderer that manages renderables,
+	// shaders, textures & more.
+	std::vector<std::shared_ptr<RenderPass>>
+		render_passes{};
+
+	// TODO: Make this optional for subrenderers?
+	auto asset_manager = std::make_shared<renderer::resources::AssetManager>(
+		renderer,
+		path["assets"]["test"]);
+
+	// Renders the background
+	auto skybox_renderer = std::make_shared<renderer::skybox::SkyboxRenderStage>(
+		window,
+		renderer,
+		path["assets"]["shaders"]);
+	skybox_renderer->set_color(1.0f, 0.5f, 0.0f, 1.0f); // orange color
+
+	// Renders the terrain in 3D
+	auto terrain_renderer = std::make_shared<renderer::terrain::TerrainRenderStage>(
+		window,
+		renderer,
+		camera,
+		path["assets"]["shaders"],
+		asset_manager,
+		clock);
+
+	// Renders units/buildings/other objects
+	auto world_renderer = std::make_shared<renderer::world::WorldRenderStage>(
+		window,
+		renderer,
+		camera,
+		path["assets"]["shaders"],
+		asset_manager,
+		clock);
+
+	// Store the render passes of the renderers
+	// The order is important as its also the order in which they
+	// are rendered and drawn onto the screen.
+	render_passes.push_back(skybox_renderer->get_render_pass());
+	render_passes.push_back(terrain_renderer->get_render_pass());
+	render_passes.push_back(world_renderer->get_render_pass());
+
+	// Final output on screen has its own subrenderer
+	// It takes the outputs of all previous render passes
+	// and blends them together
+	auto screen_renderer = std::make_shared<renderer::screen::ScreenRenderStage>(
+		window,
+		renderer,
+		path["assets"]["shaders"]);
+	std::vector<std::shared_ptr<renderer::RenderTarget>> targets{};
+	for (auto &pass : render_passes) {
+		targets.push_back(pass->get_target());
+	}
+	screen_renderer->set_render_targets(targets);
+
+	window->add_resize_callback([&](size_t, size_t, double /*scale*/) {
+		// Acquire the render targets for all previous passes
+		std::vector<std::shared_ptr<renderer::RenderTarget>> targets{};
+		for (size_t i = 0; i < render_passes.size() - 1; ++i) {
+			targets.push_back(render_passes[i]->get_target());
+		}
+		screen_renderer->set_render_targets(targets);
+	});
+
+	render_passes.push_back(screen_renderer->get_render_pass());
+
+	// Create some entities to populate the scene
+	auto render_factory = std::make_shared<RenderFactory>(terrain_renderer, world_renderer);
+
+	// Fill a 10x10 terrain grid with height values
+	auto terrain_size = util::Vector2s{10, 10};
+	std::vector<std::pair<terrain::TerrainRenderEntity::terrain_elevation_t, std::string>> tiles{};
+	tiles.reserve(terrain_size[0] * terrain_size[1]);
+	for (size_t i = 0; i < terrain_size[0] * terrain_size[1]; ++i) {
+		tiles.emplace_back(0.0f, "./textures/test_terrain.terrain");
+	}
+
+	// Create entity for terrain rendering
+	auto terrain0 = render_factory->add_terrain_render_entity(terrain_size,
+	                                                          coord::tile_delta{0, 0});
+
+	// send the terrain data to the terrain renderer
+	terrain0->update(terrain_size, tiles);
+
+    std::vector<std::shared_ptr<renderer::world::WorldRenderEntity>> render_entities{};
+	auto add_world_entity = [&](const coord::phys3 initial_pos,
+	                            const time::time_t time) {
+		const auto animation_path = "./textures/test_tank_mirrored.sprite";
+
+		auto position = curve::Continuous<coord::phys3>{nullptr, 0, "", nullptr, coord::phys3(0, 0, 0)};
+		position.set_insert(time, initial_pos);
+		position.set_insert(time + 1, initial_pos + coord::phys3_delta{0, 4, 0});
+		position.set_insert(time + 2, initial_pos + coord::phys3_delta{4, 8, 0});
+		position.set_insert(time + 3, initial_pos + coord::phys3_delta{8, 8, 0});
+		position.set_insert(time + 4, initial_pos + coord::phys3_delta{12, 4, 0});
+		position.set_insert(time + 5, initial_pos + coord::phys3_delta{12, 0, 0});
+		position.set_insert(time + 6, initial_pos + coord::phys3_delta{12, -4, 0});
+		position.set_insert(time + 7, initial_pos + coord::phys3_delta{4, -4, 0});
+		position.set_insert(time + 8, initial_pos);
+
+		auto angle = curve::Segmented<coord::phys_angle_t>{nullptr, 0};
+		angle.set_insert(time, coord::phys_angle_t::from_int(315));
+		angle.set_insert_jump(time + 1, coord::phys_angle_t::from_int(315), coord::phys_angle_t::from_int(270));
+		angle.set_insert_jump(time + 2, coord::phys_angle_t::from_int(270), coord::phys_angle_t::from_int(225));
+		angle.set_insert_jump(time + 3, coord::phys_angle_t::from_int(225), coord::phys_angle_t::from_int(180));
+		angle.set_insert_jump(time + 4, coord::phys_angle_t::from_int(180), coord::phys_angle_t::from_int(135));
+		angle.set_insert_jump(time + 5, coord::phys_angle_t::from_int(135), coord::phys_angle_t::from_int(90));
+		angle.set_insert_jump(time + 6, coord::phys_angle_t::from_int(90), coord::phys_angle_t::from_int(45));
+		angle.set_insert_jump(time + 7, coord::phys_angle_t::from_int(45), coord::phys_angle_t::from_int(0));
+		angle.set_insert_jump(time + 8, coord::phys_angle_t::from_int(0), coord::phys_angle_t::from_int(315));
+
+		auto entity = render_factory->add_world_render_entity();
+		entity->update(render_entities.size(),
+		               position,
+		               angle,
+		               animation_path,
+		               time);
+		render_entities.push_back(entity);
+	};
+
+	// Stop after 8000 entities
+	size_t entity_limit = 8000;
+
+	clock->start();
+
+	util::FrameCounter timer;
+
+	add_world_entity(coord::phys3(0.0f, 10.0f, 0.0f), clock->get_time());
+	time::time_t next_entity = clock->get_real_time() + 0.1;
+	while (render_entities.size() <= entity_limit) {
+		// Print FPS
+		timer.frame();
+		std::cout
+			<< "Entities: " << render_entities.size()
+			<< " -- "
+			<< "FPS: " << timer.fps << "\r" << std::flush;
+
+		qtapp->process_events();
+
+		// Advance time
+		clock->update_time();
+		auto current_time = clock->get_real_time();
+		if (current_time > next_entity) {
+			add_world_entity(coord::phys3(0.0f, 10.0f, 0.0f), clock->get_time());
+            add_world_entity(coord::phys3(-1.f, 9.0f, 0.0f), clock->get_time());
+			next_entity = current_time + 0.1;
+		}
+
+		// Update the renderables of the subrenderers
+		terrain_renderer->update();
+		world_renderer->update();
+
+		// Draw everything
+		for (auto &pass : render_passes) {
+			renderer->render(pass);
+		}
+
+		renderer->check_error();
+
+		// Display final output on screen
+		window->update();
+	}
+
+	clock->stop();
+	log::log(MSG(info) << "Stopped after rendering " << render_entities.size() << " entities");
+
+	window->close();
+}
+}

--- a/libopenage/renderer/demo/stresstest_1.h
+++ b/libopenage/renderer/demo/stresstest_1.h
@@ -1,0 +1,16 @@
+// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include "util/path.h"
+
+namespace openage::renderer::tests {
+
+/**
+ * Stresstest for the renderer's frustum culling feature.
+ *
+ * @param path Path to the openage asset directory.
+ */
+void renderer_stresstest_1(const util::Path &path);
+
+}

--- a/libopenage/renderer/demo/tests.cpp
+++ b/libopenage/renderer/demo/tests.cpp
@@ -12,7 +12,7 @@
 #include "renderer/demo/demo_4.h"
 #include "renderer/demo/demo_5.h"
 #include "renderer/demo/stresstest_0.h"
-
+#include "renderer/demo/stresstest_1.h"
 
 namespace openage::renderer::tests {
 
@@ -53,7 +53,9 @@ OAAPI void renderer_stresstest(int demo_id, const util::Path &path) {
 	case 0:
 		renderer_stresstest_0(path);
 		break;
-
+	case 1:
+		renderer_stresstest_1(path);
+		break;
 	default:
 		log::log(MSG(err) << "Unknown renderer stresstest requested: " << demo_id << ".");
 		break;

--- a/libopenage/renderer/renderer.h
+++ b/libopenage/renderer/renderer.h
@@ -98,6 +98,7 @@ protected:
 	/// Create a new RenderPass. This is called from Renderer::add_render_pass,
 	/// which then creates the proper subclass of RenderPass, depending on the backend.
 	RenderPass(std::vector<Renderable>, const std::shared_ptr<RenderTarget> &);
+public:
 	/// The renderables to parse and possibly execute.
 	std::vector<Renderable> renderables;
 

--- a/libopenage/renderer/resources/parser/common.cpp
+++ b/libopenage/renderer/resources/parser/common.cpp
@@ -20,7 +20,13 @@ TextureData parse_texture(const std::vector<std::string> &args) {
 	texture.texture_id = std::stoul(args[1]);
 
 	// Call substr() to get rid of the quotes
-	texture.path = args[2].substr(1, args[2].size() - 2);
+	// If the line ends in a carriage return, remove it as well
+	if (args[2][args[2].size() - 1] == '\r') {
+		texture.path = args[2].substr(1, args[2].size() - 3);
+	}
+	else {
+		texture.path = args[2].substr(1, args[2].size() - 2);
+	}
 
 	return texture;
 }

--- a/libopenage/renderer/resources/parser/parse_sprite.cpp
+++ b/libopenage/renderer/resources/parser/parse_sprite.cpp
@@ -195,8 +195,8 @@ Animation2dInfo parse_sprite_file(const util::Path &file,
 		})};
 
 	for (auto line : lines) {
-		// Skip empty lines and comments
-		if (line.empty() || line.substr(0, 1) == "#") {
+		// Skip empty lines, lines with carriage returns, and comments
+		if (line.empty() || line.substr(0, 1) == "#" || line[0] == '\r') {
 			continue;
 		}
 		std::vector<std::string> args{util::split(line, ' ')};

--- a/libopenage/renderer/resources/parser/parse_terrain.cpp
+++ b/libopenage/renderer/resources/parser/parse_terrain.cpp
@@ -200,8 +200,8 @@ TerrainInfo parse_terrain_file(const util::Path &file,
 		})};
 
 	for (auto line : lines) {
-		// Skip empty lines and comments
-		if (line.empty() || line.substr(0, 1) == "#") {
+		// Skip empty lines, lines with carriage returns, and comments
+		if (line.empty() || line.substr(0, 1) == "#" || line[0] == '\r') {
 			continue;
 		}
 		std::vector<std::string> args{util::split(line, ' ')};

--- a/libopenage/renderer/resources/parser/parse_texture.cpp
+++ b/libopenage/renderer/resources/parser/parse_texture.cpp
@@ -56,6 +56,11 @@ std::string parse_imagefile(const std::vector<std::string> &args) {
 	// it should result in an error if wrongly used here.
 
 	// Call substr() to get rid of the quotes
+	// If the line ends in a carriage return, remove it as well
+	if (args[1][args[1].size() - 1] == '\r') {
+		return args[1].substr(1, args[1].size() - 3);
+	}
+
 	return args[1].substr(1, args[1].size() - 2);
 }
 
@@ -179,8 +184,8 @@ Texture2dInfo parse_texture_file(const util::Path &file) {
 		})};
 
 	for (auto line : lines) {
-		// Skip empty lines and comments
-		if (line.empty() || line.substr(0, 1) == "#") {
+		// Skip empty lines, lines with carriage returns, and comments
+		if (line.empty() || line.substr(0, 1) == "#" || line[0] == '\r') {
 			continue;
 		}
 		std::vector<std::string> args{util::split(line, ' ')};

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -186,4 +186,13 @@ void WorldObject::set_uniforms(const std::shared_ptr<renderer::UniformInput> &un
 	this->uniforms = uniforms;
 }
 
+bool WorldObject::within_camera_frustum(const std::shared_ptr<camera::Camera> &camera) {
+	if (!camera->using_frustum_culling()) {
+		return true;
+	}
+
+	Eigen::Vector3f current_pos = this->position.get(this->last_update).to_world_space();
+	return camera->is_in_frustum(current_pos);
+}
+
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/object.h
+++ b/libopenage/renderer/stages/world/object.h
@@ -123,6 +123,8 @@ public:
 	 */
 	void set_uniforms(const std::shared_ptr<renderer::UniformInput> &uniforms);
 
+	bool within_camera_frustum(const std::shared_ptr<camera::Camera> &camera);
+
 	/**
 	 * Shader uniform IDs for setting uniform values.
 	 */

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -58,6 +58,10 @@ void WorldRenderStage::update() {
 	std::unique_lock lock{this->mutex};
 	auto current_time = this->clock->get_real_time();
 	for (auto &obj : this->render_objects) {
+		if (!obj->within_camera_frustum(this->camera)) {
+			continue;
+		}
+
 		obj->fetch_updates(current_time);
 		if (obj->is_changed()) {
 			if (obj->requires_renderable()) {
@@ -90,6 +94,8 @@ void WorldRenderStage::update() {
 		}
 		obj->update_uniforms(current_time);
 	}
+
+	std::cout << this->render_pass->renderables.size() << std::flush;
 }
 
 void WorldRenderStage::resize(size_t width, size_t height) {


### PR DESCRIPTION
Implemented Frustum Culling into the renderer. Currently only applies to the world renderer. The camera has a frustum data structure to allow it to cull objects outside the frustum. 

An additional stresstest has been created for the renderer to test out frustum culling.

Additional fixes to loading files on windows that have the special \r character are also included in this pull request.