### PR TITLE
Rename `codegen` target to `cppgen`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ libopenage: $(BUILDDIR)
 
 .PHONY: codegen
 codegen: $(BUILDDIR)
-	$(MAKE) $(MAKEARGS) -C $(BUILDDIR) codegen
+	$(MAKE) $(MAKEARGS) -C $(BUILDDIR) cppgen
+
+.PHONY: cppgen
+cppgen: $(BUILDDIR)
+	$(MAKE) $(MAKEARGS) -C $(BUILDDIR) cppgen
 
 .PHONY: pxdgen
 pxdgen: $(BUILDDIR)

--- a/buildsystem/codegen.cmake
+++ b/buildsystem/codegen.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 the openage authors. See copying.md for legal info.
+# Copyright 2014-2025 the openage authors. See copying.md for legal info.
 
 # set CODEGEN_SCU_FILE to the absolute path to SCU file
 macro(get_codegen_scu_file)
@@ -52,7 +52,7 @@ function(codegen_run)
 		COMMENT "openage.codegen: generating c++ code"
 	)
 
-	add_custom_target(codegen
+	add_custom_target(cppgen
 		DEPENDS "${CODEGEN_TIMEFILE}"
 	)
 

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2014-2019 the openage authors. See copying.md for legal info.
+# Copyright 2014-2025 the openage authors. See copying.md for legal info.
 
 # main C++ library definitions.
 # dependency and source file setup for the resulting library.
@@ -13,7 +13,7 @@ declare_binary(libopenage openage library allow_no_undefined)
 set_target_properties(libopenage PROPERTIES
 	VERSION 0
 	AUTOMOC ON
-	AUTOGEN_TARGET_DEPENDS "codegen"
+	AUTOGEN_TARGET_DEPENDS "cppgen"
 )
 
 ##################################################


### PR DESCRIPTION
`codegen` is now a reserved name in CMake, so we should rename our own codegen target to something else.

This only affects the target name. The invocation and Python code still uses `codegen` as the name.