### PR TITLE
Add CLI Support for Window Parameters

### DIFF
--- a/libopenage/engine/engine.cpp
+++ b/libopenage/engine/engine.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 the openage authors. See copying.md for legal info.
+// Copyright 2023-2024 the openage authors. See copying.md for legal info.
 
 #include "engine.h"
 
@@ -16,7 +16,8 @@ namespace openage::engine {
 Engine::Engine(mode mode,
                const util::Path &root_dir,
                const std::vector<std::string> &mods,
-               bool debug_graphics) :
+               bool debug_graphics,
+               const renderer::window_settings &window_settings) :
 	running{true},
 	run_mode{mode},
 	root_dir{root_dir},
@@ -56,7 +57,7 @@ Engine::Engine(mode mode,
 	// if presenter is used, run it in a separate thread
 	if (this->run_mode == mode::FULL) {
 		this->threads.emplace_back([&, debug_graphics]() {
-			this->presenter->run(debug_graphics);
+			this->presenter->run(debug_graphics, window_settings);
 
 			// Make sure that the presenter gets destructed in the same thread
 			// otherwise OpenGL complains about missing contexts

--- a/libopenage/engine/engine.cpp
+++ b/libopenage/engine/engine.cpp
@@ -16,7 +16,6 @@ namespace openage::engine {
 Engine::Engine(mode mode,
                const util::Path &root_dir,
                const std::vector<std::string> &mods,
-               bool debug_graphics,
                const renderer::window_settings &window_settings) :
 	running{true},
 	run_mode{mode},
@@ -56,8 +55,8 @@ Engine::Engine(mode mode,
 
 	// if presenter is used, run it in a separate thread
 	if (this->run_mode == mode::FULL) {
-		this->threads.emplace_back([&, debug_graphics]() {
-			this->presenter->run(debug_graphics, window_settings);
+		this->threads.emplace_back([&]() {
+			this->presenter->run(window_settings);
 
 			// Make sure that the presenter gets destructed in the same thread
 			// otherwise OpenGL complains about missing contexts

--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -7,9 +7,9 @@
 #include <thread>
 #include <vector>
 
+#include "renderer/window.h"
 #include "util/path.h"
 
-#include <renderer/window.h>
 
 // TODO: Remove custom jthread definition when clang/libc++ finally supports it
 #if __llvm__
@@ -73,13 +73,11 @@ public:
 	 * @param mode The run mode to use.
 	 * @param root_dir openage root directory.
 	 * @param mods The mods to load.
-	 * @param debug_graphics If true, enable OpenGL debug logging.
-	 * @param window_settings window display setting
+	 * @param window_settings The settings to customize the display window (e.g. size, display mode, vsync).
 	 */
 	Engine(mode mode,
 	       const util::Path &root_dir,
 	       const std::vector<std::string> &mods,
-	       bool debug_graphics = false,
 	       const renderer::window_settings &window_settings = {});
 
 	// engine should not be copied or moved

--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -9,6 +9,8 @@
 
 #include "util/path.h"
 
+#include <renderer/window.h>
+
 // TODO: Remove custom jthread definition when clang/libc++ finally supports it
 #if __llvm__
 	#if !__cpp_lib_jthread
@@ -72,11 +74,13 @@ public:
 	 * @param root_dir openage root directory.
 	 * @param mods The mods to load.
 	 * @param debug_graphics If true, enable OpenGL debug logging.
+	 * @param window_settings window display setting
 	 */
 	Engine(mode mode,
 	       const util::Path &root_dir,
 	       const std::vector<std::string> &mods,
-	       bool debug_graphics = false);
+	       bool debug_graphics = false,
+	       const renderer::window_settings &window_settings = {});
 
 	// engine should not be copied or moved
 	Engine(const Engine &) = delete;

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -44,12 +44,16 @@ int run_game(const main_arguments &args) {
 	else if (args.window_args.mode == "borderless") {
 		wmode = renderer::window_mode::BORDERLESS;
 	}
-	else {
+	else if (args.window_args.mode == "windowed") {
 		wmode = renderer::window_mode::WINDOWED;
 	}
+	else {
+		throw Error(MSG(err) << "Invalid window mode: " << args.window_args.mode);
+	}
 	win_settings.mode = wmode;
+	win_settings.debug = args.gl_debug;
 
-	openage::engine::Engine engine{run_mode, args.root_path, args.mods, args.gl_debug, win_settings};
+	openage::engine::Engine engine{run_mode, args.root_path, args.mods, win_settings};
 
 	engine.loop();
 

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #include "main.h"
 
@@ -31,7 +31,25 @@ int run_game(const main_arguments &args) {
 		run_mode = openage::engine::Engine::mode::HEADLESS;
 	}
 
-	openage::engine::Engine engine{run_mode, args.root_path, args.mods, args.gl_debug};
+	// convert window arguments to window settings
+	renderer::window_settings win_settings = {};
+	win_settings.width = args.window_args.width;
+	win_settings.height = args.window_args.height;
+	win_settings.vsync = args.window_args.vsync;
+
+	renderer::window_mode wmode;
+	if (args.window_args.mode == "fullscreen") {
+		wmode = renderer::window_mode::FULLSCREEN;
+	}
+	else if (args.window_args.mode == "borderless") {
+		wmode = renderer::window_mode::BORDERLESS;
+	}
+	else {
+		wmode = renderer::window_mode::WINDOWED;
+	}
+	win_settings.mode = wmode;
+
+	openage::engine::Engine engine{run_mode, args.root_path, args.mods, args.gl_debug, win_settings};
 
 	engine.loop();
 

--- a/libopenage/main.h
+++ b/libopenage/main.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,6 +17,24 @@
 namespace openage {
 
 /**
+ * Window parameters struct.
+ *
+ * pxd:
+ *
+ * cppclass window_arguments:
+ *     int width
+ *     int height
+ *     bool vsync
+ *     string mode
+ */
+struct window_arguments {
+	int width;
+	int height;
+	bool vsync;
+	std::string mode;
+};
+
+/**
  * Used for passing arguments to run_game.
  *
  * pxd:
@@ -26,12 +44,14 @@ namespace openage {
  *     bool gl_debug
  *     bool headless
  *     vector[string] mods
+ *     window_arguments window_args
  */
 struct main_arguments {
 	util::Path root_path;
 	bool gl_debug;
 	bool headless;
 	std::vector<std::string> mods;
+	window_arguments window_args;
 };
 
 

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -32,7 +32,6 @@
 #include "renderer/stages/skybox/render_stage.h"
 #include "renderer/stages/terrain/render_stage.h"
 #include "renderer/stages/world/render_stage.h"
-#include "renderer/window.h"
 #include "time/time_loop.h"
 #include "util/path.h"
 
@@ -48,10 +47,10 @@ Presenter::Presenter(const util::Path &root_dir,
 	time_loop{time_loop} {}
 
 
-void Presenter::run(bool debug_graphics) {
+void Presenter::run(bool debug_graphics, const renderer::window_settings &window_settings) {
 	log::log(INFO << "Presenter: Launching subsystems...");
 
-	this->init_graphics(debug_graphics);
+	this->init_graphics(debug_graphics, window_settings);
 
 	this->init_input();
 
@@ -93,18 +92,14 @@ std::shared_ptr<qtgui::GuiApplication> Presenter::init_window_system() {
 	return std::make_shared<renderer::gui::GuiApplicationWithLogger>();
 }
 
-void Presenter::init_graphics(bool debug) {
+void Presenter::init_graphics(bool debug, const renderer::window_settings &window_settings) {
 	log::log(INFO << "Presenter: Initializing graphics subsystems...");
 
 	// Start up rendering framework
 	this->gui_app = this->init_window_system();
 
 	// Window and renderer
-	renderer::window_settings settings;
-	settings.width = 1024;
-	settings.height = 768;
-	settings.debug = debug;
-	this->window = renderer::Window::create("openage presenter test", settings);
+	this->window = renderer::Window::create("openage presenter test", window_settings);
 	this->renderer = this->window->make_renderer();
 
 	// Asset mangement

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -47,10 +47,10 @@ Presenter::Presenter(const util::Path &root_dir,
 	time_loop{time_loop} {}
 
 
-void Presenter::run(bool debug_graphics, const renderer::window_settings &window_settings) {
+void Presenter::run(const renderer::window_settings &window_settings) {
 	log::log(INFO << "Presenter: Launching subsystems...");
 
-	this->init_graphics(debug_graphics, window_settings);
+	this->init_graphics(window_settings);
 
 	this->init_input();
 
@@ -92,7 +92,7 @@ std::shared_ptr<qtgui::GuiApplication> Presenter::init_window_system() {
 	return std::make_shared<renderer::gui::GuiApplicationWithLogger>();
 }
 
-void Presenter::init_graphics(bool debug, const renderer::window_settings &window_settings) {
+void Presenter::init_graphics(const renderer::window_settings &window_settings) {
 	log::log(INFO << "Presenter: Initializing graphics subsystems...");
 
 	// Start up rendering framework

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -47,7 +47,7 @@ Presenter::Presenter(const util::Path &root_dir,
 	time_loop{time_loop} {}
 
 
-void Presenter::run(const renderer::window_settings &window_settings) {
+void Presenter::run(const renderer::window_settings window_settings) {
 	log::log(INFO << "Presenter: Launching subsystems...");
 
 	this->init_graphics(window_settings);

--- a/libopenage/presenter/presenter.h
+++ b/libopenage/presenter/presenter.h
@@ -7,6 +7,9 @@
 
 #include "util/path.h"
 
+#include <renderer/window.h>
+
+
 namespace qtgui {
 class GuiApplication;
 }
@@ -88,8 +91,9 @@ public:
 	 * Start the presenter and initialize subsystems.
 	 *
 	 * @param debug_graphics If true, enable OpenGL debug logging.
+	 * @param window_settings window display setting
 	 */
-	void run(bool debug_graphics = false);
+	void run(bool debug_graphics = false, const renderer::window_settings &window_settings = {});
 
 	/**
 	 * Set the game simulation controlled by this presenter.
@@ -120,7 +124,7 @@ protected:
 	 *     - main renderer
 	 *     - component renderers (Terrain, Game Entities, GUI)
 	 */
-	void init_graphics(bool debug = false);
+	void init_graphics(bool debug = false, const renderer::window_settings &window_settings = {});
 
 	/**
 	 * Initialize the GUI.

--- a/libopenage/presenter/presenter.h
+++ b/libopenage/presenter/presenter.h
@@ -5,9 +5,8 @@
 #include <memory>
 #include <vector>
 
+#include "renderer/window.h"
 #include "util/path.h"
-
-#include <renderer/window.h>
 
 
 namespace qtgui {
@@ -90,10 +89,9 @@ public:
 	/**
 	 * Start the presenter and initialize subsystems.
 	 *
-	 * @param debug_graphics If true, enable OpenGL debug logging.
-	 * @param window_settings window display setting
+	 * @param window_settings The settings to customize the display window (e.g. size, display mode, vsync).
 	 */
-	void run(bool debug_graphics = false, const renderer::window_settings &window_settings = {});
+	void run(const renderer::window_settings &window_settings = {});
 
 	/**
 	 * Set the game simulation controlled by this presenter.
@@ -124,7 +122,7 @@ protected:
 	 *     - main renderer
 	 *     - component renderers (Terrain, Game Entities, GUI)
 	 */
-	void init_graphics(bool debug = false, const renderer::window_settings &window_settings = {});
+	void init_graphics(const renderer::window_settings &window_settings = {});
 
 	/**
 	 * Initialize the GUI.

--- a/libopenage/presenter/presenter.h
+++ b/libopenage/presenter/presenter.h
@@ -91,7 +91,7 @@ public:
 	 *
 	 * @param window_settings The settings to customize the display window (e.g. size, display mode, vsync).
 	 */
-	void run(const renderer::window_settings &window_settings = {});
+	void run(const renderer::window_settings window_settings = {});
 
 	/**
 	 * Set the game simulation controlled by this presenter.

--- a/libopenage/renderer/opengl/window.cpp
+++ b/libopenage/renderer/opengl/window.cpp
@@ -62,7 +62,7 @@ GlWindow::GlWindow(const std::string &title,
 	this->window->setWindowState(Qt::WindowNoState);
 	switch (settings.mode) {
 	case window_mode::WINDOWED:
-		this->window->setFlags(this->window->flags() & ~Qt::FramelessWindowHint);
+		// nothing to do because it's the default
 		break;
 	case window_mode::BORDERLESS:
 		this->window->setFlags(this->window->flags() | Qt::FramelessWindowHint);

--- a/libopenage/renderer/opengl/window.cpp
+++ b/libopenage/renderer/opengl/window.cpp
@@ -58,18 +58,20 @@ GlWindow::GlWindow(const std::string &title,
 	this->window->create();
 
 	// set display mode
+	// Reset to a known state
+	this->window->setWindowState(Qt::WindowNoState);
 	switch (settings.mode) {
-	case window_mode::FULLSCREEN:
-		this->window->showFullScreen();
+	case window_mode::WINDOWED:
+		this->window->setFlags(this->window->flags() & ~Qt::FramelessWindowHint);
 		break;
 	case window_mode::BORDERLESS:
 		this->window->setFlags(this->window->flags() | Qt::FramelessWindowHint);
-		this->window->show();
 		break;
-	case window_mode::WINDOWED:
+	case window_mode::FULLSCREEN:
+		this->window->setWindowState(Qt::WindowFullScreen);
+		break;
 	default:
-		this->window->showNormal();
-		break;
+		throw Error{MSG(err) << "Invalid window mode."};
 	}
 
 	this->context = std::make_shared<GlContext>(this->window, settings.debug);

--- a/libopenage/renderer/opengl/window.cpp
+++ b/libopenage/renderer/opengl/window.cpp
@@ -57,6 +57,21 @@ GlWindow::GlWindow(const std::string &title,
 	this->window->setFormat(format);
 	this->window->create();
 
+	// set display mode
+	switch (settings.mode) {
+	case window_mode::FULLSCREEN:
+		this->window->showFullScreen();
+		break;
+	case window_mode::BORDERLESS:
+		this->window->setFlags(this->window->flags() | Qt::FramelessWindowHint);
+		this->window->show();
+		break;
+	case window_mode::WINDOWED:
+	default:
+		this->window->showNormal();
+		break;
+	}
+
 	this->context = std::make_shared<GlContext>(this->window, settings.debug);
 	if (not this->context->get_raw_context()->isValid()) {
 		throw Error{MSG(err) << "Failed to create Qt OpenGL context."};

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -45,7 +45,7 @@ struct window_settings {
 	// If true, enable debug logging for the selected backend.
 	bool debug = false;
 	// Display mode for the window.
-	window_mode mode = window_mode::FULLSCREEN;
+	window_mode mode = window_mode::WINDOWED;
 };
 
 

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -22,6 +22,15 @@ namespace openage::renderer {
 class WindowEventHandler;
 
 /**
+ * Modes for window display.
+ */
+enum class window_mode {
+	FULLSCREEN,
+	BORDERLESS,
+	WINDOWED
+};
+
+/**
  * Settings for creating a window.
  */
 struct window_settings {
@@ -35,6 +44,8 @@ struct window_settings {
 	bool vsync = true;
 	// If true, enable debug logging for the selected backend.
 	bool debug = false;
+	// Display mode for the window.
+	window_mode mode = window_mode::FULLSCREEN;
 };
 
 

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -36,6 +36,19 @@ def init_subparser(cli: ArgumentParser) -> None:
         help="Check if the assets are up to date"
     )
 
+    cli.add_argument(
+        "--window-size", nargs=2, type=int, default=[1024, 768],
+        metavar=('WIDTH', 'HEIGHT'),
+        help="initial window size in pixels, e.g., --window-size 1024 768")
+
+    cli.add_argument(
+        "--vsync", action='store_true',
+        help="enable vertical synchronization")
+
+    cli.add_argument(
+        "--window-mode", choices=["fullscreen", "borderless", "windowed"], default="windowed",
+        help="set the window mode: fullscreen, borderless, or windowed (default)")
+
 
 def main(args, error):
     """
@@ -97,6 +110,14 @@ def main(args, error):
 
     # encode modpacks as bytes for the C++ interface
     args.modpacks = [modpack.encode('utf-8') for modpack in args.modpacks]
+
+    # Pass window parameters to engine
+    args.window_args = {
+        "width": args.window_size[0],
+        "height": args.window_size[1],
+        "vsync": args.vsync,
+        "window_mode": args.window_mode,
+    }
 
     # start the game, continue in main_cpp.pyx!
     return run_game(args, root)

--- a/openage/game/main.py
+++ b/openage/game/main.py
@@ -39,15 +39,15 @@ def init_subparser(cli: ArgumentParser) -> None:
     cli.add_argument(
         "--window-size", nargs=2, type=int, default=[1024, 768],
         metavar=('WIDTH', 'HEIGHT'),
-        help="initial window size in pixels, e.g., --window-size 1024 768")
+        help="Initial window size in pixels")
 
     cli.add_argument(
         "--vsync", action='store_true',
-        help="enable vertical synchronization")
+        help="Enable vertical synchronization")
 
     cli.add_argument(
         "--window-mode", choices=["fullscreen", "borderless", "windowed"], default="windowed",
-        help="set the window mode: fullscreen, borderless, or windowed (default)")
+        help="Set the window mode")
 
 
 def main(args, error):

--- a/openage/game/main_cpp.pyx
+++ b/openage/game/main_cpp.pyx
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 the openage authors. See copying.md for legal info.
+# Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 from cpython.ref cimport PyObject
 from libcpp.string cimport string
@@ -36,6 +36,12 @@ def run_game(args, root_path):
             args_cpp.mods = args.modpacks
         else:
             args_cpp.mods = vector[string]()
+
+        # window
+        args_cpp.window_args.width = args.window_args["width"]
+        args_cpp.window_args.height = args.window_args["height"]
+        args_cpp.window_args.vsync = args.window_args["vsync"]
+        args_cpp.window_args.mode = args.window_args["window_mode"].encode('utf-8')
 
         # run the game!
         with nogil:

--- a/openage/main/main.py
+++ b/openage/main/main.py
@@ -28,6 +28,19 @@ def init_subparser(cli: ArgumentParser):
         "--modpacks", nargs="+", type=str,
         help="list of modpacks to load")
 
+    cli.add_argument(
+        "--window-size", nargs=2, type=int, default=[1024, 768],
+        metavar=('WIDTH', 'HEIGHT'),
+        help="initial window size in pixels, e.g., --window-size 1024 768")
+
+    cli.add_argument(
+        "--vsync", action='store_true',
+        help="enable vertical synchronization")
+
+    cli.add_argument(
+        "--window-mode", choices=["fullscreen", "borderless", "windowed"], default="windowed",
+        help="set the window mode: fullscreen, borderless, or windowed (default)")
+
 
 def main(args, error):
     """
@@ -105,6 +118,14 @@ def main(args, error):
 
     else:
         args.modpacks = [query_modpack(list(available_modpacks.keys())).encode("utf-8")]
+
+    # Pass window parameters to engine
+    args.window_args = {
+        "width": args.window_size[0],
+        "height": args.window_size[1],
+        "vsync": args.vsync,
+        "window_mode": args.window_mode,
+    }
 
     # start the game, continue in main_cpp.pyx!
     return run_game(args, root)

--- a/openage/main/main.py
+++ b/openage/main/main.py
@@ -31,15 +31,15 @@ def init_subparser(cli: ArgumentParser):
     cli.add_argument(
         "--window-size", nargs=2, type=int, default=[1024, 768],
         metavar=('WIDTH', 'HEIGHT'),
-        help="initial window size in pixels, e.g., --window-size 1024 768")
+        help="Initial window size in pixels")
 
     cli.add_argument(
         "--vsync", action='store_true',
-        help="enable vertical synchronization")
+        help="Enable vertical synchronization")
 
     cli.add_argument(
         "--window-mode", choices=["fullscreen", "borderless", "windowed"], default="windowed",
-        help="set the window mode: fullscreen, borderless, or windowed (default)")
+        help="Set the window mode")
 
 
 def main(args, error):

--- a/openage/main/main_cpp.pyx
+++ b/openage/main/main_cpp.pyx
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 the openage authors. See copying.md for legal info.
+# Copyright 2015-2024 the openage authors. See copying.md for legal info.
 
 from cpython.ref cimport PyObject
 from libcpp.string cimport string
@@ -36,6 +36,12 @@ def run_game(args, root_path):
             args_cpp.mods = args.modpacks
         else:
             args_cpp.mods = vector[string]()
+
+        # window
+        args_cpp.window_args.width = args.window_args["width"]
+        args_cpp.window_args.height = args.window_args["height"]
+        args_cpp.window_args.vsync = args.window_args["vsync"]
+        args_cpp.window_args.mode = args.window_args["window_mode"].encode('utf-8')
 
         # run the game!
         with nogil:


### PR DESCRIPTION
Close #1546 

+ Defined window-related startup parameters (size, vsync, mode) in Python for `main` and `game` start modes.
+ Passed these parameters to the `main_arguments` struct by creating a `window_arguments` struct
+ Updated C++ logic to forward parameters along `main.cpp` -> `engine.cpp` -> `presenter.cpp`
+ Implemented Fullscreen, Borderless, Windowed three display model in `libopenage/renderer/opengl/window.cpp`