### PR TITLE
Force install pip packages in macOS CI

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -66,7 +66,7 @@ jobs:
         # cython, numpy and pygments are in homebrew,
         # but "cython is keg-only, which means it was not symlinked into /usr/local"
         # numpy pulls gcc as dep? and pygments doesn't work.
-        run: pip3 install --upgrade cython numpy mako lz4 pillow pygments setuptools toml
+        run: pip3 install --upgrade --break-system-packages cython numpy mako lz4 pillow pygments setuptools toml
       - name: Configure
         run: |
           CLANG_PATH="$HOME/clang-15.0.0/bin/clang++"


### PR DESCRIPTION
This forces all macOS Python dependencies to be installed via `pip` and not `homebrew`. The homebrew variants didn't always work, so we have to do this workaround.