### PR TITLE
Fix macOS build and run issues + input/simulation deadlock

### DIFF
--- a/assets/shaders/identity.vert.glsl
+++ b/assets/shaders/identity.vert.glsl
@@ -1,16 +1,14 @@
-#version 120
+#version 330 core
 
-// no-transformation texture mapping vertex shader
+// Input vertex position
+layout(location = 0) in vec4 vertex_position;
 
-// the position of this vertex
-attribute vec4 vertex_position;
-
-// interpolated texture coordinates sent to fragment shader
-varying vec2 tex_position;
+// Output to fragment shader
+out vec2 tex_position;
 
 void main(void) {
-	gl_Position = vertex_position;
+    gl_Position = vertex_position;
 
-	// convert from screen coordinates (-1, 1) to texture coordinates (0, 1)
-	tex_position = (vertex_position.xy + vec2(1.f)) / 2.f;
+    // Convert from clip space (-1, 1) to texture space (0, 1)
+    tex_position = (vertex_position.xy + vec2(1.0)) * 0.5;
 }

--- a/assets/shaders/maptexture.frag.glsl
+++ b/assets/shaders/maptexture.frag.glsl
@@ -1,13 +1,10 @@
-#version 120
-// total basic standard texture drawing fragment shader
+#version 330 core
 
-// the texture data
-uniform sampler2D texture;
+uniform sampler2D tex;
 
-// interpolated texture coordinates received from vertex shader
-varying vec2 tex_position;
+in vec2 tex_position;
+out vec4 frag_color;
 
-void main (void) {
-	// this sets the fragment color to the corresponding texel.
-	gl_FragColor = texture2D(texture, tex_position);
+void main(void) {
+    frag_color = texture(tex, tex_position);
 }

--- a/assets/shaders/maptexture.vert.glsl
+++ b/assets/shaders/maptexture.vert.glsl
@@ -1,21 +1,16 @@
-//total basic standard texture mapping vertex shader
+#version 330 core
 
-//modelview*projection matrix
+// Input attributes (set via glVertexAttribPointer)
+layout(location = 0) in vec4 vertex_position;
+layout(location = 1) in vec2 tex_coordinates;
+
+// Output to fragment shader
+out vec2 tex_position;
+
+// Uniform matrix
 uniform mat4 mvp_matrix;
 
-//the position of this vertex
-attribute vec4 vertex_position;
-
-//the texture coordinates assigned to this vertex
-attribute vec2 tex_coordinates;
-
-//interpolated texture coordinates sent to fragment shader
-varying vec2 tex_position;
-
 void main(void) {
-	//transform the vertex coordinates
-	gl_Position = gl_ModelViewProjectionMatrix * vertex_position;
-
-	//pass the fix points for texture coordinates set at this vertex
-	tex_position = tex_coordinates;
+    gl_Position = mvp_matrix * vertex_position;
+    tex_position = tex_coordinates;
 }

--- a/assets/shaders/world2d.frag.glsl
+++ b/assets/shaders/world2d.frag.glsl
@@ -19,25 +19,21 @@ vec2 uv = vec2(
 void main() {
 	vec4 tex_val = texture(tex, uv);
 	int alpha = int(round(tex_val.a * 255));
-	switch (alpha) {
-		case 0:
-			col = tex_val;
-			discard;
-
-			// do not save the ID
-			return;
-		case 254:
-			col = vec4(1.0f, 0.0f, 0.0f, 1.0f);
-			break;
-		case 252:
-			col = vec4(0.0f, 1.0f, 0.0f, 1.0f);
-			break;
-		case 250:
-			col = vec4(0.0f, 0.0f, 1.0f, 1.0f);
-			break;
-		default:
-			col = tex_val;
-			break;
+	// NOTE: written as if/else instead of a switch statement because the
+	// macOS OpenGL driver crashes (SIGSEGV in glpLLVMCGSwitchStatement during
+	// glLinkProgram) when compiling a switch statement here. See PR #1777.
+	if (alpha == 0) {
+		col = tex_val;
+		discard;
+		return;
+	} else if (alpha == 254) {
+		col = vec4(1.0f, 0.0f, 0.0f, 1.0f);
+	} else if (alpha == 252) {
+		col = vec4(0.0f, 1.0f, 0.0f, 1.0f);
+	} else if (alpha == 250) {
+		col = vec4(0.0f, 0.0f, 1.0f, 1.0f);
+	} else {
+		col = tex_val;
 	}
 	id = u_id;
 }

--- a/assets/test/shaders/demo_2_obj.frag.glsl
+++ b/assets/test/shaders/demo_2_obj.frag.glsl
@@ -10,22 +10,18 @@ layout(location=1) out uint id;
 void main() {
 	vec4 tex_val = texture(tex, v_uv);
 	int alpha = int(round(tex_val.a * 255));
-	switch (alpha) {
-		case 0:
-		discard;
-		break;
-		case 254:
-		col = vec4(1.0f, 0.0f, 0.0f, 1.0f);
-		break;
-		case 252:
-		col = vec4(0.0f, 1.0f, 0.0f, 1.0f);
-		break;
-		case 250:
-		col = vec4(0.0f, 0.0f, 1.0f, 1.0f);
-		break;
-		default:
+
+	if (alpha == 0) {
+	    discard;
+	} else if (alpha == 254) {
+	    col = vec4(1.0, 0.0, 0.0, 1.0);
+	} else if (alpha == 252) {
+	    col = vec4(0.0, 1.0, 0.0, 1.0);
+	} else if (alpha == 250) {
+	    col = vec4(0.0, 0.0, 1.0, 1.0);
+	} else {
 	    col = tex_val;
-		break;
 	}
+
 	id = u_id;
 }

--- a/assets/test/shaders/demo_4_obj.frag.glsl
+++ b/assets/test/shaders/demo_4_obj.frag.glsl
@@ -10,22 +10,18 @@ layout(location=1) out uint id;
 void main() {
 	vec4 tex_val = texture(tex, v_uv);
 	int alpha = int(round(tex_val.a * 255));
-	switch (alpha) {
-		case 0:
-		discard;
-		break;
-		case 254:
-		col = vec4(1.0f, 0.0f, 0.0f, 1.0f);
-		break;
-		case 252:
-		col = vec4(0.0f, 1.0f, 0.0f, 1.0f);
-		break;
-		case 250:
-		col = vec4(0.0f, 0.0f, 1.0f, 1.0f);
-		break;
-		default:
+
+	if (alpha == 0) {
+	    discard;
+	} else if (alpha == 254) {
+	    col = vec4(1.0, 0.0, 0.0, 1.0);
+	} else if (alpha == 252) {
+	    col = vec4(0.0, 1.0, 0.0, 1.0);
+	} else if (alpha == 250) {
+	    col = vec4(0.0, 0.0, 1.0, 1.0);
+	} else {
 	    col = tex_val;
-		break;
 	}
+
 	id = u_id;
 }

--- a/copying.md
+++ b/copying.md
@@ -167,6 +167,7 @@ _the openage authors_ are:
 | Jordan Sutton               | jsutCodes                   | jsutcodes à gmail dawt com                        |
 | Daniel Wieczorek            | Danio                       | danielwieczorek96 à gmail dawt com                |
 |                             | bytegrrrl                   | bytegrrrl à proton dawt me                        |
+|                             | hellvoid                    | hell à void dawt lan                              |
 | Nicolas Sanchez             | nicolassanchez02            | nicolasjpsanchez à gmail dawt com                 |
 | Manas Pradhan               | manas-maker                 | manasmpradhan5 à gmail dawt com                   |
 

--- a/libopenage/engine/engine.cpp
+++ b/libopenage/engine/engine.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 the openage authors. See copying.md for legal info.
+// Copyright 2023-2025 the openage authors. See copying.md for legal info.
 
 #include "engine.h"
 
@@ -33,7 +33,6 @@ Engine::Engine(mode mode,
 	this->time_loop = std::make_shared<time::TimeLoop>();
 
 	// game simulation
-	// this is run in the main thread
 	this->simulation = std::make_shared<gamestate::GameSimulation>(this->root_dir,
 	                                                               this->cvar_manager,
 	                                                               this->time_loop);
@@ -43,36 +42,58 @@ Engine::Engine(mode mode,
 	if (this->run_mode == mode::FULL) {
 		this->presenter = std::make_shared<presenter::Presenter>(this->root_dir,
 		                                                         this->simulation,
-		                                                         this->time_loop);
+		                                                         this->time_loop,
+		                                                         window_settings);
 	}
-
-	// spawn thread to run time loop
-	this->threads.emplace_back([&]() {
-		this->time_loop->run();
-
-		this->time_loop.reset();
-	});
-
-	// if presenter is used, run it in a separate thread
-	if (this->run_mode == mode::FULL) {
-		this->threads.emplace_back([&]() {
-			this->presenter->run(window_settings);
-
-			// Make sure that the presenter gets destructed in the same thread
-			// otherwise OpenGL complains about missing contexts
-			this->presenter.reset();
-			this->running = false;
-		});
-	}
-
-	log::log(INFO << "Using " << this->threads.size() + 1 << " threads "
-	              << "(" << std::jthread::hardware_concurrency() << " available)");
 }
 
 void Engine::loop() {
+	// Spawn the time loop in a worker thread. The time loop advances the
+	// simulation clock and runs independently of the main loop.
+	this->threads.emplace_back([&]() {
+		this->run_time_loop();
+	});
+
+	if (this->run_mode == mode::FULL) {
+		// Run the simulation in a worker thread...
+		this->threads.emplace_back([&]() {
+			this->run_simulation();
+		});
+
+		log::log(INFO << "Using " << this->threads.size() + 1 << " threads "
+		              << "(" << std::jthread::hardware_concurrency() << " available)");
+
+		// ...while the presenter runs on the main thread. The presenter owns the
+		// QGuiApplication, which Qt requires to be created and operated on the
+		// main thread (on macOS, QGuiApplication setup on a non-main thread is
+		// an API misuse that the platform plugin rejects). This is also why the
+		// simulation cannot stay on the main thread in FULL mode: the main
+		// thread must be free to drive the presenter.
+		this->presenter->run();
+		log::log(MSG(info) << "presenter exited");
+		// Make sure that the presenter gets destructed in the same thread,
+		// otherwise OpenGL complains about missing contexts.
+		this->presenter.reset();
+		this->running = false;
+	}
+	else {
+		log::log(INFO << "Using " << this->threads.size() + 1 << " threads "
+		              << "(" << std::jthread::hardware_concurrency() << " available)");
+
+		// In headless mode there is no presenter, so the main thread is free to
+		// run the simulation directly.
+		this->run_simulation();
+	}
+}
+
+void Engine::run_time_loop() {
+	this->time_loop->run();
+	this->time_loop.reset();
+}
+
+void Engine::run_simulation() {
 	// Run the main game simulation loop:
 	this->simulation->run();
-
 	// After stopping, clean up the simulation
 	this->simulation.reset();
 	if (this->run_mode != mode::FULL) {

--- a/libopenage/engine/engine.h
+++ b/libopenage/engine/engine.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 the openage authors. See copying.md for legal info.
+// Copyright 2023-2025 the openage authors. See copying.md for legal info.
 
 #pragma once
 
@@ -100,6 +100,18 @@ public:
 	bool running;
 
 private:
+
+	/**
+	 * Run the time loop. Executed in a worker thread.
+	 */
+	void run_time_loop();
+
+	/**
+	 * Run the simulation loop. Executed in a worker thread in FULL mode and on
+	 * the main thread in headless mode.
+	 */
+	void run_simulation();
+
 	/**
 	 * The run mode to use.
 	 */

--- a/libopenage/input/controller/game/controller.cpp
+++ b/libopenage/input/controller/game/controller.cpp
@@ -58,8 +58,7 @@ void Controller::set_selected(const std::vector<gamestate::entity_id_t> ids) {
 }
 
 bool Controller::process(const event_arguments &ev_args, const std::shared_ptr<BindingContext> &ctx) {
-	std::unique_lock lock{this->mutex};
-
+	// BindingContext is filled at setup time and only read here; no lock needed.
 	if (not ctx->is_bound(ev_args.e)) {
 		return false;
 	}
@@ -67,22 +66,37 @@ bool Controller::process(const event_arguments &ev_args, const std::shared_ptr<B
 	// TODO: check if action is allowed
 	auto bind = ctx->lookup(ev_args.e);
 	auto controller = this->shared_from_this();
+
+	// NOTE: bind.transform() may call back into this Controller (get_controlled,
+	// get_selected, ...) and into EventLoop::create_event (via the input
+	// bindings). It must run WITHOUT holding this->mutex: the simulation thread
+	// takes the locks in the order EventLoop -> Controller, so taking them here
+	// in the order Controller -> EventLoop would deadlock (AB-BA).
 	auto game_event = bind.transform(ev_args, controller);
 
 	switch (bind.action_type) {
 	case forward_action_t::SEND:
+	{
+		std::unique_lock lock{this->mutex};
 		this->outqueue.push_back(game_event);
 		for (auto event : this->outqueue) {
 			// TODO: Send gamestate event
 		}
+	}
 		break;
 
 	case forward_action_t::QUEUE:
+	{
+		std::unique_lock lock{this->mutex};
 		this->outqueue.push_back(game_event);
+	}
 		break;
 
 	case forward_action_t::CLEAR:
+	{
+		std::unique_lock lock{this->mutex};
 		this->outqueue.clear();
+	}
 		break;
 
 	default:

--- a/libopenage/main.cpp
+++ b/libopenage/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 the openage authors. See copying.md for legal info.
+// Copyright 2015-2025 the openage authors. See copying.md for legal info.
 
 #include "main.h"
 

--- a/libopenage/main/demo/pong/gui.cpp
+++ b/libopenage/main/demo/pong/gui.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 the openage authors. See copying.md for legal info.
+// Copyright 2019-2025 the openage authors. See copying.md for legal info.
 
 #include "gui.h"
 

--- a/libopenage/presenter/presenter.cpp
+++ b/libopenage/presenter/presenter.cpp
@@ -40,17 +40,19 @@ namespace openage::presenter {
 
 Presenter::Presenter(const util::Path &root_dir,
                      const std::shared_ptr<gamestate::GameSimulation> &simulation,
-                     const std::shared_ptr<time::TimeLoop> &time_loop) :
+                     const std::shared_ptr<time::TimeLoop> &time_loop,
+                     const renderer::window_settings &window_settings) :
 	root_dir{root_dir},
+	window_settings{window_settings},
 	render_passes{},
 	simulation{simulation},
 	time_loop{time_loop} {}
 
 
-void Presenter::run(const renderer::window_settings window_settings) {
+void Presenter::run() {
 	log::log(INFO << "Presenter: Launching subsystems...");
 
-	this->init_graphics(window_settings);
+	this->init_graphics();
 
 	this->init_input();
 
@@ -92,14 +94,14 @@ std::shared_ptr<qtgui::GuiApplication> Presenter::init_window_system() {
 	return std::make_shared<renderer::gui::GuiApplicationWithLogger>();
 }
 
-void Presenter::init_graphics(const renderer::window_settings &window_settings) {
+void Presenter::init_graphics() {
 	log::log(INFO << "Presenter: Initializing graphics subsystems...");
 
 	// Start up rendering framework
 	this->gui_app = this->init_window_system();
 
 	// Window and renderer
-	this->window = renderer::Window::create("openage presenter test", window_settings);
+	this->window = renderer::Window::create("openage presenter test", this->window_settings);
 	this->renderer = this->window->make_renderer();
 
 	// Asset mangement

--- a/libopenage/presenter/presenter.h
+++ b/libopenage/presenter/presenter.h
@@ -79,19 +79,19 @@ public:
 	 * @param path Root directory path.
 	 * @param simulation Game simulation. Can be set later with \p set_engine()
 	 * @param time_loop Time loop which controls simulation time. Can be set later with \p set_time_loop()
+	 * @param window_settings The settings to customize the display window (e.g. size, display mode, vsync).
 	 */
 	Presenter(const util::Path &path,
 	          const std::shared_ptr<gamestate::GameSimulation> &simulation = nullptr,
-	          const std::shared_ptr<time::TimeLoop> &time_loop = nullptr);
+	          const std::shared_ptr<time::TimeLoop> &time_loop = nullptr,
+	          const renderer::window_settings &window_settings = {});
 
 	~Presenter() = default;
 
 	/**
 	 * Start the presenter and initialize subsystems.
-	 *
-	 * @param window_settings The settings to customize the display window (e.g. size, display mode, vsync).
 	 */
-	void run(const renderer::window_settings window_settings = {});
+	void run();
 
 	/**
 	 * Set the game simulation controlled by this presenter.
@@ -122,7 +122,7 @@ protected:
 	 *     - main renderer
 	 *     - component renderers (Terrain, Game Entities, GUI)
 	 */
-	void init_graphics(const renderer::window_settings &window_settings = {});
+	void init_graphics();
 
 	/**
 	 * Initialize the GUI.
@@ -149,6 +149,12 @@ protected:
 
 	// TODO: remove and move into our config/settings system
 	util::Path root_dir;
+
+	/**
+	 * The settings to customize the display window (e.g. size, display mode, vsync).
+	 * Stored in the presenter because the presenter owns the window.
+	 */
+	const renderer::window_settings window_settings;
 
 	// graphis components
 	/**

--- a/libopenage/renderer/gui/gui.cpp
+++ b/libopenage/renderer/gui/gui.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 the openage authors. See copying.md for legal info.
+// Copyright 2015-2025 the openage authors. See copying.md for legal info.
 
 #include "gui.h"
 
@@ -15,7 +15,6 @@
 #include "renderer/shader_program.h"
 #include "renderer/window.h"
 #include "util/path.h"
-
 
 namespace openage::renderer::gui {
 
@@ -87,7 +86,7 @@ void GUI::initialize_render_pass(size_t width,
 		resources::Texture2dInfo(width, height, resources::pixel_format::rgba8));
 	auto fbo = this->renderer->create_texture_target({output_texture});
 
-	this->texture_unif = maptex_shader->new_uniform_input("texture", this->texture);
+	this->texture_unif = maptex_shader->new_uniform_input("tex", this->texture);
 	Renderable display_obj{
 		this->texture_unif,
 		quad,
@@ -119,7 +118,7 @@ void GUI::resize(size_t width, size_t height) {
 		auto fbo = renderer->create_texture_target({output_texture});
 
 		// pass the new texture to shader uniform
-		this->texture_unif->update("texture", this->texture);
+		this->texture_unif->update("tex", this->texture);
 
 		this->render_pass->set_target(fbo);
 	}

--- a/libopenage/renderer/gui/guisys/private/gui_application_impl.cpp
+++ b/libopenage/renderer/gui/guisys/private/gui_application_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 the openage authors. See copying.md for legal info.
+// Copyright 2015-2025 the openage authors. See copying.md for legal info.
 
 #include "gui_application_impl.h"
 
@@ -35,9 +35,7 @@ GuiApplicationImpl::~GuiApplicationImpl() {
 
 void GuiApplicationImpl::processEvents() {
 	assert(std::this_thread::get_id() == this->owner);
-#ifndef __APPLE__
 	this->app.processEvents();
-#endif
 }
 
 namespace {


### PR DESCRIPTION
Continuation of #1777 (Fix macos build and run issues by @Skosulor), rebased onto current master with the review feedback addressed and an additional deadlock fix that the parallel threading exposes on macOS.

## What this does

### macOS build/run fixes (from #1777)

1. **Run the presenter on the main thread.** `QGuiApplication` must be created and operated on the main thread. On macOS 26 (Tahoe) the platform plugin asserts in `-[NSMenu _setMenuName:]` ("API misuse: setting the main menu on a non-main thread") otherwise. The simulation is moved to a worker thread instead.
2. **Remove the `#ifndef __APPLE__` guard** that stopped Qt events from being processed on macOS (`gui_application_impl.cpp`).
3. **Fix shaders that crashed `glLinkProgram` on macOS.** The macOS OpenGL driver crashes (SIGSEGV in `glpLLVMCGSwitchStatement` during `glLinkProgram`) when compiling a `switch` statement in `world2d.frag.glsl` — switched to `if`/`else`. Also upgraded the GUI shaders from GLSL 1.2 (`#version 120`, `attribute`/`varying`) to 3.3 core (`in`/`out`, `layout(location=)`), and renamed the `texture` uniform to `tex` to avoid the GLSL reserved keyword.

### Deadlock fix (new, exposed by parallel sim/presenter)

Once the simulation runs in a worker thread and the presenter on the main thread, mouse interaction deadlocks within a few seconds:

- **Main thread (presenter):** `Controller::process` holds `Controller::mutex`, then calls `bind.transform()` → `EventLoop::create_event` (takes `EventLoop::mutex`). Lock order: **Controller → EventLoop**.
- **Worker thread (simulation):** `EventLoop::reach_time` holds `EventLoop::mutex`, executes `DragSelectHandler::invoke` → `select_cb` → `Controller::set_selected` (takes `Controller::mutex`). Lock order: **EventLoop → Controller**.

Classic AB-BA deadlock (confirmed via `lldb attach` + `thread backtrace all`, both threads in `__psynch_mutexwait`).

**Fix:** narrow `Controller::process`'s lock scope to only protect the `outqueue` operations; `bind.transform()` now runs without holding `Controller::mutex`. Both threads then take the locks in the order **EventLoop → Controller**, eliminating the cycle. The bindings' callbacks (`get_controlled`, `get_selected`, `reset_drag_select`, …) already take `Controller::mutex` themselves and are safe to call unlocked because it is a `recursive_mutex`.

This is the same class of issue @Skosulor reported in #1777 (`mutex lock failed: Invalid argument`), just triggered through the drag-select path.

### Review feedback (@heinezen) addressed

- **Engine:** thread functions (time loop, simulation) extracted into `run_time_loop()` / `run_simulation()`; all thread spawning moved into `Engine::loop()`; comments explain why the main thread runs the presenter in FULL mode (Qt requirement) and the simulation in headless mode. Thread-count log is now printed after spawning (so the number is correct).
- **`window_settings`** moved from `Engine` into `Presenter` (stored as a member, passed via the Presenter constructor); `Presenter::run()` and `init_graphics()` no longer take it as a parameter.
- **`gui.cpp`:** removed the `static constexpr` for the texture uniform name; the name is passed inline (now `\"tex\"`).
- **`maptexture.frag.glsl`:** uniform renamed `texture_` → `tex`.

### Two suggestions intentionally not applied — would like your input

1. **`identity.vert.glsl`:** kept `gl_Position = vertex_position;`. In GLSL 330 core, `gl_Position` does not automatically contain the current vertex position (it's a write-only output with undefined default); removing it would collapse the GUI quad to the origin `(0,0,0,1)`. This may be a confusion with compatibility-profile `gl_Vertex`. Could you double-check @heinezen?
2. **`world2d.frag.glsl` / `demo_2_obj` / `demo_4_obj`:** kept `if`/`else` instead of `switch`, with a comment explaining the macOS driver crash (`glpLLVMCGSwitchStatement` SIGSEGV during `glLinkProgram`). This is a driver bug, not a shader-authoring issue — confirmed by the crash stack. A `switch` reliably crashes on macOS even though it's valid GLSL.

## Verification

Built and run on macOS 26.3 (Apple Silicon), Homebrew Qt 6.11.1 + LLVM clang 22.1.8, Python 3.14. Tested:

- Game window opens, terrain renders, all render stages (Skybox/Terrain/World/HUD/Screen) initialize.
- Mouse interaction (drag-select, click) no longer deadlocks; window closes cleanly with all threads exiting (`Draw loop exited` → `Game simulation stopped` → `Time loop stopped` → `presenter exited`).
- `renderer_stresstest 0` runs end-to-end (shaders link, entities spawn, FPS stable), confirming the shader fixes.

Supersedes #1777. Happy to split the deadlock fix into a separate PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)