### PR TITLE
Add Nix build result folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ __pycache__
 /.ccls-cache
 /.cache
 
+# Nix build output
+/result
+
 # root dir run script
 /run
 /run.cpp

--- a/copying.md
+++ b/copying.md
@@ -159,6 +159,7 @@ _the openage authors_ are:
 | Tobias Alam                 | alamt22                     | tobiasal à umich dawt edu                         |
 | Alex Zhuohao He             | ZzzhHe                      | zhuohao dawt he à outlook dawt com                |
 | David Wever                 | dmwever                     | dmwever à crimson dawt ua dawt edu                |
+| Michael Lynch               | mtlynch                     | git à mtlynch dawt io                             |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.


### PR DESCRIPTION
The nix build step creates an output folder called /result. I've added this to the .gitignore file so that git doesn't try to add generated files/binaries to the source tree.