### PR TITLE
Fix definition of static functions for creating temp files/dirs

### DIFF
--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -122,12 +122,20 @@ std::ostream &operator<<(std::ostream &stream, const File &file) {
 	return stream;
 }
 
-File File::get_temp_file() {
+File File::get_temp_file(bool executable) {
 	fslike::Directory temp_dir = fslike::Directory::get_temp_directory();
 	std::string file_name = std::tmpnam(nullptr);
 	std::ostringstream dir_path;
 	temp_dir.repr(dir_path);
-	File file_wrapper = File(dir_path.str() + file_name, 0777);
+
+	if (executable) {
+		// 0755 == rwxr-xr-x
+		File file_wrapper = File(dir_path.str() + file_name, 0755);
+		return file_wrapper;
+	}
+
+	// 0644 == rw-r--r--
+	File file_wrapper = File(dir_path.str() + file_name, 0644);
 	return file_wrapper;
 }
 

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -14,9 +14,9 @@
 
 #include "util/filelike/native.h"
 #include "util/filelike/python.h"
+#include "util/fslike/directory.h"
 #include "util/path.h"
 #include "util/strings.h"
-#include "util/fslike/directory.h"
 
 
 namespace openage::util {
@@ -122,13 +122,12 @@ std::ostream &operator<<(std::ostream &stream, const File &file) {
 	return stream;
 }
 
-static File get_temp_file() {
+File File::get_temp_file() {
 	fslike::Directory temp_dir = fslike::Directory::get_temp_directory();
 	std::string file_name = std::tmpnam(nullptr);
 	std::ostringstream dir_path;
 	temp_dir.repr(dir_path);
-	mode_t mode = 0777;
-	File file_wrapper = File(dir_path.str() + file_name, mode);
+	File file_wrapper = File(dir_path.str() + file_name, 0777);
 	return file_wrapper;
 }
 

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -100,7 +100,7 @@ public:
 	std::vector<std::string> get_lines();
 	std::shared_ptr<filelike::FileLike> get_fileobj() const;
 
-	static File get_temp_file();
+	static File get_temp_file(bool executable = false);
 
 protected:
 	std::shared_ptr<filelike::FileLike> filelike;

--- a/libopenage/util/fslike/directory.cpp
+++ b/libopenage/util/fslike/directory.cpp
@@ -11,8 +11,8 @@
 #include <cstdio>
 #include <dirent.h>
 #include <fcntl.h>
-#include <iostream>
 #include <filesystem>
+#include <iostream>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <utility>
@@ -293,7 +293,7 @@ std::ostream &Directory::repr(std::ostream &stream) {
 	return stream;
 }
 
-static Directory get_temp_directory() {
+Directory Directory::get_temp_directory() {
 	std::string temp_dir_path = std::filesystem::temp_directory_path() / std::tmpnam(nullptr);
 	bool create = true;
 	Directory directory = Directory(temp_dir_path, create);


### PR DESCRIPTION
Not sure why the CI checks in https://github.com/SFTtech/openage/pull/1706 didn't catch this but the definition of the functions produced linker errors in my local builds. I have edited the definition, so that this does not happen anymore.