### PR TITLE
Fix import of `gdb.printing` Python module

### DIFF
--- a/etc/gdb_pretty/printers.py
+++ b/etc/gdb_pretty/printers.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2024 the openage authors. See copying.md for legal info.
+# Copyright 2024-2025 the openage authors. See copying.md for legal info.
 
 """
 Pretty printers for GDB.
@@ -6,6 +6,7 @@ Pretty printers for GDB.
 
 import re
 import gdb  # type: ignore
+import gdb.printing  # type: ignore
 
 # TODO: Printers should inherit from gdb.ValuePrinter when gdb 14.1 is available in all distros.
 


### PR DESCRIPTION
Just importing `gdb` doesn't work anymore in gdb 16 apparently. You have to import `gdb.printing` explictly.