### PR TITLE
codecompliance: check spaces around compound/comparison operators

### DIFF
--- a/buildsystem/codecompliance/cppstyle.py
+++ b/buildsystem/codecompliance/cppstyle.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2017 the openage authors. See copying.md for legal info.
+# Copyright 2015-2026 the openage authors. See copying.md for legal info.
 
 """
 Checks some code style rules for cpp files.
@@ -47,6 +47,33 @@ INDENT_FAIL_LINE_RE = re.compile(
     r")"
 )
 
+# Compound-assignment and comparison operators that must be surrounded by spaces.
+# Ordered longest-first; < and >-based ops use lookbehind/lookahead to avoid
+# matching the shorter pattern inside a longer one (e.g. >= inside >>=,
+# <= inside <<= or the C++20 <=> spaceship operator).
+_SPACED_OPS_ALT = (
+    r'<<=|>>=|'
+    r'\+=|-=|\*=|%=|\^=|\|=|&=|~=|'
+    r'(?<!<)<=(?!>)|(?<!>)>=|'
+    r'==|!='
+)
+
+OPERATOR_SPACING_RE = re.compile(
+    r'(?<!\s)(?:' + _SPACED_OPS_ALT + r')'
+    r'|'
+    r'(?:' + _SPACED_OPS_ALT + r')(?!\s)'
+)
+
+# Strips // comments, inline /* */ comments, and double-quoted string literals
+# by replacing each with equal-length spaces (preserves column offsets).
+_CLEAN_LINE_RE = re.compile(r'//.*|/\*.*?\*/|"(?:[^"\\]|\\.)*"')
+
+# Matches the start of a block-comment continuation line (e.g. " * text").
+_BLOCK_CMT_CONT_RE = re.compile(r'^\s*\*')
+
+# Matches the 'operator' keyword (used to skip operator-overload declarations).
+_OPERATOR_KW_RE = re.compile(r'\boperator\b')
+
 
 def filter_file_list(check_files, dirnames):
     """
@@ -81,7 +108,8 @@ def find_issues(check_files, dirnames):
 
         if MISSING_SPACES_RE.search(data) or\
            EXTRA_SPACES_RE.search(data) or\
-           INDENT_FAIL_RE.search(data):
+           INDENT_FAIL_RE.search(data) or\
+           OPERATOR_SPACING_RE.search(data):
 
             analyse_each_line = True
 
@@ -116,3 +144,16 @@ def find_issues_with_lines(data, filename):
             yield issue_str_line("Wrong indentation",
                                  filename, line, num,
                                  (match.start(1), match.end(1)))
+
+        # Check that compound-assignment and comparison operators have spaces
+        # on both sides. Operate on a cleaned copy of the line (comments and
+        # string literals blanked out) to avoid false positives; also skip
+        # block-comment continuation lines and operator-overload declarations.
+        check_line = _CLEAN_LINE_RE.sub(lambda m: ' ' * len(m.group()), line)
+        if (not _BLOCK_CMT_CONT_RE.match(check_line) and
+                not _OPERATOR_KW_RE.search(check_line)):
+            match = OPERATOR_SPACING_RE.search(check_line)
+            if match:
+                yield issue_str_line("Missing space around operator",
+                                     filename, line, num,
+                                     (match.start(), match.end()))


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md) (landed in #1797)
- [x] I have run `make checkmerge`

`cppstyle.py` flags a handful of C++ spacing slips but not missing spaces around the compound-assignment and comparison operators (`+=`, `==`, `<=`, and friends), which is what #837 asks for. This adds that check.

The operators overlap, so a naive scan false-matches: `>=` sits inside `>>=`, `<=` inside `<<=` and the C++20 `<=>` spaceship. The regex uses lookbehind/lookahead to only catch the standalone forms. Comments and string literals are blanked before checking, and operator-overload declarations are skipped, so `// a==b`, `"x==y"` and `bool operator==(...)` don't trip it.

Ran it across libopenage and it's zero hits, the tree already complies, so this is purely additive. Spot-checked that it does flag `a==b`, `y+=2`, `c <=d` and leaves `>>=`, `<=>`, `operator==`, comments and strings alone.

Closes #837.
