### PR TITLE
Make `util::constexpr_` consteval

### DIFF
--- a/libopenage/log/message.h
+++ b/libopenage/log/message.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -11,7 +11,7 @@
 #include <string>
 
 #include "../util/compiler.h"
-#include "../util/constexpr.h"
+#include "../util/consteval.h"
 #include "../util/stringformatter.h"
 #include "config.h"
 #include "logsink.h"
@@ -165,7 +165,7 @@ private:
 // for use with existing log::level objects
 #define MSG_LVLOBJ(LVLOBJ) \
 	::openage::log::MessageBuilder( \
-		::openage::util::constexpr_::strip_prefix( \
+		::openage::util::consteval_::strip_prefix( \
 			__FILE__, \
 			::openage::config::buildsystem_sourcefile_dir), \
 		__LINE__, \

--- a/libopenage/util/consteval.h
+++ b/libopenage/util/consteval.h
@@ -6,15 +6,15 @@
 
 
 /**
- * This namespace contains constexpr functions, i.e. C++14 functions that are designed
- * to run at compile-time.
+ * This namespace contains consteval functions, i.e. C++20 functions that are designed
+ * to be evaluated at compile-time.
  */
-namespace openage::util::constexpr_ {
+namespace openage::util::consteval_ {
 
 /**
  * Returns true IFF the string literals have equal content.
  */
-constexpr bool streq(const char *a, const char *b) {
+consteval bool streq(const char *a, const char *b) {
 	for (; *a == *b; ++a, ++b) {
 		if (*a == '\0') {
 			return true;
@@ -27,7 +27,7 @@ constexpr bool streq(const char *a, const char *b) {
 /**
  * Returns the length of the string literal, excluding the terminating NULL byte.
  */
-constexpr size_t strlen(const char *str) {
+consteval size_t strlen(const char *str) {
 	for (size_t len = 0;; ++len) {
 		if (str[len] == '\0') {
 			return len;
@@ -56,7 +56,7 @@ struct truncated_string_literal {
  *
  * Raises 'false' if str doesn't end in the given suffix.
  */
-constexpr truncated_string_literal get_prefix(const char *str, const char *suffix) {
+consteval truncated_string_literal get_prefix(const char *str, const char *suffix) {
 	if (strlen(str) < strlen(suffix)) {
 		// suffix is longer than str
 		throw false;
@@ -74,14 +74,14 @@ constexpr truncated_string_literal get_prefix(const char *str, const char *suffi
 /**
  * Creates a truncated_string_literal from a regular string literal.
  */
-constexpr truncated_string_literal create_truncated_string_literal(const char *str) {
+consteval truncated_string_literal create_truncated_string_literal(const char *str) {
 	return truncated_string_literal{str, strlen(str)};
 }
 
 /**
  * Tests whether a string literal starts with the given prefix.
  */
-constexpr bool has_prefix(const char *str, const truncated_string_literal prefix) {
+consteval bool has_prefix(const char *str, const truncated_string_literal prefix) {
 	for (size_t pos = 0; pos < prefix.length; ++pos) {
 		if (str[pos] != prefix.literal[pos]) {
 			return false;
@@ -96,7 +96,7 @@ constexpr bool has_prefix(const char *str, const truncated_string_literal prefix
  *
  * If the string literal doesn't have that prefix, returns the string literal itself.
  */
-constexpr const char *strip_prefix(const char *str, const truncated_string_literal prefix) {
+consteval const char *strip_prefix(const char *str, const truncated_string_literal prefix) {
 	if (has_prefix(str, prefix)) {
 		return str + prefix.length;
 	}
@@ -111,8 +111,8 @@ constexpr const char *strip_prefix(const char *str, const truncated_string_liter
  *
  * If the string literal doesn't have that prefix, returns the string literal itself.
  */
-constexpr const char *strip_prefix(const char *str, const char *prefix) {
+consteval const char *strip_prefix(const char *str, const char *prefix) {
 	return strip_prefix(str, create_truncated_string_literal(prefix));
 }
 
-} // namespace openage::util::constexpr_
+} // namespace openage::util::consteval_


### PR DESCRIPTION
`util::constexpr_` contains helper functions for the openage logger that should be evaluated at compile-time. However, at least for me, these functions were still evaluated at runtime instead. This created a lot of unnecessary call to these functions, especially `strip_prefix`, when logging messages. The log messages take up a giant amount of resources in the event loop for example, due to the frequent calls to the logger.

Since C++20 can enforce compile-time evaluation with the `consteval` keyword, so I replaced all `constexpr` specifiers in the namespace with that. I also changed the name of the namespace to `util::consteval_` to make this change more clear.