### PR TITLE
File system api c++: added support for creating temp. files and directories

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -156,6 +156,7 @@ _the openage authors_ are:
 | Nikhil Ghosh                | NikhilGhosh75               | nghosh606 à gmail dawt com                        |
 | Edvin Lindholm              | EdvinLndh                   | edvinlndh à gmail dawt com                        |
 | Jeremiah Morgan             | jere8184                    | jeremiahmorgan dawt bham à outlook dawt com       |
+| Tobias Alam                 | alamt22                     | tobiasal à umich dawt edu                         |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -121,5 +121,13 @@ std::ostream &operator<<(std::ostream &stream, const File &file) {
 	return stream;
 }
 
+static File get_temp_file() {
+	std::FILE* tmp_file = std::tmpfile();
+	int temp_fd = fileno(tmp_file);
+	std::string tf_path = "/proc/self/fd/" + std::to_string(temp_fd);
+	mode_t mode = 0777;
+	File file_wrapper = File(tf_path, mode);
+	return file_wrapper;
+}
 
 } // namespace openage::util

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -16,6 +16,7 @@
 #include "util/filelike/python.h"
 #include "util/path.h"
 #include "util/strings.h"
+#include "util/fslike/directory.h"
 
 
 namespace openage::util {
@@ -122,11 +123,12 @@ std::ostream &operator<<(std::ostream &stream, const File &file) {
 }
 
 static File get_temp_file() {
-	std::FILE* tmp_file = std::tmpfile();
-	int temp_fd = fileno(tmp_file);
-	std::string tf_path = "/proc/self/fd/" + std::to_string(temp_fd);
+	fslike::Directory temp_dir = fslike::Directory::get_temp_directory();
+	std::string file_name = std::tmpnam(nullptr);
+	std::ostringstream dir_path;
+	temp_dir.repr(dir_path);
 	mode_t mode = 0777;
-	File file_wrapper = File(tf_path, mode);
+	File file_wrapper = File(dir_path.str() + file_name, mode);
 	return file_wrapper;
 }
 

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -99,7 +99,7 @@ public:
 	ssize_t size();
 	std::vector<std::string> get_lines();
 	std::shared_ptr<filelike::FileLike> get_fileobj() const;
-	
+
 	static File get_temp_file();
 
 protected:

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -98,8 +98,9 @@ public:
 	void flush();
 	ssize_t size();
 	std::vector<std::string> get_lines();
-
 	std::shared_ptr<filelike::FileLike> get_fileobj() const;
+	
+	static File get_temp_file();
 
 protected:
 	std::shared_ptr<filelike::FileLike> filelike;

--- a/libopenage/util/fslike/directory.cpp
+++ b/libopenage/util/fslike/directory.cpp
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <iostream>
+#include <filesystem>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <utility>
@@ -290,6 +291,13 @@ uint64_t Directory::get_filesize(const Path::parts_t &parts) {
 std::ostream &Directory::repr(std::ostream &stream) {
 	stream << this->basepath;
 	return stream;
+}
+
+static Directory get_temp_directory() {
+	std::string temp_dir_path = std::filesystem::temp_directory_path() / std::tmpnam(nullptr);
+	bool create = true;
+	Directory directory = Directory(temp_dir_path, create);
+	return directory;
 }
 
 } // namespace openage::util::fslike

--- a/libopenage/util/fslike/directory.h
+++ b/libopenage/util/fslike/directory.h
@@ -47,6 +47,8 @@ public:
 	uint64_t get_filesize(const Path::parts_t &parts) override;
 
 	std::ostream &repr(std::ostream &) override;
+	
+	static Directory get_temp_directory();
 
 protected:
 	/**
@@ -54,12 +56,10 @@ protected:
 	 * basically basepath + "/".join(parts)
 	 */
 	std::string resolve(const Path::parts_t &parts) const;
-
 	std::tuple<struct stat, int> do_stat(const Path::parts_t &parts) const;
-
+	
 	std::string basepath;
 };
-
 } // namespace fslike
 } // namespace util
 } // namespace openage

--- a/libopenage/util/fslike/directory.h
+++ b/libopenage/util/fslike/directory.h
@@ -56,8 +56,9 @@ protected:
 	 * basically basepath + "/".join(parts)
 	 */
 	std::string resolve(const Path::parts_t &parts) const;
+
 	std::tuple<struct stat, int> do_stat(const Path::parts_t &parts) const;
-	
+
 	std::string basepath;
 };
 } // namespace fslike

--- a/libopenage/util/fslike/directory.h
+++ b/libopenage/util/fslike/directory.h
@@ -47,7 +47,7 @@ public:
 	uint64_t get_filesize(const Path::parts_t &parts) override;
 
 	std::ostream &repr(std::ostream &) override;
-	
+
 	static Directory get_temp_directory();
 
 protected:

--- a/libopenage/util/path.cpp
+++ b/libopenage/util/path.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "path.h"
 

--- a/libopenage/util/path.cpp
+++ b/libopenage/util/path.cpp
@@ -3,7 +3,6 @@
 #include "path.h"
 
 #include <utility>
-#include <stdio.h>
 
 #include "../error/error.h"
 #include "compiler.h"
@@ -12,7 +11,6 @@
 #include "fslike/python.h"
 #include "misc.h"
 #include "strings.h"
-#include "file.h"
 
 
 namespace openage::util {
@@ -392,15 +390,6 @@ std::string dirname(const std::string &fullpath) {
 	else {
 		return fullpath.substr(0, rsep_pos);
 	}
-}
-
-static File get_temp_file() {
-	std::FILE* tmp_file = std::tmpfile();
-	int temp_fd = fileno(tmp_file);
-	std::string tf_path = "/proc/self/fd/" + std::to_string(temp_fd);
-	mode_t mode = 0777;
-	File file_wrapper = File(tf_path, mode);
-	return file_wrapper;
 }
 
 

--- a/libopenage/util/path.cpp
+++ b/libopenage/util/path.cpp
@@ -3,6 +3,7 @@
 #include "path.h"
 
 #include <utility>
+#include <stdio.h>
 
 #include "../error/error.h"
 #include "compiler.h"
@@ -11,6 +12,7 @@
 #include "fslike/python.h"
 #include "misc.h"
 #include "strings.h"
+#include "file.h"
 
 
 namespace openage::util {
@@ -390,6 +392,15 @@ std::string dirname(const std::string &fullpath) {
 	else {
 		return fullpath.substr(0, rsep_pos);
 	}
+}
+
+static File get_temp_file() {
+	std::FILE* tmp_file = std::tmpfile();
+	int temp_fd = fileno(tmp_file);
+	std::string tf_path = "/proc/self/fd/" + std::to_string(temp_fd);
+	mode_t mode = 0777;
+	File file_wrapper = File(tf_path, mode);
+	return file_wrapper;
 }
 
 

--- a/libopenage/util/path.h
+++ b/libopenage/util/path.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/util/path.h
+++ b/libopenage/util/path.h
@@ -96,7 +96,7 @@ public:
 	File open_rw() const;
 	File open_a() const;
 	File open_ar() const;
-	static File get_temp_file();
+
 	/**
 	 * Resolve the native path by flattening all underlying
 	 * filesystem objects (like unions).
@@ -137,6 +137,7 @@ public:
 	Path operator[](const parts_t &subpaths) const;
 	Path operator[](const part_t &subpath) const;
 	Path operator/(const part_t &subpath) const;
+
 	Path with_name(const part_t &name) const;
 	Path with_suffix(const part_t &suffix) const;
 

--- a/libopenage/util/path.h
+++ b/libopenage/util/path.h
@@ -96,7 +96,7 @@ public:
 	File open_rw() const;
 	File open_a() const;
 	File open_ar() const;
-
+	static File get_temp_file();
 	/**
 	 * Resolve the native path by flattening all underlying
 	 * filesystem objects (like unions).
@@ -137,7 +137,6 @@ public:
 	Path operator[](const parts_t &subpaths) const;
 	Path operator[](const part_t &subpath) const;
 	Path operator/(const part_t &subpath) const;
-
 	Path with_name(const part_t &name) const;
 	Path with_suffix(const part_t &suffix) const;
 


### PR DESCRIPTION
Addresses #1540

This is currently a static method in util/path.cpp for creating a temp file, wrapping it in a File object, and returning it. I am planning on doing one for temporary directories later, wrapping it in a Directory object instead. Let me know if you'd like me to wrap both in Path objects instead--I'm not really sure how to do that since Path takes in a fslike shared pointer rather than the file_like one produced by File.