### PR TITLE
Fix tex unit assignment to `std::optional` type

### DIFF
--- a/libopenage/renderer/opengl/shader_program.cpp
+++ b/libopenage/renderer/opengl/shader_program.cpp
@@ -424,8 +424,11 @@ void GlShaderProgram::update_uniforms(std::shared_ptr<GlUniformInput> const &uni
 			glBindTexture(GL_TEXTURE_2D, tex);
 			// TODO: maybe call this at a more appropriate position
 			glUniform1i(loc, tex_unit_id);
-			auto &tex_value = *this->textures_per_texunits[tex_unit_id];
-			tex_value = tex;
+			ENSURE(tex_unit_id < this->textures_per_texunits.size(),
+			       "Tried to assign texture to non-existant texture unit at index "
+			           << tex_unit_id
+			           << " (max: " << this->textures_per_texunits.size() << ").");
+			this->textures_per_texunits[tex_unit_id] = tex;
 			break;
 		}
 		default:

--- a/libopenage/renderer/opengl/shader_program.h
+++ b/libopenage/renderer/opengl/shader_program.h
@@ -195,6 +195,7 @@ private:
 	std::unordered_map<std::string, GlVertexAttrib> attribs;
 
 	/// Store which texture handles are currently bound to the shader's texture units.
+	/// A value of std::nullopt means the texture unit is unbound (no texture assigned).
 	std::vector<std::optional<GLuint>> textures_per_texunits;
 
 	/// Whether this program has been validated.


### PR DESCRIPTION
Fixes a small bug in the storage of the texture to tex unit bindings in the shader program. 

https://github.com/SFTtech/openage/blob/02d324292d9b6410655e1052a311ff315b909372/libopenage/renderer/opengl/shader_program.cpp#L427-L429

The current code (see above) assumes that there always exists a binding from tex unit to texture and the `std::optional` type always contains a value. However, this is not always the case, e.g. when the shader is first initialized and no textures have been bound yet. We also wouldn't need to use `std::optional` then, don't we?