### PR TITLE
Clang format rule: Indent preprocessor directives

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,7 +81,7 @@ IndentCaseBlocks: false
 IndentCaseLabels: false
 IndentExternBlock: NoIndent
 IndentGotoLabels: false
-IndentPPDirectives: None
+IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 # clang-format-16 InsertNewlineAtEOF: true

--- a/libopenage/console/tests.cpp
+++ b/libopenage/console/tests.cpp
@@ -1,12 +1,12 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #ifdef _MSC_VER
-#define STDOUT_FILENO 1
+	#define STDOUT_FILENO 1
 #else
-#include <unistd.h>
+	#include <unistd.h>
 #endif
 #include "../util/fds.h"
 #include "../util/pty.h"
@@ -15,8 +15,8 @@
 #include <cstdlib>
 #include <fcntl.h>
 
-#include "../log/log.h"
 #include "../error/error.h"
+#include "../log/log.h"
 
 #include "buf.h"
 #include "console.h"
@@ -51,7 +51,7 @@ void render() {
 
 
 void interactive() {
-	#ifndef _WIN32
+#ifndef _WIN32
 
 	console::Buf buf{{80, 25}, 1337, 80};
 	struct winsize ws;
@@ -75,7 +75,7 @@ void interactive() {
 		throw Error(MSG(err) << "execl(\"" << shell << "\", \"" << shell << "\", nullptr) failed: " << strerror(errno));
 	}
 	default:
-		//we are the parent
+		// we are the parent
 		break;
 	}
 
@@ -143,7 +143,7 @@ void interactive() {
 				ssize_t retval = read(ptyin.fd, rdbuf, rdbuf_size);
 				switch (retval) {
 				case -1:
-					switch(errno) {
+					switch (errno) {
 					case EIO:
 						loop = false;
 						break;
@@ -175,7 +175,7 @@ void interactive() {
 	// show cursor
 	termout.puts("\x1b[?25h");
 
-	#endif /* _WIN32 */
+#endif /* _WIN32 */
 }
 
 

--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -11,7 +11,7 @@
 
 // TODO: Remove custom jthread definition when clang/libc++ finally supports it
 #if __llvm__
-#if !__cpp_lib_jthread
+	#if !__cpp_lib_jthread
 namespace std {
 class jthread : public thread {
 public:
@@ -27,9 +27,9 @@ public:
 	}
 };
 } // namespace std
-#endif
+	#endif
 #else
-#include <stop_token>
+	#include <stop_token>
 #endif
 
 

--- a/libopenage/error/handlers.cpp
+++ b/libopenage/error/handlers.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 /*
  * This file holds handlers for std::terminate and SIGSEGV.
@@ -17,9 +17,9 @@
 #include <iostream>
 
 #ifdef _MSC_VER
-#include <io.h>
+	#include <io.h>
 #else
-#include <unistd.h>
+	#include <unistd.h>
 #endif
 
 #include "util/init.h"

--- a/libopenage/error/stackanalyzer.cpp
+++ b/libopenage/error/stackanalyzer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "stackanalyzer.h"
 
@@ -30,8 +30,8 @@ constexpr uint64_t base_skip_frames = 1;
 
 #if WITH_BACKTRACE
 
-// use modern <backtrace.h>
-#include <backtrace.h>
+	// use modern <backtrace.h>
+	#include <backtrace.h>
 
 namespace openage {
 namespace error {
@@ -59,7 +59,7 @@ struct backtrace_state *bt_state;
 util::OnInit init_backtrace_state([]() {
 	bt_state = backtrace_create_state(
 		nullptr, // auto-determine filename
-		1, // threaded
+		1,       // threaded
 		backtrace_error_callback,
 		nullptr // passed to the callback
 	);
@@ -189,8 +189,8 @@ void StackAnalyzer::get_symbols(std::function<void(const backtrace_symbol *)> cb
 
 #else // WITHOUT_BACKTRACE
 
-#ifdef _WIN32
-#include <windows.h>
+	#ifdef _WIN32
+		#include <windows.h>
 
 namespace openage {
 namespace error {
@@ -208,10 +208,10 @@ void StackAnalyzer::analyze() {
 } // namespace error
 } // namespace openage
 
-#else // not _MSC_VER
+	#else // not _MSC_VER
 
-// use GNU's <execinfo.h>
-#include <execinfo.h>
+		// use GNU's <execinfo.h>
+		#include <execinfo.h>
 
 namespace openage::error {
 
@@ -256,7 +256,7 @@ void StackAnalyzer::analyze() {
 
 } // namespace openage::error
 
-#endif // for _MSC_VER or GNU execinfo
+	#endif // for _MSC_VER or GNU execinfo
 
 namespace openage::error {
 

--- a/libopenage/event/demo/gui.cpp
+++ b/libopenage/event/demo/gui.cpp
@@ -1,25 +1,25 @@
-// Copyright 2016-2023 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #include "gui.h"
 
 // the gui requires ncurses.
 #if WITH_NCURSES
 
-#include <algorithm>
-#include <array>
-#include <cstdlib>
-#include <cstring>
-#ifdef __MINGW32__
-#include <ncurses/ncurses.h>
-#else
-#include <ncurses.h>
-#endif // __MINGW32__
-#include <vector>
+	#include <algorithm>
+	#include <array>
+	#include <cstdlib>
+	#include <cstring>
+	#ifdef __MINGW32__
+		#include <ncurses/ncurses.h>
+	#else
+		#include <ncurses.h>
+	#endif // __MINGW32__
+	#include <vector>
 
-#include "curve/continuous.h"
-#include "curve/discrete.h"
-#include "event/demo/gamestate.h"
-#include "util/fixed_point.h"
+	#include "curve/continuous.h"
+	#include "curve/discrete.h"
+	#include "event/demo/gamestate.h"
+	#include "util/fixed_point.h"
 
 namespace openage::event::demo {
 

--- a/libopenage/event/demo/gui.h
+++ b/libopenage/event/demo/gui.h
@@ -1,18 +1,18 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include "config.h"
 
 #if WITH_NCURSES
-#include <deque>
-#include <memory>
-#include <string>
-#include <vector>
+	#include <deque>
+	#include <memory>
+	#include <string>
+	#include <vector>
 
-#include "event/demo/gamestate.h"
-#include "time/time.h"
-#include "util/vector.h"
+	#include "event/demo/gamestate.h"
+	#include "time/time.h"
+	#include "util/vector.h"
 
 
 namespace openage::event::demo {

--- a/libopenage/event/demo/main.cpp
+++ b/libopenage/event/demo/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 the openage authors. See copying.md for legal info.
+// Copyright 2016-2024 the openage authors. See copying.md for legal info.
 
 #include "main.h"
 
@@ -16,11 +16,11 @@
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 
 #if WITH_NCURSES
-#ifdef __MINGW32__
-#include <ncurses/ncurses.h>
-#else
-#include <ncurses.h>
-#endif // __MINGW32__
+	#ifdef __MINGW32__
+		#include <ncurses/ncurses.h>
+	#else
+		#include <ncurses.h>
+	#endif // __MINGW32__
 #endif
 
 

--- a/libopenage/event/demo/physics.cpp
+++ b/libopenage/event/demo/physics.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "physics.h"
 
@@ -9,13 +9,13 @@
 #include <string>
 
 #if WITH_NCURSES
-#ifdef __MINGW32__
-#include <ncurses/ncurses.h>
-#else
-#include <ncurses.h>
-#endif // __MINGW32__
+	#ifdef __MINGW32__
+		#include <ncurses/ncurses.h>
+	#else
+		#include <ncurses.h>
+	#endif // __MINGW32__
 
-#include "gui.h"
+	#include "gui.h"
 #endif
 
 #include "error/error.h"
@@ -377,7 +377,7 @@ void Physics::init(const std::shared_ptr<PongState> &gstate,
 	loop->create_event("demo.ball.reflect_panel", state->ball->position, state, now);
 
 	// FIXME once "reset": deregister
-	//reset(state, mgr, now);
+	// reset(state, mgr, now);
 }
 
 void Physics::process_input(const std::shared_ptr<PongState> &state,
@@ -466,11 +466,11 @@ void Physics::process_input(const std::shared_ptr<PongState> &state,
 				Physics::reset(state, *mgr, now);
 				break;
 
-				//if (player->state->get(now).state == PongEvent::LOST) {
+				// if (player->state->get(now).state == PongEvent::LOST) {
 				//	state->ball.position->set_last(now, state.display_boundary * 0.5);
-				//}
-				//update_ball(state, now, init_recursion_limit);
-				//break;
+				// }
+				// update_ball(state, now, init_recursion_limit);
+				// break;
 
 			default:
 				break;

--- a/libopenage/log/level.h
+++ b/libopenage/log/level.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -50,11 +50,11 @@ struct OAAPI level : util::Enum<level_value> {
 	level();
 
 #ifdef __MINGW32__
-// Do not try to optimize these out even if it seems they are not used.
-// Namely MIN that is not used within the library.
-#define NOOPTIMIZE __attribute__((__used__))
+	// Do not try to optimize these out even if it seems they are not used.
+	// Namely MIN that is not used within the library.
+	#define NOOPTIMIZE __attribute__((__used__))
 #else
-#define NOOPTIMIZE
+	#define NOOPTIMIZE
 #endif // _win32
 
 	static constexpr level_value MIN NOOPTIMIZE{{"min loglevel", -1000}, "5"};

--- a/libopenage/log/message.h
+++ b/libopenage/log/message.h
@@ -21,11 +21,11 @@
 
 
 #if defined(__GNUC__)
-#define OPENAGE_FUNC_NAME __PRETTY_FUNCTION__
+	#define OPENAGE_FUNC_NAME __PRETTY_FUNCTION__
 #elif defined(_MSC_VER)
-#define OPENAGE_FUNC_NAME __FUNCSIG__
+	#define OPENAGE_FUNC_NAME __FUNCSIG__
 #else
-#define OPENAGE_FUNC_NAME __FUNCTION__
+	#define OPENAGE_FUNC_NAME __FUNCTION__
 #endif
 
 namespace openage {

--- a/libopenage/log/stdout_logsink.cpp
+++ b/libopenage/log/stdout_logsink.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "stdout_logsink.h"
 
@@ -7,8 +7,8 @@
 #include <string>
 
 #ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+	#define WIN32_LEAN_AND_MEAN
+	#include <Windows.h>
 #endif
 
 #include "log/level.h"

--- a/libopenage/renderer/color.cpp
+++ b/libopenage/renderer/color.cpp
@@ -1,12 +1,11 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "color.h"
 
 namespace openage {
 namespace renderer {
 
-Color::Color()
-	:
+Color::Color() :
 	r{0},
 	g{0},
 	b{0},
@@ -14,8 +13,7 @@ Color::Color()
 	// Empty
 }
 
-Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-	:
+Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a) :
 	r{r},
 	g{g},
 	b{b},
@@ -32,6 +30,7 @@ bool Color::operator!=(const Color &other) const {
 }
 
 Color Colors::WHITE = {255, 255, 255, 255};
-Color Colors::BLACK = {  0,   0,   0, 255};
+Color Colors::BLACK = {0, 0, 0, 255};
 
-}} // openage::renderer
+} // namespace renderer
+} // namespace openage

--- a/libopenage/renderer/gui/guisys/private/opengl_debug_logger.cpp
+++ b/libopenage/renderer/gui/guisys/private/opengl_debug_logger.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "opengl_debug_logger.h"
 
@@ -7,11 +7,11 @@
 #include <QOpenGLVersionFunctionsFactory>
 
 #ifdef __APPLE__
-// from https://www.khronos.org/registry/OpenGL/api/GL/glext.h
-#define GL_DEBUG_CALLBACK_FUNCTION 0x8244
-#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
-#define GL_DEBUG_TYPE_ERROR 0x824C
-#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
+	// from https://www.khronos.org/registry/OpenGL/api/GL/glext.h
+	#define GL_DEBUG_CALLBACK_FUNCTION 0x8244
+	#define GL_DEBUG_OUTPUT_SYNCHRONOUS 0x8242
+	#define GL_DEBUG_TYPE_ERROR 0x824C
+	#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR 0x824E
 #endif
 
 namespace qtgui {

--- a/libopenage/renderer/vulkan/loader.cpp
+++ b/libopenage/renderer/vulkan/loader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "loader.h"
 
@@ -9,14 +9,14 @@ namespace openage {
 namespace renderer {
 namespace vulkan {
 
-VlkLoader::VlkLoader()
-	: inited(false) {}
+VlkLoader::VlkLoader() :
+	inited(false) {}
 
 void VlkLoader::init(VkInstance instance) {
-	#ifndef NDEBUG
+#ifndef NDEBUG
 	this->pCreateDebugReportCallbackEXT = PFN_vkCreateDebugReportCallbackEXT(vkGetInstanceProcAddr(instance, "vkCreateDebugReportCallbackEXT"));
 	this->pDestroyDebugReportCallbackEXT = PFN_vkDestroyDebugReportCallbackEXT(vkGetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT"));
-	#endif
+#endif
 
 	this->inited = true;
 }
@@ -24,10 +24,9 @@ void VlkLoader::init(VkInstance instance) {
 #ifndef NDEBUG
 VkResult VlkLoader::vkCreateDebugReportCallbackEXT(
 	VkInstance instance,
-	const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-	const VkAllocationCallbacks* pAllocator,
-	VkDebugReportCallbackEXT* pCallback
-) {
+	const VkDebugReportCallbackCreateInfoEXT *pCreateInfo,
+	const VkAllocationCallbacks *pAllocator,
+	VkDebugReportCallbackEXT *pCallback) {
 	if (!this->inited) {
 		throw Error(MSG(err) << "Tried to request function from Vulkan extension loader before initializing it.");
 	}
@@ -42,8 +41,7 @@ VkResult VlkLoader::vkCreateDebugReportCallbackEXT(
 void VlkLoader::vkDestroyDebugReportCallbackEXT(
 	VkInstance instance,
 	VkDebugReportCallbackEXT callback,
-	const VkAllocationCallbacks* pAllocator
-) {
+	const VkAllocationCallbacks *pAllocator) {
 	if (!this->inited) {
 		throw Error(MSG(err) << "Tried to request function from Vulkan extension loader before initializing it.");
 	}
@@ -54,4 +52,6 @@ void VlkLoader::vkDestroyDebugReportCallbackEXT(
 }
 #endif
 
-}}} // openage::renderer::vulkan
+} // namespace vulkan
+} // namespace renderer
+} // namespace openage

--- a/libopenage/util/compiler.cpp
+++ b/libopenage/util/compiler.cpp
@@ -1,22 +1,22 @@
-// Copyright 2015-2019 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "compiler.h"
 
 #ifndef _WIN32
-#include <cxxabi.h>
-#include <dlfcn.h>
+	#include <cxxabi.h>
+	#include <dlfcn.h>
 #else
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <DbgHelp.h>
+	#define WIN32_LEAN_AND_MEAN
+	#include <DbgHelp.h>
+	#include <Windows.h>
 #endif
 
 #include "strings.h"
 
 #include <array>
 #include <iostream>
-#include <optional>
 #include <mutex>
+#include <optional>
 
 namespace openage {
 namespace util {
@@ -34,7 +34,8 @@ std::string demangle(const char *symbol) {
 
 	if (status != 0) {
 		return symbol;
-	} else {
+	}
+	else {
 		std::string result{buf};
 		free(buf);
 		return result;
@@ -78,12 +79,12 @@ std::optional<std::string> symbol_name_win(const void *addr) {
 		constexpr int buffer_size = sizeof(SYMBOL_INFO) + name_buffer_size * sizeof(char);
 		std::array<char, buffer_size> buffer;
 
-		SYMBOL_INFO *symbol_info = reinterpret_cast<SYMBOL_INFO*>(buffer.data());
+		SYMBOL_INFO *symbol_info = reinterpret_cast<SYMBOL_INFO *>(buffer.data());
 
 		symbol_info->SizeOfStruct = sizeof(SYMBOL_INFO);
 		symbol_info->MaxNameLen = name_buffer_size;
 
-		if (SymFromAddr(process_handle, reinterpret_cast<DWORD64>(addr), nullptr, symbol_info))	{
+		if (SymFromAddr(process_handle, reinterpret_cast<DWORD64>(addr), nullptr, symbol_info)) {
 			return std::string(symbol_info->Name);
 		}
 	}
@@ -92,7 +93,7 @@ std::optional<std::string> symbol_name_win(const void *addr) {
 }
 
 
-}
+} // namespace
 #endif
 
 std::string symbol_name(const void *addr, bool require_exact_addr, bool no_pure_addrs) {
@@ -100,8 +101,7 @@ std::string symbol_name(const void *addr, bool require_exact_addr, bool no_pure_
 
 	auto symbol_name_result = symbol_name_win(addr);
 
-	if (!initialized_symbol_handler_successfully ||
-		!symbol_name_result.has_value()) {
+	if (!initialized_symbol_handler_successfully || !symbol_name_result.has_value()) {
 		return no_pure_addrs ? "" : addr_to_string(addr);
 	}
 
@@ -113,8 +113,9 @@ std::string symbol_name(const void *addr, bool require_exact_addr, bool no_pure_
 	if (dladdr(addr, &addr_info) == 0) {
 		// dladdr has... failed.
 		return no_pure_addrs ? "" : addr_to_string(addr);
-	} else {
-		size_t symbol_offset = (size_t) addr - (size_t) addr_info.dli_saddr;
+	}
+	else {
+		size_t symbol_offset = (size_t)addr - (size_t)addr_info.dli_saddr;
 
 		if (addr_info.dli_sname == nullptr or (symbol_offset != 0 and require_exact_addr)) {
 			return no_pure_addrs ? "" : addr_to_string(addr);
@@ -123,7 +124,8 @@ std::string symbol_name(const void *addr, bool require_exact_addr, bool no_pure_
 		if (symbol_offset == 0) {
 			// this is our symbol name.
 			return demangle(addr_info.dli_sname);
-		} else {
+		}
+		else {
 			return util::sformat("%s+0x%lx",
 			                     demangle(addr_info.dli_sname).c_str(),
 			                     symbol_offset);
@@ -138,7 +140,8 @@ bool is_symbol(const void *addr) {
 
 	if (!initialized_symbol_handler_successfully) {
 		return true;
-	} else {
+	}
+	else {
 		return symbol_name_win(addr).has_value();
 	}
 
@@ -154,4 +157,5 @@ bool is_symbol(const void *addr) {
 }
 
 
-}} // openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/util/fds.h
+++ b/libopenage/util/fds.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #ifndef _WIN32
-#include <termios.h>
+	#include <termios.h>
 #endif
 
 namespace openage {

--- a/libopenage/util/fslike/directory.cpp
+++ b/libopenage/util/fslike/directory.cpp
@@ -1,11 +1,11 @@
-// Copyright 2017-2019 the openage authors. See copying.md for legal info.
+// Copyright 2017-2024 the openage authors. See copying.md for legal info.
 
 #include "directory.h"
 
 // HACK: windows.h defines max and min as macros. This results in compile errors.
 #ifdef _WIN32
-// defining `NOMINMAX` disables the definition of those macros.
-#define NOMINMAX
+	// defining `NOMINMAX` disables the definition of those macros.
+	#define NOMINMAX
 #endif
 
 #include <cstdio>
@@ -17,34 +17,32 @@
 #include <utility>
 
 #ifdef __APPLE__
-#include <sys/time.h>
+	#include <sys/time.h>
 #endif
 #ifdef _WIN32
-#include <direct.h>
-#include <io.h>
-#include <sys/utime.h>
-// HACK: What the heck? I want the std::filesystem library!
-#define O_NOCTTY 0
-#define O_NONBLOCK 0
-#define W_OK 2
+	#include <direct.h>
+	#include <io.h>
+	#include <sys/utime.h>
+	// HACK: What the heck? I want the std::filesystem library!
+	#define O_NOCTTY 0
+	#define O_NONBLOCK 0
+	#define W_OK 2
 #else // ! _MSC_VER
-#include <unistd.h>
+	#include <unistd.h>
 #endif
 
-#include "./native.h"
 #include "../file.h"
 #include "../filelike/native.h"
 #include "../misc.h"
 #include "../path.h"
+#include "./native.h"
 
 
 namespace openage::util::fslike {
 
 
-Directory::Directory(std::string basepath, bool create_if_missing)
-	:
+Directory::Directory(std::string basepath, bool create_if_missing) :
 	basepath{std::move(basepath)} {
-
 	if (create_if_missing) {
 		this->mkdirs({});
 	}
@@ -78,8 +76,7 @@ bool Directory::is_file(const Path::parts_t &parts) {
 	auto stat_result = this->do_stat(parts);
 
 	// test for regular file
-	if (std::get<1>(stat_result) == 0 and
-	    S_ISREG(std::get<0>(stat_result).st_mode)) {
+	if (std::get<1>(stat_result) == 0 and S_ISREG(std::get<0>(stat_result).st_mode)) {
 		return true;
 	}
 
@@ -91,8 +88,7 @@ bool Directory::is_dir(const Path::parts_t &parts) {
 	auto stat_result = this->do_stat(parts);
 
 	// test for regular file
-	if (std::get<1>(stat_result) == 0 and
-	    S_ISDIR(std::get<0>(stat_result).st_mode)) {
+	if (std::get<1>(stat_result) == 0 and S_ISDIR(std::get<0>(stat_result).st_mode)) {
 		return true;
 	}
 
@@ -104,9 +100,7 @@ bool Directory::writable(const Path::parts_t &parts) {
 	Path::parts_t parts_test = parts;
 
 	// try to find the first existing path-part
-	while (not (this->is_dir(parts_test) or
-	            this->is_file(parts_test))) {
-
+	while (not(this->is_dir(parts_test) or this->is_file(parts_test))) {
 		if (parts_test.size() == 0) {
 			throw Error{ERR << "file not found"};
 		}
@@ -120,7 +114,6 @@ bool Directory::writable(const Path::parts_t &parts) {
 
 
 std::vector<Path::part_t> Directory::list(const Path::parts_t &parts) {
-
 	const std::string path = this->resolve(parts);
 	std::vector<Path::part_t> ret;
 
@@ -145,7 +138,6 @@ std::vector<Path::part_t> Directory::list(const Path::parts_t &parts) {
 
 
 bool Directory::mkdirs(const Path::parts_t &parts) {
-
 	Path::parts_t all_parts = util::split(this->basepath, PATHSEP);
 
 	vector_extend(all_parts, parts);
@@ -158,9 +150,7 @@ bool Directory::mkdirs(const Path::parts_t &parts) {
 		struct stat buf;
 
 		// it it exists already, try creating the next one
-		if (stat(dirpath.c_str(), &buf) == 0 and
-		    S_ISDIR(buf.st_mode)) {
-
+		if (stat(dirpath.c_str(), &buf) == 0 and S_ISDIR(buf.st_mode)) {
 			continue;
 		}
 
@@ -184,40 +174,35 @@ bool Directory::mkdirs(const Path::parts_t &parts) {
 File Directory::open_r(const Path::parts_t &parts) {
 	return File{
 		std::make_shared<filelike::Native>(this->resolve(parts),
-		                                   filelike::Native::mode_t::R)
-	};
+	                                       filelike::Native::mode_t::R)};
 }
 
 
 File Directory::open_w(const Path::parts_t &parts) {
 	return File{
 		std::make_shared<filelike::Native>(this->resolve(parts),
-		                                   filelike::Native::mode_t::W)
-	};
+	                                       filelike::Native::mode_t::W)};
 }
 
 
 File Directory::open_rw(const Path::parts_t &parts) {
 	return File{
 		std::make_shared<filelike::Native>(this->resolve(parts),
-		                                   filelike::Native::mode_t::RW)
-	};
+	                                       filelike::Native::mode_t::RW)};
 }
 
 
 File Directory::open_a(const Path::parts_t &parts) {
 	return File{
 		std::make_shared<filelike::Native>(this->resolve(parts),
-		                                   filelike::Native::mode_t::A)
-	};
+	                                       filelike::Native::mode_t::A)};
 }
 
 
 File Directory::open_ar(const Path::parts_t &parts) {
 	return File{
 		std::make_shared<filelike::Native>(this->resolve(parts),
-		                                   filelike::Native::mode_t::AR)
-	};
+	                                       filelike::Native::mode_t::AR)};
 }
 
 
@@ -228,9 +213,9 @@ std::string Directory::get_native_path(const Path::parts_t &parts) {
 
 bool Directory::rename(const Path::parts_t &parts,
                        const Path::parts_t &target_parts) {
-
 	return std::rename(this->resolve(parts).c_str(),
-	                   this->resolve(target_parts).c_str()) == 0;
+	                   this->resolve(target_parts).c_str())
+	       == 0;
 }
 
 
@@ -245,9 +230,8 @@ bool Directory::touch(const Path::parts_t &parts) {
 	// create the file if missing
 	int fd = open(
 		path.c_str(),
-		O_WRONLY|O_CREAT|O_NOCTTY|O_NONBLOCK,
-		0666
-	);
+		O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK,
+		0666);
 
 	if (fd < 0) {
 		return false;
@@ -308,4 +292,4 @@ std::ostream &Directory::repr(std::ostream &stream) {
 	return stream;
 }
 
-} // openage::util::fslike
+} // namespace openage::util::fslike

--- a/libopenage/util/macro/concat.h
+++ b/libopenage/util/macro/concat.h
@@ -9,16 +9,16 @@
 #define CONCAT_N(_1, _2, _3, NAME, ...) NAME
 
 #ifdef _MSC_VER
-#define CONCAT_COUNT_ARGS_IMPL(args) CONCAT_N args
-#define CONCAT_COUNT_ARGS(...) CONCAT_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
-#define CONCAT_HELPER2(count) CONCAT_##count
-#define CONCAT_HELPER1(count) CONCAT_HELPER2(count)
-#define CONCAT_HELPER(count) CONCAT_HELPER1(count)
-#define CONCAT_GLUE(x, y) x y
-#define CONCAT(OP, ...) CONCAT_GLUE(CONCAT_HELPER(CONCAT_COUNT_ARGS(__VA_ARGS__)), (OP, __VA_ARGS__))
+	#define CONCAT_COUNT_ARGS_IMPL(args) CONCAT_N args
+	#define CONCAT_COUNT_ARGS(...) CONCAT_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
+	#define CONCAT_HELPER2(count) CONCAT_##count
+	#define CONCAT_HELPER1(count) CONCAT_HELPER2(count)
+	#define CONCAT_HELPER(count) CONCAT_HELPER1(count)
+	#define CONCAT_GLUE(x, y) x y
+	#define CONCAT(OP, ...) CONCAT_GLUE(CONCAT_HELPER(CONCAT_COUNT_ARGS(__VA_ARGS__)), (OP, __VA_ARGS__))
 #else
-#define CONCAT(OP, ...) CONCAT_N(__VA_ARGS__, \
-	                             CONCAT_3, \
-	                             CONCAT_2, \
-	                             CONCAT_1)(OP, __VA_ARGS__)
+	#define CONCAT(OP, ...) CONCAT_N(__VA_ARGS__, \
+		                             CONCAT_3, \
+		                             CONCAT_2, \
+		                             CONCAT_1)(OP, __VA_ARGS__)
 #endif

--- a/libopenage/util/macro/loop.h
+++ b/libopenage/util/macro/loop.h
@@ -9,16 +9,16 @@
 #define LOOP_N(_1, _2, _3, NAME, ...) NAME
 
 #ifdef _MSC_VER
-#define LOOP_COUNT_ARGS_IMPL(args) LOOP_N args
-#define LOOP_COUNT_ARGS(...) LOOP_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
-#define LOOP_HELPER2(count) LOOP_##count
-#define LOOP_HELPER1(count) LOOP_HELPER2(count)
-#define LOOP_HELPER(count) LOOP_HELPER1(count)
-#define LOOP_GLUE(x, y) x y
-#define LOOP(MACRO, ...) LOOP_GLUE(LOOP_HELPER(LOOP_COUNT_ARGS(__VA_ARGS__)), (MACRO, __VA_ARGS__))
+	#define LOOP_COUNT_ARGS_IMPL(args) LOOP_N args
+	#define LOOP_COUNT_ARGS(...) LOOP_COUNT_ARGS_IMPL((__VA_ARGS__, 3, 2, 1))
+	#define LOOP_HELPER2(count) LOOP_##count
+	#define LOOP_HELPER1(count) LOOP_HELPER2(count)
+	#define LOOP_HELPER(count) LOOP_HELPER1(count)
+	#define LOOP_GLUE(x, y) x y
+	#define LOOP(MACRO, ...) LOOP_GLUE(LOOP_HELPER(LOOP_COUNT_ARGS(__VA_ARGS__)), (MACRO, __VA_ARGS__))
 #else
-#define LOOP(MACRO, ...) LOOP_N(__VA_ARGS__, \
-	                            LOOP_3, \
-	                            LOOP_2, \
-	                            LOOP_1)(MACRO, __VA_ARGS__)
+	#define LOOP(MACRO, ...) LOOP_N(__VA_ARGS__, \
+		                            LOOP_3, \
+		                            LOOP_2, \
+		                            LOOP_1)(MACRO, __VA_ARGS__)
 #endif

--- a/libopenage/util/os.cpp
+++ b/libopenage/util/os.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #include "os.h"
 
@@ -7,16 +7,16 @@
 #ifdef _WIN32
 // TODO not yet implemented
 #else
-#include <unistd.h>
+	#include <unistd.h>
 #endif
 
 #ifdef __APPLE__
-#include <mach-o/dyld.h>
+	#include <mach-o/dyld.h>
 #endif
 
 #ifdef __FreeBSD__
-#include <sys/types.h>
-#include <sys/sysctl.h>
+	#include <sys/sysctl.h>
+	#include <sys/types.h>
 #endif
 
 #include "../log/log.h"
@@ -77,8 +77,7 @@ std::string self_exec_filename() {
 		CTL_KERN,
 		KERN_PROC,
 		KERN_PROC_PATHNAME,
-		-1
-	};
+		-1};
 
 	while (true) {
 		std::unique_ptr<char[]> buf{new char[bufsize]};
@@ -103,23 +102,23 @@ int execute_file(const char *path, bool background) {
 	// TODO some sort of shell-open, not yet implemented
 	return -1; // failure
 #else
-		std::string runner = "";
-#ifdef __APPLE__
-			runner = subprocess::which("open");
-#else
-			runner = subprocess::which("xdg-open");
-			// fallback
-			if (runner.size() == 0) {
-				runner = subprocess::which("gnome-open");
-			}
-#endif
-		if (runner.size() == 0) {
-			log::log(MSG(err) << "could not locate file-opener");
-			return -1;
-		}
+	std::string runner = "";
+	#ifdef __APPLE__
+	runner = subprocess::which("open");
+	#else
+	runner = subprocess::which("xdg-open");
+	// fallback
+	if (runner.size() == 0) {
+		runner = subprocess::which("gnome-open");
+	}
+	#endif
+	if (runner.size() == 0) {
+		log::log(MSG(err) << "could not locate file-opener");
+		return -1;
+	}
 
-		return subprocess::call({runner.c_str(), path, nullptr}, not background);
+	return subprocess::call({runner.c_str(), path, nullptr}, not background);
 #endif
 }
 
-} // namespace openage
+} // namespace openage::os

--- a/libopenage/util/pty.h
+++ b/libopenage/util/pty.h
@@ -3,14 +3,14 @@
 #pragma once
 
 #ifdef __APPLE__
-#include <util.h>
+	#include <util.h>
 #elif defined(__FreeBSD__)
-#include <libutil.h>
-#include <sys/ioctl.h>
-#include <sys/types.h>
-#include <termios.h>
+	#include <libutil.h>
+	#include <sys/ioctl.h>
+	#include <sys/types.h>
+	#include <termios.h>
 #elif _WIN32
 // TODO not yet implemented
 #else
-#include <pty.h>
+	#include <pty.h>
 #endif

--- a/libopenage/util/strings.h
+++ b/libopenage/util/strings.h
@@ -11,9 +11,9 @@
 #include <vector>
 
 #if defined(__GNUC__)
-#define ATTRIBUTE_FORMAT(i, j) __attribute__((format(printf, i, j)))
+	#define ATTRIBUTE_FORMAT(i, j) __attribute__((format(printf, i, j)))
 #else
-#define ATTRIBUTE_FORMAT(i, j)
+	#define ATTRIBUTE_FORMAT(i, j)
 #endif
 
 namespace openage {

--- a/libopenage/util/subprocess.cpp
+++ b/libopenage/util/subprocess.cpp
@@ -1,19 +1,19 @@
-// Copyright 2014-2019 the openage authors. See copying.md for legal info.
+// Copyright 2014-2024 the openage authors. See copying.md for legal info.
 
 #include "subprocess.h"
 
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 
 #ifdef _WIN32
 // TODO not yet implemented
 #else
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/wait.h>
+	#include <fcntl.h>
+	#include <sys/stat.h>
+	#include <sys/types.h>
+	#include <sys/wait.h>
+	#include <unistd.h>
 #endif
 
 #include "../log/log.h"
@@ -90,7 +90,7 @@ int call(const std::vector<const char *> &argv, bool wait, const char *redirect_
 	if (redirect_stdout_to != nullptr) {
 		replacement_stdout_fd = open(
 			redirect_stdout_to,
-			O_WRONLY | O_CREAT|O_TRUNC|O_CLOEXEC,
+			O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
 			0644);
 
 		if (replacement_stdout_fd < 0) {
@@ -215,8 +215,8 @@ int call(const std::vector<const char *> &argv, bool wait, const char *redirect_
 		}
 
 		if (child_errno > 0) {
-		    log::log(MSG(err) << "execv has failed: " << strerror(child_errno));
-		    return -1;
+			log::log(MSG(err) << "execv has failed: " << strerror(child_errno));
+			return -1;
 		}
 	}
 
@@ -235,7 +235,7 @@ int call(const std::vector<const char *> &argv, bool wait, const char *redirect_
 
 	// everything went well.
 	return status;
-	#endif
+#endif
 }
 
 } // namespace openage::subprocess

--- a/libopenage/util/thread_id.cpp
+++ b/libopenage/util/thread_id.cpp
@@ -1,13 +1,13 @@
-// Copyright 2015-2018 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "thread_id.h"
 
 #include "config.h"
 
 #if HAVE_THREAD_LOCAL_STORAGE
-#include <atomic>
+	#include <atomic>
 #else
-#include <thread>
+	#include <thread>
 #endif
 
 namespace openage {
@@ -23,9 +23,8 @@ namespace util {
  */
 class ThreadIdSupplier {
 public:
-	ThreadIdSupplier()
-	:
-	val{ThreadIdSupplier::counting_id++} {}
+	ThreadIdSupplier() :
+		val{ThreadIdSupplier::counting_id++} {}
 
 	const size_t val;
 
@@ -42,12 +41,13 @@ std::atomic<size_t> ThreadIdSupplier::counting_id{0};
 #endif
 
 size_t get_current_thread_id() {
-	#if HAVE_THREAD_LOCAL_STORAGE
+#if HAVE_THREAD_LOCAL_STORAGE
 	static thread_local ThreadIdSupplier current_thread_id;
 	return current_thread_id.val;
-	#else
+#else
 	return std::hash<std::thread::id>()(std::this_thread::get_id());
-	#endif
+#endif
 }
 
-}} // namespace openage::util
+} // namespace util
+} // namespace openage

--- a/libopenage/versions/versions.cpp
+++ b/libopenage/versions/versions.cpp
@@ -1,9 +1,9 @@
-// Copyright 2020-2023 the openage authors. See copying.md for legal info.
+// Copyright 2020-2024 the openage authors. See copying.md for legal info.
 
 #include "versions.h"
 
 #ifdef __linux__
-#include <gnu/libc-version.h>
+	#include <gnu/libc-version.h>
 #endif
 
 #include <eigen3/Eigen/Dense>


### PR DESCRIPTION
Aligns the clang formatting rules for preprocesser directives with what we already use in the files.