### PR TITLE
ci: build the macOS job with Apple clang

### DIFF
--- a/.github/workflows/macosx-ci.yml
+++ b/.github/workflows/macosx-ci.yml
@@ -44,8 +44,6 @@ jobs:
         run: brew install --cask font-dejavu
       - name: Install environment helpers with homebrew
         run: brew install --force ccache
-      - name: Install LLVM with homebrew
-        run: brew install --force llvm
       - name: Install openage dependencies with homebrew
         run: brew install --force cmake python3 libepoxy freetype fontconfig harfbuzz opus opusfile qt6 libogg libpng toml11 eigen
       - name: Install nyan dependencies with homebrew
@@ -56,7 +54,7 @@ jobs:
         # numpy pulls gcc as dep? and pygments doesn't work.
         run: pip3 install --upgrade --break-system-packages cython numpy mako lz4 pillow pygments setuptools toml
       - name: Configure
-        run: ./configure --compiler="$(brew --prefix llvm)/bin/clang++" --mode=release --ccache --download-nyan
+        run: ./configure --compiler=clang --mode=release --ccache --download-nyan
       - name: Build
         run: make -j$(sysctl -n hw.logicalcpu) VERBOSE=1
       - name: Test

--- a/libopenage/CMakeLists.txt
+++ b/libopenage/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 the openage authors. See copying.md for legal info.
+# Copyright 2014-2026 the openage authors. See copying.md for legal info.
 
 # main C++ library definitions.
 # dependency and source file setup for the resulting library.
@@ -56,7 +56,12 @@ find_package(PNG REQUIRED)
 find_package(Opusfile REQUIRED)
 find_package(Epoxy REQUIRED)
 find_package(HarfBuzz 1.0.0 REQUIRED)
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+# Eigen dropped strict config-version compatibility across its 3 to 5 major
+# bump, so pinning "3.3" here makes find_package reject Eigen 5 (shipped by
+# Arch and Homebrew) even though openage only uses the stable core/geometry
+# API. A version range would need cmake 3.19; our floor is 3.16, so require
+# any Eigen3 config instead.
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (already in master via #1797)
- [x] I have run `make checkmerge` (changed file is the workflow YAML; clean)

### Description

The macOS-CI job forces Homebrew's LLVM (`--compiler="$(brew --prefix llvm)/bin/clang++"`). On the current runner that is clang 22, whose libc++ can't find its own `<math.h>`/`<stddef.h>` ahead of the SDK's C headers, so every C++ translation unit fails to compile with "header search paths are not configured properly". None of the errors are in openage code.

`doc/building.md` already recommends `--compiler=clang` (the Xcode clang) as the hassle-free macOS toolchain. This points CI at it and drops the now-unused Homebrew LLVM install. Apple clang is built for the macOS SDK and its libc++, so the header-ordering problem goes away.

### Note on the diff (stacked on #1801)

The macOS job can't reach compilation today regardless of the compiler, because `find_package(Eigen3 3.3 REQUIRED NO_MODULE)` rejects the Eigen 5 the runner now ships (that is #1801, closing #1793). So this branch is based on top of #1801, otherwise CI would still abort at configure and this change couldn't be exercised. The branch therefore shows two commits; once #1801 lands I will rebase this down to just the workflow commit. Happy to fold it into #1801 instead if you would rather have one "fix the macOS build" PR.
