### PR TITLE
convert/tech_subprocessor: extend contextual KeyErrors to RoR and SWGB

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -168,6 +168,7 @@ _the openage authors_ are:
 | Daniel Wieczorek            | Danio                       | danielwieczorek96 à gmail dawt com                |
 |                             | bytegrrrl                   | bytegrrrl à proton dawt me                        |
 | Nicolas Sanchez             | nicolassanchez02            | nicolasjpsanchez à gmail dawt com                 |
+| Manas Pradhan               | manas-maker                 | manasmpradhan5 à gmail dawt com                   |
 
 If you're a first-time committer, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/openage/convert/processor/conversion/ror/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/ror/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 the openage authors. See copying.md for legal info.
+# Copyright 2020-2026 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 #
@@ -158,7 +158,13 @@ class RoRTechSubprocessor:
         else:
             return patches
 
-        upgrade_func = RoRTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        try:
+            upgrade_func = RoRTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"unit attribute: {attribute_type}"
+            ) from exc
         for affected_entity in affected_entities:
             patches.extend(upgrade_func(converter_group, affected_entity, value, operator, team))
 
@@ -202,7 +208,13 @@ class RoRTechSubprocessor:
             # 30 = building limits (unused)
             return patches
 
-        upgrade_func = RoRTechSubprocessor.upgrade_resource_funcs[resource_id]
+        try:
+            upgrade_func = RoRTechSubprocessor.upgrade_resource_funcs[resource_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"resource: {resource_id}"
+            ) from exc
         patches.extend(upgrade_func(converter_group, value, operator, team))
 
         return patches

--- a/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
+++ b/openage/convert/processor/conversion/swgbcc/tech_subprocessor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 the openage authors. See copying.md for legal info.
+# Copyright 2020-2026 the openage authors. See copying.md for legal info.
 #
 # pylint: disable=too-many-locals,too-many-branches
 #
@@ -245,7 +245,13 @@ class SWGBCCTechSubprocessor:
         else:
             return patches
 
-        upgrade_func = SWGBCCTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        try:
+            upgrade_func = SWGBCCTechSubprocessor.upgrade_attribute_funcs[attribute_type]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"unit attribute: {attribute_type}"
+            ) from exc
         for affected_entity in affected_entities:
             patches.extend(upgrade_func(converter_group, affected_entity, value, operator, team))
 
@@ -288,7 +294,13 @@ class SWGBCCTechSubprocessor:
             # 21 = tech count (unused)
             return patches
 
-        upgrade_func = SWGBCCTechSubprocessor.upgrade_resource_funcs[resource_id]
+        try:
+            upgrade_func = SWGBCCTechSubprocessor.upgrade_resource_funcs[resource_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No subprocessor function found for handling upgrade of "
+                f"resource: {resource_id}"
+            ) from exc
         patches.extend(upgrade_func(converter_group, value, operator, team))
 
         return patches


### PR DESCRIPTION
### Merge Checklist

- [x] I have read the [contribution guide](doc/contributing.md)
- [x] I have added my info to [copying.md](copying.md)
- [x] I have run `make checkmerge`

PR #1799 wrapped the `upgrade_*_funcs` lookups in AoC and DE2 with contextual
KeyError messages. This applies the same `try/except + raise from` pattern to
the remaining RoR and SWGBCC tech subprocessors, covering the last four bare
lookups.

Closes #1344.
