### PR TITLE
Make comparisons not ambiguous (fixes clang warnings)

### DIFF
--- a/libopenage/coord/coord.h.template
+++ b/libopenage/coord/coord.h.template
@@ -74,12 +74,8 @@ struct Coord${camelcase}Absolute {
 		return static_cast<Absolute &>(*this);
 	}
 
-	constexpr bool operator ==(const Absolute &other) const {
-		return ${formatted_members("(this->{0} == other.{0})", join_with=" && ")};
-	}
-
-	constexpr bool operator !=(const Absolute &other) const {
-		return !(*this == other);
+	friend constexpr bool operator ==(const Absolute &lhs, const Absolute &rhs) {
+		return ${formatted_members("(lhs.{0} == rhs.{0})", join_with=" && ")};
 	}
 };
 
@@ -167,12 +163,8 @@ struct Coord${camelcase}Relative {
 		return static_cast<Relative &>(*this);
 	}
 
-	constexpr bool operator ==(const Relative &other) const {
-		return ${formatted_members("(this->{0} == other.{0})", join_with=" && ")};
-	}
-
-	constexpr bool operator !=(const Relative &other) const {
-		return !(*this == other);
+	friend constexpr bool operator ==(const Relative &lhs, const Relative &rhs) {
+		return ${formatted_members("(lhs.{0} == rhs.{0})", join_with=" && ")};
 	}
 };
 


### PR DESCRIPTION
We previoulsy had a bunch of clang warnings that looked like this:

```
/home/chantal/repo/libopenage/coord/coord_test.cpp:60:5: warning: ISO C++20 considers use of overloaded operator '!=' (with operand types 'openage::coord::tests::(anonymous namespace)::TestCoordsAbsolute' and 'openage::coord::tests::(anonymous namespace)::TestCoordsAbsolute') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Wambiguous-reversed-operator]
    TESTEQUALS(a0, a1);
    ^~~~~~~~~~~~~~~~~~
/home/chantal/repo/libopenage/coord/../testing/testing.h:53:25: note: expanded from macro 'TESTEQUALS'
                        if (test_result_left != (right)) { \
                            ~~~~~~~~~~~~~~~~ ^  ~~~~~~~
/home/chantal/repo/.bin/clang++-debug-Oauto-sanitize-none/libopenage/coord/coord_xy.gen.h:86:17: note: candidate function with non-reversed arguments
        constexpr bool operator !=(const Absolute &other) const {
                       ^
/home/chantal/repo/.bin/clang++-debug-Oauto-sanitize-none/libopenage/coord/coord_xy.gen.h:82:17: note: ambiguous candidate function with reversed arguments
        constexpr bool operator ==(const Absolute &other) const {'
```

These were the result of a few changes to the C++20 standard. The warnings were exclusively located in the coordinate system templates.

I think I fixed this issue now by removing the `operator!=` implementation (which should be generated implicitely now) and using a different `operator==` overload. This gets rid of the warnings completely.