### PR TITLE
Fix thread-safe access for render entities

### DIFF
--- a/libopenage/gamestate/game_entity.cpp
+++ b/libopenage/gamestate/game_entity.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "game_entity.h"
 
@@ -30,7 +30,7 @@ entity_id_t GameEntity::get_id() const {
 	return this->id;
 }
 
-void GameEntity::set_render_entity(const std::shared_ptr<renderer::world::WorldRenderEntity> &entity) {
+void GameEntity::set_render_entity(const std::shared_ptr<renderer::world::RenderEntity> &entity) {
 	// TODO: Transfer state from old render entity to new one?
 
 	this->render_entity = entity;

--- a/libopenage/gamestate/game_entity.h
+++ b/libopenage/gamestate/game_entity.h
@@ -14,7 +14,7 @@
 namespace openage {
 
 namespace renderer::world {
-class WorldRenderEntity;
+class RenderEntity;
 }
 
 namespace gamestate {
@@ -62,7 +62,7 @@ public:
 	 *
 	 * @param entity New render entity.
 	 */
-	void set_render_entity(const std::shared_ptr<renderer::world::WorldRenderEntity> &entity);
+	void set_render_entity(const std::shared_ptr<renderer::world::RenderEntity> &entity);
 
 	/**
 	 * Set the event manager of this entity.
@@ -142,7 +142,7 @@ private:
 	/**
 	 * Render entity for pushing updates to the renderer. Can be \p nullptr.
 	 */
-	std::shared_ptr<renderer::world::WorldRenderEntity> render_entity;
+	std::shared_ptr<renderer::world::RenderEntity> render_entity;
 
 	/**
 	 * Event manager.

--- a/libopenage/gamestate/terrain_chunk.cpp
+++ b/libopenage/gamestate/terrain_chunk.cpp
@@ -18,7 +18,7 @@ TerrainChunk::TerrainChunk(const util::Vector2s size,
 	}
 }
 
-void TerrainChunk::set_render_entity(const std::shared_ptr<renderer::terrain::TerrainRenderEntity> &entity) {
+void TerrainChunk::set_render_entity(const std::shared_ptr<renderer::terrain::RenderEntity> &entity) {
 	this->render_entity = entity;
 }
 

--- a/libopenage/gamestate/terrain_chunk.h
+++ b/libopenage/gamestate/terrain_chunk.h
@@ -32,7 +32,7 @@ public:
 	 *
 	 * @param entity New render entity.
 	 */
-	void set_render_entity(const std::shared_ptr<renderer::terrain::TerrainRenderEntity> &entity);
+	void set_render_entity(const std::shared_ptr<renderer::terrain::RenderEntity> &entity);
 
 	/**
 	 * Get the size of this terrain chunk.
@@ -78,7 +78,7 @@ private:
 	/**
 	 * Render entity for pushing updates to the renderer. Can be \p nullptr.
 	 */
-	std::shared_ptr<renderer::terrain::TerrainRenderEntity> render_entity;
+	std::shared_ptr<renderer::terrain::RenderEntity> render_entity;
 };
 
 } // namespace openage::gamestate

--- a/libopenage/input/controller/hud/controller.cpp
+++ b/libopenage/input/controller/hud/controller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "controller.h"
 
@@ -27,11 +27,11 @@ bool Controller::process(const event_arguments &ev_args,
 	return true;
 }
 
-void Controller::set_drag_entity(const std::shared_ptr<renderer::hud::HudDragRenderEntity> &entity) {
+void Controller::set_drag_entity(const std::shared_ptr<renderer::hud::DragRenderEntity> &entity) {
 	this->drag_entity = entity;
 }
 
-const std::shared_ptr<renderer::hud::HudDragRenderEntity> &Controller::get_drag_entity() const {
+const std::shared_ptr<renderer::hud::DragRenderEntity> &Controller::get_drag_entity() const {
 	return this->drag_entity;
 }
 
@@ -39,7 +39,7 @@ void setup_defaults(const std::shared_ptr<BindingContext> &ctx,
                     const std::shared_ptr<renderer::hud::HudRenderStage> &hud_renderer) {
 	binding_func_t drag_selection_init{[&](const event_arguments &args,
 	                                       const std::shared_ptr<Controller> controller) {
-		auto render_entity = std::make_shared<renderer::hud::HudDragRenderEntity>(args.mouse);
+		auto render_entity = std::make_shared<renderer::hud::DragRenderEntity>(args.mouse);
 		hud_renderer->add_drag_entity(render_entity);
 		controller->set_drag_entity(render_entity);
 	}};

--- a/libopenage/input/controller/hud/controller.h
+++ b/libopenage/input/controller/hud/controller.h
@@ -10,7 +10,7 @@
 namespace openage {
 
 namespace renderer::hud {
-class HudDragRenderEntity;
+class DragRenderEntity;
 class HudRenderStage;
 } // namespace renderer::hud
 
@@ -42,20 +42,20 @@ public:
 	 *
 	 * @param entity New render entity.
 	 */
-	void set_drag_entity(const std::shared_ptr<renderer::hud::HudDragRenderEntity> &entity);
+	void set_drag_entity(const std::shared_ptr<renderer::hud::DragRenderEntity> &entity);
 
 	/**
 	 * Get the render entity for the selection box.
 	 *
 	 * @return Render entity for the selection box.
 	 */
-	const std::shared_ptr<renderer::hud::HudDragRenderEntity> &get_drag_entity() const;
+	const std::shared_ptr<renderer::hud::DragRenderEntity> &get_drag_entity() const;
 
 private:
 	/**
 	 * Render entity for the selection box.
 	 */
-	std::shared_ptr<renderer::hud::HudDragRenderEntity> drag_entity;
+	std::shared_ptr<renderer::hud::DragRenderEntity> drag_entity;
 };
 
 /**

--- a/libopenage/renderer/demo/demo_3.cpp
+++ b/libopenage/renderer/demo/demo_3.cpp
@@ -123,7 +123,7 @@ void renderer_demo_3(const util::Path &path) {
 
 	// Fill a 10x10 terrain grid with height values
 	auto terrain_size = util::Vector2s{10, 10};
-	std::vector<std::pair<terrain::TerrainRenderEntity::terrain_elevation_t, std::string>> tiles{};
+	std::vector<std::pair<terrain::RenderEntity::terrain_elevation_t, std::string>> tiles{};
 	tiles.reserve(terrain_size[0] * terrain_size[1]);
 	for (size_t i = 0; i < terrain_size[0] * terrain_size[1]; ++i) {
 		tiles.emplace_back(0.0f, "./textures/test_terrain.terrain");

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -147,7 +147,7 @@ void renderer_stresstest_0(const util::Path &path) {
 	terrain0->update(terrain_size, tiles);
 
 	// World entities
-	std::vector<std::shared_ptr<renderer::world::WorldRenderEntity>> render_entities{};
+	std::vector<std::shared_ptr<renderer::world::RenderEntity>> render_entities{};
 	auto add_world_entity = [&](const coord::phys3 initial_pos,
 	                            const time::time_t time) {
 		const auto animation_path = "./textures/test_tank_mirrored.sprite";

--- a/libopenage/renderer/demo/stresstest_0.cpp
+++ b/libopenage/renderer/demo/stresstest_0.cpp
@@ -133,7 +133,7 @@ void renderer_stresstest_0(const util::Path &path) {
 
 	// Fill a 10x10 terrain grid with height values
 	auto terrain_size = util::Vector2s{10, 10};
-	std::vector<std::pair<terrain::TerrainRenderEntity::terrain_elevation_t, std::string>> tiles{};
+	std::vector<std::pair<terrain::RenderEntity::terrain_elevation_t, std::string>> tiles{};
 	tiles.reserve(terrain_size[0] * terrain_size[1]);
 	for (size_t i = 0; i < terrain_size[0] * terrain_size[1]; ++i) {
 		tiles.emplace_back(0.0f, "./textures/test_terrain.terrain");

--- a/libopenage/renderer/demo/stresstest_1.cpp
+++ b/libopenage/renderer/demo/stresstest_1.cpp
@@ -151,7 +151,7 @@ void renderer_stresstest_1(const util::Path &path) {
 	// send the terrain data to the terrain renderer
 	terrain0->update(terrain_size, tiles);
 
-	std::vector<std::shared_ptr<renderer::world::WorldRenderEntity>> render_entities{};
+	std::vector<std::shared_ptr<renderer::world::RenderEntity>> render_entities{};
 	auto add_world_entity = [&](const coord::phys3 initial_pos,
 	                            const time::time_t time) {
 		const auto animation_path = "./textures/test_tank_mirrored.sprite";

--- a/libopenage/renderer/demo/stresstest_1.cpp
+++ b/libopenage/renderer/demo/stresstest_1.cpp
@@ -138,7 +138,7 @@ void renderer_stresstest_1(const util::Path &path) {
 
 	// Fill a 10x10 terrain grid with height values
 	auto terrain_size = util::Vector2s{10, 10};
-	std::vector<std::pair<terrain::TerrainRenderEntity::terrain_elevation_t, std::string>> tiles{};
+	std::vector<std::pair<terrain::RenderEntity::terrain_elevation_t, std::string>> tiles{};
 	tiles.reserve(terrain_size[0] * terrain_size[1]);
 	for (size_t i = 0; i < terrain_size[0] * terrain_size[1]; ++i) {
 		tiles.emplace_back(0.0f, "./textures/test_terrain.terrain");

--- a/libopenage/renderer/render_factory.cpp
+++ b/libopenage/renderer/render_factory.cpp
@@ -23,8 +23,8 @@ std::shared_ptr<terrain::RenderEntity> RenderFactory::add_terrain_render_entity(
 	return entity;
 }
 
-std::shared_ptr<world::WorldRenderEntity> RenderFactory::add_world_render_entity() {
-	auto entity = std::make_shared<world::WorldRenderEntity>();
+std::shared_ptr<world::RenderEntity> RenderFactory::add_world_render_entity() {
+	auto entity = std::make_shared<world::RenderEntity>();
 	this->world_renderer->add_render_entity(entity);
 
 	return entity;

--- a/libopenage/renderer/render_factory.cpp
+++ b/libopenage/renderer/render_factory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "render_factory.h"
 
@@ -15,9 +15,9 @@ RenderFactory::RenderFactory(const std::shared_ptr<terrain::TerrainRenderStage> 
 	world_renderer{world_renderer} {
 }
 
-std::shared_ptr<terrain::TerrainRenderEntity> RenderFactory::add_terrain_render_entity(const util::Vector2s chunk_size,
-                                                                                       const coord::tile_delta chunk_offset) {
-	auto entity = std::make_shared<terrain::TerrainRenderEntity>();
+std::shared_ptr<terrain::RenderEntity> RenderFactory::add_terrain_render_entity(const util::Vector2s chunk_size,
+                                                                                const coord::tile_delta chunk_offset) {
+	auto entity = std::make_shared<terrain::RenderEntity>();
 	this->terrain_renderer->add_render_entity(entity, chunk_size, chunk_offset.to_phys2().to_scene2());
 
 	return entity;

--- a/libopenage/renderer/render_factory.h
+++ b/libopenage/renderer/render_factory.h
@@ -16,7 +16,7 @@ class RenderEntity;
 
 namespace world {
 class WorldRenderStage;
-class WorldRenderEntity;
+class RenderEntity;
 } // namespace world
 
 /**
@@ -55,7 +55,7 @@ public:
 	 *
 	 * @return Render entity for pushing terrain updates.
 	 */
-	std::shared_ptr<world::WorldRenderEntity> add_world_render_entity();
+	std::shared_ptr<world::RenderEntity> add_world_render_entity();
 
 private:
 	/**

--- a/libopenage/renderer/render_factory.h
+++ b/libopenage/renderer/render_factory.h
@@ -11,7 +11,7 @@
 namespace openage::renderer {
 namespace terrain {
 class TerrainRenderStage;
-class TerrainRenderEntity;
+class RenderEntity;
 } // namespace terrain
 
 namespace world {
@@ -47,8 +47,8 @@ public:
 	 *
 	 * @return Render entity for pushing terrain updates.
 	 */
-	std::shared_ptr<terrain::TerrainRenderEntity> add_terrain_render_entity(const util::Vector2s chunk_size,
-	                                                                        const coord::tile_delta chunk_offset);
+	std::shared_ptr<terrain::RenderEntity> add_terrain_render_entity(const util::Vector2s chunk_size,
+	                                                                 const coord::tile_delta chunk_offset);
 
 	/**
 	 * Create a new world render entity and register it at the world renderer.

--- a/libopenage/renderer/stages/CMakeLists.txt
+++ b/libopenage/renderer/stages/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_sources(libopenage
+	render_entity.cpp
+)
+
 add_subdirectory(camera/)
 add_subdirectory(hud/)
 add_subdirectory(screen/)

--- a/libopenage/renderer/stages/hud/object.cpp
+++ b/libopenage/renderer/stages/hud/object.cpp
@@ -38,7 +38,14 @@ void HudDragObject::fetch_updates(const time::time_t &time) {
 
 	// Get data from render entity
 	this->drag_start = this->render_entity->get_drag_start();
+
+	// Thread-safe access to curves needs a lock on the render entity's mutex
+	auto read_lock = this->render_entity->get_read_lock();
+
 	this->drag_pos.sync(this->render_entity->get_drag_pos() /* , this->last_update */);
+
+	// Unlock the render entity mutex
+	read_lock.unlock();
 
 	// Set self to changed so that world renderer can update the renderable
 	this->changed = true;

--- a/libopenage/renderer/stages/hud/object.cpp
+++ b/libopenage/renderer/stages/hud/object.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "object.h"
 
@@ -21,7 +21,7 @@ HudDragObject::HudDragObject(const std::shared_ptr<renderer::resources::AssetMan
 	last_update{0.0} {
 }
 
-void HudDragObject::set_render_entity(const std::shared_ptr<HudDragRenderEntity> &entity) {
+void HudDragObject::set_render_entity(const std::shared_ptr<DragRenderEntity> &entity) {
 	this->render_entity = entity;
 	this->fetch_updates();
 }

--- a/libopenage/renderer/stages/hud/object.h
+++ b/libopenage/renderer/stages/hud/object.h
@@ -26,7 +26,7 @@ class Animation2dInfo;
 } // namespace resources
 
 namespace hud {
-class HudDragRenderEntity;
+class DragRenderEntity;
 
 /**
  * Stores the state of a renderable object in the HUD render stage.
@@ -46,7 +46,7 @@ public:
 	 *
 	 * @param entity New world render entity.
 	 */
-	void set_render_entity(const std::shared_ptr<HudDragRenderEntity> &entity);
+	void set_render_entity(const std::shared_ptr<DragRenderEntity> &entity);
 
 	/**
 	 * Set the current camera of the scene.
@@ -147,7 +147,7 @@ private:
 	/**
 	 * Source for positional and texture data.
 	 */
-	std::shared_ptr<HudDragRenderEntity> render_entity;
+	std::shared_ptr<DragRenderEntity> render_entity;
 
 	/**
 	 * Position of the dragged corner.

--- a/libopenage/renderer/stages/hud/render_entity.cpp
+++ b/libopenage/renderer/stages/hud/render_entity.cpp
@@ -24,10 +24,14 @@ void DragRenderEntity::update(const coord::input drag_pos,
 }
 
 const curve::Continuous<coord::input> &DragRenderEntity::get_drag_pos() {
+	std::shared_lock lock{this->mutex};
+
 	return this->drag_pos;
 }
 
-const coord::input &DragRenderEntity::get_drag_start() {
+const coord::input DragRenderEntity::get_drag_start() {
+	std::shared_lock lock{this->mutex};
+
 	return this->drag_start;
 }
 

--- a/libopenage/renderer/stages/hud/render_entity.cpp
+++ b/libopenage/renderer/stages/hud/render_entity.cpp
@@ -7,14 +7,14 @@
 
 namespace openage::renderer::hud {
 
-HudDragRenderEntity::HudDragRenderEntity(const coord::input drag_start) :
-	RenderEntity{},
+DragRenderEntity::DragRenderEntity(const coord::input drag_start) :
+	renderer::RenderEntity{},
 	drag_pos{nullptr, 0, "", nullptr, drag_start},
 	drag_start{drag_start} {
 }
 
-void HudDragRenderEntity::update(const coord::input drag_pos,
-                                 const time::time_t time) {
+void DragRenderEntity::update(const coord::input drag_pos,
+                              const time::time_t time) {
 	std::unique_lock lock{this->mutex};
 
 	this->drag_pos.set_insert(time, drag_pos);
@@ -23,11 +23,11 @@ void HudDragRenderEntity::update(const coord::input drag_pos,
 	this->changed = true;
 }
 
-const curve::Continuous<coord::input> &HudDragRenderEntity::get_drag_pos() {
+const curve::Continuous<coord::input> &DragRenderEntity::get_drag_pos() {
 	return this->drag_pos;
 }
 
-const coord::input &HudDragRenderEntity::get_drag_start() {
+const coord::input &DragRenderEntity::get_drag_start() {
 	return this->drag_start;
 }
 

--- a/libopenage/renderer/stages/hud/render_entity.cpp
+++ b/libopenage/renderer/stages/hud/render_entity.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "render_entity.h"
 
@@ -8,8 +8,7 @@
 namespace openage::renderer::hud {
 
 HudDragRenderEntity::HudDragRenderEntity(const coord::input drag_start) :
-	changed{false},
-	last_update{0.0},
+	RenderEntity{},
 	drag_pos{nullptr, 0, "", nullptr, drag_start},
 	drag_start{drag_start} {
 }
@@ -24,30 +23,12 @@ void HudDragRenderEntity::update(const coord::input drag_pos,
 	this->changed = true;
 }
 
-time::time_t HudDragRenderEntity::get_update_time() {
-	std::shared_lock lock{this->mutex};
-
-	return this->last_update;
-}
-
 const curve::Continuous<coord::input> &HudDragRenderEntity::get_drag_pos() {
 	return this->drag_pos;
 }
 
 const coord::input &HudDragRenderEntity::get_drag_start() {
 	return this->drag_start;
-}
-
-bool HudDragRenderEntity::is_changed() {
-	std::shared_lock lock{this->mutex};
-
-	return this->changed;
-}
-
-void HudDragRenderEntity::clear_changed_flag() {
-	std::unique_lock lock{this->mutex};
-
-	this->changed = false;
 }
 
 } // namespace openage::renderer::hud

--- a/libopenage/renderer/stages/hud/render_entity.h
+++ b/libopenage/renderer/stages/hud/render_entity.h
@@ -14,15 +14,15 @@ namespace openage::renderer::hud {
 /**
  * Render entity for pushing drag selection updates to the HUD renderer.
  */
-class HudDragRenderEntity final : public renderer::RenderEntity {
+class DragRenderEntity final : public renderer::RenderEntity {
 public:
 	/**
 	 * Create a new render entity for drag selection in the HUD.
 	 *
 	 * @param drag_start Position of the start corner.
 	 */
-	HudDragRenderEntity(const coord::input drag_start);
-	~HudDragRenderEntity() = default;
+	DragRenderEntity(const coord::input drag_start);
+	~DragRenderEntity() = default;
 
 	/**
 	 * Update the render entity with information from the gamestate

--- a/libopenage/renderer/stages/hud/render_entity.h
+++ b/libopenage/renderer/stages/hud/render_entity.h
@@ -3,12 +3,10 @@
 #pragma once
 
 #include <cstdint>
-#include <shared_mutex>
-#include <string>
 
 #include "coord/pixel.h"
 #include "curve/continuous.h"
-#include "time/time.h"
+#include "renderer/stages/render_entity.h"
 
 
 namespace openage::renderer::hud {
@@ -16,7 +14,7 @@ namespace openage::renderer::hud {
 /**
  * Render entity for pushing drag selection updates to the HUD renderer.
  */
-class HudDragRenderEntity {
+class HudDragRenderEntity final : public renderer::RenderEntity {
 public:
 	/**
 	 * Create a new render entity for drag selection in the HUD.
@@ -37,13 +35,6 @@ public:
 	            const time::time_t time = 0.0);
 
 	/**
-	 * Get the time of the last update.
-	 *
-	 * @return Time of last update.
-	 */
-	time::time_t get_update_time();
-
-	/**
 	 * Get the position of the dragged corner.
 	 *
 	 * @return Coordinates of the dragged corner.
@@ -57,31 +48,7 @@ public:
 	 */
 	const coord::input &get_drag_start();
 
-	/**
-	 * Check whether the render entity has received new updates.
-	 *
-	 * @return true if updates have been received, else false.
-	 */
-	bool is_changed();
-
-	/**
-	 * Clear the update flag by setting it to false.
-	 */
-	void clear_changed_flag();
-
 private:
-	/**
-	 * Flag for determining if the render entity has been updated by the
-	 * corresponding gamestate entity. Set to true every time \p update()
-	 * is called.
-	 */
-	bool changed;
-
-	/**
-	 * Time of the last update call.
-	 */
-	time::time_t last_update;
-
 	/**
 	 * Position of the dragged corner.
 	 */
@@ -91,10 +58,5 @@ private:
 	 * Position of the start corner.
 	 */
 	coord::input drag_start;
-
-	/**
-	 * Mutex for protecting threaded access.
-	 */
-	std::shared_mutex mutex;
 };
 } // namespace openage::renderer::hud

--- a/libopenage/renderer/stages/hud/render_entity.h
+++ b/libopenage/renderer/stages/hud/render_entity.h
@@ -28,6 +28,8 @@ public:
 	 * Update the render entity with information from the gamestate
 	 * or input system.
 	 *
+	 * Updating the render entity with this method is thread-safe.
+	 *
 	 * @param drag_pos Position of the dragged corner.
 	 * @param time Current simulation time.
 	 */
@@ -37,6 +39,9 @@ public:
 	/**
 	 * Get the position of the dragged corner.
 	 *
+	 * Accessing the drag position curve REQUIRES a read lock on the render entity
+	 * (using \p get_read_lock()) to ensure thread safety.
+	 *
 	 * @return Coordinates of the dragged corner.
 	 */
 	const curve::Continuous<coord::input> &get_drag_pos();
@@ -44,9 +49,11 @@ public:
 	/**
 	 * Get the position of the start corner.
 	 *
+	 * Accessing the drag start is thread-safe.
+	 *
 	 * @return Coordinates of the start corner.
 	 */
-	const coord::input &get_drag_start();
+	const coord::input get_drag_start();
 
 private:
 	/**

--- a/libopenage/renderer/stages/hud/render_stage.cpp
+++ b/libopenage/renderer/stages/hud/render_stage.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<renderer::RenderPass> HudRenderStage::get_render_pass() {
 	return this->render_pass;
 }
 
-void HudRenderStage::add_drag_entity(const std::shared_ptr<HudDragRenderEntity> entity) {
+void HudRenderStage::add_drag_entity(const std::shared_ptr<DragRenderEntity> entity) {
 	std::unique_lock lock{this->mutex};
 
 	auto hud_object = std::make_shared<HudDragObject>(this->asset_manager);

--- a/libopenage/renderer/stages/hud/render_stage.h
+++ b/libopenage/renderer/stages/hud/render_stage.h
@@ -31,7 +31,7 @@ class AssetManager;
 
 namespace hud {
 class HudDragObject;
-class HudDragRenderEntity;
+class DragRenderEntity;
 
 /**
  * Renderer for the "Heads-Up Display" (HUD).
@@ -71,7 +71,7 @@ public:
 	 *
 	 * @param render_entity New render entity.
 	 */
-	void add_drag_entity(const std::shared_ptr<HudDragRenderEntity> entity);
+	void add_drag_entity(const std::shared_ptr<DragRenderEntity> entity);
 
 	/**
 	 * Remove the render object for drag selection.

--- a/libopenage/renderer/stages/render_entity.cpp
+++ b/libopenage/renderer/stages/render_entity.cpp
@@ -1,0 +1,37 @@
+// Copyright 2024-2024 the openage authors. See copying.md for legal info.
+
+#include "render_entity.h"
+
+#include <mutex>
+
+
+namespace openage::renderer {
+
+RenderEntity::RenderEntity() :
+	changed{false},
+	last_update{time::time_t::zero()} {
+}
+
+time::time_t RenderEntity::get_update_time() {
+	std::shared_lock lock{this->mutex};
+
+	return this->last_update;
+}
+
+bool RenderEntity::is_changed() {
+	std::shared_lock lock{this->mutex};
+
+	return this->changed;
+}
+
+void RenderEntity::clear_changed_flag() {
+	std::unique_lock lock{this->mutex};
+
+	this->changed = false;
+}
+
+std::shared_lock<std::shared_mutex> RenderEntity::get_read_lock() {
+	return std::shared_lock{this->mutex};
+}
+
+} // namespace openage::renderer

--- a/libopenage/renderer/stages/render_entity.h
+++ b/libopenage/renderer/stages/render_entity.h
@@ -1,0 +1,83 @@
+// Copyright 2024-2024 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <mutex>
+#include <shared_mutex>
+
+#include <eigen3/Eigen/Dense>
+
+#include "time/time.h"
+
+
+namespace openage::renderer {
+
+/**
+ * Interface for render entities that allow pushing updates from game simulation
+ * to renderer.
+ */
+class RenderEntity {
+public:
+	~RenderEntity() = default;
+
+	/**
+	 * Get the time of the last update.
+	 *
+	 * Accessing the update time is thread-safe.
+	 *
+	 * @return Time of last update.
+	 */
+	time::time_t get_update_time();
+
+	/**
+	 * Check whether the render entity has received new updates from the
+	 * gamestate.
+	 *
+	 * @return true if updates have been received, else false.
+	 */
+	bool is_changed();
+
+	/**
+	 * Clear the update flag by setting it to false.
+	 */
+	void clear_changed_flag();
+
+	/**
+	 * Get a shared lock for thread-safe reading from the render entity.
+	 *
+	 * The caller is responsible for unlocking the mutex after reading.
+	 *
+	 * @return Lock for the render entity.
+	 */
+	std::shared_lock<std::shared_mutex> get_read_lock();
+
+protected:
+	/**
+	 * Create a new render entity.
+	 *
+	 * Members are initialized to these values by default:
+	 * - \p changed: false
+	 * - \p last_update: time::time_t::zero()
+	 *
+	 * Declared as protected to prevent direct instantiation of this class.
+	 */
+	RenderEntity();
+
+	/**
+	 * Flag for determining if the render entity has been updated by the
+	 * corresponding gamestate entity. Set to true every time \p update()
+	 * is called.
+	 */
+	bool changed;
+
+	/**
+	 * Time of the last update call.
+	 */
+	time::time_t last_update;
+
+	/**
+	 * Mutex for protecting threaded access.
+	 */
+	std::shared_mutex mutex;
+};
+} // namespace openage::renderer

--- a/libopenage/renderer/stages/terrain/chunk.cpp
+++ b/libopenage/renderer/stages/terrain/chunk.cpp
@@ -31,11 +31,19 @@ void TerrainChunk::fetch_updates(const time::time_t & /* time */) {
 	if (not this->render_entity->is_changed()) {
 		return;
 	}
+
+	// Get the terrain data from the render entity
+	auto terrain_size = this->render_entity->get_size();
+	auto terrain_paths = this->render_entity->get_terrain_paths();
+	auto tiles = this->render_entity->get_tiles();
+	auto heightmap_verts = this->render_entity->get_vertices();
+
+	// Recreate the mesh data
 	// TODO: Change mesh instead of recreating it
 	// TODO: Multiple meshes
 	this->meshes.clear();
-	for (const auto &terrain_path : this->render_entity->get_terrain_paths()) {
-		auto new_mesh = this->create_mesh(terrain_path);
+	for (const auto &terrain_path : terrain_paths) {
+		auto new_mesh = this->create_mesh(terrain_size, tiles, heightmap_verts, terrain_path);
 		new_mesh->create_model_matrix(this->offset);
 		this->meshes.push_back(new_mesh);
 	}
@@ -59,13 +67,12 @@ const std::vector<std::shared_ptr<TerrainRenderMesh>> &TerrainChunk::get_meshes(
 	return this->meshes;
 }
 
-std::shared_ptr<TerrainRenderMesh> TerrainChunk::create_mesh(const std::string &texture_path) {
-	auto size = this->render_entity->get_size();
-	auto v_width = size[0];
-	auto v_height = size[1];
-
-	auto tiles = this->render_entity->get_tiles();
-	auto heightmap_verts = this->render_entity->get_vertices();
+std::shared_ptr<TerrainRenderMesh> TerrainChunk::create_mesh(const util::Vector2s vert_size,
+                                                             const RenderEntity::tiles_t &tiles,
+                                                             const std::vector<coord::scene3> &heightmap_verts,
+                                                             const std::string &texture_path) {
+	auto v_width = vert_size[0];
+	auto v_height = vert_size[1];
 
 	// vertex data for the mesh
 	std::vector<float> mesh_verts{};

--- a/libopenage/renderer/stages/terrain/chunk.cpp
+++ b/libopenage/renderer/stages/terrain/chunk.cpp
@@ -17,7 +17,7 @@ TerrainChunk::TerrainChunk(const std::shared_ptr<renderer::resources::AssetManag
 	offset{offset},
 	asset_manager{asset_manager} {}
 
-void TerrainChunk::set_render_entity(const std::shared_ptr<TerrainRenderEntity> &entity) {
+void TerrainChunk::set_render_entity(const std::shared_ptr<RenderEntity> &entity) {
 	this->render_entity = entity;
 }
 

--- a/libopenage/renderer/stages/terrain/chunk.h
+++ b/libopenage/renderer/stages/terrain/chunk.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "coord/scene.h"
+#include "renderer/stages/terrain/render_entity.h"
 #include "time/time.h"
 #include "util/vector.h"
 
@@ -19,7 +20,6 @@ class AssetManager;
 
 namespace terrain {
 class TerrainRenderMesh;
-class RenderEntity;
 
 /**
  * Stores the state of a terrain chunk in the terrain render stage.
@@ -85,9 +85,17 @@ private:
 	/**
 	 * Create a terrain mesh from the data provided by the render entity.
 	 *
+	 * @param vert_size Size of the terrain in vertices.
+	 * @param tiles Data for each tile (elevation, terrain path).
+	 * @param heightmap_verts Position of each vertex in the chunk.
+	 * @param texture_path Path to the texture for the terrain.
+	 *
 	 * @return New terrain mesh.
 	 */
-	std::shared_ptr<TerrainRenderMesh> create_mesh(const std::string &texture_path);
+	std::shared_ptr<TerrainRenderMesh> create_mesh(const util::Vector2s vert_size,
+	                                               const RenderEntity::tiles_t &tiles,
+	                                               const std::vector<coord::scene3> &heightmap_verts,
+	                                               const std::string &texture_path);
 
 	/**
 	 * Size of the chunk in tiles (width x height).

--- a/libopenage/renderer/stages/terrain/chunk.h
+++ b/libopenage/renderer/stages/terrain/chunk.h
@@ -19,7 +19,7 @@ class AssetManager;
 
 namespace terrain {
 class TerrainRenderMesh;
-class TerrainRenderEntity;
+class RenderEntity;
 
 /**
  * Stores the state of a terrain chunk in the terrain render stage.
@@ -44,7 +44,7 @@ public:
 	 * @param size Size of the chunk in tiles.
 	 * @param offset Offset of the chunk from origin in tiles.
 	 */
-	void set_render_entity(const std::shared_ptr<TerrainRenderEntity> &entity);
+	void set_render_entity(const std::shared_ptr<RenderEntity> &entity);
 
 	/**
 	 * Fetch updates from the render entity.
@@ -114,7 +114,7 @@ private:
 	 * Source for ingame terrain coordinates. These coordinates are translated into
 	 * our render vertex mesh when \p update() is called.
 	 */
-	std::shared_ptr<TerrainRenderEntity> render_entity;
+	std::shared_ptr<RenderEntity> render_entity;
 };
 
 

--- a/libopenage/renderer/stages/terrain/model.cpp
+++ b/libopenage/renderer/stages/terrain/model.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "model.h"
 
@@ -26,7 +26,7 @@ TerrainRenderModel::TerrainRenderModel(const std::shared_ptr<renderer::resources
 	asset_manager{asset_manager} {
 }
 
-void TerrainRenderModel::add_chunk(const std::shared_ptr<TerrainRenderEntity> &entity,
+void TerrainRenderModel::add_chunk(const std::shared_ptr<RenderEntity> &entity,
                                    const util::Vector2s size,
                                    const coord::scene2_delta offset) {
 	auto chunk = std::make_shared<TerrainChunk>(this->asset_manager, size, offset);

--- a/libopenage/renderer/stages/terrain/model.h
+++ b/libopenage/renderer/stages/terrain/model.h
@@ -21,7 +21,7 @@ class AssetManager;
 }
 
 namespace terrain {
-class TerrainRenderEntity;
+class RenderEntity;
 class TerrainRenderMesh;
 class TerrainChunk;
 
@@ -46,7 +46,7 @@ public:
 	 * @param chunk_size Size of the chunk in tiles.
 	 * @param chunk_offset Offset of the chunk from origin in tiles.
 	 */
-	void add_chunk(const std::shared_ptr<TerrainRenderEntity> &entity,
+	void add_chunk(const std::shared_ptr<RenderEntity> &entity,
 	               const util::Vector2s chunk_size,
 	               const coord::scene2_delta chunk_offset);
 

--- a/libopenage/renderer/stages/terrain/render_entity.cpp
+++ b/libopenage/renderer/stages/terrain/render_entity.cpp
@@ -9,8 +9,8 @@
 
 namespace openage::renderer::terrain {
 
-TerrainRenderEntity::TerrainRenderEntity() :
-	RenderEntity{},
+RenderEntity::RenderEntity() :
+	renderer::RenderEntity{},
 	size{0, 0},
 	tiles{},
 	terrain_paths{},
@@ -19,11 +19,11 @@ TerrainRenderEntity::TerrainRenderEntity() :
 {
 }
 
-void TerrainRenderEntity::update_tile(const util::Vector2s size,
-                                      const coord::tile &pos,
-                                      const terrain_elevation_t elevation,
-                                      const std::string terrain_path,
-                                      const time::time_t time) {
+void RenderEntity::update_tile(const util::Vector2s size,
+                               const coord::tile &pos,
+                               const terrain_elevation_t elevation,
+                               const std::string terrain_path,
+                               const time::time_t time) {
 	std::unique_lock lock{this->mutex};
 
 	if (this->vertices.empty()) {
@@ -51,9 +51,9 @@ void TerrainRenderEntity::update_tile(const util::Vector2s size,
 	this->changed = true;
 }
 
-void TerrainRenderEntity::update(const util::Vector2s size,
-                                 const tiles_t tiles,
-                                 const time::time_t time) {
+void RenderEntity::update(const util::Vector2s size,
+                          const tiles_t tiles,
+                          const time::time_t time) {
 	std::unique_lock lock{this->mutex};
 
 	// increase by 1 in every dimension because tiles
@@ -107,25 +107,25 @@ void TerrainRenderEntity::update(const util::Vector2s size,
 	this->changed = true;
 }
 
-const std::vector<coord::scene3> &TerrainRenderEntity::get_vertices() {
+const std::vector<coord::scene3> &RenderEntity::get_vertices() {
 	std::shared_lock lock{this->mutex};
 
 	return this->vertices;
 }
 
-const TerrainRenderEntity::tiles_t &TerrainRenderEntity::get_tiles() {
+const RenderEntity::tiles_t &RenderEntity::get_tiles() {
 	std::shared_lock lock{this->mutex};
 
 	return this->tiles;
 }
 
-const std::unordered_set<std::string> &TerrainRenderEntity::get_terrain_paths() {
+const std::unordered_set<std::string> &RenderEntity::get_terrain_paths() {
 	std::shared_lock lock{this->mutex};
 
 	return this->terrain_paths;
 }
 
-const util::Vector2s &TerrainRenderEntity::get_size() {
+const util::Vector2s &RenderEntity::get_size() {
 	std::shared_lock lock{this->mutex};
 
 	return this->size;

--- a/libopenage/renderer/stages/terrain/render_entity.cpp
+++ b/libopenage/renderer/stages/terrain/render_entity.cpp
@@ -14,9 +14,7 @@ RenderEntity::RenderEntity() :
 	size{0, 0},
 	tiles{},
 	terrain_paths{},
-	vertices{}
-// terrain_path{nullptr, 0},
-{
+	vertices{} {
 }
 
 void RenderEntity::update_tile(const util::Vector2s size,
@@ -107,25 +105,25 @@ void RenderEntity::update(const util::Vector2s size,
 	this->changed = true;
 }
 
-const std::vector<coord::scene3> &RenderEntity::get_vertices() {
+const std::vector<coord::scene3> RenderEntity::get_vertices() {
 	std::shared_lock lock{this->mutex};
 
 	return this->vertices;
 }
 
-const RenderEntity::tiles_t &RenderEntity::get_tiles() {
+const RenderEntity::tiles_t RenderEntity::get_tiles() {
 	std::shared_lock lock{this->mutex};
 
 	return this->tiles;
 }
 
-const std::unordered_set<std::string> &RenderEntity::get_terrain_paths() {
+const std::unordered_set<std::string> RenderEntity::get_terrain_paths() {
 	std::shared_lock lock{this->mutex};
 
 	return this->terrain_paths;
 }
 
-const util::Vector2s &RenderEntity::get_size() {
+const util::Vector2s RenderEntity::get_size() {
 	std::shared_lock lock{this->mutex};
 
 	return this->size;

--- a/libopenage/renderer/stages/terrain/render_entity.cpp
+++ b/libopenage/renderer/stages/terrain/render_entity.cpp
@@ -10,10 +10,9 @@
 namespace openage::renderer::terrain {
 
 TerrainRenderEntity::TerrainRenderEntity() :
-	changed{false},
+	RenderEntity{},
 	size{0, 0},
 	tiles{},
-	last_update{0.0},
 	terrain_paths{},
 	vertices{}
 // terrain_path{nullptr, 0},
@@ -130,18 +129,6 @@ const util::Vector2s &TerrainRenderEntity::get_size() {
 	std::shared_lock lock{this->mutex};
 
 	return this->size;
-}
-
-bool TerrainRenderEntity::is_changed() {
-	std::shared_lock lock{this->mutex};
-
-	return this->changed;
-}
-
-void TerrainRenderEntity::clear_changed_flag() {
-	std::unique_lock lock{this->mutex};
-
-	this->changed = false;
 }
 
 } // namespace openage::renderer::terrain

--- a/libopenage/renderer/stages/terrain/render_entity.h
+++ b/libopenage/renderer/stages/terrain/render_entity.h
@@ -18,10 +18,10 @@ namespace openage::renderer::terrain {
 /**
  * Render entity for pushing updates to the Terrain renderer.
  */
-class TerrainRenderEntity final : public renderer::RenderEntity {
+class RenderEntity final : public renderer::RenderEntity {
 public:
-	TerrainRenderEntity();
-	~TerrainRenderEntity() = default;
+	RenderEntity();
+	~RenderEntity() = default;
 
 	using terrain_elevation_t = util::FixedPoint<uint64_t, 16>;
 	using tiles_t = std::vector<std::pair<terrain_elevation_t, std::string>>;

--- a/libopenage/renderer/stages/terrain/render_entity.h
+++ b/libopenage/renderer/stages/terrain/render_entity.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <memory>
-#include <shared_mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -11,7 +9,7 @@
 #include "coord/scene.h"
 #include "coord/tile.h"
 #include "curve/discrete.h"
-#include "time/time.h"
+#include "renderer/stages/render_entity.h"
 #include "util/vector.h"
 
 
@@ -20,7 +18,7 @@ namespace openage::renderer::terrain {
 /**
  * Render entity for pushing updates to the Terrain renderer.
  */
-class TerrainRenderEntity {
+class TerrainRenderEntity final : public renderer::RenderEntity {
 public:
 	TerrainRenderEntity();
 	~TerrainRenderEntity() = default;
@@ -84,27 +82,7 @@ public:
 	 */
 	const util::Vector2s &get_size();
 
-	/**
-	 * Check whether the render entity has received new updates from the
-	 * gamestate.
-	 *
-	 * @return true if updates have been received, else false.
-	 */
-	bool is_changed();
-
-	/**
-	 * Clear the update flag by setting it to false.
-	 */
-	void clear_changed_flag();
-
 private:
-	/**
-	 * Flag for determining if the render entity has been updated by the
-	 * corresponding gamestate entity. Set to true every time \p update()
-	 * is called.
-	 */
-	bool changed;
-
 	/**
 	 * Chunk dimensions (width x height).
 	 */
@@ -116,11 +94,6 @@ private:
 	tiles_t tiles;
 
 	/**
-	 * Time of the last update call.
-	 */
-	time::time_t last_update;
-
-	/**
 	 * Terrain texture paths used in \p tiles .
 	 */
 	std::unordered_set<std::string> terrain_paths;
@@ -129,10 +102,5 @@ private:
 	 * Terrain vertices (ingame coordinates).
 	 */
 	std::vector<coord::scene3> vertices;
-
-	/**
-	 * Mutex for protecting threaded access.
-	 */
-	std::shared_mutex mutex;
 };
 } // namespace openage::renderer::terrain

--- a/libopenage/renderer/stages/terrain/render_entity.h
+++ b/libopenage/renderer/stages/terrain/render_entity.h
@@ -30,6 +30,8 @@ public:
 	 * Update a single tile of the displayed terrain (chunk) with information from the
 	 * gamestate.
 	 *
+	 * Updating the render entity with this method is thread-safe.
+	 *
 	 * @param size Size of the terrain in tiles (width x length)
 	 * @param pos Position of the tile in the chunk.
 	 * @param elevation Height of terrain tile.
@@ -46,6 +48,8 @@ public:
 	 * Update the full grid of the displayed terrain (chunk) with information from the
 	 * gamestate.
 	 *
+	 * Updating the render entity with this method is thread-safe.
+	 *
 	 * @param size Size of the terrain in tiles (width x length)
 	 * @param tiles Animation data for each tile (elevation, terrain path).
 	 * @param time Simulation time of the update.
@@ -57,30 +61,38 @@ public:
 	/**
 	 * Get the vertices of the terrain.
 	 *
+	 * Accessing the terrain vertices is thread-safe.
+	 *
 	 * @return Vector of vertex coordinates.
 	 */
-	const std::vector<coord::scene3> &get_vertices();
+	const std::vector<coord::scene3> get_vertices();
 
 	/**
 	 * Get the tiles of the terrain.
 	 *
+	 * Accessing the terrain tiles is thread-safe.
+	 *
 	 * @return Terrain tiles.
 	 */
-	const tiles_t &get_tiles();
+	const tiles_t get_tiles();
 
 	/**
 	 * Get the terrain paths used in the terrain.
 	 *
+	 * Accessing the terrain paths is thread-safe.
+	 *
 	 * @return Terrain paths.
 	 */
-	const std::unordered_set<std::string> &get_terrain_paths();
+	const std::unordered_set<std::string> get_terrain_paths();
 
 	/**
 	 * Get the number of vertices on each side of the terrain.
 	 *
+	 * Accessing the vertices size is thread-safe.
+	 *
 	 * @return Vector with width as first element and height as second element.
 	 */
-	const util::Vector2s &get_size();
+	const util::Vector2s get_size();
 
 private:
 	/**

--- a/libopenage/renderer/stages/terrain/render_stage.cpp
+++ b/libopenage/renderer/stages/terrain/render_stage.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<renderer::RenderPass> TerrainRenderStage::get_render_pass() {
 	return this->render_pass;
 }
 
-void TerrainRenderStage::add_render_entity(const std::shared_ptr<TerrainRenderEntity> entity,
+void TerrainRenderStage::add_render_entity(const std::shared_ptr<RenderEntity> entity,
                                            const util::Vector2s chunk_size,
                                            const coord::scene2_delta chunk_offset) {
 	std::unique_lock lock{this->mutex};

--- a/libopenage/renderer/stages/terrain/render_stage.h
+++ b/libopenage/renderer/stages/terrain/render_stage.h
@@ -32,7 +32,7 @@ class AssetManager;
 }
 
 namespace terrain {
-class TerrainRenderEntity;
+class RenderEntity;
 class TerrainRenderMesh;
 class TerrainRenderModel;
 
@@ -73,7 +73,7 @@ public:
 	 *
 	 * @param render_entity New render entity.
 	 */
-	void add_render_entity(const std::shared_ptr<TerrainRenderEntity> entity,
+	void add_render_entity(const std::shared_ptr<RenderEntity> entity,
 	                       const util::Vector2s chunk_size,
 	                       const coord::scene2_delta chunk_offset);
 
@@ -119,7 +119,7 @@ private:
 	/**
 	 * Engine interface for updating terrain draw information.
 	 */
-	std::shared_ptr<TerrainRenderEntity> render_entity;
+	std::shared_ptr<RenderEntity> render_entity;
 
 	/**
 	 * 3D model of the terrain.

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -43,7 +43,7 @@ WorldObject::WorldObject(const std::shared_ptr<renderer::resources::AssetManager
 	last_update{0.0} {
 }
 
-void WorldObject::set_render_entity(const std::shared_ptr<WorldRenderEntity> &entity) {
+void WorldObject::set_render_entity(const std::shared_ptr<RenderEntity> &entity) {
 	this->render_entity = entity;
 	this->fetch_updates();
 }

--- a/libopenage/renderer/stages/world/object.cpp
+++ b/libopenage/renderer/stages/world/object.cpp
@@ -63,6 +63,9 @@ void WorldObject::fetch_updates(const time::time_t &time) {
 
 	// Get data from render entity
 	this->ref_id = this->render_entity->get_id();
+
+	// Thread-safe access to curves needs a lock on the render entity's mutex
+	auto read_lock = this->render_entity->get_read_lock();
 	this->position.sync(this->render_entity->get_position());
 	this->animation_info.sync(this->render_entity->get_animation_path(),
 	                          std::function<std::shared_ptr<renderer::resources::Animation2dInfo>(const std::string &)>(
@@ -78,6 +81,9 @@ void WorldObject::fetch_updates(const time::time_t &time) {
 								  }),
 	                          this->last_update);
 	this->angle.sync(this->render_entity->get_angle(), this->last_update);
+
+	// Unlock mutex of the render entity
+	read_lock.unlock();
 
 	// Set self to changed so that world renderer can update the renderable
 	this->changed = true;

--- a/libopenage/renderer/stages/world/object.h
+++ b/libopenage/renderer/stages/world/object.h
@@ -29,7 +29,7 @@ class Animation2dInfo;
 } // namespace resources
 
 namespace world {
-class WorldRenderEntity;
+class RenderEntity;
 
 /**
  * Stores the state of a renderable object in the World render stage.
@@ -49,7 +49,7 @@ public:
 	 *
 	 * @param entity New world render entity.
 	 */
-	void set_render_entity(const std::shared_ptr<WorldRenderEntity> &entity);
+	void set_render_entity(const std::shared_ptr<RenderEntity> &entity);
 
 	/**
 	 * Fetch updates from the render entity.
@@ -177,7 +177,7 @@ private:
 	 * Entity that gets updates from the gamestate, e.g. the position and
 	 * requested animation data.
 	 */
-	std::shared_ptr<WorldRenderEntity> render_entity;
+	std::shared_ptr<RenderEntity> render_entity;
 
 	/**
 	 * Reference ID for passing interaction with the graphic (e.g. mouse clicks) back to

--- a/libopenage/renderer/stages/world/render_entity.cpp
+++ b/libopenage/renderer/stages/world/render_entity.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 the openage authors. See copying.md for legal info.
+// Copyright 2022-2024 the openage authors. See copying.md for legal info.
 
 #include "render_entity.h"
 
@@ -94,6 +94,10 @@ void WorldRenderEntity::clear_changed_flag() {
 	std::unique_lock lock{this->mutex};
 
 	this->changed = false;
+}
+
+std::shared_lock<std::shared_mutex> WorldRenderEntity::get_read_lock() {
+	return std::shared_lock{this->mutex};
 }
 
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/render_entity.cpp
+++ b/libopenage/renderer/stages/world/render_entity.cpp
@@ -10,19 +10,19 @@
 
 namespace openage::renderer::world {
 
-WorldRenderEntity::WorldRenderEntity() :
-	RenderEntity{},
+RenderEntity::RenderEntity() :
+	renderer::RenderEntity{},
 	ref_id{0},
 	position{nullptr, 0, "", nullptr, SCENE_ORIGIN},
 	angle{nullptr, 0, "", nullptr, 0},
 	animation_path{nullptr, 0} {
 }
 
-void WorldRenderEntity::update(const uint32_t ref_id,
-                               const curve::Continuous<coord::phys3> &position,
-                               const curve::Segmented<coord::phys_angle_t> &angle,
-                               const std::string animation_path,
-                               const time::time_t time) {
+void RenderEntity::update(const uint32_t ref_id,
+                          const curve::Continuous<coord::phys3> &position,
+                          const curve::Segmented<coord::phys_angle_t> &angle,
+                          const std::string animation_path,
+                          const time::time_t time) {
 	std::unique_lock lock{this->mutex};
 
 	this->ref_id = ref_id;
@@ -40,10 +40,10 @@ void WorldRenderEntity::update(const uint32_t ref_id,
 	this->last_update = time;
 }
 
-void WorldRenderEntity::update(const uint32_t ref_id,
-                               const coord::phys3 position,
-                               const std::string animation_path,
-                               const time::time_t time) {
+void RenderEntity::update(const uint32_t ref_id,
+                          const coord::phys3 position,
+                          const std::string animation_path,
+                          const time::time_t time) {
 	std::unique_lock lock{this->mutex};
 
 	this->ref_id = ref_id;
@@ -53,25 +53,25 @@ void WorldRenderEntity::update(const uint32_t ref_id,
 	this->last_update = time;
 }
 
-uint32_t WorldRenderEntity::get_id() {
+uint32_t RenderEntity::get_id() {
 	std::shared_lock lock{this->mutex};
 
 	return this->ref_id;
 }
 
-const curve::Continuous<coord::scene3> &WorldRenderEntity::get_position() {
+const curve::Continuous<coord::scene3> &RenderEntity::get_position() {
 	std::shared_lock lock{this->mutex};
 
 	return this->position;
 }
 
-const curve::Segmented<coord::phys_angle_t> &WorldRenderEntity::get_angle() {
+const curve::Segmented<coord::phys_angle_t> &RenderEntity::get_angle() {
 	std::shared_lock lock{this->mutex};
 
 	return this->angle;
 }
 
-const curve::Discrete<std::string> &WorldRenderEntity::get_animation_path() {
+const curve::Discrete<std::string> &RenderEntity::get_animation_path() {
 	std::shared_lock lock{this->mutex};
 
 	return this->animation_path;

--- a/libopenage/renderer/stages/world/render_entity.cpp
+++ b/libopenage/renderer/stages/world/render_entity.cpp
@@ -11,12 +11,11 @@
 namespace openage::renderer::world {
 
 WorldRenderEntity::WorldRenderEntity() :
-	changed{false},
+	RenderEntity{},
 	ref_id{0},
 	position{nullptr, 0, "", nullptr, SCENE_ORIGIN},
 	angle{nullptr, 0, "", nullptr, 0},
-	animation_path{nullptr, 0},
-	last_update{0.0} {
+	animation_path{nullptr, 0} {
 }
 
 void WorldRenderEntity::update(const uint32_t ref_id,
@@ -76,28 +75,6 @@ const curve::Discrete<std::string> &WorldRenderEntity::get_animation_path() {
 	std::shared_lock lock{this->mutex};
 
 	return this->animation_path;
-}
-
-time::time_t WorldRenderEntity::get_update_time() {
-	std::shared_lock lock{this->mutex};
-
-	return this->last_update;
-}
-
-bool WorldRenderEntity::is_changed() {
-	std::shared_lock lock{this->mutex};
-
-	return this->changed;
-}
-
-void WorldRenderEntity::clear_changed_flag() {
-	std::unique_lock lock{this->mutex};
-
-	this->changed = false;
-}
-
-std::shared_lock<std::shared_mutex> WorldRenderEntity::get_read_lock() {
-	return std::shared_lock{this->mutex};
 }
 
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/render_entity.h
+++ b/libopenage/renderer/stages/world/render_entity.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <list>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 
@@ -30,6 +31,8 @@ public:
 	/**
 	 * Update the render entity with information from the gamestate.
 	 *
+	 * Updating the render entity with this method is thread-safe.
+	 *
 	 * @param ref_id Game entity ID.
 	 * @param position Position of the game entity inside the game world.
 	 * @param angle Angle of the game entity inside the game world.
@@ -47,6 +50,8 @@ public:
 	 *
 	 * Update the render entity with information from the gamestate.
 	 *
+	 * Updating the render entity with this method is thread-safe.
+	 *
 	 * @param ref_id Game entity ID.
 	 * @param position Position of the game entity inside the game world.
 	 * @param animation_path Path to the animation definition.
@@ -60,12 +65,17 @@ public:
 	/**
 	 * Get the ID of the corresponding game entity.
 	 *
+	 * Accessing the game entity ID is thread-safe.
+	 *
 	 * @return Game entity ID.
 	 */
 	uint32_t get_id();
 
 	/**
 	 * Get the position of the entity inside the game world.
+	 *
+	 * Accessing the position curve REQUIRES a read lock on the render entity
+	 * (using \p get_read_lock()) to ensure thread safety.
 	 *
 	 * @return Position curve of the entity.
 	 */
@@ -74,6 +84,9 @@ public:
 	/**
 	 * Get the angle of the entity inside the game world.
 	 *
+	 * Accessing the angle curve REQUIRES a read lock on the render entity
+	 * (using \p get_read_lock()) to ensure thread safety.
+	 *
 	 * @return Angle curve of the entity.
 	 */
 	const curve::Segmented<coord::phys_angle_t> &get_angle();
@@ -81,12 +94,17 @@ public:
 	/**
 	 * Get the animation definition path.
 	 *
+	 * Accessing the animation path curve requires a read lock on the render entity
+	 * (using \p get_read_lock()) to ensure thread safety.
+	 *
 	 * @return Path to the animation definition file.
 	 */
 	const curve::Discrete<std::string> &get_animation_path();
 
 	/**
 	 * Get the time of the last update.
+	 *
+	 * Accessing the update time is thread-safe.
 	 *
 	 * @return Time of last update.
 	 */
@@ -104,6 +122,15 @@ public:
 	 * Clear the update flag by setting it to false.
 	 */
 	void clear_changed_flag();
+
+	/**
+	 * Get a shared lock for thread-safe reading from the render entity.
+	 *
+	 * The caller is responsible for unlocking the mutex after reading.
+	 *
+	 * @return Lock for the render entity.
+	 */
+	std::shared_lock<std::shared_mutex> get_read_lock();
 
 private:
 	/**

--- a/libopenage/renderer/stages/world/render_entity.h
+++ b/libopenage/renderer/stages/world/render_entity.h
@@ -18,10 +18,10 @@ namespace openage::renderer::world {
 /**
  * Render entity for pushing updates to the World renderer.
  */
-class WorldRenderEntity final : public renderer::RenderEntity {
+class RenderEntity final : public renderer::RenderEntity {
 public:
-	WorldRenderEntity();
-	~WorldRenderEntity() = default;
+	RenderEntity();
+	~RenderEntity() = default;
 
 	/**
 	 * Update the render entity with information from the gamestate.

--- a/libopenage/renderer/stages/world/render_entity.h
+++ b/libopenage/renderer/stages/world/render_entity.h
@@ -3,19 +3,14 @@
 #pragma once
 
 #include <cstdint>
-#include <list>
-#include <mutex>
-#include <shared_mutex>
 #include <string>
-
-#include <eigen3/Eigen/Dense>
 
 #include "coord/phys.h"
 #include "coord/scene.h"
 #include "curve/continuous.h"
 #include "curve/discrete.h"
 #include "curve/segmented.h"
-#include "time/time.h"
+#include "renderer/stages/render_entity.h"
 
 
 namespace openage::renderer::world {
@@ -23,7 +18,7 @@ namespace openage::renderer::world {
 /**
  * Render entity for pushing updates to the World renderer.
  */
-class WorldRenderEntity {
+class WorldRenderEntity final : public renderer::RenderEntity {
 public:
 	WorldRenderEntity();
 	~WorldRenderEntity() = default;
@@ -101,45 +96,7 @@ public:
 	 */
 	const curve::Discrete<std::string> &get_animation_path();
 
-	/**
-	 * Get the time of the last update.
-	 *
-	 * Accessing the update time is thread-safe.
-	 *
-	 * @return Time of last update.
-	 */
-	time::time_t get_update_time();
-
-	/**
-	 * Check whether the render entity has received new updates from the
-	 * gamestate.
-	 *
-	 * @return true if updates have been received, else false.
-	 */
-	bool is_changed();
-
-	/**
-	 * Clear the update flag by setting it to false.
-	 */
-	void clear_changed_flag();
-
-	/**
-	 * Get a shared lock for thread-safe reading from the render entity.
-	 *
-	 * The caller is responsible for unlocking the mutex after reading.
-	 *
-	 * @return Lock for the render entity.
-	 */
-	std::shared_lock<std::shared_mutex> get_read_lock();
-
 private:
-	/**
-	 * Flag for determining if the render entity has been updated by the
-	 * corresponding gamestate entity. Set to true every time \p update()
-	 * is called.
-	 */
-	bool changed;
-
 	/**
 	 * ID of the game entity in the gamestate.
 	 */
@@ -159,15 +116,5 @@ private:
 	 * Path to the animation definition file.
 	 */
 	curve::Discrete<std::string> animation_path;
-
-	/**
-	 * Time of the last update call.
-	 */
-	time::time_t last_update;
-
-	/**
-	 * Mutex for protecting threaded access.
-	 */
-	std::shared_mutex mutex;
 };
 } // namespace openage::renderer::world

--- a/libopenage/renderer/stages/world/render_stage.cpp
+++ b/libopenage/renderer/stages/world/render_stage.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<renderer::RenderPass> WorldRenderStage::get_render_pass() {
 	return this->render_pass;
 }
 
-void WorldRenderStage::add_render_entity(const std::shared_ptr<WorldRenderEntity> entity) {
+void WorldRenderStage::add_render_entity(const std::shared_ptr<RenderEntity> entity) {
 	std::unique_lock lock{this->mutex};
 
 	auto world_object = std::make_shared<WorldObject>(this->asset_manager);

--- a/libopenage/renderer/stages/world/render_stage.h
+++ b/libopenage/renderer/stages/world/render_stage.h
@@ -31,7 +31,7 @@ class AssetManager;
 }
 
 namespace world {
-class WorldRenderEntity;
+class RenderEntity;
 class WorldObject;
 
 /**
@@ -74,7 +74,7 @@ public:
 	 *
 	 * @param render_entity New render entity.
 	 */
-	void add_render_entity(const std::shared_ptr<WorldRenderEntity> entity);
+	void add_render_entity(const std::shared_ptr<RenderEntity> entity);
 
 	/**
 	 * Update the render entities and render positions.


### PR DESCRIPTION
The current render entity code was not thread-safe because of an oversight in the implementation. When syncing data between the render entity and the objects in the renderer, sometimes references were passed instead of copying the data over, e.g. 

https://github.com/SFTtech/openage/blob/66098cea4d799634d66b0e9b9691fdf715a7118d/libopenage/renderer/stages/world/render_entity.cpp#L63-L67

After returning the reference, the lock is released even though a read has not taken place yet. This results in the simulation thread writing data into the render entity while it is still being read, with the consequence that over- or underreads might happen. I fixed this behavior now by ensuring that locks are present for the full read duration.

Changes in this PR:

- [x] Document which methods of the render entities are thread-safe in the docstrings
-  [x] Add a new method `get_read_lock()` which returns a `std::shared_lock` locking the render entity's mutex. This allows manual control of data reads from the render entity.
-  [x] Add a `renderer::RenderEntity` base class for the shared functionality of the different render entity types in HUD, terrain, and world render stages.
-  [x] Make all data transfers thread-safe