### PR TITLE
doc: fix typo in game simulation systems documentation

### DIFF
--- a/doc/code/game_simulation/systems.md
+++ b/doc/code/game_simulation/systems.md
@@ -14,7 +14,7 @@ Handles idle actions for game entities.
 
 `idle(..)` updates the animation of the game entity. This requires the game
 entity to have the `Idle` component. The function returns a time of 0 since
-no actionsconsuming simulation time are taken.
+no actions consuming simulation time are taken.
 
 
 ## Move


### PR DESCRIPTION
## Summary

Fix a small typo in the game simulation systems documentation:

`actionsconsuming` → `actions consuming` in `doc/code/game_simulation/systems.md`.

Documentation-only, single-word fix. No code or behaviour affected.