### PR TITLE
openage --version: add Platform block

### DIFF
--- a/openage/__init__.py
+++ b/openage/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 the openage authors. See copying.md for legal info.
+# Copyright 2013-2026 the openage authors. See copying.md for legal info.
 
 """
 The Python part of openage, a free engine re-write of
@@ -41,9 +41,7 @@ else:
         f"Mako          {config.MAKOVERSION}\n"
         f"NumPy         {config.NUMPYVERSION}\n"
         f"Pillow        {config.PILVERSION}\n"
-        f"Pygments      {config.PYGMENTSVERSION}\n"
-        "\n"
-        "== C++ =="
+        f"Pygments      {config.PYGMENTSVERSION}"
     )
 
 

--- a/openage/__main__.py
+++ b/openage/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 the openage authors. See copying.md for legal info.
+# Copyright 2015-2026 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-statements
 """
@@ -22,12 +22,33 @@ def print_version():
     The default version printer, unfortunately, inserts newlines.
     This is the easiest way around.
     """
+    import platform
+
     from . import LONGVERSION
     print(LONGVERSION)
-    from .versions.versions import get_version_numbers
-    version_numbers = get_version_numbers()
-    for key in version_numbers:
-        print(key.decode("utf8") + " " + version_numbers[key].decode("utf8"))
+
+    print()
+    print("== Platform ==")
+    print(f"System        {platform.system()} {platform.release()}")
+    print(f"Version       {platform.version()}")
+    print(f"Architecture  {platform.machine()}")
+    print(f"Python impl   {platform.python_implementation()} {platform.python_version()}")
+    print(f"Executable    {sys.executable}")
+    print(f"openage path  {os.path.dirname(os.path.realpath(__file__))}")
+    libc_lib, libc_ver = platform.libc_ver()
+    if libc_lib:
+        print(f"libc (probe)  {libc_lib} {libc_ver}")
+
+    print()
+    print("== C++ ==")
+    try:
+        from .versions.versions import get_version_numbers
+    except ImportError:
+        print("(unavailable; openage.versions Cython module not built)")
+    else:
+        version_numbers = get_version_numbers()
+        for key in version_numbers:
+            print(key.decode("utf8") + " " + version_numbers[key].decode("utf8"))
     sys.exit(0)
 
 


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

When someone files a bug and we ask for `openage --version`, we get the dependency versions but nothing about their machine, so the OS/arch/Python is always a follow-up question. This adds a `== Platform ==` block with that info (all stdlib, so it works on a tree that isn't built yet) and wraps the existing C++ version block in a try/except, so running it from a half-configured checkout prints a clear "not built" line instead of an `ImportError` traceback.

Left the OpenGL version out, that needs a live GL context and I didn't want to start the renderer just to answer `--version`.

Refs #1185.
