### PR TITLE
buildsystem: pull in setuptools so Cython finds distutils

### DIFF
--- a/buildsystem/cythonize.py
+++ b/buildsystem/cythonize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2015-2025 the openage authors. See copying.md for legal info.
+# Copyright 2015-2026 the openage authors. See copying.md for legal info.
 
 """
 Runs Cython on all modules that were listed via add_cython_module.
@@ -12,6 +12,19 @@ import sys
 from contextlib import redirect_stdout
 from multiprocessing import cpu_count
 from pathlib import Path
+
+# Python 3.12 removed distutils from the standard library, but Cython's build
+# dependency machinery still does `from distutils...`. setuptools bundles a
+# replacement and installs the import shim when imported, so pull it in before
+# Cython goes looking. We do it explicitly rather than rely on the site-startup
+# shim, which isn't always active depending on how setuptools got installed
+# (see issue #1769).
+try:
+    import setuptools  # noqa: F401  pylint: disable=unused-import
+except ModuleNotFoundError:
+    sys.exit("openage's build needs the 'setuptools' package (it provides "
+             "'distutils' for Cython on Python 3.12+). "
+             "Install it with: pip install setuptools")
 
 from Cython.Build import cythonize
 


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

On Python 3.12 distutils is gone from the stdlib, but `cythonize()` still does `from distutils.extension import Extension` deep in its dependency scan, so the build dies with `ModuleNotFoundError: No module named 'distutils'`. setuptools ships a stand-in and installs the import shim when it's imported, but the site-startup shim isn't always active depending on how setuptools landed on the box, which is why people hit this even with setuptools installed.

cythonize.py now imports setuptools explicitly before Cython, so the shim is in place before Cython goes looking, and if setuptools genuinely isn't there it bails with an "install setuptools" message instead of a deep traceback.

Reproduced on a python without setuptools (distutils import fails); with the change cythonize.py prints the clear message, and the normal build with setuptools present runs through untouched.

Closes #1769.
