### PR TITLE
 Add is_complete() to UniformInput and Implement Checks in Demos 

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -157,6 +157,7 @@ _the openage authors_ are:
 | Edvin Lindholm              | EdvinLndh                   | edvinlndh à gmail dawt com                        |
 | Jeremiah Morgan             | jere8184                    | jeremiahmorgan dawt bham à outlook dawt com       |
 | Tobias Alam                 | alamt22                     | tobiasal à umich dawt edu                         |
+| Alex Zhuohao He             | ZzzhHe                      | zhuohao dawt he à outlook dawt com                |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/libopenage/renderer/demo/demo_0.cpp
+++ b/libopenage/renderer/demo/demo_0.cpp
@@ -9,6 +9,7 @@
 #include "renderer/resources/mesh_data.h"
 #include "renderer/resources/shader_source.h"
 #include "renderer/shader_program.h"
+#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -43,17 +44,16 @@ void renderer_demo_0(const util::Path &path) {
 	auto display_shader = renderer->add_shader({display_vshader_src, display_fshader_src});
 
 	auto quad = renderer->add_mesh_geometry(resources::MeshData::make_quad());
-	auto display_unif = display_shader->create_empty_input();
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!display_unif->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
-	}
 	Renderable display_stuff{
-		display_unif,
+		display_shader->create_empty_input(),
 		quad,
 		false,
 		false,
 	};
+
+	if (!check_uniform_completeness({display_stuff})) {
+		log::log(WARN << "Uniforms not complete.");
+	}
 
 	auto pass = renderer->add_render_pass({display_stuff}, renderer->get_display_target());
 

--- a/libopenage/renderer/demo/demo_0.cpp
+++ b/libopenage/renderer/demo/demo_0.cpp
@@ -43,8 +43,13 @@ void renderer_demo_0(const util::Path &path) {
 	auto display_shader = renderer->add_shader({display_vshader_src, display_fshader_src});
 
 	auto quad = renderer->add_mesh_geometry(resources::MeshData::make_quad());
+	auto display_unif = display_shader->create_empty_input();
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!display_unif->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
 	Renderable display_stuff{
-		display_shader->create_empty_input(),
+		display_unif,
 		quad,
 		false,
 		false,

--- a/libopenage/renderer/demo/demo_0.cpp
+++ b/libopenage/renderer/demo/demo_0.cpp
@@ -2,6 +2,7 @@
 
 #include "demo_0.h"
 
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -9,7 +10,6 @@
 #include "renderer/resources/mesh_data.h"
 #include "renderer/resources/shader_source.h"
 #include "renderer/shader_program.h"
-#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -51,7 +51,7 @@ void renderer_demo_0(const util::Path &path) {
 		false,
 	};
 
-	if (!check_uniform_completeness({display_stuff})) {
+	if (not check_uniform_completeness({display_stuff})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -172,6 +172,12 @@ void renderer_demo_1(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!obj1_unifs->is_complete() || !obj2_unifs->is_complete() || !obj3_unifs->is_complete()
+		|| !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
+
 	/* Data retrieved from the object index texture. */
 	resources::Texture2dData id_texture_data = id_texture->into_data();
 	bool texture_data_valid = false;

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -6,6 +6,7 @@
 #include <epoxy/gl.h>
 #include <QMouseEvent>
 
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -15,7 +16,6 @@
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
 #include "util/math_constants.h"
-#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -173,7 +173,7 @@ void renderer_demo_1(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	if (!check_uniform_completeness({obj1, obj2, obj3, proj_update, display_obj})) {
+	if (not check_uniform_completeness({obj1, obj2, obj3, proj_update, display_obj})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -15,6 +15,7 @@
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
 #include "util/math_constants.h"
+#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -172,10 +173,8 @@ void renderer_demo_1(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!obj1_unifs->is_complete() || !obj2_unifs->is_complete() || !obj3_unifs->is_complete()
-		|| !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
+	if (!check_uniform_completeness({obj1, obj2, obj3, proj_update, display_obj})) {
+		log::log(WARN << "Uniforms not complete.");
 	}
 
 	/* Data retrieved from the object index texture. */

--- a/libopenage/renderer/demo/demo_1.cpp
+++ b/libopenage/renderer/demo/demo_1.cpp
@@ -193,7 +193,7 @@ void renderer_demo_1(const util::Path &path) {
 			ssize_t y = qpos.y();
 
 			log::log(INFO << "Clicked at location (" << x << ", " << y << ")");
-			if (!texture_data_valid) {
+			if (not texture_data_valid) {
 				id_texture_data = id_texture->into_data();
 				texture_data_valid = true;
 			}

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -18,6 +18,7 @@
 #include "renderer/resources/texture_data.h"
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
+#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -224,9 +225,8 @@ void renderer_demo_2(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!obj1_unifs->is_complete() || !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
+	if (!check_uniform_completeness({proj_update, obj1, display_obj})) {
+		log::log(WARN << "Uniforms not complete.");
 	}
 
 	/* Data retrieved from the object index texture. */

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -6,6 +6,7 @@
 #include <epoxy/gl.h>
 #include <QMouseEvent>
 
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -18,7 +19,6 @@
 #include "renderer/resources/texture_data.h"
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
-#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -225,7 +225,7 @@ void renderer_demo_2(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	if (!check_uniform_completeness({proj_update, obj1, display_obj})) {
+	if (not check_uniform_completeness({proj_update, obj1, display_obj})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -248,7 +248,7 @@ void renderer_demo_2(const util::Path &path) {
 			ssize_t y = qpos.y();
 
 			log::log(INFO << "Clicked at location (" << x << ", " << y << ")");
-			if (!texture_data_valid) {
+			if (not texture_data_valid) {
 				id_texture_data = id_texture->into_data();
 				texture_data_valid = true;
 			}

--- a/libopenage/renderer/demo/demo_2.cpp
+++ b/libopenage/renderer/demo/demo_2.cpp
@@ -224,6 +224,11 @@ void renderer_demo_2(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!obj1_unifs->is_complete() || !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
+
 	/* Data retrieved from the object index texture. */
 	resources::Texture2dData id_texture_data = id_texture->into_data();
 	bool texture_data_valid = false;

--- a/libopenage/renderer/demo/demo_4.cpp
+++ b/libopenage/renderer/demo/demo_4.cpp
@@ -16,6 +16,7 @@
 #include "renderer/resources/shader_source.h"
 #include "renderer/resources/texture_data.h"
 #include "renderer/shader_program.h"
+#include "renderer/demo/util.h"
 #include "time/clock.h"
 
 
@@ -165,9 +166,8 @@ void renderer_demo_4(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!obj1_unifs->is_complete() || !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
+	if (!check_uniform_completeness({proj_update, obj1, display_obj})) {
+		log::log(WARN << "Uniforms not complete.");
 	}
 
 	window.add_resize_callback([&](size_t w, size_t h, double /*scale*/) {

--- a/libopenage/renderer/demo/demo_4.cpp
+++ b/libopenage/renderer/demo/demo_4.cpp
@@ -165,6 +165,11 @@ void renderer_demo_4(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!obj1_unifs->is_complete() || !proj_unif->is_complete() || !color_texture_unif->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
+
 	window.add_resize_callback([&](size_t w, size_t h, double /*scale*/) {
 		/* Calculate a projection matrix for the new screen size. */
 		float aspectRatio = float(w) / float(h);

--- a/libopenage/renderer/demo/demo_4.cpp
+++ b/libopenage/renderer/demo/demo_4.cpp
@@ -5,6 +5,7 @@
 #include <eigen3/Eigen/Dense>
 #include <QKeyEvent>
 
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -16,7 +17,6 @@
 #include "renderer/resources/shader_source.h"
 #include "renderer/resources/texture_data.h"
 #include "renderer/shader_program.h"
-#include "renderer/demo/util.h"
 #include "time/clock.h"
 
 
@@ -166,7 +166,7 @@ void renderer_demo_4(const util::Path &path) {
 
 	auto pass2 = renderer->add_render_pass({display_obj}, renderer->get_display_target());
 
-	if (!check_uniform_completeness({proj_update, obj1, display_obj})) {
+	if (not check_uniform_completeness({proj_update, obj1, display_obj})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 

--- a/libopenage/renderer/demo/demo_5.cpp
+++ b/libopenage/renderer/demo/demo_5.cpp
@@ -17,6 +17,7 @@
 #include "renderer/shader_program.h"
 #include "renderer/uniform_buffer.h"
 #include "renderer/uniform_input.h"
+#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -134,9 +135,8 @@ void renderer_demo_5(const util::Path &path) {
 		"tex",
 		gltex);
 
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!transform_unifs->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
+	if (!check_uniform_completeness({terrain_obj})) {
+		log::log(WARN << "Uniforms not complete.");
 	}
 
 	// Move around the scene with WASD

--- a/libopenage/renderer/demo/demo_5.cpp
+++ b/libopenage/renderer/demo/demo_5.cpp
@@ -7,6 +7,7 @@
 #include <QMouseEvent>
 
 #include "renderer/camera/camera.h"
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -17,7 +18,6 @@
 #include "renderer/shader_program.h"
 #include "renderer/uniform_buffer.h"
 #include "renderer/uniform_input.h"
-#include "renderer/demo/util.h"
 
 
 namespace openage::renderer::tests {
@@ -135,7 +135,7 @@ void renderer_demo_5(const util::Path &path) {
 		"tex",
 		gltex);
 
-	if (!check_uniform_completeness({terrain_obj})) {
+	if (not check_uniform_completeness({terrain_obj})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 

--- a/libopenage/renderer/demo/demo_5.cpp
+++ b/libopenage/renderer/demo/demo_5.cpp
@@ -134,6 +134,11 @@ void renderer_demo_5(const util::Path &path) {
 		"tex",
 		gltex);
 
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!transform_unifs->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
+
 	// Move around the scene with WASD
 	window.add_key_callback([&](const QKeyEvent &ev) {
 		bool cam_update = false;

--- a/libopenage/renderer/demo/demo_6.cpp
+++ b/libopenage/renderer/demo/demo_6.cpp
@@ -9,6 +9,7 @@
 #include "renderer/camera/camera.h"
 #include "renderer/camera/frustum_2d.h"
 #include "renderer/camera/frustum_3d.h"
+#include "renderer/demo/util.h"
 #include "renderer/gui/integration/public/gui_application_with_logger.h"
 #include "renderer/opengl/window.h"
 #include "renderer/render_pass.h"
@@ -23,7 +24,6 @@
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
 #include "renderer/uniform_buffer.h"
-#include "renderer/demo/util.h"
 #include "time/clock.h"
 #include "util/path.h"
 #include "util/vector.h"
@@ -490,7 +490,7 @@ void RenderManagerDemo6::create_render_passes() {
 		{display_obj_3d, display_obj_2d, display_obj_frame},
 		renderer->get_display_target());
 
-	if (!check_uniform_completeness({display_obj_3d, display_obj_2d, display_obj_frame})) {
+	if (not check_uniform_completeness({display_obj_3d, display_obj_2d, display_obj_frame})) {
 		log::log(WARN << "Uniforms not complete.");
 	}
 }

--- a/libopenage/renderer/demo/demo_6.cpp
+++ b/libopenage/renderer/demo/demo_6.cpp
@@ -179,6 +179,10 @@ const std::vector<renderer::Renderable> RenderManagerDemo6::create_2d_obj() {
 			this->obj_2d_texture,
 			"tile_params",
 			tile_params);
+		/* Check if all uniform values for uniform inputs have been set */
+		if (!animation_2d_unifs->is_complete()) {
+			log::log(WARN << "Some Uniform values have not been set.");
+		}
 		auto quad = this->renderer->add_mesh_geometry(resources::MeshData::make_quad());
 		Renderable animation_2d_obj{
 			animation_2d_unifs,
@@ -198,6 +202,11 @@ const renderer::Renderable RenderManagerDemo6::create_3d_obj() {
 	auto terrain_unifs = this->obj_3d_shader->new_uniform_input(
 		"tex",
 		this->obj_3d_texture);
+	/* Check if all uniform values for uniform inputs have been set */
+	if (!terrain_unifs->is_complete()) {
+		log::log(WARN << "Some Uniform values have not been set.");
+	}
+
 	std::vector<coord::scene3> terrain_pos{};
 	terrain_pos.push_back({-25, -25, 0});
 	terrain_pos.push_back({25, -25, 0});
@@ -260,6 +269,9 @@ const std::vector<renderer::Renderable> RenderManagerDemo6::create_frame_obj() {
 			frame_size,
 			"incol",
 			Eigen::Vector4f{0.0f, 0.0f, 1.0f, 1.0f});
+		if (!frame_unifs->is_complete()) {
+			log::log(WARN << "Some Uniform values have not been set.");
+		}
 		Renderable frame_obj{
 			frame_unifs,
 			frame_geometry,

--- a/libopenage/renderer/demo/demo_6.cpp
+++ b/libopenage/renderer/demo/demo_6.cpp
@@ -23,6 +23,7 @@
 #include "renderer/shader_program.h"
 #include "renderer/texture.h"
 #include "renderer/uniform_buffer.h"
+#include "renderer/demo/util.h"
 #include "time/clock.h"
 #include "util/path.h"
 #include "util/vector.h"
@@ -179,10 +180,6 @@ const std::vector<renderer::Renderable> RenderManagerDemo6::create_2d_obj() {
 			this->obj_2d_texture,
 			"tile_params",
 			tile_params);
-		/* Check if all uniform values for uniform inputs have been set */
-		if (!animation_2d_unifs->is_complete()) {
-			log::log(WARN << "Some Uniform values have not been set.");
-		}
 		auto quad = this->renderer->add_mesh_geometry(resources::MeshData::make_quad());
 		Renderable animation_2d_obj{
 			animation_2d_unifs,
@@ -202,10 +199,6 @@ const renderer::Renderable RenderManagerDemo6::create_3d_obj() {
 	auto terrain_unifs = this->obj_3d_shader->new_uniform_input(
 		"tex",
 		this->obj_3d_texture);
-	/* Check if all uniform values for uniform inputs have been set */
-	if (!terrain_unifs->is_complete()) {
-		log::log(WARN << "Some Uniform values have not been set.");
-	}
 
 	std::vector<coord::scene3> terrain_pos{};
 	terrain_pos.push_back({-25, -25, 0});
@@ -269,9 +262,6 @@ const std::vector<renderer::Renderable> RenderManagerDemo6::create_frame_obj() {
 			frame_size,
 			"incol",
 			Eigen::Vector4f{0.0f, 0.0f, 1.0f, 1.0f});
-		if (!frame_unifs->is_complete()) {
-			log::log(WARN << "Some Uniform values have not been set.");
-		}
 		Renderable frame_obj{
 			frame_unifs,
 			frame_geometry,
@@ -499,6 +489,10 @@ void RenderManagerDemo6::create_render_passes() {
 	this->display_pass = renderer->add_render_pass(
 		{display_obj_3d, display_obj_2d, display_obj_frame},
 		renderer->get_display_target());
+
+	if (!check_uniform_completeness({display_obj_3d, display_obj_2d, display_obj_frame})) {
+		log::log(WARN << "Uniforms not complete.");
+	}
 }
 
 } // namespace openage::renderer::tests

--- a/libopenage/renderer/demo/util.cpp
+++ b/libopenage/renderer/demo/util.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "util.h"
 #include "renderer/uniform_input.h"

--- a/libopenage/renderer/demo/util.cpp
+++ b/libopenage/renderer/demo/util.cpp
@@ -10,7 +10,7 @@ namespace openage::renderer::tests {
 bool check_uniform_completeness(const std::vector<Renderable> &renderables) {
 	// Iterate over each renderable object
 	for (const auto &renderable : renderables) {
-		if (renderable.uniform && not renderable.uniform->is_complete()) {
+		if (renderable.uniform and not renderable.uniform->is_complete()) {
 			return false;
 		}
 	}

--- a/libopenage/renderer/demo/util.cpp
+++ b/libopenage/renderer/demo/util.cpp
@@ -1,8 +1,22 @@
 // Copyright 2015-2023 the openage authors. See copying.md for legal info.
 
 #include "util.h"
+#include "renderer/uniform_input.h"
 
 
 namespace openage::renderer::tests {
+
+bool check_uniform_completeness(const std::vector<Renderable> &renderables) {
+	bool all_complete = true;
+
+	// Iterate over each renderable object
+	for (const auto &renderable : renderables) {
+		if (renderable.uniform && !renderable.uniform->is_complete()) {
+			all_complete = false;
+		}
+	}
+
+	return all_complete;
+}
 
 } // namespace openage::renderer::tests

--- a/libopenage/renderer/demo/util.cpp
+++ b/libopenage/renderer/demo/util.cpp
@@ -1,22 +1,21 @@
 // Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "util.h"
+
 #include "renderer/uniform_input.h"
 
 
 namespace openage::renderer::tests {
 
 bool check_uniform_completeness(const std::vector<Renderable> &renderables) {
-	bool all_complete = true;
-
 	// Iterate over each renderable object
 	for (const auto &renderable : renderables) {
-		if (renderable.uniform && !renderable.uniform->is_complete()) {
-			all_complete = false;
+		if (renderable.uniform && not renderable.uniform->is_complete()) {
+			return false;
 		}
 	}
 
-	return all_complete;
+	return true;
 }
 
 } // namespace openage::renderer::tests

--- a/libopenage/renderer/demo/util.h
+++ b/libopenage/renderer/demo/util.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 

--- a/libopenage/renderer/demo/util.h
+++ b/libopenage/renderer/demo/util.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vector>
+
 #include "renderer/renderable.h"
 
 namespace openage::renderer::tests {

--- a/libopenage/renderer/demo/util.h
+++ b/libopenage/renderer/demo/util.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <vector>
+#include "renderer/renderable.h"
 
 namespace openage::renderer::tests {
 
@@ -10,5 +12,13 @@ namespace openage::renderer::tests {
 	printf("before %s\n", txt); \
 	opengl::GlContext::check_error(); \
 	printf("after %s\n", txt);
+
+/**
+ * Check if all uniform values for the given renderables have been set.
+ *
+ * @param renderables The list of renderable objects to check.
+ * @return true if all uniforms have been set, false otherwise.
+ */
+bool check_uniform_completeness(const std::vector<Renderable> &renderables);
 
 } // namespace openage::renderer::tests

--- a/libopenage/renderer/opengl/uniform_input.cpp
+++ b/libopenage/renderer/opengl/uniform_input.cpp
@@ -52,7 +52,7 @@ GlUniformBufferInput::GlUniformBufferInput(const std::shared_ptr<UniformBuffer> 
 
 bool GlUniformInput::is_complete() const {
 	for (const auto &uniform : this->update_offs) {
-		if (!uniform.used) {
+		if (not uniform.used) {
 			return false;
 		}
 	}

--- a/libopenage/renderer/opengl/uniform_input.cpp
+++ b/libopenage/renderer/opengl/uniform_input.cpp
@@ -51,12 +51,12 @@ GlUniformBufferInput::GlUniformBufferInput(const std::shared_ptr<UniformBuffer> 
 }
 
 bool GlUniformInput::is_complete() const {
-  for (const auto& uniform : this->update_offs) {
-    if (!uniform.used) {
-      return false;
-    }
-  }
-  return true;
+	for (const auto& uniform : this->update_offs) {
+		if (!uniform.used) {
+			return false;
+		}
+	}
+	return true;
 }
 
 } // namespace openage::renderer::opengl

--- a/libopenage/renderer/opengl/uniform_input.cpp
+++ b/libopenage/renderer/opengl/uniform_input.cpp
@@ -50,4 +50,13 @@ GlUniformBufferInput::GlUniformBufferInput(const std::shared_ptr<UniformBuffer> 
 	this->update_data.resize(offset);
 }
 
+bool GlUniformInput::is_complete() const {
+  for (const auto& uniform : this->update_offs) {
+    if (!uniform.used) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace openage::renderer::opengl

--- a/libopenage/renderer/opengl/uniform_input.cpp
+++ b/libopenage/renderer/opengl/uniform_input.cpp
@@ -51,7 +51,7 @@ GlUniformBufferInput::GlUniformBufferInput(const std::shared_ptr<UniformBuffer> 
 }
 
 bool GlUniformInput::is_complete() const {
-	for (const auto& uniform : this->update_offs) {
+	for (const auto &uniform : this->update_offs) {
 		if (!uniform.used) {
 			return false;
 		}

--- a/libopenage/renderer/opengl/uniform_input.h
+++ b/libopenage/renderer/opengl/uniform_input.h
@@ -35,6 +35,11 @@ private:
 public:
 	GlUniformInput(const std::shared_ptr<ShaderProgram> &prog);
 
+  /**
+   * Check if all uniforms have been set.
+   */
+    bool is_complete() const override;
+
 	/**
 	 * Store the IDs of the uniforms from the shader set by this uniform input.
 	 */

--- a/libopenage/renderer/opengl/uniform_input.h
+++ b/libopenage/renderer/opengl/uniform_input.h
@@ -35,10 +35,10 @@ private:
 public:
 	GlUniformInput(const std::shared_ptr<ShaderProgram> &prog);
 
-  /**
-   * Check if all uniforms have been set.
-   */
-    bool is_complete() const override;
+	/**
+	 * Check if all uniforms have been set.
+	 */
+	bool is_complete() const override;
 
 	/**
 	 * Store the IDs of the uniforms from the shader set by this uniform input.

--- a/libopenage/renderer/uniform_input.h
+++ b/libopenage/renderer/uniform_input.h
@@ -66,6 +66,8 @@ protected:
 public:
 	virtual ~UniformInput() = default;
 
+	virtual bool is_complete() const = 0;
+
 	void update() override;
 	void update(const char *unif, int32_t val) override;
 	void update(const char *unif, uint32_t val) override;


### PR DESCRIPTION
Hi, This is my first PR! Issue resolve #1681 

This PR introduces a virtual is_complete() method to UniformInput, with an override in GlUniformInput to validate that all required uniform values are set. 

I'm currently a bit unsure about the optimal place to call is_complete() in the demos. Here are the options I'm considering:
+ After Creation by `new_uniform_input()`:  Might miss uniforms that are added later using the update() method.
+ After Every `update()`: This could introduce unnecessary overhead, especially if updates occur frequently.
+ Before Rendering: Might not catch updates made inside the rendering loop.

I'm looking forward to any feedback!

