### PR TITLE
Change type of 'effect_apply_type' to 'uint8_t'

### DIFF
--- a/openage/convert/value_object/read/media/datfile/lookup_dicts.py
+++ b/openage/convert/value_object/read/media/datfile/lookup_dicts.py
@@ -285,7 +285,7 @@ RESOURCE_TYPES = {
 
 EFFECT_APPLY_TYPE = {
     # unused assignage: a = -1, b = -1, c = -1, d = 0
-    -1: "DISABLED",
+    255: "DISABLED",
     # if a != -1: a == unit_id, else b == unit_class_id; c =
     # attribute_id, d = new_value
     0: "ATTRIBUTE_ABSSET",
@@ -340,9 +340,10 @@ EFFECT_APPLY_TYPE = {
     102: "TECH_TOGGLE",       # d == research_id
     103: "TECH_TIME_MODIFY",  # a == research_id, if c == 0: d==absval else d==relval
 
-    -54: "UNKNOWN",  # 199: "UNKNOWN",
-    -55: "UNKNOWN",  # 200: "UNKNOWN",
-    -56: "UNKNOWN",  # 201: "UNKNOWN",
+    # unknown; used in DE2 BfG
+    199: "UNKNOWN",
+    200: "UNKNOWN",
+    201: "UNKNOWN",
 
     # attribute_id:
     # 0: hit points

--- a/openage/convert/value_object/read/media/datfile/tech.py
+++ b/openage/convert/value_object/read/media/datfile/tech.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 the openage authors. See copying.md for legal info.
+# Copyright 2013-2024 the openage authors. See copying.md for legal info.
 
 # TODO pylint: disable=C,R
 from __future__ import annotations
@@ -31,7 +31,7 @@ class Effect(GenieStructure):
         """
         data_format = [
             (READ_GEN, "type_id", StorageType.ID_MEMBER, EnumLookupMember(
-                raw_type="int8_t",
+                raw_type="uint8_t",
                 type_name="effect_apply_type",
                 lookup_dict=EFFECT_APPLY_TYPE
             )),


### PR DESCRIPTION
Follow up to https://github.com/SFTtech/openage/pull/1712#discussion_r1855573668

This changes the signage of `effect_apply_type` to unsigned (uint8) as genieutils also uses this type.