### PR TITLE
Change mentions of 'checkall' to 'checkmerge'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATES/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATES/pull_request_template.md
@@ -5,7 +5,7 @@
 
 - [ ] I have read the [contribution guide](doc/contributing.md)
 - [ ] I have added my info to [copying.md](copying.md) (only first time contributors)
-- [ ] I have run `make checkall` and fixed all mentioned problems
+- [ ] I have run `make checkmerge` and fixed all mentioned problems
 
 
 ### Description

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ help: $(BUILDDIR)/Makefile
 	@echo "tests              -> run the tests (py + cpp)"
 	@echo ""
 	@echo "checkall           -> full code compliance check"
+	@echo "checkmerge         -> code compliance check for merging to master"
 	@echo "checkfast          -> fast checks only"
 	@echo "checkchanged       -> full check for all files changed since origin/master"
 	@echo "checkuncommited    -> full check for all currently uncommited files"

--- a/doc/buildsystem.md
+++ b/doc/buildsystem.md
@@ -42,7 +42,7 @@ Additional recipes:
  - `doc` (generate docs via Doxygen)
  - `test` (runs the various tests)
  - various cleaning recipes: `cleanelf`, `cleancodegen`, `cleancython`, `cleaninsourcebuild`, `cleanpxdgen`, `cleanbuilddirs`, `mrproper`, `mrproperer`
- - various compliance checkers: `checkfast`, `checkall`, ...
+ - various compliance checkers: `checkfast`, `checkmerge`, `checkall`, ...
 
 
 Phases

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -52,7 +52,7 @@ tl;dr
 - Add yourself to `copying.md`
 - `git add libopenage/unit/tentacle_monster.cpp`
 - `git commit -m "engine: fixed vomiting animation of tentacle monster"`
-- `make checkall`
+- `make checkmerge`
 - `make test`
 - `git push origin tentacle-monster-fix`
 - Create a pull request and look at the CI output
@@ -101,7 +101,7 @@ Before making a pull request, it's good to review these things:
 - Run `make test` to check whether any functionality has been broken
 - [Check your whitespaces](https://github.com/SFTtech/openage/blob/master/doc/code_style/tabs_n_spaces.md)
 - [Read all the codestyle docs]( https://github.com/SFTtech/openage/tree/master/doc/code_style)
-- Before pushing, run `make checkall`. If that fails, the automatic buildbot will reject your code.
+- Before pushing, run `make checkmerge`. If that fails, the automatic buildbot will reject your code.
 - If this is your first contribution, add yourself to the authors list in [copying.md](/copying.md).
 - Commit messages should be meaningful, they should say in a sentence (or very little text) what
   changes it has without requiring to read the entire diff. [tpope knows this very well!](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

--- a/doc/ide/configs/vscode/tasks.json
+++ b/doc/ide/configs/vscode/tasks.json
@@ -51,7 +51,7 @@
             "type": "shell",
             "command": "make",
             "args": [
-                "checkall"
+                "checkmerge"
             ],
             "group": "build",
             "presentation": {


### PR DESCRIPTION
In https://github.com/SFTtech/openage/pull/1710, we introduced `make checkmerge` which replaced `make checkall` for Ci tests. This was not reflected in some of the documentation, which is now fixed with this PR.