### PR TITLE
buildsystem: drop source __pycache__ dirs in mrproper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ cleaninsourcebuild:
 	@find . -not -path "./.bin/*" -type f -name CMakeCache.txt                   -print -delete
 	@find . -not -path "./.bin/*" -type f -name Makefile -not -path "./Makefile" -print -delete
 	@find . -not -path "./.bin/*" -type d -name CMakeFiles                       -print -exec rm -r {} +
+	@find . -not -path "./.bin/*" -type d -name __pycache__                       -print -exec rm -r {} +
 
 .PHONY: cleanbuilddirs
 cleanbuilddirs: cleaninsourcebuild


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

`make mrproper` left every `__pycache__/` in the source tree behind. The clean targets only run against the out-of-source build dir, but running python from the repo (tests, codegen, the converter) scatters bytecode caches through `openage/` and `buildsystem/` and nothing swept those up. `cleaninsourcebuild` now removes them too, outside `.bin`, alongside the other in-source cleanups it already does.

Checked on a built tree: 46 `__pycache__` dirs before, `git clean -ndx` clean after `make mrproper`.

Closes #442.
