### PR TITLE
Set multiprocessing start method only if not already set

### DIFF
--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -175,6 +175,7 @@ if __name__ == '__main__':
     multiprocessing.freeze_support()
 
     # openage is complicated and multithreaded; better not use fork.
-    multiprocessing.set_start_method('spawn')
+    if mmultiprocessing.get_start_method(allow_none=True) is None:
+        mmultiprocessing.set_start_method('spawn')
 
     sys.exit(main())


### PR DESCRIPTION
I was getting this error when trying to build the project for the first time using the `./configure --download-nyan` command:
```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/josj/scr/openage/.bin/g++-debug-Oauto-sanitize-none/openage/__main__.py", line 178, in <module>
    multiprocessing.set_start_method('spawn')
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib64/python3.14/multiprocessing/context.py", line 247, in set_start_method
    raise RuntimeError('context has already been set')
RuntimeError: context has already been set
CMake Error at buildsystem/codegen.cmake:32 (message):
  failed to get target list from codegen invocation
Call Stack (most recent call first):
  buildsystem/python.cmake:495 (codegen_run)
  CMakeLists.txt:261 (python_finalize)
```
It required a very simple fix, just added a check before setting the multiprocessing start method to ensure that it only gets set once. After this change was made to the build script worked perfectly.