### PR TITLE
Fix portal node initialization

### DIFF
--- a/libopenage/gamestate/map.cpp
+++ b/libopenage/gamestate/map.cpp
@@ -58,6 +58,7 @@ Map::Map(const std::shared_ptr<GameState> &state,
 	for (const auto &path_type : this->grid_lookup) {
 		auto grid = this->pathfinder->get_grid(path_type.second);
 		grid->init_portals();
+		grid->init_portal_nodes();
 	}
 }
 


### PR DESCRIPTION
The portal nodes were not created for the grids created by the map generator resulting in a crash. Should be fixed now.