### PR TITLE
Enhance DLL search on Windows

### DIFF
--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -31,27 +31,15 @@ def print_version():
     sys.exit(0)
 
 
-def add_dll_search_paths(dll_paths):
+def add_dll_search_paths(dll_paths: list[str]):
     """
     This function adds DLL search paths.
-    This function does nothing if current OS is not Windows.
     """
+    from .util.dll import DllDirectoryManager
 
-    def close_windows_dll_path_handles(dll_path_handles):
-        """
-        This function calls close() method on each of the handles.
-        """
-        for handle in dll_path_handles:
-            handle.close()
+    manager = DllDirectoryManager(dll_paths)
 
-    if sys.platform != 'win32' or dll_paths is None:
-        return
-
-    import atexit
-    win_dll_path_handles = []
-    for addtional_path in dll_paths:
-        win_dll_path_handles.append(os.add_dll_directory(addtional_path))
-    atexit.register(close_windows_dll_path_handles, win_dll_path_handles)
+    return manager
 
 
 def main(argv=None):
@@ -62,11 +50,11 @@ def main(argv=None):
     )
 
     if sys.platform == 'win32':
-        import inspect
+        from .util.dll import default_paths
         cli.add_argument(
             "--add-dll-search-path", action='append', dest='dll_paths',
             # use path of current openage executable as default
-            default=[os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda: 0)))],
+            default=default_paths(),
             help="(Windows only) provide additional DLL search path")
 
     cli.add_argument("--version", "-V", action='store_true', dest='print_version',
@@ -142,7 +130,11 @@ def main(argv=None):
     args = cli.parse_args(argv)
 
     if sys.platform == 'win32':
-        add_dll_search_paths(args.dll_paths)
+        args.dll_manager = add_dll_search_paths(args.dll_paths)
+        args.dll_manager.add_directories()
+
+    else:
+        args.dll_manager = None
 
     if args.print_version:
         print_version()

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -129,12 +129,10 @@ def main(argv=None):
 
     args = cli.parse_args(argv)
 
+    dll_manager = None
     if sys.platform == 'win32':
-        args.dll_manager = add_dll_search_paths(args.dll_paths)
-        args.dll_manager.add_directories()
-
-    else:
-        args.dll_manager = None
+        dll_manager = add_dll_search_paths(args.dll_paths)
+        dll_manager.add_directories()
 
     if args.print_version:
         print_version()
@@ -142,6 +140,8 @@ def main(argv=None):
     if not args.subcommand:
         # the user didn't specify a subcommand. default to 'main'.
         args = main_cli.parse_args(argv)
+
+    args.dll_manager = dll_manager
 
     # process the shared args
     set_loglevel(verbosity_to_level(args.verbose - args.quiet))

--- a/openage/convert/tool/singlefile.py
+++ b/openage/convert/tool/singlefile.py
@@ -1,10 +1,11 @@
-# Copyright 2015-2023 the openage authors. See copying.md for legal info.
+# Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 """
 Convert a single slp/wav file from some drs archive to a png/opus file.
 """
 from __future__ import annotations
 
+import sys
 
 from pathlib import Path
 
@@ -58,6 +59,11 @@ def main(args, error):
 
     file_path = Path(args.filename)
     file_extension = file_path.suffix[1:].lower()
+
+    if sys.platform == "win32":
+        from openage.util.dll import DllDirectoryManager, default_paths
+        dll_manager = DllDirectoryManager(default_paths())
+        dll_manager.add_directories()
 
     if not (args.mode in ("sld", "drs-wav", "wav") or file_extension in ("sld", "wav")):
         if not args.palettes_path:

--- a/openage/util/CMakeLists.txt
+++ b/openage/util/CMakeLists.txt
@@ -3,6 +3,7 @@ add_py_modules(
 	bytequeue.py
 	context.py
 	decorators.py
+	dll.py
 	files.py
 	fsprinting.py
 	hash.py

--- a/openage/util/dll.py
+++ b/openage/util/dll.py
@@ -13,13 +13,22 @@ DEFAULT_PYTHON_DLL_DIR = os.path.dirname(sys.executable)
 
 # openage.dll locations (relative to this file)
 DEFAULT_OPENAGE_DLL_DIRs = [
+    "../../libopenage/Debug",
+    "../../libopenage/Release",
     "../../libopenage/RelWithDebInfo",
+    "../../libopenage/MinSizeRel",
 ]
 
 # nyan.dll locations (relative to this file)
 DEFAULT_NYAN_DLL_DIRS = [
+    "../../../../nyan/build/nyan/Debug",
+    "../../../../nyan/build/nyan/Release",
     "../../../../nyan/build/nyan/RelWithDebInfo",
+    "../../../../nyan/build/nyan/MinSizeRel",
+    "../../nyan-external/bin/nyan/Debug",
+    "../../nyan-external/bin/nyan/Release",
     "../../nyan-external/bin/nyan/RelWithDebInfo",
+    "../../nyan-external/bin/nyan/MinSizeRel",
 ]
 
 

--- a/openage/util/dll.py
+++ b/openage/util/dll.py
@@ -67,10 +67,24 @@ class DllDirectoryManager:
         self.remove_directories()
 
     def __enter__(self):
+        """
+        Enter a context guard.
+        """
         self.add_directories()
 
     def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Exit a context guard.
+        """
         self.remove_directories()
+
+    def __getstate__(self):
+        """
+        Change pickling behavior so that directory handles are not serialized.
+        """
+        content = self.__dict__
+        content["handles"] = []
+        return content
 
 
 def default_paths() -> list[str]:

--- a/openage/util/dll.py
+++ b/openage/util/dll.py
@@ -1,0 +1,95 @@
+# Copyright 2024-2024 the openage authors. See copying.md for legal info.
+
+"""
+Windows-specific loading of compiled Python modules and DLLs.
+"""
+
+import inspect
+import os
+import sys
+
+# python.dll location
+DEFAULT_PYTHON_DLL_DIR = os.path.dirname(sys.executable)
+
+# openage.dll locations (relative to this file)
+DEFAULT_OPENAGE_DLL_DIRs = [
+    "../../libopenage/RelWithDebInfo",
+]
+
+# nyan.dll locations (relative to this file)
+DEFAULT_NYAN_DLL_DIRS = [
+    "../../../../nyan/build/nyan/RelWithDebInfo",
+    "../../nyan-external/bin/nyan/RelWithDebInfo",
+]
+
+
+class DllDirectoryManager:
+    """
+    Manages directories that should be added to/removed from Python's DLL search path.
+
+    All dependent DLLs or compiled cython modules that are not in Python's default search path
+    mst be added manually at runtime. Basically, this applies to all openage-specific libraries.
+    """
+
+    def __init__(self, directory_paths: list[str]):
+        """
+        Create a new DLL directory manager.
+
+        :param directory_paths: Absolute paths to the directories that are added.
+        """
+        # Directory paths
+        self.directories = directory_paths
+
+        # Store handles for added directories
+        self.handles = []
+
+    def add_directories(self):
+        """
+        Add the manager's directories to Python's DLL search path.
+        """
+        for directory in self.directories:
+            handle = os.add_dll_directory(directory)
+            self.handles.append(handle)
+
+    def remove_directories(self):
+        """
+        Remove the manager's directories from Python's DLL search path.
+        """
+        for handle in self.handles:
+            handle.close()
+
+        self.handles = []
+
+    def __del__(self):
+        """
+        Ensure that DLL paths are removed when the object is deleted.
+        """
+        self.remove_directories()
+
+    def __enter__(self):
+        self.add_directories()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.remove_directories()
+
+
+def default_paths() -> list[str]:
+    """
+    Create a list of default paths.
+    """
+    directory_paths = []
+
+    # Add Python DLL search path
+    directory_paths.append(DEFAULT_PYTHON_DLL_DIR)
+
+    file_dir = os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda: 0)))
+
+    # Add openage DLL search paths
+    for path in DEFAULT_OPENAGE_DLL_DIRs:
+        directory_paths.append(os.path.join(file_dir, path))
+
+    # Add nyan DLL search paths
+    for path in DEFAULT_NYAN_DLL_DIRS:
+        directory_paths.append(os.path.join(file_dir, path))
+
+    return directory_paths

--- a/openage/util/dll.py
+++ b/openage/util/dll.py
@@ -99,11 +99,15 @@ def default_paths() -> list[str]:
     file_dir = os.path.dirname(os.path.abspath(inspect.getsourcefile(lambda: 0)))
 
     # Add openage DLL search paths
-    for path in DEFAULT_OPENAGE_DLL_DIRs:
-        directory_paths.append(os.path.join(file_dir, path))
+    for candidate in DEFAULT_OPENAGE_DLL_DIRs:
+        path = os.path.join(file_dir, candidate)
+        if os.path.exists(path):
+            directory_paths.append(path)
 
     # Add nyan DLL search paths
-    for path in DEFAULT_NYAN_DLL_DIRS:
-        directory_paths.append(os.path.join(file_dir, path))
+    for candidate in DEFAULT_NYAN_DLL_DIRS:
+        path = os.path.join(file_dir, candidate)
+        if os.path.exists(path):
+            directory_paths.append(path)
 
     return directory_paths


### PR DESCRIPTION
Fixes the import errors for the compiled libraries and Python modules on Windows by adding better default search paths. If you build openage from source with the documented instructions, there shouldn't be any Python errors after this PR.

The problem in https://github.com/SFTtech/openage/issues/1644 was that the dependent libraries were no longer found automatically since Python 3.8 and you had to use `--add-dll-search-path` to avoid errors. However, it's not always obvious how this argument should be used. Therefore, openage now sets sane defaults to search for:

- `python.dll`
- `openage.dll`
- `nyan.dll`

Furthermore, it fixes the errors in https://github.com/SFTtech/openage/issues/1624 . These happened because the DLLs are only set *per process*, so subprocesses in `multiprocessing` were not aware about the DLL search paths. This problem is now solved by adding a `DllDirectoryManager` object that can be passed around and then used to add/remove DLL search paths.