### PR TITLE
util/version: fix SemanticVersion comparison precedence

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -167,6 +167,7 @@ _the openage authors_ are:
 | Jordan Sutton               | jsutCodes                   | jsutcodes à gmail dawt com                        |
 | Daniel Wieczorek            | Danio                       | danielwieczorek96 à gmail dawt com                |
 |                             | bytegrrrl                   | bytegrrrl à proton dawt me                        |
+| Nicolas Sanchez             | nicolassanchez02            | nicolasjpsanchez à gmail dawt com                 |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/testing/testlist.py
+++ b/openage/testing/testlist.py
@@ -11,6 +11,7 @@ def doctest_modules():
     yield "openage.util.math"
     yield "openage.util.strings"
     yield "openage.util.system"
+    yield "openage.util.version"
 
 
 def tests_py():

--- a/openage/util/version.py
+++ b/openage/util/version.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2024 the openage authors. See copying.md for legal info.
+# Copyright 2024-2026 the openage authors. See copying.md for legal info.
 
 """
 Handling of version information for openage.
@@ -6,6 +6,7 @@ Handling of version information for openage.
 from __future__ import annotations
 
 import re
+from functools import total_ordering
 
 SEMVER_REGEX = re.compile(
     (r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
@@ -14,9 +15,31 @@ SEMVER_REGEX = re.compile(
      r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"))
 
 
+@total_ordering
 class SemanticVersion:
     """
     Semantic versioning information.
+
+    Precedence is determined by major, then minor, then patch, as per
+    semver 2.0.0. Build metadata is ignored for ordering. Prerelease
+    ordering follows the semver rule that any prerelease is lower than
+    the same MAJOR.MINOR.PATCH without one; full prerelease identifier
+    comparison (alpha < beta < rc, etc.) is not implemented here yet.
+
+    >>> SemanticVersion("1.0.0") > SemanticVersion("0.5.0")
+    True
+    >>> SemanticVersion("2.0.0") > SemanticVersion("1.99.99")
+    True
+    >>> SemanticVersion("1.2.3") < SemanticVersion("1.2.4")
+    True
+    >>> SemanticVersion("1.0.5") < SemanticVersion("1.1.0")
+    True
+    >>> SemanticVersion("1.0.0") == SemanticVersion("1.0.0")
+    True
+    >>> SemanticVersion("1.0.0-alpha") < SemanticVersion("1.0.0")
+    True
+    >>> str(SemanticVersion("1.2.3-rc.1+build.7"))
+    '1.2.3-rc.1+build.7'
     """
 
     def __init__(self, version: str) -> None:
@@ -35,41 +58,32 @@ class SemanticVersion:
         self.prerelease = match.group("prerelease")
         self.buildmetadata = match.group("buildmetadata")
 
+    def _precedence_key(self) -> tuple:
+        # A version with no prerelease ranks higher than one with a
+        # prerelease at the same MAJOR.MINOR.PATCH (semver 11.3). We
+        # encode that by giving "no prerelease" a 1 and any prerelease
+        # a 0 as the next tuple element. The prerelease string itself
+        # is included so two prereleases compare stably, but note this
+        # is a lexicographic fallback, not the full semver 11.4
+        # identifier comparison.
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            1 if self.prerelease is None else 0,
+            self.prerelease or "",
+        )
+
     def __lt__(self, other: SemanticVersion) -> bool:
-        if self.major < other.major:
-            return True
-        if self.minor < other.minor:
-            return True
-        if self.patch < other.patch:
-            return True
+        return self._precedence_key() < other._precedence_key()
 
-        return False
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemanticVersion):
+            return NotImplemented
+        return self._precedence_key() == other._precedence_key()
 
-    def __le__(self, other: SemanticVersion) -> bool:
-        if self.major <= other.major:
-            return True
-
-        if self.minor <= other.minor:
-            return True
-
-        if self.patch <= other.patch:
-            return True
-
-        return False
-
-    def __eq__(self, other: SemanticVersion) -> bool:
-        return (self.major == other.major and
-                self.minor == other.minor and
-                self.patch == other.patch)
-
-    def __ne__(self, other: SemanticVersion) -> bool:
-        return not self.__eq__(other)
-
-    def __gt__(self, other: SemanticVersion) -> bool:
-        return not self.__le__(other)
-
-    def __ge__(self, other: SemanticVersion) -> bool:
-        return not self.__lt__(other)
+    def __hash__(self) -> int:
+        return hash(self._precedence_key())
 
     def __str__(self) -> str:
         version = f"{self.major}.{self.minor}.{self.patch}"


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (only first time contributors)
- [x] I have run `make checkmerge` and fixed all mentioned problems (no local build setup; relying on CI)

### Description

`SemanticVersion.__lt__/__le__/__gt__/__ge__` in `openage/util/version.py` short-circuit on the first field that differs and return `True` as soon as any of `major`/`minor`/`patch` satisfies the relation, instead of comparing fields lexicographically. The bug:

```python
>>> from openage.util.version import SemanticVersion as V
>>> V("1.0.0") > V("0.5.0")
False          # wrong, should be True
>>> V("2.0.0") > V("1.99.99")
False          # wrong, should be True
>>> V("1.0.0") < V("0.5.0")
True           # wrong, should be False
```

The only current caller is `openage/convert/service/init/changelog.py:43`, which uses `>` to decide whether a converted modpack is outdated, so this silently flipped some "up-to-date" vs "outdated" decisions.

### Fix

Switch the operators to a tuple precedence key and use `functools.total_ordering`, so the operators agree with each other by construction. Prerelease versions now sort below the same `MAJOR.MINOR.PATCH` per semver 11.3. Build metadata is ignored for precedence, matching semver 10. Full identifier-by-identifier prerelease comparison (semver 11.4, i.e. `alpha < beta < rc`) is noted as not yet implemented; the current usage in `changelog.py` does not need it.

### Tests

Added inline doctests covering the regression cases, and registered `openage.util.version` in `openage/testing/testlist.py` `doctest_modules()` so they run as part of the doctest suite.