### PR TITLE
buildsystem: reconfigure when git HEAD or current ref changes

### DIFF
--- a/buildsystem/DetectProjectVersion.cmake
+++ b/buildsystem/DetectProjectVersion.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 the openage authors. See copying.md for legal info.
+# Copyright 2015-2026 the openage authors. See copying.md for legal info.
 
 # Determines the version of the project
 # stores a full version string with commit hash and number in the variable `PROJECT_VERSION`
@@ -11,6 +11,35 @@ endif()
 # if .git exists, try running git describe
 if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
 	message(STATUS "Set PROJECT_VERSION from git.")
+
+	# Tell CMake to reconfigure when the commit hash changes. Without this,
+	# PROJECT_VERSION is baked into the generated config files at the first
+	# configure and goes stale on every subsequent commit until the user
+	# explicitly reruns cmake. Watch .git/HEAD (so branch switches and
+	# detached-HEAD moves trigger), the ref file HEAD currently points at
+	# (so commits on the current branch trigger), and packed-refs (so the
+	# git gc / repack path is covered too). New tags will still need a
+	# manual reconfigure, since watching .git/refs/tags/ as a glob would
+	# scale poorly on repos with many tags.
+	set(_OPENAGE_GIT_HEAD "${CMAKE_SOURCE_DIR}/.git/HEAD")
+	if(EXISTS "${_OPENAGE_GIT_HEAD}")
+		set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_OPENAGE_GIT_HEAD}")
+
+		file(READ "${_OPENAGE_GIT_HEAD}" _OPENAGE_GIT_HEAD_CONTENT)
+		string(STRIP "${_OPENAGE_GIT_HEAD_CONTENT}" _OPENAGE_GIT_HEAD_CONTENT)
+		if(_OPENAGE_GIT_HEAD_CONTENT MATCHES "^ref: (.+)$")
+			set(_OPENAGE_GIT_REF_FILE "${CMAKE_SOURCE_DIR}/.git/${CMAKE_MATCH_1}")
+			if(EXISTS "${_OPENAGE_GIT_REF_FILE}")
+				set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_OPENAGE_GIT_REF_FILE}")
+			endif()
+		endif()
+
+		set(_OPENAGE_GIT_PACKED_REFS "${CMAKE_SOURCE_DIR}/.git/packed-refs")
+		if(EXISTS "${_OPENAGE_GIT_PACKED_REFS}")
+			set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_OPENAGE_GIT_PACKED_REFS}")
+		endif()
+	endif()
+
 	execute_process(
 		COMMAND git describe --tags --long
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

`PROJECT_VERSION` is set once at configure time from `git describe` and baked into config.h, so it goes stale on every commit until someone re-runs cmake by hand. This points `CMAKE_CONFIGURE_DEPENDS` at `.git/HEAD`, the ref HEAD points to, and `.git/packed-refs`, so a plain make/ninja reconfigures itself on a branch switch or a new commit.

New tags won't trigger it: globbing `.git/refs/tags/` scales badly once a repo has a lot of tags, and the cmake docs warn against glob `CONFIGURE_DEPENDS` anyway, so tagging stays a manual reconfigure.

Closes #381.
