### PR TITLE
Add pure FixedPoint implementations and tests for sin(), cos(), and tan()

### DIFF
--- a/libopenage/util/fixed_point.h
+++ b/libopenage/util/fixed_point.h
@@ -176,6 +176,13 @@ public:
 	}
 
 	/**
+	 * FixedPoint value that is preinitialized to one.
+	 */
+	static constexpr FixedPoint one() {
+		return FixedPoint::from_int(1);
+	}
+
+	/**
 	 * Math constants represented in FixedPoint
 	 */
 	// naming, definition and value are kept compatible with `math_constants.h`
@@ -366,6 +373,26 @@ public:
 			static_cast<FixedPoint::unsigned_int_type>(this->raw_value) & std::integral_constant<int_type, FixedPoint::fractional_part_bitmask()>::value);
 	}
 
+	/**
+	 * Converter to retrieve the integral (pre-decimal) part of the number.
+	 */
+	constexpr FixedPoint get_integral_part() const {
+		// similar to the get_fractional_part() implementation, but the opposite bits.
+		return FixedPoint::from_raw_value(this->raw_value & ~std::integral_constant<int_type, FixedPoint::fractional_part_bitmask()>::value);
+	}
+
+	/**
+	 * Round to the nearest integer.
+	 */
+	constexpr FixedPoint round() const {
+		if (this->get_fractional_part() < same_type_but_unsigned(0.5)) {
+			return this->get_integral_part();
+		}
+		else {
+			return this->get_integral_part() + one();
+		}
+	}
+
 	// Comparison operators for comparison with other
 	constexpr auto operator<=>(const FixedPoint &o) const = default;
 
@@ -531,7 +558,7 @@ public:
 		// Ensure we're in the interval (-pi, pi)
 		// Since this is a series expansion approximation around 0, this interval is where we are most accurate
 		if (x > FixedPoint::pi()) {
-			size_t n = round((x / FixedPoint::tau()).to_double());
+			int_type n = (x / FixedPoint::tau()).round().to_int();
 			x -= FixedPoint::tau() * n;
 		}
 
@@ -568,7 +595,7 @@ public:
 		// Ensure we're in the interval (-pi, pi)
 		// Since this is a series expansion approximation around 0, this interval is where we are most accurate
 		if (x > FixedPoint::pi()) {
-			size_t n = round((x / FixedPoint::tau()).to_double());
+			int_type n = (x / FixedPoint::tau()).round().to_int();
 			x -= FixedPoint::tau() * n;
 		}
 
@@ -605,7 +632,7 @@ public:
 
 		// Ensure we are in the interval (-pi/2, pi/2) for maximum accuracy
 		if (x > FixedPoint::pi_2()) {
-			size_t n = round((x / FixedPoint::pi()).to_double());
+			int_type n = (x / FixedPoint::pi()).round().to_int();
 			x -= FixedPoint::pi() * n;
 		}
 

--- a/libopenage/util/fixed_point_test.cpp
+++ b/libopenage/util/fixed_point_test.cpp
@@ -127,7 +127,8 @@ void fixed_point() {
 		using T = FixedPoint<uint16_t, 7U, uint64_t>;
 
 		auto a = S::from_int(16U);
-		TESTNOTEQUALS((a*a).to_int(), 256U);
+		// This test case is now equal with the improved multiplication algorithm
+		TESTEQUALS((a*a).to_int(), 256U);
 
 		auto b = T::from_int(16U);
 		TESTEQUALS((b*b).to_int(), 256U);
@@ -139,7 +140,8 @@ void fixed_point() {
 		using S = FixedPoint<int32_t, 12U>;
 		auto a = S::from_int(256);
 		auto b = S::from_int(8);
-		TESTNOTEQUALS((a/b).to_int(), 32);
+		// This test case is now equal with the improved division algorithm
+		TESTEQUALS((a/b).to_int(), 32);
 
 
 		using T = FixedPoint<int32_t, 12, int64_t>;
@@ -206,7 +208,7 @@ void fixed_point() {
 
 	// Pure FixedPoint trig tests
 	{
-		using TrigType = FixedPoint<int64_t, 32, __int128>;
+		using TrigType = FixedPoint<int64_t, 32, int64_t>;
 
 		// Testing sin() and cos()
 		for (int i = -100'000; i <= 100'000; i++) {
@@ -222,6 +224,7 @@ void fixed_point() {
 
 			// Test some trig identities
 			TESTEQUALS_FLOAT(std::cos(x), std::sin(TrigType::pi_2() - x), 1e-7);
+
 			TESTEQUALS_FLOAT(std::cos(TrigType::pi_2() - x), std::sin(x), 1e-7);
 			TESTEQUALS_FLOAT(std::sin(x) * std::sin(x) + std::cos(x) * std::cos(x), 1.0, 1e-7);
 			TESTEQUALS_FLOAT(std::sin(x * 2), std::sin(x) * std::cos(x) * 2, 1e-7);


### PR DESCRIPTION
Per #1543.

Notes:
This uses a power series approximation to calculate sine and cosine. Tangent is just calculated using `sin()` and `cos()`. The input value is first shifted into the interval `(-pi, pi)` for `sin()` and `cos()`and `(-pi/2, pi/2)` for `tan()`. At the asymptotes for tan, an exception will be thrown because the FixedPoint doesn't implement `inf` (yet). Near the asymptotes absolute precision is a bit poor.

It's possible to use another expansion for `tan()`, but it's not as nice as those for `sin()` and `cos()`. I'd be happy to implement that down the road if that would be preferred. (It will still have problems at the asymptotes though). 