### PR TITLE
Change recommended entrypoint for Windows build

### DIFF
--- a/doc/build_instructions/windows_msvc.md
+++ b/doc/build_instructions/windows_msvc.md
@@ -93,7 +93,7 @@ _Note:_ If you want to download and build Nyan automatically add `-DDOWNLOAD_NYA
       - If prebuilt QT6 was installed, the original location of QT6 DLLs is `<QT6 directory>\bin`.
 
   - Now, to run the openage:
-    - Open a CMD window in `<openage directory>\build\` and run `python -m openage game`
+    - Open a CMD window in `<openage directory>\build\` and run `python -m openage main`
     - Execute`<openage directory>\build\run.exe` every time after that and enjoy!
 
 ## Packaging


### PR DESCRIPTION
Small fix that changes the recommended entrypoint in the Windows build docs from `game` to `main`. `main` includes a user flow that enables the user to convert assets, while `game` doesn't, so it should be a bit easier for newcomers.