### PR TITLE
buildsystem: fix the macOS build (Eigen 5 + Apple clang)

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -44,8 +44,6 @@ jobs:
         run: brew install --cask font-dejavu
       - name: Install environment helpers with homebrew
         run: brew install --force ccache
-      - name: Install LLVM with homebrew
-        run: brew install --force llvm
       - name: Install openage dependencies with homebrew
         run: brew install --force cmake python3 libepoxy freetype fontconfig harfbuzz opus opusfile qt6 libogg libpng toml11 eigen
       - name: Install nyan dependencies with homebrew
@@ -56,7 +54,7 @@ jobs:
         # numpy pulls gcc as dep? and pygments doesn't work.
         run: pip3 install --upgrade --break-system-packages cython numpy mako lz4 pillow pygments setuptools toml
       - name: Configure
-        run: ./configure --compiler="$(brew --prefix llvm)/bin/clang++" --mode=release --ccache --download-nyan
+        run: ./configure --compiler=clang --mode=release --ccache --download-nyan
       - name: Build
         run: make -j$(sysctl -n hw.logicalcpu) VERBOSE=1
       - name: Test

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 the openage authors. See copying.md for legal info.
+# Copyright 2014-2026 the openage authors. See copying.md for legal info.
 
 # main C++ library definitions.
 # dependency and source file setup for the resulting library.
@@ -56,7 +56,12 @@ find_package(PNG REQUIRED)
 find_package(Opusfile REQUIRED)
 find_package(Epoxy REQUIRED)
 find_package(HarfBuzz 1.0.0 REQUIRED)
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+# Eigen dropped strict config-version compatibility across its 3 to 5 major
+# bump, so pinning "3.3" here makes find_package reject Eigen 5 (shipped by
+# Arch and Homebrew) even though openage only uses the stable core/geometry
+# API. A version range would need cmake 3.19; our floor is 3.16, so require
+# any Eigen3 config instead.
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

The macOS build is broken two ways. `find_package(Eigen3 3.3 REQUIRED NO_MODULE)` at `libopenage/CMakeLists.txt:59` won't take Eigen 5: the config is found, it's just refused on version (found 5.0.1, asked for 3.3), because Eigen's cmake config stopped treating a new major as satisfying an old request. Arch and Homebrew ship Eigen 5 now, so configure dies before it builds anything (that's the Arch failure in #1793). We only use the fixed-size Vector/Matrix/Affine types and none of that changed in Eigen 5, so I dropped the version bound. A range would read nicer but needs cmake 3.19 and we're on 3.16.

Past that, the build still fell over compiling: the macOS job forced Homebrew's llvm, and clang 22's libc++ couldn't find its own `<math.h>` before the SDK's, so nothing built. None of that was our code, it was just hidden behind the Eigen abort. building.md already says to build with `--compiler=clang` on macOS, so I pointed CI there and dropped the leftover llvm install.

Built and tested against Eigen 5.0.1 with the system Eigen removed so only 5.x was visible: reproduced the failure, then it builds and tests clean. macOS runner's green now.

Closes #1793.
