### PR TITLE
convert/tech_subprocessor: contextual KeyErrors on unmapped IDs

### DIFF
--- a/openage/convert/processor/conversion/aoc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/aoc/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 the openage authors. See copying.md for legal info.
+# Copyright 2020-2026 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-statements,too-many-branches
 #
@@ -241,7 +241,13 @@ class AoCTechSubprocessor:
         else:
             return patches
 
-        upgrade_func = AoCTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        try:
+            upgrade_func = AoCTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"unit attribute: {attribute_type}"
+            ) from exc
         for affected_entity in affected_entities:
             patches.extend(upgrade_func(converter_group, affected_entity, value, operator, team))
 
@@ -284,7 +290,13 @@ class AoCTechSubprocessor:
             # 21 = tech count (unused)
             return patches
 
-        upgrade_func = AoCTechSubprocessor.upgrade_resource_funcs[resource_id]
+        try:
+            upgrade_func = AoCTechSubprocessor.upgrade_resource_funcs[resource_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"resource: {resource_id}"
+            ) from exc
         patches.extend(upgrade_func(converter_group, value, operator, team))
 
         return patches

--- a/openage/convert/processor/conversion/de2/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/de2/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 the openage authors. See copying.md for legal info.
+# Copyright 2020-2026 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 
@@ -303,7 +303,13 @@ class DE2TechSubprocessor:
         else:
             return patches
 
-        upgrade_func = DE2TechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        try:
+            upgrade_func = DE2TechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        except KeyError as exc:
+            raise KeyError(
+                f"No DE2 subprocessor function found for handling upgrade of "
+                f"unit attribute: {attribute_type}"
+            ) from exc
         for affected_entity in affected_entities:
             patches.extend(upgrade_func(converter_group, affected_entity, value, operator, team))
 
@@ -346,7 +352,13 @@ class DE2TechSubprocessor:
             # 21 = tech count (unused)
             return patches
 
-        upgrade_func = DE2TechSubprocessor.upgrade_resource_funcs[resource_id]
+        try:
+            upgrade_func = DE2TechSubprocessor.upgrade_resource_funcs[resource_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No DE2 subprocessor function found for handling upgrade of "
+                f"civ resource: {resource_id}"
+            ) from exc
         patches.extend(upgrade_func(converter_group, value, operator, team))
 
         return patches


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

Unmapped AoE2 attribute/resource ids throw a bare `KeyError: 208`, with nothing to say what 208 actually is. Wrapped the four `upgrade_*_funcs[id]` lookups in the AoC/DE2 tech subprocessors so the error names the category (e.g. "... civ resource: 208") and chains the original with `raise ... from`.

Just the spot from the issue plus the AoC parent.

Refs #1344.
