### PR TITLE
Bind empty VAO to bufferless quad rendering

### DIFF
--- a/libopenage/renderer/opengl/geometry.cpp
+++ b/libopenage/renderer/opengl/geometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 the openage authors. See copying.md for legal info.
+// Copyright 2015-2025 the openage authors. See copying.md for legal info.
 
 #include "geometry.h"
 
@@ -54,6 +54,7 @@ void GlGeometry::update_verts_offset(std::vector<uint8_t> const &verts, size_t o
 void GlGeometry::draw() const {
 	switch (this->get_type()) {
 	case geometry_t::bufferless_quad:
+		// any VAO must be bound before this call
 		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		break;
 

--- a/libopenage/renderer/opengl/renderer.h
+++ b/libopenage/renderer/opengl/renderer.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2024 the openage authors. See copying.md for legal info.
+// Copyright 2017-2025 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -17,6 +17,7 @@ namespace opengl {
 class GlContext;
 class GlRenderPass;
 class GlRenderTarget;
+class GlVertexArray;
 class GlWindow;
 
 /// The OpenGL specialization of the rendering interface.
@@ -67,6 +68,14 @@ private:
 
 	/// The main screen surface as a render target.
 	std::shared_ptr<GlRenderTarget> display;
+
+	/// An empty vertex array object (VAO).
+	///
+	/// This VAO has to be bound at the start of a render pass to ensure
+	/// that bufferless quad geometry can be drawn without errors. Drawing a
+	/// bufferless quad requires any VAO to be bound
+	/// see https://www.khronos.org/opengl/wiki/Vertex_Rendering#Causes_of_rendering_failure
+	std::shared_ptr<GlVertexArray> shared_quad_vao;
 };
 
 } // namespace opengl


### PR DESCRIPTION
Hey! 👋  resolve #1659

I've made some initial fixes for the bufferless quad VAO issue, but wanted to get some advice before finalizing:

1. I tested my current code and noticed the VAO error was still there but occurred during shader validation in [`GlShaderProgram::use()`](https://github.com/SFTtech/openage/blob/beb894520e552cb6224cdd2f64697b2cf6e4ad8a/libopenage/renderer/opengl/shader_program.cpp#L295C1-L302C3). 

    This happens during `program->update_uniforms(in);` before `geom->draw()`; in `GlRenderer::render()`.

3. My current fix is binding the empty VAO in `geometry.cpp`, but I'm wondering:
  - Should we bind VAO before shader program validation?
  - Or should we handle/modify the validation error check in `GlShaderProgram::use()`?

appreciate your thoughts on the best approach! 