### PR TITLE
libopenage: fix typos in code comments

### DIFF
--- a/libopenage/coord/coord_test.cpp
+++ b/libopenage/coord/coord_test.cpp
@@ -34,7 +34,7 @@ struct TestCoordsRelative : CoordXYRelative<int, TestCoordsAbsolute, TestCoordsR
  * test method for the base CoordXY* classes.
  */
 void coord() {
-    // test comparision
+    // test comparison
     TESTEQUALS(TestCoordsAbsolute(3, 4) == TestCoordsAbsolute(3, 4), true);
     TESTEQUALS(TestCoordsAbsolute(3, 4) != TestCoordsAbsolute(3, 4), false);
     TESTEQUALS(TestCoordsAbsolute(3, 4) == TestCoordsAbsolute(3, 5), false);

--- a/libopenage/input/input_manager.h
+++ b/libopenage/input/input_manager.h
@@ -174,7 +174,7 @@ private:
 	std::vector<std::shared_ptr<InputContext>> active_contexts;
 
 	/**
-	 * Map of all available contexts, referencable by an ID.
+	 * Map of all available contexts, referenceable by an ID.
 	 *
 	 * TODO: Move this to cvar manager?
 	 */

--- a/libopenage/options.h
+++ b/libopenage/options.h
@@ -259,7 +259,7 @@ private:
 /**
  * A interaface variable which gets monitored by an
  * option node allowing reflection, while also
- * being directly accessable as a typed member
+ * being directly accessible as a typed member
  */
 template <class T>
 class Var : public util::Variable<T> {

--- a/libopenage/pathfinding/demo/demo_0.cpp
+++ b/libopenage/pathfinding/demo/demo_0.cpp
@@ -771,7 +771,7 @@ renderer::resources::MeshData RenderManager0::get_flow_field_mesh(const std::sha
 				auto int_flags = int_field->get_cell(i / resolution, (j - 1) / resolution).flags;
 				int_surround.push_back(int_flags);
 			}
-			// combine the flags of the sorrounding tiles
+			// combine the flags of the surrounding tiles
 			auto ff_max_flags = 0;
 			for (auto &val : ff_surround) {
 				ff_max_flags |= val & 0xF0;

--- a/libopenage/pathfinding/grid.h
+++ b/libopenage/pathfinding/grid.h
@@ -102,7 +102,7 @@ public:
 	const nodemap_t &get_portal_map();
 
 	/**
-	 * Initialize the portal nodes of the grid with neigbouring nodes and distance costs.
+	 * Initialize the portal nodes of the grid with neighbouring nodes and distance costs.
 	 */
 	void init_portal_nodes();
 
@@ -128,7 +128,7 @@ private:
 	std::vector<std::shared_ptr<Sector>> sectors;
 
 	/**
-	 *	maps portal_ids to portal nodes, which store their neigbouring nodes and associated distance costs
+	 *	maps portal_ids to portal nodes, which store their neighbouring nodes and associated distance costs
 	 *  for pathfinding
 	 */
 

--- a/libopenage/pathfinding/integration_field.cpp
+++ b/libopenage/pathfinding/integration_field.cpp
@@ -66,7 +66,7 @@ std::vector<size_t> IntegrationField::integrate_los(const std::shared_ptr<CostFi
 		// Do a preliminary LOS integration wave for targets that have cost > min cost
 		// This avoids the bresenham's line algorithm calculations
 		// (which wouldn't return accurate results for blocker == target)
-		// and makes sure that sorrounding cells that are min cost are considered
+		// and makes sure that surrounding cells that are min cost are considered
 		// in line-of-sight.
 
 		this->cells[target_idx].flags |= INTEGRATE_FOUND_MASK;

--- a/libopenage/pathfinding/integration_field.h
+++ b/libopenage/pathfinding/integration_field.h
@@ -176,7 +176,7 @@ public:
 
 private:
 	/**
-	 * Update a neigbor cell during the cost integration process.
+	 * Update a neighbor cell during the cost integration process.
 	 *
 	 * @param idx Index of the neighbor cell that is updated.
 	 * @param cell_cost Cost of the neighbor cell from the cost field.

--- a/libopenage/pathfinding/pathfinder.h
+++ b/libopenage/pathfinding/pathfinder.h
@@ -188,7 +188,7 @@ public:
 
 
 	/**
-	 * maps node_t of a neigbhour portal to the distance cost to travel between the portals
+	 * maps node_t of a neighbour portal to the distance cost to travel between the portals
 	 */
 	using exits_t = std::map<const node_t, int>;
 

--- a/libopenage/pathfinding/portal.h
+++ b/libopenage/pathfinding/portal.h
@@ -213,14 +213,14 @@ private:
 	/**
 	 * Exits in sector 0 reachable from the portal.
 	 *
-	 * TODO: Also store avarage cost to reach each exit.
+	 * TODO: Also store average cost to reach each exit.
 	 */
 	std::vector<std::shared_ptr<Portal>> sector0_exits;
 
 	/**
 	 * Exits in sector 1 reachable from the portal.
 	 *
-	 * TODO: Also store avarage cost to reach each exit.
+	 * TODO: Also store average cost to reach each exit.
 	 */
 	std::vector<std::shared_ptr<Portal>> sector1_exits;
 

--- a/libopenage/renderer/camera/camera.cpp
+++ b/libopenage/renderer/camera/camera.cpp
@@ -289,7 +289,7 @@ Eigen::Vector3f Camera::calc_look_at(Eigen::Vector3f target) {
 	// get x and z offsets
 	// the camera is pointed diagonally to the negative x and z axis
 	// a is the length of the diagonal from camera.xz to scene_pos.xz
-	// so the x and z offest are sides of a square with the same diagonal
+	// so the x and z offset are sides of a square with the same diagonal
 	auto side_length = xz_distance / std::numbers::sqrt2;
 	return Eigen::Vector3f(
 		target[0] + side_length,

--- a/libopenage/renderer/demo/demo_6.cpp
+++ b/libopenage/renderer/demo/demo_6.cpp
@@ -364,7 +364,7 @@ void RenderManagerDemo6::load_shaders() {
 		frame_fshader_file.read());
 	frame_fshader_file.close();
 
-	/* Shader for frustrum frame */
+	/* Shader for frustum frame */
 	auto frustum_vshader_file = (shaderdir / "demo_6_2d_frustum_frame.vert.glsl").open();
 	auto frustum_vshader_src = resources::ShaderSource(
 		resources::shader_lang_t::glsl,

--- a/libopenage/renderer/font/font_manager.cpp
+++ b/libopenage/renderer/font/font_manager.cpp
@@ -27,7 +27,7 @@ std::string FontManager::get_font_filename(const char *family, const char *style
 	FcResult font_match_result;
 	FcPattern *font_match = FcFontMatch(nullptr, font_pattern, &font_match_result);
 
-	// get attibute FC_FILE (= filename) of best-matched font
+	// get attribute FC_FILE (= filename) of best-matched font
 	FcChar8 *font_filename_tmp;
 	if (FcPatternGetString(font_match, FC_FILE, 0, &font_filename_tmp) != FcResultMatch) {
 		throw Error(ERR << "Fontconfig could not provide font " << family << " " << style);

--- a/libopenage/renderer/gui/gui.h
+++ b/libopenage/renderer/gui/gui.h
@@ -76,7 +76,7 @@ private:
 	 *
 	 * @param width Width of the GUI.
 	 * @param height Height of the GUI.
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(size_t width,
 	                            size_t height,

--- a/libopenage/renderer/opengl/context.cpp
+++ b/libopenage/renderer/opengl/context.cpp
@@ -212,7 +212,7 @@ void GlContext::check_error() {
 		}();
 
 		throw Error(
-			MSG(err) << "An OpenGL error has occured.\n\t"
+			MSG(err) << "An OpenGL error has occurred.\n\t"
 					 << "(" << error_state << "): " << msg);
 	}
 }

--- a/libopenage/renderer/opengl/context.h
+++ b/libopenage/renderer/opengl/context.h
@@ -116,7 +116,7 @@ public:
 	 * Store the currently active shader program for this context.
 	 *
 	 * Note that this method does not load the shader in OpenGL. It is merely
-	 * a conveniance function so that the renderer can check which program
+	 * a convenience function so that the renderer can check which program
 	 * is currently used.
 	 *
 	 * @param prog Currently active shader program.

--- a/libopenage/renderer/opengl/framebuffer.h
+++ b/libopenage/renderer/opengl/framebuffer.h
@@ -49,7 +49,7 @@ public:
 	 *
 	 * @param context OpenGL context used for drawing.
 	 * @param textures Textures targeted by the framebuffer. They are automatically
-	 *                 attached to the correct attachement points depending on their type.
+	 *                 attached to the correct attachment points depending on their type.
 	 */
 	GlFramebuffer(const std::shared_ptr<GlContext> &context,
 	              std::vector<std::shared_ptr<GlTexture2d>> const &textures);

--- a/libopenage/renderer/opengl/render_target.h
+++ b/libopenage/renderer/opengl/render_target.h
@@ -31,7 +31,7 @@ enum class gl_render_target_t {
 
 /**
  * Represents an OpenGL target that can be drawn into.
- * It can be either a framebuffer with texture attachements or the display (the window).
+ * It can be either a framebuffer with texture attachments or the display (the window).
  */
 class GlRenderTarget final : public RenderTarget {
 public:
@@ -52,7 +52,7 @@ public:
 	 * e.g. a depth texture will be set as the depth target.
 	 *
 	 * @param context OpenGL context used for drawing.
-	 * @param textures Texture attachements.
+	 * @param textures Texture attachments.
 	 */
 	GlRenderTarget(const std::shared_ptr<GlContext> &context,
 	               std::vector<std::shared_ptr<GlTexture2d>> const &textures);

--- a/libopenage/renderer/opengl/shader.cpp
+++ b/libopenage/renderer/opengl/shader.cpp
@@ -36,7 +36,7 @@ GlShader::GlShader(const std::shared_ptr<GlContext> &context,
 	// compile shader source
 	glCompileShader(handle);
 
-	// check compiliation result
+	// check compilation result
 	GLint status;
 	glGetShaderiv(handle, GL_COMPILE_STATUS, &status);
 

--- a/libopenage/renderer/opengl/shader_program.cpp
+++ b/libopenage/renderer/opengl/shader_program.cpp
@@ -425,7 +425,7 @@ void GlShaderProgram::update_uniforms(std::shared_ptr<GlUniformInput> const &uni
 			// TODO: maybe call this at a more appropriate position
 			glUniform1i(loc, tex_unit_id);
 			ENSURE(tex_unit_id < this->textures_per_texunits.size(),
-			       "Tried to assign texture to non-existant texture unit at index "
+			       "Tried to assign texture to non-existent texture unit at index "
 			           << tex_unit_id
 			           << " (max: " << this->textures_per_texunits.size() << ").");
 			this->textures_per_texunits[tex_unit_id] = tex;

--- a/libopenage/renderer/resources/animation/angle_info.h
+++ b/libopenage/renderer/resources/animation/angle_info.h
@@ -29,7 +29,7 @@ public:
 	/**
 	 * Create a 2D Angle Info.
 	 *
-	 * @param angle_start Rotation in degress at which the frames are displayed.
+	 * @param angle_start Rotation in degrees at which the frames are displayed.
 	 * @param frames Frame information.
 	 * @param mirror_from Mirror frames from another angle instead of using uniquely
 	 *                    defined frames.
@@ -88,7 +88,7 @@ public:
 
 private:
 	/**
-	 * Starting rotation in degress at which the frames are displayed.
+	 * Starting rotation in degrees at which the frames are displayed.
 	 */
 	float angle_start;
 

--- a/libopenage/renderer/stages/hud/render_stage.h
+++ b/libopenage/renderer/stages/hud/render_stage.h
@@ -102,7 +102,7 @@ private:
 	 *
 	 * @param width Width of the FBO.
 	 * @param height Height of the FBO.
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(size_t width,
 	                            size_t height,

--- a/libopenage/renderer/stages/screen/render_stage.h
+++ b/libopenage/renderer/stages/screen/render_stage.h
@@ -63,7 +63,7 @@ private:
 	 *
 	 * Called during initialization of the screen renderer.
 	 *
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(const util::Path &shaderdir);
 

--- a/libopenage/renderer/stages/screen/screenshot.cpp
+++ b/libopenage/renderer/stages/screen/screenshot.cpp
@@ -53,7 +53,7 @@ std::string ScreenshotManager::gen_next_filename() {
 
 
 void ScreenshotManager::save_screenshot() {
-	// get screenshot image from scren renderer
+	// get screenshot image from screen renderer
 	auto pass = this->renderer->get_render_pass();
 	auto target = pass->get_target();
 	auto image = target->into_data();

--- a/libopenage/renderer/stages/skybox/render_stage.h
+++ b/libopenage/renderer/stages/skybox/render_stage.h
@@ -80,7 +80,7 @@ private:
 	 *
 	 * @param width Width of the FBO.
 	 * @param height Height of the FBO.
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(size_t width,
 	                            size_t height,

--- a/libopenage/renderer/stages/terrain/render_entity.cpp
+++ b/libopenage/renderer/stages/terrain/render_entity.cpp
@@ -28,7 +28,7 @@ void RenderEntity::update_tile(const util::Vector2s size,
 		throw Error(MSG(err) << "Cannot update tile: Vertices have not been initialized yet.");
 	}
 
-	// find the postion of the tile in the vertex array
+	// find the position of the tile in the vertex array
 	auto left_corner = pos.ne * size[0] + pos.se;
 
 	// update the 4 vertices of the tile

--- a/libopenage/renderer/stages/terrain/render_stage.h
+++ b/libopenage/renderer/stages/terrain/render_stage.h
@@ -99,7 +99,7 @@ private:
 	 *
 	 * @param width Width of the FBO.
 	 * @param height Height of the FBO.
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(size_t width,
 	                            size_t height,

--- a/libopenage/renderer/stages/world/render_stage.h
+++ b/libopenage/renderer/stages/world/render_stage.h
@@ -98,7 +98,7 @@ private:
 	 *
 	 * @param width Width of the FBO.
 	 * @param height Height of the FBO.
-	 * @param shaderdir Directory containg the shader source files.
+	 * @param shaderdir Directory containing the shader source files.
 	 */
 	void initialize_render_pass(size_t width, size_t height, const util::Path &shaderdir);
 

--- a/libopenage/renderer/window.h
+++ b/libopenage/renderer/window.h
@@ -138,7 +138,7 @@ public:
 
 	/**
 	 * Force this window to the given size. It's generally not a good idea to use this,
-	 * as it makes the window jump around wierdly.
+	 * as it makes the window jump around weirdly.
 	 *
 	 * @param width Width in pixels.
 	 * @param height Height in pixels.

--- a/libopenage/util/compiler.cpp
+++ b/libopenage/util/compiler.cpp
@@ -25,7 +25,7 @@ namespace util {
 std::string demangle(const char *symbol) {
 #ifdef _WIN32
 	//  MSVC's typeid(T).name() already returns a demangled name
-	// unlike clang and gcc the MSVC demangled name is prefixed with "class " or "stuct "
+	// unlike clang and gcc the MSVC demangled name is prefixed with "class " or "struct "
 	// we remove the prefix to match the format of clang and gcc
 	return strchr(symbol, ' ') + 1;
 #else
@@ -65,7 +65,7 @@ std::optional<std::string> symbol_name_win(const void *addr) {
 	std::lock_guard<std::mutex> sym_lock_guard{sym_mutex};
 
 	// Initialize symbol handler for process, if it has not yet been initialized
-	// If we are not succesful on the first try, leave it, since MSDN says that searching for symbol files is very time consuming
+	// If we are not successful on the first try, leave it, since MSDN says that searching for symbol files is very time consuming
 	if (!initialized_symbol_handler) {
 		initialized_symbol_handler = true;
 

--- a/libopenage/util/compress/bitstream.h
+++ b/libopenage/util/compress/bitstream.h
@@ -420,7 +420,7 @@ public:
 	}
 
 	/**
-	 * Aligns the bitstream - that is, _if_ we're currenlty in bitstream mode.
+	 * Aligns the bitstream - that is, _if_ we're currently in bitstream mode.
 	 *
 	 * Otherwise, a no-op.
 	 */

--- a/libopenage/util/compress/lzxd.cpp
+++ b/libopenage/util/compress/lzxd.cpp
@@ -170,7 +170,7 @@ public:
 	// IO buffering
 	BitStream<4096> bits;
 
-	// huffman code lenghts
+	// huffman code lengths
 	HuffmanTable<LZX_PRETREE_MAXSYMBOLS, LZX_PRETREE_TABLEBITS> htpre;
 	HuffmanTable<LZX_MAINTREE_MAXSYMBOLS, LZX_MAINTREE_TABLEBITS> htmain;
 	HuffmanTable<LZX_LENGTH_MAXSYMBOLS, LZX_LENGTH_TABLEBITS, true> htlength;
@@ -879,7 +879,7 @@ void LZXDStream::postprocess_intel_e8(unsigned char *buf, int frame_size) {
 		return;
 	}
 
-	// search the block for occurances of '0xe8'
+	// search the block for occurrences of '0xe8'
 	// the last 10 bytes of the frame are not e8-handled, because reasons.
 	for (int pos = 0; pos < frame_size - 10; pos++) {
 		bool is_e8 = (buf[pos] == 0xe8);

--- a/libopenage/util/file.cpp
+++ b/libopenage/util/file.cpp
@@ -100,7 +100,7 @@ ssize_t File::size() {
 
 
 std::vector<std::string> File::get_lines() {
-	// TODO: relay the get_lines to the underlaying filelike
+	// TODO: relay the get_lines to the underlying filelike
 	//       which may do a better job in getting the lines.
 	//       instead, we read everything and then split up into lines.
 	std::vector<std::string> result = util::split_newline(this->read());

--- a/libopenage/util/file.h
+++ b/libopenage/util/file.h
@@ -23,7 +23,7 @@ class Path;
 
 /**
  * Generic File implementation, used in our filesystem-like and file-like
- * abtraction system. Can be created from Python :)
+ * abstraction system. Can be created from Python :)
  *
  * TODO: maybe inherit from std::iostream so we can use it the c++-way
  *

--- a/libopenage/util/strings.cpp
+++ b/libopenage/util/strings.cpp
@@ -120,7 +120,7 @@ bool string_matches_pattern(const char *str, const char *pattern) {
 		}
 
 		if (*pattern == '\0') {
-			// comparision done
+			// comparison done
 			return true;
 		}
 

--- a/libopenage/util/variable.h
+++ b/libopenage/util/variable.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	/**
-	 * accessable typed value
+	 * accessible typed value
 	 */
 	T value;
 };

--- a/libopenage/util/vector.h
+++ b/libopenage/util/vector.h
@@ -165,7 +165,7 @@ public:
 	}
 
 	/**
-	 * Euclidian norm aka length
+	 * Euclidean norm aka length
 	 */
 	T norm() const {
 		return std::sqrt(this->dot(*this));


### PR DESCRIPTION
## Summary

Fixes spelling mistakes in code comments across `libopenage`:

- **renderer**: `containg`→`containing` (world/screen/terrain/skybox/hud stages,
  gui), `frustrum`→`frustum`, `offest`→`offset`, `degress`→`degrees`,
  `attibute`→`attribute`, `attachement(s)`→`attachment(s)`,
  `compiliation`→`compilation`, `conveniance`→`convenience`, `scren`→`screen`,
  `postion`→`position`, `wierdly`→`weirdly`
- **pathfinding**: `neigbouring`/`neigbor`/`neigbhour`→neighbour(ing)/neighbor,
  `sorrounding`→`surrounding`, `avarage`→`average`
- **util / input / coord**: `comparision`→`comparison`, `accessable`→`accessible`,
  `underlaying`→`underlying`, `abtraction`→`abstraction`, `Euclidian`→`Euclidean`,
  `currenlty`→`currently`, `lenghts`→`lengths`, `occurances`→`occurrences`,
  `succesful`→`successful`, `stuct`→`struct`, `referencable`→`referenceable`

Two user-facing OpenGL error strings are also corrected
(`occured`→`occurred`, `non-existant`→`non-existent`).

Comment and string-literal changes only — no logic, identifiers or behaviour
are affected. Found with `codespell`; each ambiguous case was checked in
context before applying.
