### PR TITLE
Make component classes `final`

### DIFF
--- a/libopenage/gamestate/component/api/idle.h
+++ b/libopenage/gamestate/component/api/idle.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -7,7 +7,7 @@
 
 namespace openage::gamestate::component {
 
-class Idle : public APIComponent {
+class Idle final : public APIComponent {
 public:
 	using APIComponent::APIComponent;
 

--- a/libopenage/gamestate/component/api/live.h
+++ b/libopenage/gamestate/component/api/live.h
@@ -14,7 +14,7 @@
 
 
 namespace openage::gamestate::component {
-class Live : public APIComponent {
+class Live final : public APIComponent {
 public:
 	using APIComponent::APIComponent;
 

--- a/libopenage/gamestate/component/api/move.h
+++ b/libopenage/gamestate/component/api/move.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -8,7 +8,7 @@
 
 namespace openage::gamestate::component {
 
-class Move : public APIComponent {
+class Move final : public APIComponent {
 public:
 	using APIComponent::APIComponent;
 

--- a/libopenage/gamestate/component/api/selectable.h
+++ b/libopenage/gamestate/component/api/selectable.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -10,7 +10,7 @@
 
 namespace openage::gamestate::component {
 
-class Selectable : public APIComponent {
+class Selectable final : public APIComponent {
 public:
 	using APIComponent::APIComponent;
 

--- a/libopenage/gamestate/component/api/turn.h
+++ b/libopenage/gamestate/component/api/turn.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -10,7 +10,7 @@
 
 namespace openage::gamestate::component {
 
-class Turn : public APIComponent {
+class Turn final : public APIComponent {
 public:
 	using APIComponent::APIComponent;
 

--- a/libopenage/gamestate/component/internal/activity.h
+++ b/libopenage/gamestate/component/internal/activity.h
@@ -27,7 +27,7 @@ class Node;
 
 namespace component {
 
-class Activity : public InternalComponent {
+class Activity final : public InternalComponent {
 public:
 	/**
 	 * Creates a new activity component.

--- a/libopenage/gamestate/component/internal/command_queue.h
+++ b/libopenage/gamestate/component/internal/command_queue.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the openage authors. See copying.md for legal info.
+// Copyright 2021-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -19,7 +19,7 @@ class EventLoop;
 
 namespace gamestate::component {
 
-class CommandQueue : public InternalComponent {
+class CommandQueue final : public InternalComponent {
 public:
 	/**
 	 * Creates an Ownership component.

--- a/libopenage/gamestate/component/internal/ownership.h
+++ b/libopenage/gamestate/component/internal/ownership.h
@@ -19,7 +19,7 @@ class EventLoop;
 
 namespace gamestate::component {
 
-class Ownership : public InternalComponent {
+class Ownership final : public InternalComponent {
 public:
 	/**
 	 * Creates an Ownership component.

--- a/libopenage/gamestate/component/internal/position.h
+++ b/libopenage/gamestate/component/internal/position.h
@@ -20,7 +20,7 @@ class EventLoop;
 
 namespace gamestate::component {
 
-class Position : public InternalComponent {
+class Position final : public InternalComponent {
 public:
 	/**
 	 * Create a Position component.


### PR DESCRIPTION
Small optimization that labels game simulation components as `final`, so they can't be overriden.