### PR TITLE
Fix configuration step for macos

### DIFF
--- a/doc/build_instructions/macos.md
+++ b/doc/build_instructions/macos.md
@@ -38,7 +38,7 @@ We advise against using the clang version that comes with macOS (Apple Clang) as
 ```
 # on Intel macOS, llvm is by default in /usr/local/Cellar/llvm/bin/
 # on ARM macOS, llvm is by default in /opt/homebrew/Cellar/llvm/bin/
-./configure --compiler="$(brew --prefix llvm)/bin/clang" --download-nyan
+./configure --compiler="$(brew --prefix llvm)/bin/clang++" --download-nyan
 ```
 
 Afterwards, trigger the build using `make`:


### PR DESCRIPTION
Updated build doc for macos.

In the configuration step for macos "clang" is specified instead of "clang++" which causes the linker to output errors due to clang not automatically linking c++ libraries which clang++ will do.