### PR TITLE
Fixes a bug in the doctest runner where error messages were suppressed.

### DIFF
--- a/openage/testing/doctest.py
+++ b/openage/testing/doctest.py
@@ -17,5 +17,5 @@ def test():
     """
     for modname in doctest_modules():
         mod = importlib.import_module(modname)
-        if testmod(mod, report=False).failed:
+        if testmod(mod).failed:
             raise TestError("Errors have been detected during doctest")


### PR DESCRIPTION
**Bug Report**

*   **File**: `openage/testing/doctest.py`
*   **Line**: 20
*   **Description**: The `testmod` function was called with `report=False`, which suppresses detailed output of doctest failures. This makes it difficult to debug failing doctests, as the only output is a generic `TestError`.
*   **Fix**: Removed the `report=False` argument from the `testmod` call to enable detailed reporting of doctest failures.

**Verification**

1.  Created a new doctest that was designed to fail.
2.  Ran the tests and confirmed that the error message was generic.
3.  Applied the fix.
4.  Ran the tests again and confirmed that the error message was detailed and specific.
5.  Removed the failing doctest.
6.  Ran the tests one last time to ensure everything passed.